### PR TITLE
Issue #11: Add support for fact acct without lines

### DIFF
--- a/src/org/openbravo/erpCommon/ad_forms/AcctServer.java
+++ b/src/org/openbravo/erpCommon/ad_forms/AcctServer.java
@@ -876,9 +876,7 @@ public abstract class AcctServer {
         if (m_fact != null && m_fact.length != 0) {
           log4j.debug("AcctServer - postCommit - m_fact.length = " + m_fact.length);
           for (int i = 0; i < m_fact.length; i++) {
-            if (m_fact[i].save(con, conn, vars)) {
-              ;
-            } else {
+            if (!m_fact[i].save(con, conn, vars)) {
               unlock(conn);
               Status = AcctServer.STATUS_Error;
             }

--- a/src/org/openbravo/erpCommon/ad_forms/AcctServer.java
+++ b/src/org/openbravo/erpCommon/ad_forms/AcctServer.java
@@ -835,7 +835,7 @@ public abstract class AcctServer {
       log4j.debug("AcctServer - Post - Before the postCommit - C_CURRENCY_ID = " + C_Currency_ID);
     }
     for (int i = 0; i < m_fact.length; i++) {
-      if (m_fact[i] != null && (m_fact[i].getLines() == null || m_fact[i].getLines().length == 0)) {
+      if (m_fact[i] != null && (m_fact[i].getLines() == null || m_fact[i].getLines().length == 0) && !STATUS_Posted.equals(getStatus())) {
         return false;
       }
     }
@@ -876,7 +876,7 @@ public abstract class AcctServer {
         if (m_fact != null && m_fact.length != 0) {
           log4j.debug("AcctServer - postCommit - m_fact.length = " + m_fact.length);
           for (int i = 0; i < m_fact.length; i++) {
-            if (m_fact[i] != null && m_fact[i].save(con, conn, vars)) {
+            if (m_fact[i].save(con, conn, vars)) {
               ;
             } else {
               unlock(conn);


### PR DESCRIPTION
Add support for showing success message without lines in fact acct. When you create a template for accounting and not generate any lines before showing a error message with the correct text. Now showing the success message with the correct text