### PR TITLE
Issue #23:Improve error messages in the post/unpost process

### DIFF
--- a/src/org/openbravo/erpCommon/ad_forms/AcctServer.java
+++ b/src/org/openbravo/erpCommon/ad_forms/AcctServer.java
@@ -754,7 +754,7 @@ public abstract class AcctServer {
         log4j.error("An error ocurred posting RecordId: " + strClave + " - tableId: " + AD_Table_ID,
             e);
         if(throwErrors) {
-          throw new OBException(e.getMessage());
+          throw new OBException(messageResult.getMessage());
         }
       }
     } catch (ServletException e) {


### PR DESCRIPTION
EPL-276: The exception error is printed when the accounting process fails, instead of just printing the exception.