### PR TITLE
Issue #70: Roll back change in Posted button logic to avoid error

### DIFF
--- a/src/org/openbravo/erpCommon/ad_actionButton/Posted.java
+++ b/src/org/openbravo/erpCommon/ad_actionButton/Posted.java
@@ -170,8 +170,7 @@ public class Posted extends HttpSecureAppServlet {
             }
           }
         }
-      }
-      if (strEliminar.equals("N")) {
+      } else if (strEliminar.equals("N")) {
         PostedData[] data = PostedData.select(this, strKey, strTableId);
         if (data == null || data.length == 0 || data[0].id.equals("")) {
           vars.setMessage(strTabId,


### PR DESCRIPTION
EPL-383: Add 'else if' deleted for a Sonar comment