### PR TITLE
Issue #222: modified CompileSqlc task,included class.path.full

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -348,4 +348,4 @@ task djmh(type: JavaExec, dependsOn: jmhCompileGeneratedClasses) {
     classpath = sourceSets.jmh.compileClasspath + sourceSets.jmh.runtimeClasspath
 }
 
-ant.lifecycleLogLevel = "DEBUG"
+//ant.lifecycleLogLevel = "DEBUG"

--- a/build.gradle
+++ b/build.gradle
@@ -347,3 +347,5 @@ task djmh(type: JavaExec, dependsOn: jmhCompileGeneratedClasses) {
     main = project.hasProperty("benchmark") ? project.getProperty("benchmark") : null
     classpath = sourceSets.jmh.compileClasspath + sourceSets.jmh.runtimeClasspath
 }
+
+ant.lifecycleLogLevel = "DEBUG"

--- a/build.gradle
+++ b/build.gradle
@@ -348,4 +348,3 @@ task djmh(type: JavaExec, dependsOn: jmhCompileGeneratedClasses) {
     classpath = sourceSets.jmh.compileClasspath + sourceSets.jmh.runtimeClasspath
 }
 
-//ant.lifecycleLogLevel = "DEBUG"

--- a/build.xml
+++ b/build.xml
@@ -342,7 +342,6 @@ export.database: exports database structure and data to xml files.
     </dirset>
     <dirset dir="${extra.modules.location}" erroronmissingdir="false" >
       <include name="*/build/classes/" />
-      <include name="*/build/tmp/" />
     </dirset>
 
     <pathelement path="${basedir}/src-util/modulescript/build/classes/" />

--- a/build.xml
+++ b/build.xml
@@ -342,6 +342,7 @@ export.database: exports database structure and data to xml files.
     </dirset>
     <dirset dir="${extra.modules.location}" erroronmissingdir="false" >
       <include name="*/build/classes/" />
+      <include name="*/build/tmp/" />
     </dirset>
 
     <pathelement path="${basedir}/src-util/modulescript/build/classes/" />

--- a/src-util/buildvalidation/build.xml
+++ b/src-util/buildvalidation/build.xml
@@ -186,14 +186,7 @@
   <target name="compile" depends="checkmodule, check.module.exists, init, sqlcCore, sqlcModules, sqlcModulesCore, sqlcExtraModule, javacCore, javacModule, javacModuleCore, javacExtraModule">
   </target>
 
-  <target name="list-files">
-    <pathconvert pathsep="${line.separator}" property="files.list" refid="project.class.path" />
-
-    <echo>Archivos incluidos en el fileset:</echo>
-    <echo>${files.list}</echo>
-  </target>
-
-  <target name="buildvalidation" if="buildValidation.var" depends="list-files">
+  <target name="buildvalidation" if="buildValidation.var">
     <java classname="org.openbravo.buildvalidation.BuildValidationHandler" jvm="${env.JAVA_HOME}/bin/java" fork="yes" maxmemory="${build.maxmemory}" failonerror="yes">
       <arg value="${base.src}/../"/>
       <arg value="${module}"/>

--- a/src/build.xml
+++ b/src/build.xml
@@ -300,7 +300,7 @@ build.war: build a war file in the lib directory.
   <target name="list-files">
     <pathconvert pathsep="${line.separator}" property="files.list" refid="project.class.path.full" />
 
-    <echo>Archivos incluidos en el fileset:</echo>
+    <echo>Files included in the fileset:</echo>
     <echo>${files.list}</echo>
   </target>
 

--- a/src/build.xml
+++ b/src/build.xml
@@ -297,10 +297,17 @@ build.war: build a war file in the lib directory.
     </dirset>
   </path>
 
-  <target name="compileSqlc" depends="sqlc">
+  <target name="list-files">
+    <pathconvert pathsep="${line.separator}" property="files.list" refid="project.class.path.full" />
+
+    <echo>Archivos incluidos en el fileset:</echo>
+    <echo>${files.list}</echo>
+  </target>
+
+  <target name="compileSqlc" depends="sqlc , list-files" >
     <javac excludes="*/src-wad/**,*/src-util/**,**/org/openbravo/erpWindows/**" destdir="${build}" encoding="UTF-8" fork="true" memorymaximumsize="${build.maxmemory}" debug="true" debuglevel="lines,vars,source" nowarn="${friendlyWarnings}" includeantruntime="false">
       <src refid="my-src-dirs"/>
-      <classpath refid="project.class.path" />
+      <classpath refid="project.class.path.full" />
     </javac>
 
     <javac srcdir="${build.sqlc}/srcAD" destdir="${build}" encoding="UTF-8" fork="true" memorymaximumsize="${build.maxmemory}" debug="true" debuglevel="lines,vars,source" nowarn="${friendlyWarnings}" includeantruntime="false">

--- a/src/build.xml
+++ b/src/build.xml
@@ -297,13 +297,6 @@ build.war: build a war file in the lib directory.
     </dirset>
   </path>
 
-  <target name="list-files">
-    <pathconvert pathsep="${line.separator}" property="files.list" refid="project.class.path.full" />
-
-    <echo>Files included in the fileset:</echo>
-    <echo>${files.list}</echo>
-  </target>
-
   <target name="compileSqlc" depends="sqlc" >
     <javac excludes="*/src-wad/**,*/src-util/**,**/org/openbravo/erpWindows/**" destdir="${build}" encoding="UTF-8" fork="true" memorymaximumsize="${build.maxmemory}" debug="true" debuglevel="lines,vars,source" nowarn="${friendlyWarnings}" includeantruntime="false">
       <src refid="my-src-dirs"/>

--- a/src/build.xml
+++ b/src/build.xml
@@ -304,7 +304,7 @@ build.war: build a war file in the lib directory.
     <echo>${files.list}</echo>
   </target>
 
-  <target name="compileSqlc" depends="sqlc , list-files" >
+  <target name="compileSqlc" depends="sqlc" >
     <javac excludes="*/src-wad/**,*/src-util/**,**/org/openbravo/erpWindows/**" destdir="${build}" encoding="UTF-8" fork="true" memorymaximumsize="${build.maxmemory}" debug="true" debuglevel="lines,vars,source" nowarn="${friendlyWarnings}" includeantruntime="false">
       <src refid="my-src-dirs"/>
       <classpath refid="project.class.path.full" />

--- a/src/build.xml
+++ b/src/build.xml
@@ -297,10 +297,10 @@ build.war: build a war file in the lib directory.
     </dirset>
   </path>
 
-  <target name="compileSqlc" depends="sqlc" >
+  <target name="compileSqlc" depends="sqlc">
     <javac excludes="*/src-wad/**,*/src-util/**,**/org/openbravo/erpWindows/**" destdir="${build}" encoding="UTF-8" fork="true" memorymaximumsize="${build.maxmemory}" debug="true" debuglevel="lines,vars,source" nowarn="${friendlyWarnings}" includeantruntime="false">
       <src refid="my-src-dirs"/>
-      <classpath refid="project.class.path.full" />
+      <classpath refid="project.class.path.full"/>
     </javac>
 
     <javac srcdir="${build.sqlc}/srcAD" destdir="${build}" encoding="UTF-8" fork="true" memorymaximumsize="${build.maxmemory}" debug="true" debuglevel="lines,vars,source" nowarn="${friendlyWarnings}" includeantruntime="false">


### PR DESCRIPTION
The modifications made in this pull request correspond to the solution of issue #222.
The src/build.xml file, specifically the compileSqlc task, has been modified, changing the path to the classpath, now the path is project.class.path.full, this reference is defined within the build.xml file in the root of the project.
In addition, a new task is added which can be used to display the content of the classpath