### PR TITLE
Issue #224: Error adding line in sales order

### DIFF
--- a/src/org/openbravo/erpCommon/ad_callouts/SL_Order_Product.java
+++ b/src/org/openbravo/erpCommon/ad_callouts/SL_Order_Product.java
@@ -119,9 +119,10 @@ public class SL_Order_Product extends SimpleCallout {
     BigDecimal calculatedDiscount = BigDecimal.ZERO;
     BigDecimal price = isTaxIncludedPriceList ? grossPriceList : netPriceList;
     if (!BigDecimal.ZERO.equals(price)) {
+      int precision = order.getCurrency().getPricePrecision().intValue();
       calculatedDiscount = price.subtract(priceActual)
               .multiply(BigDecimal.valueOf(100))
-              .divide(price, 2)
+              .divide(price, precision)
               .setScale(0, RoundingMode.HALF_UP);
     }
     if (calculatedDiscount.compareTo(info.getBigDecimalParameter("inpdiscount")) != 0) {

--- a/src/org/openbravo/erpCommon/ad_callouts/SL_Order_Product.java
+++ b/src/org/openbravo/erpCommon/ad_callouts/SL_Order_Product.java
@@ -116,11 +116,14 @@ public class SL_Order_Product extends SimpleCallout {
     }
 
     // Discount
+    BigDecimal calculatedDiscount = BigDecimal.ZERO;
     BigDecimal price = isTaxIncludedPriceList ? grossPriceList : netPriceList;
-    BigDecimal calculatedDiscount = price.subtract(priceActual)
-        .multiply(BigDecimal.valueOf(100))
-        .divide(price, 2)
-        .setScale(0, RoundingMode.HALF_UP);
+    if (!BigDecimal.ZERO.equals(price)) {
+      calculatedDiscount = price.subtract(priceActual)
+              .multiply(BigDecimal.valueOf(100))
+              .divide(price, 2)
+              .setScale(0, RoundingMode.HALF_UP);
+    }
     if (calculatedDiscount.compareTo(info.getBigDecimalParameter("inpdiscount")) != 0) {
       info.addResult("inpdiscount", calculatedDiscount);
     }


### PR DESCRIPTION
It was detected that the problem in the SL_Order_Product callout occurs due to a division by 0 in the discount calculation. This occurs when the price in the rate is 0.

Validation was added so that when this case occurs, now when the price in the rate is 0 the calculated discount will also be 0