### PR TITLE
Issue #260: prevent hide message bar when refresh child tab

### DIFF
--- a/modules_core/org.openbravo.client.application/web/org.openbravo.client.application/js/main/ob-standard-view.js
+++ b/modules_core/org.openbravo.client.application/web/org.openbravo.client.application/js/main/ob-standard-view.js
@@ -1698,7 +1698,7 @@ isc.OBStandardView.addProperties({
       // at this point the time fields of the record are formatted in local time
       localTime = true;
     this.messageBar.hide();
-    if (this.parentView) {
+    if (this.parentView && (this.parentView.entity !== this.entity)) {
       this.parentView.messageBar.hide();
     }
 


### PR DESCRIPTION
This error happens when the parent tab shows a message and a child that is from the same entity (like the Business Partner window) is refreshed. This fix prevents the hide of the message bar in the parent tab.