### PR TITLE
Hotfix ETO-279: Prevent Oracle pipeline concurrency conflicts

### DIFF
--- a/pipelines/unittests/JenkinsfileOracle
+++ b/pipelines/unittests/JenkinsfileOracle
@@ -2,6 +2,7 @@ pipeline {
 
     options {
         disableConcurrentBuilds()
+        lock(resource: 'pipeline-lock-for-oracle')
     }
 
     environment {


### PR DESCRIPTION
Introduce a lock to avoid concurrent builds and resolve pipeline conflicts.