### PR TITLE
Issue #282: Change the validation to check for undefined too

### DIFF
--- a/modules_core/org.openbravo.client.application/web/org.openbravo.client.application/js/process/ob-parameter-window-view.js
+++ b/modules_core/org.openbravo.client.application/web/org.openbravo.client.application/js/process/ob-parameter-window-view.js
@@ -484,7 +484,7 @@ isc.OBParameterWindowView.addProperties({
         },
         function(rpcResponse, data, rpcRequest) {
           view.handleResponse(
-            !(data && data.refreshParent !== true),
+            data && data.refreshParent === true),
             data && data.message,
             data && data.responseActions,
             data && data.retryExecution,

--- a/modules_core/org.openbravo.client.application/web/org.openbravo.client.application/js/process/ob-parameter-window-view.js
+++ b/modules_core/org.openbravo.client.application/web/org.openbravo.client.application/js/process/ob-parameter-window-view.js
@@ -484,7 +484,7 @@ isc.OBParameterWindowView.addProperties({
         },
         function(rpcResponse, data, rpcRequest) {
           view.handleResponse(
-            !(data && !data.refreshParent),
+            !(data && data.refreshParent !== true),
             data && data.message,
             data && data.responseActions,
             data && data.retryExecution,

--- a/modules_core/org.openbravo.client.application/web/org.openbravo.client.application/js/process/ob-parameter-window-view.js
+++ b/modules_core/org.openbravo.client.application/web/org.openbravo.client.application/js/process/ob-parameter-window-view.js
@@ -484,7 +484,7 @@ isc.OBParameterWindowView.addProperties({
         },
         function(rpcResponse, data, rpcRequest) {
           view.handleResponse(
-            !(data && data.refreshParent === false),
+            !(data && !data.refreshParent),
             data && data.message,
             data && data.responseActions,
             data && data.retryExecution,


### PR DESCRIPTION
EPL-1197.

(26/01) - With the implementation of Actions, now the Object returned from the AddPaymentActionHandler is an ActionResult. This causes the properties added as "false" are not included in the response, it just avoids adding at least they were "true".
Arriving at the JS (modules_core/org.openbravo.client.application/web/org.openbravo.client.application/js/process/ob-parameter-window-view.js) this response (data) doesn't have the properties needed to be checked, they are "undefined" and comparing "undefined === false" is not the same that "false === false", so I have changed the validation to check for undefined too.

(29/01) - Change the logic of the validation to avoid being confusing.