### PR TITLE
Issue #329: Fixed ResponseActionsBuilder using refreshParent as default

### DIFF
--- a/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/actionHandler/AddPaymentActionHandler.java
+++ b/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/actionHandler/AddPaymentActionHandler.java
@@ -218,8 +218,8 @@ public class AddPaymentActionHandler extends Action {
     if (resultProcess.has(RETRY_EXECUTION) && resultProcess.getBoolean(RETRY_EXECUTION)) {
       responseActions.retryExecution();
     }
-    if (resultProcess.has(REFRESH_PARENT) && resultProcess.getBoolean(REFRESH_PARENT)) {
-      responseActions.refreshParent();
+    if (resultProcess.has(REFRESH_PARENT)) {
+      responseActions.setRefreshParent(resultProcess.getBoolean(REFRESH_PARENT));
     }
     actionResult.setResponseActionsBuilder(responseActions);
     actionResult.setOutput(getInput());

--- a/modules_core/org.openbravo.client.application/src/org/openbravo/client/application/process/ResponseActionsBuilder.java
+++ b/modules_core/org.openbravo.client.application/src/org/openbravo/client/application/process/ResponseActionsBuilder.java
@@ -67,6 +67,7 @@ public class ResponseActionsBuilder {
 
   ResponseActionsBuilder() {
     responseActions = new JSONArray();
+    refreshParent = true;
   }
 
   /**
@@ -256,11 +257,27 @@ public class ResponseActionsBuilder {
   /**
    * Allows to re-execute the process again, by enabling the process UI. This is useful to do
    * backend validations as this allows the user to fix data and resubmit again.
+   * @deprecated
+   * This method is no longer acceptable to compute time between versions.
+   * <p> Use {@link ResponseActionsBuilder#setRefreshParent(boolean)} instead.
    *
    * @return a ResponseActionsBuilder configured to retry the process execution.
    */
+  @Deprecated
   public ResponseActionsBuilder refreshParent() {
     refreshParent = true;
+    return this;
+  }
+
+  /**
+   * Allows refresh parent window when the process execution finished. This is useful to shows
+   * changes in values of current records selected.
+   * @param refreshParent
+   *          If true, the parent window when the process execution finished it will do a refresh.
+   * @return a ResponseActionsBuilder configured to refresh parent window when the process execution finished.
+   */
+  public ResponseActionsBuilder setRefreshParent(boolean refreshParent) {
+    this.refreshParent = refreshParent;
     return this;
   }
 
@@ -345,6 +362,9 @@ public class ResponseActionsBuilder {
       if (showResultsInProcessView) {
         result.put("showResultsInProcessView", true);
       }
+
+      result.put("refreshParent", refreshParent);
+
       return result;
     } catch (JSONException jsonex) {
       log.error("Error building process response actions", jsonex);


### PR DESCRIPTION
EPL-1356: Fixed ResponseActionsBuilder to use refreshParent as default also fixed AddPaymentActionHandler class to used refreshParent param as false.