### PR TITLE
Issue #299: Oracle DB, fix when deleting order lines and invoices

### DIFF
--- a/src-db/database/model/triggers/C_INVOICELINETAX_TRG.xml
+++ b/src-db/database/model/triggers/C_INVOICELINETAX_TRG.xml
@@ -170,10 +170,11 @@ BEGIN
     AND NOT EXISTS 
         (
             SELECT 1
-            FROM C_INVOICELINETAX
+            FROM C_INVOICELINE
             WHERE C_TAX_ID = :OLD.C_TAX_ID
             AND C_INVOICE_ID = :OLD.C_INVOICE_ID
-        );    
+            AND C_INVOICELINE_ID <> :OLD.C_INVOICELINE_ID
+        );   
   END IF;
 END IF;
 END C_INVOICELINETAX_TRG

--- a/src-db/database/model/triggers/C_ORDERLINETAX_TRG.xml
+++ b/src-db/database/model/triggers/C_ORDERLINETAX_TRG.xml
@@ -169,9 +169,10 @@ BEGIN
     AND NOT EXISTS 
         (
             SELECT 1
-            FROM C_ORDERLINETAX
+            FROM C_ORDERLINE
             WHERE C_TAX_ID = :OLD.C_TAX_ID
             AND C_ORDER_ID = :OLD.C_ORDER_ID
+            AND C_ORDERLINE_ID <> :OLD.C_ORDERLINE_ID
         );
   END IF;
 END C_ORDERLINETAX_TRG


### PR DESCRIPTION
In Oracle databases, when the C_INVOICELINETAX_TRG trigger is fired, a mutation of the C_INVOICELINETAX table occurs. Table mutation occurs when a trigger or function attempts to view or manipulate data from the same table that is being modified by the current operation. This occurs because the C_INVOICELINE_TRG2 trigger performs a query to the C_INVOICELINETAX_TRG table while the C_INVOICELINETAX_TRG trigger performs the same query and then deletes content from the table.

To solve the problem, the data source table was modified, now we pull C_INVOICELINE.

This same problem occurred in sales orders, although this issue does not mention it, the problem was detected and corrected there as well.