### PR TITLE
Issue #388: Filter out inactive Orgs from 'Module Management' window

### DIFF
--- a/src/org/openbravo/erpCommon/ad_forms/UpdateReferenceData_data.xsql
+++ b/src/org/openbravo/erpCommon/ad_forms/UpdateReferenceData_data.xsql
@@ -43,6 +43,7 @@
        AND R.ISACTIVE = 'Y'
        AND A_R_O.AD_ROLE_ID = ? 
        AND A_O.AD_Org_ID IN('1')
+       AND A_O.ISACTIVE = 'Y'
        ORDER BY A_O.NAME
      ]]></Sql>
        <Parameter name="rol"/>


### PR DESCRIPTION
EPL-1472: this change will prevent inactive organizations from appearing in the Organization selector of the 'Enterprise Module Management' window