### PR TITLE
Issue #448: Refactored accounting tests in Internal consumption

### DIFF
--- a/src-test/src/org/openbravo/test/accounting/PostedNoDocConfigTest.java
+++ b/src-test/src/org/openbravo/test/accounting/PostedNoDocConfigTest.java
@@ -9,40 +9,39 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.hibernate.criterion.Restrictions;
+import org.junit.Before;
+import org.junit.Test;
 import org.openbravo.base.exception.OBException;
 import org.openbravo.base.provider.OBConfigFileProvider;
+import org.openbravo.base.provider.OBProvider;
+import org.openbravo.base.secureApp.VariablesSecureApp;
 import org.openbravo.base.structure.BaseOBObject;
+import org.openbravo.base.weld.test.WeldBaseTest;
+import org.openbravo.client.kernel.RequestContext;
+import org.openbravo.dal.core.OBContext;
 import org.openbravo.dal.service.OBCriteria;
+import org.openbravo.dal.service.OBDal;
 import org.openbravo.database.ConnectionProvider;
 import org.openbravo.database.ConnectionProviderImpl;
 import org.openbravo.erpCommon.ad_forms.AcctServer;
+import org.openbravo.erpCommon.utility.OBDateUtils;
 import org.openbravo.erpCommon.utility.OBMessageUtils;
 import org.openbravo.exception.PoolNotFoundException;
 import org.openbravo.financial.ResetAccounting;
 import org.openbravo.model.ad.datamodel.Table;
-import org.openbravo.model.ad.system.Client;
 import org.openbravo.model.common.enterprise.DocumentType;
-import org.openbravo.model.common.enterprise.Organization;
-import org.openbravo.model.financialmgmt.gl.GLCategory;
-import org.openbravo.test.costing.utils.TestCostingUtils;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.openbravo.base.provider.OBProvider;
-import org.openbravo.base.secureApp.VariablesSecureApp;
-import org.openbravo.base.weld.test.WeldBaseTest;
-import org.openbravo.client.kernel.RequestContext;
-import org.openbravo.dal.core.OBContext;
-import org.openbravo.dal.service.OBDal;
 import org.openbravo.model.common.enterprise.Locator;
 import org.openbravo.model.common.plm.Product;
 import org.openbravo.model.financialmgmt.accounting.coa.AcctSchemaTable;
+import org.openbravo.model.financialmgmt.gl.GLCategory;
 import org.openbravo.model.materialmgmt.transaction.InternalConsumption;
 import org.openbravo.model.materialmgmt.transaction.InternalConsumptionLine;
 import org.openbravo.service.db.CallStoredProcedure;
 import org.openbravo.test.base.TestConstants;
+import org.openbravo.test.costing.utils.TestCostingUtils;
 
 /**
  * This class tests the behavior of internal consumption operations when document types
@@ -65,9 +64,7 @@ public class PostedNoDocConfigTest extends WeldBaseTest {
   private static final String PRODUCT_ID = "C0E3824CC5184B7F9746D195ACAC2CCF"; // Cerveza Lager 0,5L
   private static final String STORAGE_BIN_ID = "54EB861A446D464EAA433477A1D867A6"; // Rn-0-0-0
   private static final String MATERIAL_MANAGEMENT_CONSUMPTION = "B70331659B1142FFB0AA0F862B3A9079";
-  private static final String GL_CATEGORY = "2B5AE4A4047540A1A5DCEC9E3B9441C1"; // ES AP Invoice
-  private static final String ORG_STR = "organization";
-  private static final String CLIENT_STR = "client";
+  private static final String GL_CATEGORY = "EDA7B85AF9A5486D9B00CAFFD3B86FC2"; // ES Standard
   private static final String DOC_TYPE_NAME = "Material Internal Consumption";
   private static final String DB_MESSAGE_NAME = "NoDocTypeForDocument";
   private static final Logger log4j = Logger.getLogger(PostedNoDocConfigTest.class);
@@ -84,65 +81,155 @@ public class PostedNoDocConfigTest extends WeldBaseTest {
     RequestContext.get().setVariableSecureApp(vars);
   }
 
+  /**
+   * Test to verify the correct processing of an internal consumption document
+   * when no document type is configured. The test simulates the creation and
+   * processing of an internal consumption, ensures the document is posted
+   * correctly, and checks the expected error message when no document type is configured.
+   * <p>
+   * Steps:
+   * 1. Create an internal consumption document with material management lines.
+   * 2. Process the internal consumption and refresh its status.
+   * 3. Activate the material management consumption table and run costing background.
+   * 4. Attempt to post the document and verify the expected posting result.
+   * 5. If the document is in the "Completed" status, it is voided; otherwise, it is deleted.
+   * <p>
+   * Expected Result:
+   * - The expected error message is displayed when no document type is configured.
+   */
   @Test
   public void testCountWithoutDocTypeConfigured() {
+    InternalConsumption internalConsumption = null;
+    Table materialManagementConsumptionTable = null;
     try {
-      InternalConsumption internalConsumption = createInternalConsumption();
-
-      createInternalConsumptionLine(internalConsumption);
-
-      processInternalConsumption(internalConsumption);
+      internalConsumption = createHeaderAndMaterialManagementConsumptionLines();
+      processInternalConsumption(internalConsumption, "CO");
+      OBDal.getInstance().refresh(internalConsumption);
 
       activeOrDeactiveMaterialManagementConsumptionTable(true);
-
       TestCostingUtils.runCostingBackground();
 
-      OBDal.getInstance().commitAndClose();
-
-      String result = postDocument(internalConsumption);
+      materialManagementConsumptionTable = getMaterialManagementConsumptionTable(internalConsumption);
+      String result = postDocument(internalConsumption, materialManagementConsumptionTable);
+      OBDal.getInstance().refresh(internalConsumption);
 
       assertEquals(OBMessageUtils.messageBD(DB_MESSAGE_NAME), result);
-      assertEquals("N", internalConsumption.getPosted());
+      assertEquals("DT", internalConsumption.getPosted());
     } catch (Exception e) {
       log4j.error(e.getMessage(), e);
       fail(e.getMessage());
+    } finally {
+      if (internalConsumption != null) {
+        OBDal.getInstance().refresh(internalConsumption);
+        if (StringUtils.equals("CO", internalConsumption.getStatus())) {
+          processInternalConsumption(internalConsumption, "VO");
+        } else {
+          OBDal.getInstance().remove(internalConsumption);
+        }
+        OBDal.getInstance().flush();
+      }
     }
   }
 
+  /**
+   * Test to ensure that an OBException is thrown when posting an internal consumption document
+   * with a document type that is later removed. The test handles document creation, processing,
+   * and posting, and it verifies that the proper exception is raised when the document type is missing.
+   * <p>
+   * Steps:
+   * 1. Create and process an internal consumption document with material management lines.
+   * 2. Activate the material management consumption table.
+   * 3. Create a document type and associate it with the internal consumption.
+   * 4. Run the costing background and attempt to post the document.
+   * 5. Verify the posting status and remove the document type.
+   * 6. Attempt to delete accounting records and expect an OBException due to the missing document type.
+   * 7. In the finally block, ensure proper cleanup of the internal consumption and document type.
+   * <p>
+   * Expected Result:
+   * - The document should post with a status of "Y".
+   * - An OBException with the message "@NoDocTypeForDocument@" should be thrown when the document type is missing.
+   */
   @Test
   public void testDiscountWithoutDocTypeConfigured() {
+    String docTypeId = null;
+    InternalConsumption internalConsumption = null;
+    Table materialManagementConsumptionTable = null;
     try {
-      InternalConsumption internalConsumption = createInternalConsumption();
+      internalConsumption = createHeaderAndMaterialManagementConsumptionLines();
+      processInternalConsumption(internalConsumption, "CO");
 
-      createInternalConsumptionLine(internalConsumption);
-
-      processInternalConsumption(internalConsumption);
-
+      materialManagementConsumptionTable = getMaterialManagementConsumptionTable(internalConsumption);
       activeOrDeactiveMaterialManagementConsumptionTable(true);
-
-      DocumentType docType = createDocumentType();
-
+      docTypeId = createDocumentType(materialManagementConsumptionTable).getId();
       TestCostingUtils.runCostingBackground();
 
-      OBDal.getInstance().commitAndClose();
-
-      postDocument(internalConsumption);
-
+      postDocument(internalConsumption, materialManagementConsumptionTable);
       OBDal.getInstance().refresh(internalConsumption);
       assertEquals("Y", internalConsumption.getPosted());
 
-      OBDal.getInstance().remove(docType);
-      OBDal.getInstance().flush();
+      removeDocType(docTypeId);
 
       ResetAccounting.delete(internalConsumption.getClient().getId(),
-              internalConsumption.getOrganization().getId(),
-              internalConsumption.getEntity().getTableId(), internalConsumption.getId(), null, null);
+          internalConsumption.getOrganization().getId(),
+          internalConsumption.getEntity().getTableId(), internalConsumption.getId(),
+          OBDateUtils.formatDate(internalConsumption.getMovementDate()), null);
 
       fail("Expected an OBException to be thrown");
     } catch (Exception e) {
       assertEquals("@NoDocTypeForDocument@", e.getMessage());
+    } finally {
+      if (internalConsumption != null) {
+        if (StringUtils.equals("Y", internalConsumption.getPosted())) {
+          processInternalConsumption(internalConsumption, "VO");
+          OBDal.getInstance().flush();
+        }
+      }
+      if (docTypeId != null) {
+        removeDocType(docTypeId);
+      }
     }
   }
+
+  /**
+   * Creates an internal consumption object and its corresponding consumption lines.
+   *
+   * @return the internal consumption object created
+   */
+  private InternalConsumption createHeaderAndMaterialManagementConsumptionLines() {
+    InternalConsumption internalConsumption = createInternalConsumption();
+    createInternalConsumptionLine(internalConsumption);
+
+    return internalConsumption;
+  }
+
+  /**
+   * Removes a document type by its ID.
+   *
+   * @param docTypeId
+   *     the ID of the document type to be removed
+   */
+  private void removeDocType(String docTypeId) {
+    DocumentType docType = OBDal.getInstance().get(DocumentType.class, docTypeId);
+    if (docType != null) {
+      OBDal.getInstance().remove(docType);
+      OBDal.getInstance().flush();
+    }
+  }
+
+  /**
+   * Retrieves a Table object related to material management consumption based on the provided document.
+   *
+   * @param document
+   *     the BaseOBObject representing the document
+   * @return the Table object related to material management consumption or null if not found
+   */
+  private Table getMaterialManagementConsumptionTable(BaseOBObject document) {
+    final OBCriteria<Table> criteria = OBDal.getInstance().createCriteria(Table.class);
+    criteria.add(Restrictions.eq(Table.PROPERTY_NAME, document.getEntityName()));
+    criteria.setMaxResults(1);
+    return (Table) criteria.uniqueResult();
+  }
+
 
   private InternalConsumption createInternalConsumption() {
     try {
@@ -183,12 +270,12 @@ public class PostedNoDocConfigTest extends WeldBaseTest {
     }
   }
 
-  private void processInternalConsumption(InternalConsumption internalConsumption) {
+  private void processInternalConsumption(InternalConsumption internalConsumption, String status) {
     try {
       List<Object> param = new ArrayList<>();
       param.add(null);
       param.add(internalConsumption.getId());
-      param.add("CO");
+      param.add(status);
 
       CallStoredProcedure.getInstance().call("m_internal_consumption_post1", param, null, true, false);
     } catch (Exception e) {
@@ -210,7 +297,7 @@ public class PostedNoDocConfigTest extends WeldBaseTest {
     }
   }
 
-  private DocumentType createDocumentType() {
+  private DocumentType createDocumentType(Table table) {
     try {
       DocumentType docType = OBProvider.getInstance().get(DocumentType.class);
       docType.setName(DOC_TYPE_NAME);
@@ -218,6 +305,7 @@ public class PostedNoDocConfigTest extends WeldBaseTest {
       docType.setGLCategory(OBDal.getInstance().get(GLCategory.class, GL_CATEGORY));
       docType.setDocumentCategory("MIC");
       docType.setActive(true);
+      docType.setTable(table);
 
       OBDal.getInstance().save(docType);
       OBDal.getInstance().flush();
@@ -230,22 +318,19 @@ public class PostedNoDocConfigTest extends WeldBaseTest {
     }
   }
 
-  public String postDocument(BaseOBObject document) {
+  public String postDocument(InternalConsumption internalConsumption, Table table) {
     ConnectionProvider conn = getConnectionProvider();
     Connection con = null;
 
     try {
-      final OBCriteria<Table> criteria = OBDal.getInstance().createCriteria(Table.class);
-      criteria.add(Restrictions.eq(Table.PROPERTY_NAME, document.getEntityName()));
-      criteria.setMaxResults(1);
-      String tableId = ((Table) criteria.uniqueResult()).getId();
-      con = conn.getTransactionConnection();
-      AcctServer acct = AcctServer.get(tableId, ((Client) document.get(CLIENT_STR)).getId(),
-          ((Organization) document.get(ORG_STR)).getId(), conn);
+      String tableId = table.getId();
+      con = conn.getConnection();
+      AcctServer acct = AcctServer.get(tableId, internalConsumption.getClient().getId(),
+          internalConsumption.getOrganization().getId(), conn);
 
-      return acct.catchPostError((String) document.getId(), false,
-          new VariablesSecureApp("100", ((Client) document.get(CLIENT_STR)).getId(),
-              ((Organization) document.get(ORG_STR)).getId()),
+      return acct.catchPostError(internalConsumption.getId(), false,
+          new VariablesSecureApp("100", internalConsumption.getClient().getId(),
+              internalConsumption.getOrganization().getId()),
           conn, con);
 
     } catch (Exception e) {

--- a/src-test/src/org/openbravo/test/accounting/PostedNoDocConfigTest.java
+++ b/src-test/src/org/openbravo/test/accounting/PostedNoDocConfigTest.java
@@ -100,7 +100,6 @@ public class PostedNoDocConfigTest extends WeldBaseTest {
   @Test
   public void testCountWithoutDocTypeConfigured() {
     InternalConsumption internalConsumption = null;
-    Table materialManagementConsumptionTable = null;
     try {
       internalConsumption = createHeaderAndMaterialManagementConsumptionLines();
       processInternalConsumption(internalConsumption, "CO");
@@ -109,7 +108,7 @@ public class PostedNoDocConfigTest extends WeldBaseTest {
       activeOrDeactiveMaterialManagementConsumptionTable(true);
       TestCostingUtils.runCostingBackground();
 
-      materialManagementConsumptionTable = getMaterialManagementConsumptionTable(internalConsumption);
+      Table materialManagementConsumptionTable = getMaterialManagementConsumptionTable(internalConsumption);
       String result = postDocument(internalConsumption, materialManagementConsumptionTable);
       OBDal.getInstance().refresh(internalConsumption);
 
@@ -153,12 +152,11 @@ public class PostedNoDocConfigTest extends WeldBaseTest {
   public void testDiscountWithoutDocTypeConfigured() {
     String docTypeId = null;
     InternalConsumption internalConsumption = null;
-    Table materialManagementConsumptionTable = null;
     try {
       internalConsumption = createHeaderAndMaterialManagementConsumptionLines();
       processInternalConsumption(internalConsumption, "CO");
 
-      materialManagementConsumptionTable = getMaterialManagementConsumptionTable(internalConsumption);
+      Table materialManagementConsumptionTable = getMaterialManagementConsumptionTable(internalConsumption);
       activeOrDeactiveMaterialManagementConsumptionTable(true);
       docTypeId = createDocumentType(materialManagementConsumptionTable).getId();
       TestCostingUtils.runCostingBackground();
@@ -179,12 +177,13 @@ public class PostedNoDocConfigTest extends WeldBaseTest {
       assertEquals("@NoDocTypeForDocument@", e.getMessage());
     } finally {
       if (internalConsumption != null) {
+        OBDal.getInstance().refresh(internalConsumption);
         if (StringUtils.equals("Y", internalConsumption.getPosted())) {
           processInternalConsumption(internalConsumption, "VO");
           OBDal.getInstance().flush();
         }
       }
-      if (docTypeId != null) {
+      if (!StringUtils.isEmpty(docTypeId)) {
         removeDocType(docTypeId);
       }
     }


### PR DESCRIPTION
ETP-166: The crash caused by the testDiscountWithoutDocTypeConfigured test when trying to remove the document type has been fixed, and improvements have been made to the accounting tests for Internal consumption. Specifically, unnecessary commits have been removed, modularity improvements, cleanup blocks and documentation in the methods.