### PR TITLE
Issue #496: Fixed BaseActionHandler not ending

### DIFF
--- a/modules_core/org.openbravo.client.application/web/org.openbravo.client.application/js/process/ob-parameter-window-view.js
+++ b/modules_core/org.openbravo.client.application/web/org.openbravo.client.application/js/process/ob-parameter-window-view.js
@@ -475,10 +475,8 @@ isc.OBParameterWindowView.addProperties({
 
       // allow to add external parameters
       isc.addProperties(allProperties._params, view.externalParams);
-
       const form = view.theForm;
-      const hasFileItems = view.theForm.getFileItemForm();
-      if (hasFileItems) {
+      if (form && form.getFileItemForm()) {
         const formData = form
           .getItems()
           .filter(item => isc.isA.FileItem(item))


### PR DESCRIPTION
ETP-459: After the inclusion of the File Upload reference, BaseActionHandlers that do not contain parameters of the FileItemForm type do not complete their execution correctly due to a bad implementation in the ob-parameter-window-view.js class. Corrections have been made to solve this problem.