### PR TITLE
Issue #547: Support for middle dash in cancel and replace

### DIFF
--- a/src/org/openbravo/erpCommon/businessUtility/CreateReplacementOrderExecutor.java
+++ b/src/org/openbravo/erpCommon/businessUtility/CreateReplacementOrderExecutor.java
@@ -98,7 +98,7 @@ class CreateReplacementOrderExecutor extends CancelAndReplaceUtils {
     newOrder.setSummedLineAmount(BigDecimal.ZERO);
     newOrder.setOrderDate(new Date());
     newOrder.setReplacedorder(oldOrder);
-    newOrder.setDocumentNo(getNextCancelDocNo(documentNo));
+    newOrder.setDocumentNo(getNextCancelDocNo(oldOrder));
     OBDal.getInstance().save(newOrder);
 
     // Create new Order lines


### PR DESCRIPTION
ETP-826: When a document number contains middle dashes due to the configuration of its prefix, problems arise when calculating the document number for cancellation. This improvement supports this case.