### PR TITLE
Feature ETP-125: fix oracle SID variable in JenkinsfileOracle

### DIFF
--- a/pipelines/unittests/JenkinsfileOracle
+++ b/pipelines/unittests/JenkinsfileOracle
@@ -106,7 +106,7 @@ spec:
       env:
         - name: ORACLE_PWD
           value: oraclepassword
-        - name ORACLE_SID
+        - name: ORACLE_SID
           value: orclsid
       ports:
         - name: oracle


### PR DESCRIPTION
An error has been corrected in the agent definition, since it had been missing : in one of the environment variables 