### PR TITLE
Issue #519: Prevent duplicate sum of payment lines in Z payments acct

### DIFF
--- a/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/ProcessInvoiceUtil.java
+++ b/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/ProcessInvoiceUtil.java
@@ -326,7 +326,10 @@ public class ProcessInvoiceUtil {
                             pd.setAmount(fpsd.getAmount());
                             pd.setRefund(false);
                             OBDal.getInstance().save(pd);
-                            
+
+                            // Remove the reference to the order payment schedule
+                            fpsd.setOrderPaymentSchedule(null);
+
                             fpsd.setPaymentDetails(pd);
 
                             pd.getFINPaymentScheduleDetailList().add(fpsd);

--- a/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/ProcessInvoiceUtil.java
+++ b/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/ProcessInvoiceUtil.java
@@ -326,9 +326,7 @@ public class ProcessInvoiceUtil {
                             pd.setAmount(fpsd.getAmount());
                             pd.setRefund(false);
                             OBDal.getInstance().save(pd);
-
-                            // Remove the reference to the order payment schedule
-                            fpsd.setOrderPaymentSchedule(null);
+                            
                             fpsd.setPaymentDetails(pd);
 
                             pd.getFINPaymentScheduleDetailList().add(fpsd);

--- a/src/org/openbravo/erpCommon/ad_forms/AcctServer.java
+++ b/src/org/openbravo/erpCommon/ad_forms/AcctServer.java
@@ -3621,7 +3621,7 @@ public abstract class AcctServer {
           // If there is a previous Payment Detail that belongs to the same Invoice and has no Order
           // related to it, return the sum of amounts.
         } else if (psdPrevious != null && psdPrevious.getInvoicePaymentSchedule() == psi
-            && psdPrevious.getOrderPaymentSchedule() == null) {
+            && psdPrevious.getOrderPaymentSchedule() == null && BigDecimal.ZERO.compareTo(paymentDetail.getFinPayment().getAmount()) != 0) {
           amountAndWriteOff.put("amount",
               paymentDetail.getAmount().add(paymentDetailPrevious.getAmount()));
           amountAndWriteOff.put("writeoff",


### PR DESCRIPTION
## API Changes Analysis
### API Change Documentation

#### 1. New Imports or Dependencies
- No new imports or dependencies added or removed.

#### 2. Endpoint Changes
- No endpoints were added, modified, or deleted.

#### 3. Method Changes and Their Signatures
- No method signatures were changed.

#### 4. Changes in Types or Interfaces Affecting the Public API
- No changes in types or interfaces that affect the public API.

#### 5. Breaking Changes Requiring User Attention
- A condition within the method in `AcctServer` was modified:
  - **Previous Condition:** `psdPrevious.getOrderPaymentSchedule() == null`
  - **Updated Condition:** `psdPrevious.getOrderPaymentSchedule() == null && BigDecimal.ZERO.compareTo(paymentDetail.getFinPayment().getAmount()) != 0`
  - **Impact:** This change ensures that the logic only applies when the payment amount is not zero, which could affect the flow of payment calculations.
  
  **Usage Example:**

  If you rely on the previous behavior where the condition did not check for non-zero amounts, you need to verify your logic to ensure it aligns with the new condition:

  ```java
  if (psdPrevious != null && psdPrevious.getInvoicePaymentSchedule() == psi
      && psdPrevious.getOrderPaymentSchedule() == null
      && BigDecimal.ZERO.compareTo(paymentDetail.getFinPayment().getAmount()) != 0) {
    // New behavior with non-zero payment amount validation
    amountAndWriteOff.put("amount", paymentDetail.getAmount().add(paymentDetailPrevious.getAmount()));
    amountAndWriteOff.put("writeoff", ...);
  }
  ```

Ensure to update any logic that interacts with this method to account for non-zero payment amounts.
