### PR TITLE
Feature ETP-1157: Update stack and docker image in testing pipelines 

### DIFF
--- a/pipelines/unittests/Jenkinsfile
+++ b/pipelines/unittests/Jenkinsfile
@@ -31,9 +31,9 @@ pipeline {
     UNSTABLE            = "UNSTABLE"
 
     // Stack
-    JAVA_HOME           = "/usr/lib/jvm/java-11-openjdk-amd64"
-    TOMCAT_URL          = "https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.86/bin/apache-tomcat-9.0.86.tar.gz"
-    POSTGRES_VERSION    = "14"
+    JAVA_HOME           = "/usr/lib/jvm/jdk-17.0.13"
+    TOMCAT_URL          = "https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.98/bin/apache-tomcat-9.0.98.tar.gz"
+    POSTGRES_VERSION    = "16"
 
     CONTEXT_BUILD       = "Unit Tests with Postgres Database"
 
@@ -72,7 +72,7 @@ spec:
         type: ''
   containers:
     - name: compiler
-      image: etendo/compiler_jenkins:1.0.6
+      image: etendo/compiler_jenkins:1.0.7-jdk.17.0.13
       ports:
         - name: ssh
           containerPort: 22
@@ -106,7 +106,7 @@ spec:
       terminationMessagePolicy: File
       imagePullPolicy: IfNotPresent
     - name: postgres
-      image: postgres:14
+      image: postgres:16
       workingDir: /home/jenkins
       env:
         - name: POSTGRES_PASSWORD

--- a/pipelines/unittests/JenkinsfileOracle
+++ b/pipelines/unittests/JenkinsfileOracle
@@ -29,8 +29,8 @@ pipeline {
         UNSTABLE            = "UNSTABLE"
 
         // Stack
-        JAVA_HOME           = "/usr/lib/jvm/java-11-openjdk-amd64"
-        TOMCAT_URL          = "https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.86/bin/apache-tomcat-9.0.86.tar.gz"
+        JAVA_HOME           = "/usr/lib/jvm/jdk-17.0.13"
+        TOMCAT_URL          = "https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.98/bin/apache-tomcat-9.0.98.tar.gz"
         ORCL_VERSION        = "19c"
 
         CONTEXT_BUILD       = "Unit Tests with Oracle Database"
@@ -67,7 +67,7 @@ spec:
         type: ''
   containers:
     - name: compiler
-      image: etendo/compiler_jenkins:1.0.6
+      image: etendo/compiler_jenkins:1.0.7-jdk.17.0.13
       ports:
         - name: ssh
           containerPort: 22


### PR DESCRIPTION
Stack updated to work with java 17.0.3, postgres 16 and tomcat 9.0.98