### PR TITLE
Feature ETP-1184: Fix UI issue in Advanced Reports

### DIFF
--- a/modules_core/org.openbravo.client.application/src/org/openbravo/client/application/report/BaseReportActionHandler.java
+++ b/modules_core/org.openbravo.client.application/src/org/openbravo/client/application/report/BaseReportActionHandler.java
@@ -122,7 +122,7 @@ public class BaseReportActionHandler extends BaseProcessActionHandler {
   protected JSONObject doExecute(Map<String, Object> parameters, String content) {
 
     try {
-      JSONObject result = getResponseBuilder().retryExecution().showResultsInProcessView().build();
+      JSONObject result = getResponseBuilder().retryExecution().build();
 
       final JSONObject jsonContent = new JSONObject(content);
       final String action = jsonContent.getString(ApplicationConstants.BUTTON_VALUE);
@@ -133,7 +133,6 @@ public class BaseReportActionHandler extends BaseProcessActionHandler {
       log.error("Error generating report id: {}", parameters.get("reportId"), e);
       Throwable uiException = DbUtility.getUnderlyingSQLException(e);
       return getResponseBuilder().retryExecution()
-          .showResultsInProcessView()
           .showMsgInProcessView(MessageType.ERROR,
               OBMessageUtils.translateError(uiException.getMessage()).getMessage())
           .build();


### PR DESCRIPTION
## API Changes Analysis
        # API Change Documentation

## 1. New Imports or Dependencies
- No new imports or dependencies were added or removed.

## 2. Endpoint Changes
- No endpoints were added, modified, or deleted.

## 3. Method Changes and Their Signatures
- **Method Modified**: `protected JSONObject doExecute(Map<String, Object> parameters, String content)`
  - **Change**: The method call to `getResponseBuilder().retryExecution().showResultsInProcessView().build()` has been modified to `getResponseBuilder().retryExecution().build()`. The `showResultsInProcessView()` method is no longer part of the method chain.

## 4. Changes in Types or Interfaces
- No changes in types or interfaces affecting the public API.

## 5. Breaking Changes
- **Breaking Change**: The removal of `showResultsInProcessView()` in the response building process affects how results are presented. Previously, results were shown in the process view, which is no longer the case.

### Usage Example
**Before Change:**
```java
JSONObject result = getResponseBuilder().retryExecution().showResultsInProcessView().build();
```

**After Change:**
```java
JSONObject result = getResponseBuilder().retryExecution().build();
```

**Impact**: Users relying on results being displayed in the process view need to adjust their implementations accordingly, as this behavior is no longer supported.
        