### PR TITLE
Issue #571: Fix automatic credit preloading when opening payment popup

### DIFF
--- a/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/filterexpression/TransactionAddPaymentDefaultValues.java
+++ b/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/filterexpression/TransactionAddPaymentDefaultValues.java
@@ -29,9 +29,11 @@ import org.apache.commons.lang.StringUtils;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import org.openbravo.advpaymentmngt.utility.APRMConstants;
+import org.openbravo.advpaymentmngt.utility.FIN_Utility;
 import org.openbravo.client.kernel.ComponentProvider;
 import org.openbravo.dal.service.OBDal;
 import org.openbravo.erpCommon.utility.OBDateUtils;
+import org.openbravo.model.common.businesspartner.BusinessPartner;
 import org.openbravo.model.financialmgmt.payment.FIN_FinancialAccount;
 import org.openbravo.model.financialmgmt.payment.FinAccPaymentMethod;
 import org.openbravo.service.json.JsonUtils;
@@ -40,6 +42,8 @@ import org.openbravo.service.json.JsonUtils;
 public class TransactionAddPaymentDefaultValues extends AddPaymentDefaultValuesHandler {
 
   private static final long SEQUENCE = 100l;
+  private static final String CONTEXT = "context";
+  private static final String INPAD_ORG_ID = "inpadOrgId";
 
   @Override
   protected long getSeq() {
@@ -54,7 +58,7 @@ public class TransactionAddPaymentDefaultValues extends AddPaymentDefaultValuesH
   @Override
   public String getDefaultActualAmount(Map<String, String> requestMap) throws JSONException {
     if ("Y".equals(getDefaultIsSOTrx(requestMap))) {
-      JSONObject context = new JSONObject(requestMap.get("context"));
+      JSONObject context = new JSONObject(requestMap.get(CONTEXT));
       if (context.has("depositamt") && context.has("withdrawalamt")) {
         return new BigDecimal(convertToSafeDecimalString(context.getString("depositamt")))
             .subtract(
@@ -125,7 +129,7 @@ public class TransactionAddPaymentDefaultValues extends AddPaymentDefaultValuesH
 
   @Override
   public String getDefaultIsSOTrx(Map<String, String> requestMap) throws JSONException {
-    JSONObject context = new JSONObject(requestMap.get("context"));
+    JSONObject context = new JSONObject(requestMap.get(CONTEXT));
     String document = null;
     if (context.has("trxtype") && context.get("trxtype") != JSONObject.NULL
         && StringUtils.isNotEmpty(context.getString("trxtype"))) {
@@ -175,7 +179,7 @@ public class TransactionAddPaymentDefaultValues extends AddPaymentDefaultValuesH
 
   @Override
   public String getDefaultReceivedFrom(Map<String, String> requestMap) throws JSONException {
-    JSONObject context = new JSONObject(requestMap.get("context"));
+    JSONObject context = new JSONObject(requestMap.get(CONTEXT));
     if (context.has("c_bpartner_id") && context.get("c_bpartner_id") != JSONObject.NULL
         && StringUtils.isNotEmpty(context.getString("c_bpartner_id"))) {
       return context.getString("c_bpartner_id");
@@ -200,22 +204,35 @@ public class TransactionAddPaymentDefaultValues extends AddPaymentDefaultValuesH
   @Override
   public String getOrganization(Map<String, String> requestMap) throws JSONException {
     // Organization of the current Payment
-    JSONObject context = new JSONObject(requestMap.get("context"));
+    JSONObject context = new JSONObject(requestMap.get(CONTEXT));
     if (context.has("ad_org_id") && context.get("ad_org_id") != JSONObject.NULL
         && StringUtils.isNotEmpty(context.getString("ad_org_id"))) {
       return context.getString("ad_org_id");
     }
-    if (context.has("inpadOrgId") && context.get("inpadOrgId") != JSONObject.NULL
-        && StringUtils.isNotEmpty(context.getString("inpadOrgId"))) {
-      return context.getString("inpadOrgId");
+    if (context.has(INPAD_ORG_ID) && context.get(INPAD_ORG_ID) != JSONObject.NULL
+        && StringUtils.isNotEmpty(context.getString(INPAD_ORG_ID))) {
+      return context.getString(INPAD_ORG_ID);
     }
     return getFinancialAccount(requestMap).getOrganization().getId();
   }
 
   @Override
   public String getDefaultPaymentMethod(Map<String, String> requestMap) throws JSONException {
+    JSONObject context = new JSONObject(requestMap.get(CONTEXT));
     boolean isReceipt = "Y".equals(getDefaultIsSOTrx(requestMap));
-
+    String bpartnerId = getDefaultReceivedFrom(requestMap);
+    if (StringUtils.isNotEmpty(bpartnerId)) {
+      BusinessPartner businessPartner = OBDal.getInstance().get(BusinessPartner.class, bpartnerId);
+      if (isReceipt && businessPartner.getPaymentMethod() != null && FIN_Utility.getFinancialAccountPaymentMethod(
+          businessPartner.getPaymentMethod().getId(), businessPartner.getAccount().getId(), isReceipt, null,
+          context.getString(INPAD_ORG_ID)) != null) {
+        return businessPartner.getPaymentMethod().getId();
+      } else if (!isReceipt && businessPartner.getPOPaymentMethod() != null && FIN_Utility.getFinancialAccountPaymentMethod(
+          businessPartner.getPOPaymentMethod().getId(), businessPartner.getPOFinancialAccount().getId(), !isReceipt,
+          null, context.getString(INPAD_ORG_ID)) != null) {
+        return businessPartner.getPOPaymentMethod().getId();
+      }
+    }
     FinAccPaymentMethod anyFinAccPaymentMethod = null;
     for (FinAccPaymentMethod finAccPaymentMethod : getFinancialAccount(requestMap)
         .getFinancialMgmtFinAccPaymentMethodList()) {
@@ -238,7 +255,7 @@ public class TransactionAddPaymentDefaultValues extends AddPaymentDefaultValuesH
   @Override
   public String getDefaultDocument(Map<String, String> requestMap) throws JSONException {
     // Document Type
-    JSONObject context = new JSONObject(requestMap.get("context"));
+    JSONObject context = new JSONObject(requestMap.get(CONTEXT));
     String document = null;
     if (context.has("trxtype") && context.get("trxtype") != JSONObject.NULL
         && StringUtils.isNotEmpty(context.getString("trxtype"))) {
@@ -258,7 +275,7 @@ public class TransactionAddPaymentDefaultValues extends AddPaymentDefaultValuesH
 
   @Override
   public String getDefaultPaymentDate(Map<String, String> requestMap) throws JSONException {
-    JSONObject context = new JSONObject(requestMap.get("context"));
+    JSONObject context = new JSONObject(requestMap.get(CONTEXT));
     String strTransactionDate = null;
     try {
       if (context.has("trxdate") && context.get("trxdate") != JSONObject.NULL
@@ -284,7 +301,7 @@ public class TransactionAddPaymentDefaultValues extends AddPaymentDefaultValuesH
 
   private FIN_FinancialAccount getFinancialAccount(Map<String, String> requestMap)
       throws JSONException {
-    JSONObject context = new JSONObject(requestMap.get("context"));
+    JSONObject context = new JSONObject(requestMap.get(CONTEXT));
     String strFinancialAccount = null;
     if (context.has("inpfinFinancialAccountId")
         && context.get("inpfinFinancialAccountId") != JSONObject.NULL
@@ -303,7 +320,7 @@ public class TransactionAddPaymentDefaultValues extends AddPaymentDefaultValuesH
 
   @Override
   public String getBankStatementLineAmount(Map<String, String> requestMap) throws JSONException {
-    JSONObject context = new JSONObject(requestMap.get("context"));
+    JSONObject context = new JSONObject(requestMap.get(CONTEXT));
     if (context.has("depositamt") && context.has("withdrawalamt")
         && context.get("depositamt") != JSONObject.NULL
         && context.get("withdrawalamt") != JSONObject.NULL) {

--- a/modules_core/org.openbravo.advpaymentmngt/web/org.openbravo.advpaymentmngt/js/ob-aprm-addPayment.js
+++ b/modules_core/org.openbravo.advpaymentmngt/web/org.openbravo.advpaymentmngt/js/ob-aprm-addPayment.js
@@ -196,6 +196,20 @@ OB.APRM.AddPayment.onLoad = function(view) {
     form.addField(orgParam);
     form.addField(bankStatementLineAmount);
   }
+
+  const ADD_PAYMENT_WINDOW_ID = "94EAA455D2644E04AB25D93BE5157B6D";
+  const windowId = view.windowId;
+
+  if (windowId === ADD_PAYMENT_WINDOW_ID && !view.hasExecutedCreditLogic) {
+    let affectedParams = [];
+    affectedParams.push(form.getField('credit_to_use_display_logic').paramId);
+    OB.APRM.AddPayment.recalcDisplayLogicOrReadOnlyLogic(
+        form,
+        view,
+        affectedParams
+    );
+    view.hasExecutedCreditLogic = true;
+  }
 };
 
 OB.APRM.AddPayment.addNewGLItem = function(grid) {


### PR DESCRIPTION
## API Changes Analysis
### API Change Documentation

#### 1. New Imports or Dependencies Added/Removed
- **Added**: `org.openbravo.advpaymentmngt.utility.FIN_Utility`
- **Added**: `org.openbravo.model.common.businesspartner.BusinessPartner`

#### 2. Endpoint Changes
- No endpoint changes detected.

#### 3. Method Changes and Their Signatures
- **Modified Method**: `getDefaultActualAmount(Map<String, String> requestMap)`
  - **Change**: Uses constant `CONTEXT` for `requestMap.get()`.
- **Modified Method**: `getDefaultIsSOTrx(Map<String, String> requestMap)`
  - **Change**: Uses constant `CONTEXT` for `requestMap.get()`.
- **Modified Method**: `getDefaultReceivedFrom(Map<String, String> requestMap)`
  - **Change**: Uses constant `CONTEXT` for `requestMap.get()`.
- **Modified Method**: `getOrganization(Map<String, String> requestMap)`
  - **Change**: Uses constants `CONTEXT` and `INPAD_ORG_ID`.
- **Modified Method**: `getDefaultPaymentMethod(Map<String, String> requestMap)`
  - **Change**: Uses constants `CONTEXT` and `INPAD_ORG_ID`.
  - **Usage Example**:
    ```java
    String paymentMethod = instance.getDefaultPaymentMethod(requestMap);
    ```
- **Modified Method**: `getDefaultDocument(Map<String, String> requestMap)`
  - **Change**: Uses constant `CONTEXT` for `requestMap.get()`.
- **Modified Method**: `getDefaultPaymentDate(Map<String, String> requestMap)`
  - **Change**: Uses constant `CONTEXT` for `requestMap.get()`.
- **Modified Method**: `getFinancialAccount(Map<String, String> requestMap)`
  - **Change**: Uses constant `CONTEXT` for `requestMap.get()`.
- **Modified Method**: `getBankStatementLineAmount(Map<String, String> requestMap)`
  - **Change**: Uses constant `CONTEXT` for `requestMap.get()`.

#### 4. Changes in Types or Interfaces Affecting the Public API
- No changes in types or interfaces affecting the public API.

#### 5. Breaking Changes Requiring User Attention
- **Breaking Change**: Usage of constants `CONTEXT` and `INPAD_ORG_ID` for accessing map keys may require updates in user implementations if they relied on hardcoded string keys.

#### Additional Modifications
- **JavaScript Change**: Added conditional logic in `ob-aprm-addPayment.js` for `ADD_PAYMENT_WINDOW_ID`.
  - **Usage Example**:
    ```javascript
    if (windowId === ADD_PAYMENT_WINDOW_ID && !view.hasExecutedCreditLogic) {
      let affectedParams = [];
      affectedParams.push(form.getField('credit_to_use_display_logic').paramId);
      OB.APRM.AddPayment.recalcDisplayLogicOrReadOnlyLogic(form, view, affectedParams);
      view.hasExecutedCreditLogic = true;
    }
    ```
