### PR TITLE
Feature ETP-1185: Add Supplier Reference field when voiding invoice

### DIFF
--- a/modules_core/com.smf.jobs.defaults/src/com/smf/jobs/defaults/ProcessInvoices.java
+++ b/modules_core/com.smf.jobs.defaults/src/com/smf/jobs/defaults/ProcessInvoices.java
@@ -90,6 +90,7 @@ public class ProcessInvoices extends Action {
                 docAction,
                 strVoidDate,
                 strVoidAcctDate,
+                null,
                 RequestContext.get().getVariablesSecureApp(),
                 new DalConnectionProvider(false)
         );

--- a/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/ProcessInvoiceUtil.java
+++ b/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/ProcessInvoiceUtil.java
@@ -63,7 +63,7 @@ public class ProcessInvoiceUtil {
      * @param conn {@link ConnectionProvider} Used to connect to the database. Use 'this' when in servlets.
      * @return an {@link OBError} with the message of the resulting operation. It can be a success.
      */
-    public OBError process(String strC_Invoice_ID, String strdocaction, String strVoidInvoiceDate, String strVoidInvoiceAcctDate, VariablesSecureApp vars, ConnectionProvider conn) {
+    public OBError process(String strC_Invoice_ID, String strdocaction, String strVoidInvoiceDate, String strVoidInvoiceAcctDate, String strSupplierReference, VariablesSecureApp vars, ConnectionProvider conn) {
         OBError myMessage = null;
         try {
 
@@ -120,6 +120,7 @@ public class ProcessInvoiceUtil {
                 parameters.put("voidedDocumentDate", OBDateUtils.formatDate(voidDate, "yyyy-MM-dd"));
                 parameters.put("voidedDocumentAcctDate",
                         OBDateUtils.formatDate(voidAcctDate, "yyyy-MM-dd"));
+                parameters.put("supplierReference", strSupplierReference);
 
             }
 

--- a/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/ProcessInvoiceUtil.java
+++ b/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/ProcessInvoiceUtil.java
@@ -59,6 +59,7 @@ public class ProcessInvoiceUtil {
      * @param strdocaction Document Action
      * @param strVoidInvoiceDate Void date where applicable
      * @param strVoidInvoiceAcctDate Void accounting date where applicable
+     * @param strSupplierReference Supplier reference associated with the invoice, used for tracking purposes.
      * @param vars {@link VariablesSecureApp} Used to obtain current language and by Payment Processes. Use {@link org.openbravo.client.kernel.RequestContext#getVariablesSecureApp()} outside of servlets.
      * @param conn {@link ConnectionProvider} Used to connect to the database. Use 'this' when in servlets.
      * @return an {@link OBError} with the message of the resulting operation. It can be a success.

--- a/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/ad_actionbutton/ProcessInvoice.java
+++ b/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/ad_actionbutton/ProcessInvoice.java
@@ -145,6 +145,7 @@ public class ProcessInvoice extends HttpSecureAppServlet {
       final String strdocaction = vars.getStringParameter("inpdocaction");
       final String strVoidInvoiceDate = vars.getStringParameter("inpVoidedDocumentDate");
       final String strVoidInvoiceAcctDate = vars.getStringParameter("inpVoidedDocumentAcctDate");
+      final String strSupplierReference = vars.getStringParameter("inpSupplierReference");
       final String strOrg = vars.getGlobalVariable("inpadOrgId", "ProcessInvoice|Org_ID",
           IsIDFilter.instance);
 
@@ -153,7 +154,7 @@ public class ProcessInvoice extends HttpSecureAppServlet {
 
         Invoice invoice = dao.getObject(Invoice.class, strC_Invoice_ID);
 
-        myMessage = weldUtils.getInstance(ProcessInvoiceUtil.class).process(strC_Invoice_ID, strdocaction, strVoidInvoiceDate, strVoidInvoiceAcctDate, vars, this);
+        myMessage = weldUtils.getInstance(ProcessInvoiceUtil.class).process(strC_Invoice_ID, strdocaction, strVoidInvoiceDate, strVoidInvoiceAcctDate, strSupplierReference, vars, this);
         log4j.debug(myMessage.getMessage());
         vars.setMessage(strTabId, myMessage);
 

--- a/src-db/database/model/functions/C_INVOICE_POST.xml
+++ b/src-db/database/model/functions/C_INVOICE_POST.xml
@@ -162,6 +162,7 @@
 
   v_voiddate_inv C_Invoice.DateInvoiced%TYPE;
   v_voiddate_acct C_Invoice.DateAcct%TYPE;
+  v_supplier_reference C_Invoice.POReference%TYPE;
 
   v_bpartner_blocked VARCHAR2(1):='N';
   v_invoiceBlocking VARCHAR2(1):='N';
@@ -203,6 +204,8 @@ BEGIN
         v_voiddate_inv := TO_DATE(Cur_Parameter.p_string, 'YYYY-MM-DD');
       ELSIF (Cur_Parameter.parametername = 'voidedDocumentAcctDate') THEN
         v_voiddate_acct := TO_DATE(Cur_Parameter.p_string, 'YYYY-MM-DD');
+      ELSIF (Cur_Parameter.parametername = 'supplierReference') THEN
+        v_supplier_reference := Cur_Parameter.p_string;
       END IF;
     END LOOP; -- Get Parameter
     DBMS_OUTPUT.PUT_LINE('  v_Record_ID=' || v_Record_ID) ;
@@ -823,6 +826,9 @@ IF (NOT FINISH_PROCESS) THEN
         END IF;
         IF (v_voiddate_acct IS NOT NULL) THEN
           UPDATE C_INVOICE SET DateAcct = v_voiddate_acct WHERE C_Invoice_ID=v_RInvoice_ID;
+        END IF;
+        IF (v_supplier_reference IS NOT NULL) THEN
+          UPDATE C_INVOICE SET POReference = v_supplier_reference WHERE C_Invoice_ID=v_RInvoice_ID;
         END IF;
         IF (v_prepaymentamt !=0) THEN
           UPDATE C_INVOICE SET prepaymentamt = v_prepaymentamt WHERE C_Invoice_ID=v_RInvoice_ID;

--- a/src-test/src/com/smf/jobs/defaults/ProcessInvoicesTest.java
+++ b/src-test/src/com/smf/jobs/defaults/ProcessInvoicesTest.java
@@ -133,6 +133,7 @@ public class ProcessInvoicesTest {
           eq(docAction),
           eq(""),
           eq(""),
+          eq(null),
           any(VariablesSecureApp.class),
           any(DalConnectionProvider.class)
       )).thenReturn(expectedResult);
@@ -181,6 +182,7 @@ public class ProcessInvoicesTest {
           eq(docAction),
           eq(formattedDate),
           eq(formattedDate),
+          eq(null),
           any(VariablesSecureApp.class),
           any(DalConnectionProvider.class)
       )).thenReturn(expectedResult);
@@ -248,6 +250,7 @@ public class ProcessInvoicesTest {
           anyString(),
           anyString(),
           anyString(),
+          eq(null),
           any(VariablesSecureApp.class),
           any(DalConnectionProvider.class)
       )).thenReturn(successResult);
@@ -300,6 +303,7 @@ public class ProcessInvoicesTest {
           eq("XL"),
           anyString(),
           anyString(),
+          eq(null),
           any(VariablesSecureApp.class),
           any(DalConnectionProvider.class)
       )).thenReturn(successResult);

--- a/src/org/openbravo/erpCommon/ad_actionButton/DocAction.html
+++ b/src/org/openbravo/erpCommon/ad_actionButton/DocAction.html
@@ -176,6 +176,7 @@
       
       displayLogicElement('voidedDocumentDateRow', displayVoidDates && (purchaseInvoiceWindow === currentWindowId || goodsReceiptWindow === currentWindowId));
       displayLogicElement('voidedDocumentDateAcctRow', displayVoidDates && (purchaseInvoiceWindow === currentWindowId || goodsReceiptWindow === currentWindowId));
+      displayLogicElement('supplierReferenceRow', displayVoidDates && purchaseInvoiceWindow === currentWindowId);
     }
     
     function applyInvoiceIfPossibleDisplayLogic() {
@@ -466,6 +467,11 @@
                 </td>
               </tr>
               
+              <tr id="supplierReferenceRow">
+              <td class="TitleCell"><span id="lblSupplierReference" class="LabelText">Supplier Reference</span></td>
+              <td class="TextBox_ContentCell"><input type="text" name="inpSupplierReference" id="paramSupplierReference" size="30" maxlength="30" value="" class="dojoValidateValid TextBox_TwoCell_width"></input>
+              </tr>
+
               <tr id="invoiceIfPossible">
               	<td class="TitleCell"><span id="lblInvoiceIfPossible" class="LabelText">Invoice if possible</span></td>
               	<td class="Radio_Check_ContentCell">

--- a/src/org/openbravo/erpCommon/ad_actionButton/DocAction.xml
+++ b/src/org/openbravo/erpCommon/ad_actionButton/DocAction.xml
@@ -54,6 +54,7 @@
   <PARAMETER id="paramVoidedDocumentAcctDate" name="voidedDocumentAcctDate" attribute="value"/>
   <PARAMETER id="paramVoidedDocumentAcctDate" name="dateDisplayFormat" attribute="displayformat" replace="xx"/>
   <PARAMETER id="paramVoidedDocumentAcctDate" name="dateDisplayFormat" attribute="saveformat" replace="yy"/>
+  <PARAMETER id="paramSupplierReference" name="supplierReference" attribute="value" default=""/>
   <PARAMETER id="documentDate" name="documentDate" attribute="value"/>
   <PARAMETER id="documentAcctDate" name="documentAcctDate" attribute="value"/>
   <PARAMETER id="fieldCalendar" name="calendar" attribute="src" replace="es" default="en"/>


### PR DESCRIPTION
## API Changes Analysis
### API Change Documentation

#### 1. New Imports or Dependencies
- No new imports or dependencies added or removed.

#### 2. Endpoint Changes
- No endpoints were added, modified, or deleted.

#### 3. Method Changes and Signatures
- **Method Modified**: `ProcessInvoiceUtil.process`
  - **Old Signature**: 
    ```java
    public OBError process(String strC_Invoice_ID, String strdocaction, String strVoidInvoiceDate, String strVoidInvoiceAcctDate, VariablesSecureApp vars, ConnectionProvider conn)
    ```
  - **New Signature**:
    ```java
    public OBError process(String strC_Invoice_ID, String strdocaction, String strVoidInvoiceDate, String strVoidInvoiceAcctDate, String strSupplierReference, VariablesSecureApp vars, ConnectionProvider conn)
    ```
  - **Description**: Added parameter `String strSupplierReference` to facilitate supplier tracking.

#### 4. Changes in Types or Interfaces
- **Database Function Update**: `C_INVOICE_POST`
  - Added variable `v_supplier_reference` of type `C_Invoice.POReference%TYPE`.
  - Logic updated to handle `supplierReference`.

#### 5. Breaking Changes
- **Method Signature Update**: The addition of `strSupplierReference` to `ProcessInvoiceUtil.process` is a breaking change. Users must update their method calls to include this new parameter.

#### Usage Example
To accommodate the updated `process` method, users should now provide a `strSupplierReference` value:

**Old Usage**:
```java
myMessage = weldUtils.getInstance(ProcessInvoiceUtil.class).process(strC_Invoice_ID, strdocaction, strVoidInvoiceDate, strVoidInvoiceAcctDate, vars, this);
```

**New Usage**:
```java
myMessage = weldUtils.getInstance(ProcessInvoiceUtil.class).process(strC_Invoice_ID, strdocaction, strVoidInvoiceDate, strVoidInvoiceAcctDate, strSupplierReference, vars, this);
```

Ensure the value for `strSupplierReference` is properly obtained and passed to maintain functionality.
