### PR TITLE
Issue #578: Add dynamic url logic for Swagger UI

### DIFF
--- a/modules_core/com.smf.securewebservices/web/com.smf.securewebservices/doc/index.html
+++ b/modules_core/com.smf.securewebservices/web/com.smf.securewebservices/doc/index.html
@@ -4,6 +4,7 @@
   <head>
     <meta charset="UTF-8">
     <title>Swagger UI</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js"></script>
     <link rel="stylesheet" type="text/css" href="./swagger-ui.css" >
     <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
@@ -38,25 +39,27 @@
     <script src="./swagger-ui-bundle.js"> </script>
     <script src="./swagger-ui-standalone-preset.js"> </script>
     <script>
-    window.onload = function() {
-      // Begin Swagger UI call region
-      const ui = SwaggerUIBundle({
-        url: "doc.yaml",
-        dom_id: '#swagger-ui',
-        deepLinking: true,
-        presets: [
-          SwaggerUIBundle.presets.apis,
-          SwaggerUIStandalonePreset
-        ],
-        plugins: [
-          SwaggerUIBundle.plugins.DownloadUrl
-        ],
-        layout: "StandaloneLayout"
-      })
-      // End Swagger UI call region
+      window.onload = function() {
+        const baseUrl = window.location.origin;
+        const pathname = window.location.pathname;
+        const contextPath = pathname.substring(0, pathname.indexOf('/', 1));
+        const apiUrl = `${baseUrl}${contextPath}`;
 
-      window.ui = ui
-    }
-  </script>
+        fetch('doc.yaml')
+          .then(response => response.text())
+          .then(yamlText => {
+            const spec = jsyaml.load(yamlText);
+            spec.servers = [{ url: apiUrl }];
+            SwaggerUIBundle({
+              spec: spec,
+              dom_id: '#swagger-ui',
+              deepLinking: true,
+              presets: [SwaggerUIBundle.presets.apis],
+              plugins: [SwaggerUIBundle.plugins.DownloadUrl]
+            });
+          })
+          .catch(error => console.error("Error loading Swagger specification:", error));
+      };
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## API Changes Analysis
### API Change Documentation

#### 1. New Imports or Dependencies Added/Removed
- **Added:** `js-yaml` library imported in `index.html` for parsing YAML files.

#### 2. Endpoint Changes
- **No endpoint changes** (new, modified, or deleted) reported in this update.

#### 3. Method Changes and Their Signatures
- **Modified Method:**
  - **Previous Implementation:**
    ```javascript
    const ui = SwaggerUIBundle({
      url: "doc.yaml",
      dom_id: '#swagger-ui',
      deepLinking: true,
      presets: [
        SwaggerUIBundle.presets.apis,
        SwaggerUIStandalonePreset
      ],
      plugins: [
        SwaggerUIBundle.plugins.DownloadUrl
      ],
      layout: "StandaloneLayout"
    })
    ```
  - **Updated Implementation:**
    ```javascript
    fetch('doc.yaml')
      .then(response => response.text())
      .then(yamlText => {
        const spec = jsyaml.load(yamlText);
        spec.servers = [{ url: apiUrl }];
        SwaggerUIBundle({
          spec: spec,
          dom_id: '#swagger-ui',
          deepLinking: true,
          presets: [SwaggerUIBundle.presets.apis],
          plugins: [SwaggerUIBundle.plugins.DownloadUrl]
        });
      })
      .catch(error => console.error("Error loading Swagger specification:", error));
    ```

#### 4. Changes in Types or Interfaces Affecting the Public API
- **No changes in types or interfaces** affecting the public API were noted.

#### 5. Breaking Changes Requiring User Attention
- **None reported.** Changes in method handling and YAML parsing should be non-breaking if the `js-yaml` library is correctly loaded.

#### Usage Example for Significant Changes
- **Updated Swagger UI Initialization:**
  ```html
  <script>
    window.onload = function() {
      const baseUrl = window.location.origin;
      const pathname = window.location.pathname;
      const contextPath = pathname.substring(0, pathname.indexOf('/', 1));
      const apiUrl = `${baseUrl}${contextPath}`;

      fetch('doc.yaml')
        .then(response => response.text())
        .then(yamlText => {
          const spec = jsyaml.load(yamlText);
          spec.servers = [{ url: apiUrl }];
          SwaggerUIBundle({
            spec: spec,
            dom_id: '#swagger-ui',
            deepLinking: true,
            presets: [SwaggerUIBundle.presets.apis],
            plugins: [SwaggerUIBundle.plugins.DownloadUrl]
          });
        })
        .catch(error => console.error("Error loading Swagger specification:", error));
    };
  </script>
  ```

This update enhances flexibility by dynamically setting the server URL based on the current context path. Ensure that the `js-yaml` library is available to prevent parsing errors.
