### PR TITLE
Issue #538: Prevent breaking criteria in grid

### DIFF
--- a/modules_core/org.openbravo.client.application/web/org.openbravo.client.application/js/form/formitem/ob-formitem-fk-filter.js
+++ b/modules_core/org.openbravo.client.application/web/org.openbravo.client.application/js/form/formitem/ob-formitem-fk-filter.js
@@ -415,6 +415,17 @@ isc.OBFKFilterTextItem.addProperties({
         me.grid.parentElement.getClassName() === 'OBPickAndExecuteGrid'
       );
     }
+    /**
+     * Checks if the current object is an instance of OBSelectorFilterSelectItem.
+     *
+     * @returns {boolean} True if the current object is an instance of OBSelectorFilterSelectItem, otherwise false.
+     */
+    function isOBSelectorFilterSelectItem() {
+      return (
+        me &&
+        me.getClassName() === 'OBSelectorFilterSelectItem'
+      );
+    }
 
     function cleanCriteria(crit, fkItem) {
       var i, criterion, fkFilterOnThisField;
@@ -433,7 +444,7 @@ isc.OBFKFilterTextItem.addProperties({
           crit.removeAt(i);
         }
 
-        if (isInPickAndExecuteGrid() && criterion.fieldName === 'id') {
+        if ((isInPickAndExecuteGrid() || isOBSelectorFilterSelectItem()) && criterion.fieldName === 'id') {
           // we're in a P&E grid, selected ids should also be removed from criteria
           crit.removeAt(i);
         }
@@ -441,7 +452,7 @@ isc.OBFKFilterTextItem.addProperties({
     }
 
     function cleanOrCriterion() {
-      if (isInPickAndExecuteGrid() && gridCriteria._OrExpression) {
+      if ((isInPickAndExecuteGrid() || isOBSelectorFilterSelectItem()) && gridCriteria._OrExpression) {
         // we're in a P&E grid, _OrExpression parameter should also be removed as it is used as part of the selection criteria
         if (gridCriteria.criteria.length > 0) {
           gridCriteria = {

--- a/modules_core/org.openbravo.client.application/web/org.openbravo.client.application/js/grid/ob-grid.js
+++ b/modules_core/org.openbravo.client.application/web/org.openbravo.client.application/js/grid/ob-grid.js
@@ -623,8 +623,8 @@ isc.OBGrid.addProperties({
       // The original criteria is in the position 0, the rest are specific ids
       length = criteria.criteria.length;
       for (i = 1; i < length; i++) {
-        if (criteria.criteria.get(i).fieldName !== 'id') {
-          return criteria;
+        if (criteria.criteria.get(i)?.fieldName !== 'id') {
+          return criteria.criteria.get(i);
         }
       }
       return criteria.criteria.get(0);


### PR DESCRIPTION
## API Changes Analysis
## API Change Documentation

### 1. New Imports or Dependencies
- No new imports or dependencies were added or removed.

### 2. Endpoint Changes
- No endpoint changes were made.

### 3. Method Changes and their Signatures
- **Modified Method**: The logic within `isc.OBGrid.addProperties` has been adjusted.
  - **Previous Logic**: 
    ```javascript
    if (criteria.criteria.get(i).fieldName !== 'id') {
      return criteria;
    }
    ```
  - **Updated Logic**:
    ```javascript
    if (criteria.criteria.get(i)?.fieldName !== 'id') {
      return criteria.criteria.get(i);
    }
    ```
  - **Usage Example**:
    The method now returns the specific criteria object instead of the entire `criteria` object when the `fieldName` is not `'id'`. This behavior change affects how criteria are processed:
    ```javascript
    // Before
    let result = processCriteria(criteria);
    // result would be the entire criteria object

    // After
    let result = processCriteria(criteria);
    // result is now the specific criteria object at position i
    ```

### 4. Changes in Types or Interfaces
- No changes in types or interfaces affecting the public API.

### 5. Breaking Changes Requiring User Attention
- **Behavior Change**: The return value for non-`'id'` fields in criteria has changed from the entire criteria object to the specific criteria object. Users relying on the full criteria object need to adjust their logic accordingly.

### Summary
This update introduces a behavior change in the grid's criteria processing logic. The method will now return a specific criteria object instead of the entire object when conditions are met, impacting how criteria are handled in user implementations.
