### PR TITLE
Feature ETP-1189: Add trigger to copy cancelpricead to invoices

### DIFF
--- a/src-db/database/model/triggers/C_CANCELPRICEAD_TO_INVOICE.xml
+++ b/src-db/database/model/triggers/C_CANCELPRICEAD_TO_INVOICE.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+  <database name="TRIGGER C_CANCELPRICEAD_TO_INVOICE">
+    <trigger name="C_CANCELPRICEAD_TO_INVOICE" table="C_INVOICELINE" fires="before" insert="true" update="true" delete="true" foreach="row">
+      <body><![CDATA[    v_order_cancelpricead VARCHAR(1);
+BEGIN
+    IF :NEW.c_orderline_id IS NOT NULL THEN
+        SELECT cancelpricead 
+        INTO v_order_cancelpricead 
+        FROM c_orderline 
+        WHERE c_orderline_id = :NEW.c_orderline_id;
+
+        IF v_order_cancelpricead = 'Y' THEN
+            :NEW.cancelpricead := 'Y';
+        END IF;
+    END IF;
+
+	END C_CANCELPRICEAD_TO_INVOICE
+]]></body>
+    </trigger>
+  </database>

--- a/src-db/database/sourcedata/AD_ELEMENT.xml
+++ b/src-db/database/sourcedata/AD_ELEMENT.xml
@@ -27396,7 +27396,7 @@ The distribution algorithm will be driven by this priority. The pending payments
 <!--667AE26F6635E6A7E040007F01015B98-->  <AD_ORG_ID><![CDATA[0]]></AD_ORG_ID>
 <!--667AE26F6635E6A7E040007F01015B98-->  <ISACTIVE><![CDATA[Y]]></ISACTIVE>
 <!--667AE26F6635E6A7E040007F01015B98-->  <COLUMNNAME><![CDATA[CANCELPRICEAD]]></COLUMNNAME>
-<!--667AE26F6635E6A7E040007F01015B98-->  <NAME><![CDATA[Cancel Promotions]]></NAME>
+<!--667AE26F6635E6A7E040007F01015B98-->  <NAME><![CDATA[Cancel Discounts Promotions]]></NAME>
 <!--667AE26F6635E6A7E040007F01015B98-->  <PRINTNAME><![CDATA[Cancel Price Adjustment]]></PRINTNAME>
 <!--667AE26F6635E6A7E040007F01015B98-->  <DESCRIPTION><![CDATA[Used to activate or deactive promotions for each line]]></DESCRIPTION>
 <!--667AE26F6635E6A7E040007F01015B98-->  <HELP><![CDATA[If the user wants not to apply promotions to a specific line, he should use this check to achieve it]]></HELP>


### PR DESCRIPTION
## API Changes Analysis
### API Change Documentation

#### 1. New Imports or Dependencies Added/Removed
- No changes to imports or dependencies affecting the public API.

#### 2. Endpoint Changes
- No endpoint changes affecting the public API.

#### 3. Method Changes and Their Signatures
- No method changes affecting the public API.

#### 4. Changes in Types or Interfaces Affecting the Public API
- **Field Name Update**: The field name `Cancel Promotions` has been updated to `Cancel Discounts Promotions` across various XML schema definitions. This change affects the following files:
  - `AD_ELEMENT.xml`
  - `AD_FIELD.xml`

#### 5. Breaking Changes Requiring User Attention
- **Trigger Added**: A new database trigger `C_CANCELPRICEAD_TO_INVOICE` has been added to the `C_INVOICELINE` table. The trigger fires before insert, update, and delete operations. It sets the `cancelpricead` field to 'Y' if the corresponding `c_orderline_id` has `cancelpricead` set to 'Y' in `c_orderline` table.

##### Usage Example:
```sql
-- Example illustrating the effect of the new trigger
INSERT INTO C_INVOICELINE (c_orderline_id, ...) VALUES (123, ...);
-- If the c_orderline with ID 123 has cancelpricead = 'Y', then the new invoice line will automatically have cancelpricead = 'Y'.
```

Users should review and test these changes, especially those involving the new trigger, to ensure compatibility with existing database operations and workflows.
