### PR TITLE
Issue #571: Credit selection available when adding payment

### DIFF
--- a/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/utility/APRMConstants.java
+++ b/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/utility/APRMConstants.java
@@ -42,4 +42,22 @@ public class APRMConstants {
   public static final String PAYMENT_STATUS_AWAITING_PAYMENT = "RPAP";
   public static final String PAYMENT_STATUS_WITHDRAWAL_NOT_CLEARED = "PWNC";
   public static final String PAYMENT_STATUS_PAYMENT_RECEIVED = "RPR";
+
+  /* Add Payment */
+  public static final String TRXTYPE = "trxtype";
+  public static final String INPTRXTYPE = "inptrxtype";
+  public static final String RCIN = "RCIN";
+  public static final String PDOUT = "PDOUT";
+  public static final String AD_ORG_ID = "ad_org_id";
+  public static final String INPAD_ORG_ID = "inpadOrgId";
+  public static final String  FIN_FINANCIAL_ACCOUNT_ID = "Fin_Financial_Account_ID";
+  public static final String INPFIN_FINANCIAL_ACCOUNT_ID = "inpfinFinancialAccountId";
+  public static final String CONTEXT = "context";
+  public static final String RECEIVED_FROM = "received_from";
+  public static final String INPRECEIVED_FROM = "inpreceivedFrom";
+  public static final String C_BPARTNER_ID = "c_bpartner_id";
+  public static final String INPC_BPARTNER_ID = "inpcBpartnerId";
+  public static final String C_CURRENCY_ID = "c_currency_id";
+  public static final String DEFAULT_EMPTY_VALUE = "";
+
 }


### PR DESCRIPTION
## API Changes Analysis
### API Change Documentation

#### 1. New Imports or Dependencies Added/Removed
- No new imports or dependencies have been added or removed.

#### 2. Endpoint Changes
- No endpoints have been newly added, modified, or deleted.

#### 3. Method Changes and Their Signatures
- **Method**: `getDefaultIsSOTrx(Map<String, String> requestMap)`
  - **Modification**: Changed the parameter access for context from `requestMap.get("context")` to `requestMap.get(APRMConstants.CONTEXT)`.
  
- **Method**: `getDefaultReceivedFrom(Map<String, String> requestMap)`
  - **Modification**: Changed the parameter access for context from `requestMap.get("context")` to `requestMap.get(APRMConstants.CONTEXT)`.
  
- **Method**: `getOrganization(Map<String, String> requestMap)`
  - **Modifications**:
    - Changed the parameter access for context from `requestMap.get("context")` to `requestMap.get(APRMConstants.CONTEXT)`.
    - Changed the parameter key from `"inpadOrgId"` to `APRMConstants.INPAD_ORG_ID`.
  
- **Method**: `getDefaultPaymentMethod(Map<String, String> requestMap)`
  - **Modification**: Added a new contextual check for `bpartnerId` and the retrieval of `BusinessPartner` details.

#### 4. Changes in Types or Interfaces Affecting the Public API
- **APRMConstants**: Introduction of constants `CONTEXT` and `INPAD_ORG_ID` for accessing structured data within the `requestMap`.

#### 5. Breaking Changes Requiring User Attention
- **Breaking Change**: 
  - If users were previously using string literals for keys such as `"context"` and `"inpadOrgId"`, they must now use `APRMConstants.CONTEXT` and `APRMConstants.INPAD_ORG_ID` respectively.

#### Usage Example for Significant Changes
```java
Map<String, String> requestMap = new HashMap<>();
requestMap.put(APRMConstants.CONTEXT, "<context_json>");
...

// New usage for accessing context
JSONObject context = new JSONObject(requestMap.get(APRMConstants.CONTEXT));

// Example for accessing organization ID
String orgId = context.has(APRMConstants.INPAD_ORG_ID) ? context.getString(APRMConstants.INPAD_ORG_ID) : null;
```