### PR TITLE
Feature ETP-1336: Fixed core reports and add new JR font library.

### DIFF
--- a/artifacts.list.COMPILATION.gradle
+++ b/artifacts.list.COMPILATION.gradle
@@ -89,7 +89,8 @@ List<String> _dependenciesListCOMPILATION = [
   'org.quartz-scheduler:quartz:2.3.2', 
   'org.redisson:redisson:3.15.4', 
   'oro:oro:2.0.8', 
-  'xerces:xercesImpl:2.9.0'
+  'xerces:xercesImpl:2.9.0',
+  'com.etendoerp:font.bitstreamverasans:1.0.0'
 ]
 
 ext {

--- a/modules_core/com.etendoerp.reportvaluationstock/src/com/etendoerp/reportvaluationstock/erpCommon/ad_reports/ReportValuationStockExcel.jrxml
+++ b/modules_core/com.etendoerp.reportvaluationstock/src/com/etendoerp/reportvaluationstock/erpCommon/ad_reports/ReportValuationStockExcel.jrxml
@@ -2,6 +2,7 @@
 <!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
 <!-- 2016-12-07T15:45:56 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportValuationStockExcel" printOrder="Horizontal" pageWidth="1325" pageHeight="595" orientation="Landscape" columnWidth="1325" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="de20ebe7-a956-454f-9dbb-a60c3e076d85">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.zoom" value="1.8150000000000042"/>
 	<property name="ireport.x" value="932"/>
 	<property name="ireport.y" value="0"/>

--- a/modules_core/com.etendoerp.reportvaluationstock/src/com/etendoerp/reportvaluationstock/erpCommon/ad_reports/ReportValuationStockPDF.jrxml
+++ b/modules_core/com.etendoerp.reportvaluationstock/src/com/etendoerp/reportvaluationstock/erpCommon/ad_reports/ReportValuationStockPDF.jrxml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 6.5.1.final using JasperReports Library version 6.5.1  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportValuationStockPDF" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="802" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isSummaryNewPage="true" uuid="9b46a237-fb86-4e6d-bf5f-15f6f1ebd47f">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.zoom" value="1.5"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>

--- a/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/ad_reports/ReportReconciliation.jrxml
+++ b/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/ad_reports/ReportReconciliation.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportReconciliation" pageWidth="595" pageHeight="842" columnWidth="495" leftMargin="50" rightMargin="50" topMargin="50" bottomMargin="50" uuid="e13c9c87-3b33-4f48-a07d-126ffc8c7729">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.652892561983471"/>

--- a/modules_core/org.openbravo.financial.paymentreport/src/org/openbravo/financial/paymentreport/erpCommon/ad_reports/PaymentReportExcel.jrxml
+++ b/modules_core/org.openbravo.financial.paymentreport/src/org/openbravo/financial/paymentreport/erpCommon/ad_reports/PaymentReportExcel.jrxml
@@ -2,6 +2,7 @@
 <!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
 <!-- 2016-03-11T16:07:53 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="PaymentReportExcel" pageWidth="2000" pageHeight="595" orientation="Landscape" whenNoDataType="NoDataSection" columnWidth="1940" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="bd54446c-5f03-492f-9be8-1942e896464a">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="2.0"/>

--- a/modules_core/org.openbravo.financial.paymentreport/src/org/openbravo/financial/paymentreport/erpCommon/ad_reports/PaymentReportPDF.jrxml
+++ b/modules_core/org.openbravo.financial.paymentreport/src/org/openbravo/financial/paymentreport/erpCommon/ad_reports/PaymentReportPDF.jrxml
@@ -2,6 +2,7 @@
 <!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
 <!-- 2016-03-11T16:07:41 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="PaymentReportPDF" pageWidth="842" pageHeight="595" orientation="Landscape" whenNoDataType="NoDataSection" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="a1c562a7-5994-47ae-b89e-6d598ae5c022">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="2.0"/>

--- a/modules_core/org.openbravo.reports.ordersawaitingdelivery/src/org/openbravo/reports/ordersawaitingdelivery/erpCommon/ad_reports/ReportOrderNotShipped.jrxml
+++ b/modules_core/org.openbravo.reports.ordersawaitingdelivery/src/org/openbravo/reports/ordersawaitingdelivery/erpCommon/ad_reports/ReportOrderNotShipped.jrxml
@@ -2,6 +2,7 @@
 <!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
 <!-- 2016-07-13T22:59:47 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportOrderNotShipped" pageWidth="842" pageHeight="595" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="b2108c38-f573-4cc5-8aee-4725a42348b0">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src-test/src/com/smf/mobile/utils/webservices/WindowTest.java
+++ b/src-test/src/com/smf/mobile/utils/webservices/WindowTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import org.junit.Before;

--- a/src-test/src/org/openbravo/advpaymentmngt/actionHandler/AddPaymentDocumentNoActionHandlerTest.java
+++ b/src-test/src/org/openbravo/advpaymentmngt/actionHandler/AddPaymentDocumentNoActionHandlerTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.codehaus.jettison.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;

--- a/src-test/src/org/openbravo/advpaymentmngt/actionHandler/AddPaymentOrganizationActionHandlerTest.java
+++ b/src-test/src/org/openbravo/advpaymentmngt/actionHandler/AddPaymentOrganizationActionHandlerTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.codehaus.jettison.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;

--- a/src-test/src/org/openbravo/materialmgmt/GenerateAggregatedDataBackgroundTest.java
+++ b/src-test/src/org/openbravo/materialmgmt/GenerateAggregatedDataBackgroundTest.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/src-test/src/org/openbravo/materialmgmt/ManageVariantsCustomProductCharacteristicWhereClauseTest.java
+++ b/src-test/src/org/openbravo/materialmgmt/ManageVariantsCustomProductCharacteristicWhereClauseTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src-test/src/org/openbravo/materialmgmt/ManageVariantsDSTest.java
+++ b/src-test/src/org/openbravo/materialmgmt/ManageVariantsDSTest.java
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONObject;
 import org.junit.After;

--- a/src-test/src/org/openbravo/materialmgmt/ServiceDeliverUtilityTest.java
+++ b/src-test/src/org/openbravo/materialmgmt/ServiceDeliverUtilityTest.java
@@ -18,7 +18,7 @@ import java.util.Map;
 
 import javax.persistence.Tuple;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.criterion.Criterion;
 import org.hibernate.query.Query;
 import org.junit.Test;

--- a/src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailHTML.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailHTML.jrxml
@@ -2,6 +2,7 @@
 <!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
 <!-- 2016-11-02T09:12:28 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="PaymentReportPDF" pageWidth="1100" pageHeight="595" orientation="Landscape" whenNoDataType="NoDataSection" columnWidth="1040" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="f73cd4f8-17ca-4505-866b-7b88e67c1d99">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.5"/>

--- a/src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailPDF.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailPDF.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="PaymentReportPDF" pageWidth="670" pageHeight="842" columnWidth="610" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailPDFDoubtfulDebt.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailPDFDoubtfulDebt.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="PaymentReportPDF" pageWidth="842" pageHeight="670" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailXLS.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailXLS.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="PaymentReportPDF" pageWidth="983" pageHeight="842" columnWidth="983" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="1db8947f-ba8e-4a27-9a66-99f493df8411">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="0.75"/>

--- a/src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailXLSDoubtfulDebt.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailXLSDoubtfulDebt.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="PaymentReportPDF" pageWidth="1138" pageHeight="842" columnWidth="1138" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.5"/>

--- a/src/org/openbravo/erpCommon/ad_reports/AgingScheduleHTML.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/AgingScheduleHTML.jrxml
@@ -2,6 +2,7 @@
 <!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
 <!-- 2016-11-02T09:12:32 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportAgingBalance" pageWidth="975" pageHeight="842" columnWidth="915" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="bd188040-4e9b-4416-89da-8ac052697179">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpCommon/ad_reports/AgingSchedulePDF.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/AgingSchedulePDF.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportAgingBalance" pageWidth="670" pageHeight="842" columnWidth="610" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.5"/>

--- a/src/org/openbravo/erpCommon/ad_reports/AgingSchedulePDFDoubtfulDebt.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/AgingSchedulePDFDoubtfulDebt.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportAgingBalance" pageWidth="842" pageHeight="670" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpCommon/ad_reports/AgingScheduleXLS.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/AgingScheduleXLS.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportAgingBalance" pageWidth="920" pageHeight="842" columnWidth="920" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="9b66e7ac-3901-4982-bf21-604fb3cb61a3">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="0.8689931392100638"/>

--- a/src/org/openbravo/erpCommon/ad_reports/CashflowForecast.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/CashflowForecast.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="CashflowForecast" pageWidth="595" pageHeight="842" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="3e8177ed-1f04-47c0-8c79-41687401c9d8">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.zoom" value="1.1000000000000052"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>

--- a/src/org/openbravo/erpCommon/ad_reports/CashflowForecastExcel.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/CashflowForecastExcel.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="CashflowForecast" pageWidth="1200" pageHeight="802" columnWidth="1200" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="8cf57cc3-56dc-49f4-9907-573fa59e1111">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.zoom" value="2.593742460100007"/>
 	<property name="ireport.x" value="2300"/>
 	<property name="ireport.y" value="0"/>

--- a/src/org/openbravo/erpCommon/ad_reports/CashflowForecastLines.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/CashflowForecastLines.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="CashFlowForecastLines" pageWidth="555" pageHeight="802" columnWidth="555" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="fcd348c6-0a67-4165-8614-88c9ae90e2f3">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.zoom" value="1.4483218986834392"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>

--- a/src/org/openbravo/erpCommon/ad_reports/CashflowForecastLinesByDate.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/CashflowForecastLinesByDate.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="CashFlowForecastLines" pageWidth="555" pageHeight="802" columnWidth="555" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="1300d746-b52d-41b8-b049-6e6f683f2fec">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.zoom" value="1.3310000000000106"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>

--- a/src/org/openbravo/erpCommon/ad_reports/CashflowForecastSummary.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/CashflowForecastSummary.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="FinaccDetailMain" pageWidth="555" pageHeight="802" columnWidth="555" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.zoom" value="1.2100000000000044"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>

--- a/src/org/openbravo/erpCommon/ad_reports/CustomerStatement.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/CustomerStatement.jrxml
@@ -2,6 +2,7 @@
 <!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
 <!-- 2019-03-20T17:42:19 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Customer Statement" pageWidth="595" pageHeight="842" whenNoDataType="AllSectionsNoDetail" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="497a0ae3-5aac-448b-a8a4-4b6619407498">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.2100000000000006"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportAgingBalance.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportAgingBalance.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportAgingBalance" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="3547a519-9e65-4956-98c7-f0145bad4e3b">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportAssetDepreciationSchedule.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportAssetDepreciationSchedule.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="AssetsReportDepreciationSchedule" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="b16175b8-cd76-4fbc-b1fe-68ce5fa2a70f">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportBankJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportBankJR.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportBankJR" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="a9061d9b-450e-43bb-9cd4-faa46dcc3ae2">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportCashJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportCashJR.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportCashJR" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="588a2887-2b38-4f00-ba36-0c169540bafe">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportCashflowForecast.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportCashflowForecast.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportCashflowForecast" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="fc8095f8-9f04-4661-beeb-629fcc853347">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportCashflowForecast_perDay.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportCashflowForecast_perDay.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportCashflowForecast_perDay" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="b76f3c88-6b2c-495d-b121-a40bbae782fe">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportCashflowForecast_sub.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportCashflowForecast_sub.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportCashflowForecast_sub" pageWidth="594" pageHeight="802" columnWidth="594" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="bcc41716-ff64-4e71-986e-a637d1f0786d">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportDebtPayment.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportDebtPayment.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportDebtPayment" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="014c66be-c06a-431e-b27a-64772c0d85b6">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportDebtPaymentTracker.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportDebtPaymentTracker.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportDebtPaymentTracker" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="9568dfef-336c-4616-b632-e8f11045fbd9">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportDebtPayment_BankAcc.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportDebtPayment_BankAcc.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportDebtPayment_BankAcc" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="59e4ea3c-3363-4fe8-b243-ed305621d781">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportDebtPayment_NoBP.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportDebtPayment_NoBP.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportDebtPayment_NoBP" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="cbac2900-62d0-4827-a55f-e5cecb1d0155">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportDebtPayment_NoBP_BankAcc.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportDebtPayment_NoBP_BankAcc.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportDebtPayment_NoBP_BankAcc" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="05b06125-43c6-42da-a22d-e3203e118eac">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportExpense.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportExpense.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportExpense" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="513ef7fc-7930-4b9f-8b3a-9c66c70094fb">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportGeneralLedger.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportGeneralLedger.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportGeneralLedger" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="4af4e236-85be-48e3-a4a6-c993069f011d">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportGeneralLedgerExcel.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportGeneralLedgerExcel.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportGeneralLedgerExcel" pageWidth="1500" pageHeight="842" orientation="Landscape" columnWidth="1500" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" isIgnorePagination="true" uuid="9e3ebcf7-143e-46f6-bcdd-683d183a424c">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportGeneralLedgerJournalExcel.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportGeneralLedgerJournalExcel.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportGeneralLedgerJournal" pageWidth="1133" pageHeight="842" orientation="Landscape" columnWidth="1133" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="6b4bb55a-5204-496f-b1c0-f518ab749f0d">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.5"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportGuaranteeDateJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportGuaranteeDateJR.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportGuaranteeDateJR" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="7e242fa6-0b5f-475c-9f7c-0caabf228a68">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesComparativeJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesComparativeJR.jrxml
@@ -2,6 +2,7 @@
 <!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
 <!-- 2017-03-02T13:15:56 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportInvoiceCustomerDimensionalAnalysesComparativeJR" pageWidth="1108" pageHeight="595" orientation="Landscape" columnWidth="970" leftMargin="14" rightMargin="14" topMargin="56" bottomMargin="28" uuid="8fac4b02-733e-45dd-b883-668ce5862e8c">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesMultiComparativeExtendedJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesMultiComparativeExtendedJR.jrxml
@@ -2,6 +2,7 @@
 <!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
 <!-- 2017-03-02T13:17:22 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportInvoiceCustomerDimensionalAnalysesMultiComparativeExtendedJR" pageWidth="1650" pageHeight="595" orientation="Landscape" columnWidth="1622" leftMargin="14" rightMargin="14" topMargin="56" bottomMargin="28" uuid="e79411c1-a0fb-4ea2-bb75-304bceb0ccb1">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="0.55"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesMultiComparativeJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesMultiComparativeJR.jrxml
@@ -2,6 +2,7 @@
 <!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
 <!-- 2017-03-02T13:17:04 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportInvoiceCustomerDimensionalAnalysesMultiComparativeJR" pageWidth="1300" pageHeight="595" orientation="Landscape" columnWidth="1272" leftMargin="14" rightMargin="14" topMargin="56" bottomMargin="28" uuid="3f1d7732-64a5-4b19-b4dd-5f06efe61a6b">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="2.0"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesNoComparativeJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesNoComparativeJR.jrxml
@@ -34,6 +34,10 @@
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==1)&&($V{NIVEL1_COUNT}.intValue()%2==0))]]></conditionExpression>
 			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
+		<conditionalStyle>
+			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
+			<style forecolor="#FF0000"/>
+		</conditionalStyle>
 	</style>
 	<style name="Level2_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
 		<conditionalStyle>
@@ -43,6 +47,10 @@
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==2)&&($V{NIVEL1_COUNT}.intValue()%2==1))]]></conditionExpression>
 			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
+		</conditionalStyle>
+		<conditionalStyle>
+			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
+			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
 	<style name="Level3_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
@@ -54,6 +62,10 @@
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==3)&&($V{NIVEL2_COUNT}.intValue()%2==1))]]></conditionExpression>
 			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
+		<conditionalStyle>
+			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
+			<style forecolor="#FF0000"/>
+		</conditionalStyle>
 	</style>
 	<style name="Level4_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
 		<conditionalStyle>
@@ -63,6 +75,10 @@
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==4)&&($V{NIVEL3_COUNT}.intValue()%2==1))]]></conditionExpression>
 			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
+		</conditionalStyle>
+		<conditionalStyle>
+			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
+			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
 	<style name="Level5_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
@@ -74,6 +90,10 @@
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==5)&&($V{NIVEL4_COUNT}.intValue()%2==1))]]></conditionExpression>
 			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
+		<conditionalStyle>
+			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
+			<style forecolor="#FF0000"/>
+		</conditionalStyle>
 	</style>
 	<style name="Level6_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
 		<conditionalStyle>
@@ -83,6 +103,10 @@
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==6)&&($V{LEVEL5_COUNT}.intValue()%2==1))]]></conditionExpression>
 			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
+		</conditionalStyle>
+		<conditionalStyle>
+			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
+			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
 	<style name="Level7_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
@@ -94,6 +118,10 @@
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==7)&&($V{LEVEL6_COUNT}.intValue()%2==1))]]></conditionExpression>
 			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
+		<conditionalStyle>
+			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
+			<style forecolor="#FF0000"/>
+		</conditionalStyle>
 	</style>
 	<style name="Level8_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
 		<conditionalStyle>
@@ -103,6 +131,10 @@
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==8)&&($V{LEVEL7_COUNT}.intValue()%2==1))]]></conditionExpression>
 			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
+		</conditionalStyle>
+		<conditionalStyle>
+			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
+			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
 	<style name="Level9_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
@@ -114,6 +146,10 @@
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==9)&&($V{LEVEL8_COUNT}.intValue()%2==1))]]></conditionExpression>
 			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
+		<conditionalStyle>
+			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
+			<style forecolor="#FF0000"/>
+		</conditionalStyle>
 	</style>
 	<style name="Level10_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
 		<conditionalStyle>
@@ -123,6 +159,10 @@
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==10)&&($V{LEVEL9_COUNT}.intValue()%2==1))]]></conditionExpression>
 			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
+		</conditionalStyle>
+		<conditionalStyle>
+			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
+			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
 	<style name="Report_Footer" vAlign="Middle" fontName="SansSerif" fontSize="11"/>
@@ -320,6 +360,7 @@
 	<field name="CONVCOSTREF" class="java.math.BigDecimal"/>
 	<field name="CONVSYM" class="java.lang.String"/>
 	<field name="CONVISOSYM" class="java.lang.String"/>
+	<field name="COSTCALCULATED" class="java.lang.Integer"/>
 	<variable name="QTY_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
 		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
 	</variable>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesNoComparativeJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesNoComparativeJR.jrxml
@@ -2,6 +2,7 @@
 <!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
 <!-- 2017-03-02T13:16:37 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportInvoiceCustomerDimensionalAnalysesNoComparativeJR" pageWidth="630" pageHeight="842" columnWidth="518" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="f36036af-e4bd-420a-b3eb-05289ad097f1">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesNoComparativeJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesNoComparativeJR.jrxml
@@ -12,160 +12,120 @@
 	<import value="net.sf.jasperreports.engine.*"/>
 	<import value="java.util.*"/>
 	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9" isBold="true"/>
+	<style name="default" isDefault="true" vAlign="Middle" fontName="SansSerif" fontSize="11"/>
+	<style name="Report_Title" fontName="SansSerif" fontSize="18"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="SansSerif" fontSize="14"/>
+	<style name="Report_Data_Label" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
+	<style name="Report_Data_Field" fontName="SansSerif" fontSize="11" isBold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="9" isBold="false"/>
 	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8" isBold="true">
+	<style name="Detail_Line" fontName="SansSerif" fontSize="8" isBold="false">
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
 			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level1_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
+	<style name="Level1_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==1)&&($V{NIVEL1_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
+			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==1)&&($V{NIVEL1_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
-		</conditionalStyle>
-		<conditionalStyle>
-			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
+			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level2_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
+	<style name="Level2_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==2)&&($V{NIVEL1_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
+			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==2)&&($V{NIVEL1_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
-		</conditionalStyle>
-		<conditionalStyle>
-			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
+			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level3_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
+	<style name="Level3_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==3)&&($V{NIVEL2_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
+			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==3)&&($V{NIVEL2_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
-		</conditionalStyle>
-		<conditionalStyle>
-			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
+			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level4_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
+	<style name="Level4_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==4)&&($V{NIVEL3_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
+			<style backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==4)&&($V{NIVEL3_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
-		</conditionalStyle>
-		<conditionalStyle>
-			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
+			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level5_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
+	<style name="Level5_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==5)&&($V{NIVEL4_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
+			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==5)&&($V{NIVEL4_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
-		</conditionalStyle>
-		<conditionalStyle>
-			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
+			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level6_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
+	<style name="Level6_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==6)&&($V{LEVEL5_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
+			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==6)&&($V{LEVEL5_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
-		</conditionalStyle>
-		<conditionalStyle>
-			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
+			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level7_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
+	<style name="Level7_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==7)&&($V{LEVEL6_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
+			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==7)&&($V{LEVEL6_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
-		</conditionalStyle>
-		<conditionalStyle>
-			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
+			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level8_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
+	<style name="Level8_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==8)&&($V{LEVEL7_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
+			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==8)&&($V{LEVEL7_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
-		</conditionalStyle>
-		<conditionalStyle>
-			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
+			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level9_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
+	<style name="Level9_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==9)&&($V{LEVEL8_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
+			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==9)&&($V{LEVEL8_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
-		</conditionalStyle>
-		<conditionalStyle>
-			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
+			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level10_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
+	<style name="Level10_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==10)&&($V{LEVEL9_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
+			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==10)&&($V{LEVEL9_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
-		</conditionalStyle>
-		<conditionalStyle>
-			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
+			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Report_Footer" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
+	<style name="Report_Footer" vAlign="Middle" fontName="SansSerif" fontSize="11"/>
 	<style name="Detail_Border" forecolor="#8A8A8A"/>
 	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA["0,1000000"]]></defaultValueExpression>
@@ -360,7 +320,6 @@
 	<field name="CONVCOSTREF" class="java.math.BigDecimal"/>
 	<field name="CONVSYM" class="java.lang.String"/>
 	<field name="CONVISOSYM" class="java.lang.String"/>
-	<field name="COSTCALCULATED" class="java.lang.Integer"/>
 	<variable name="QTY_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
 		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
 	</variable>
@@ -2470,7 +2429,7 @@ $V{PROFIT_1}.divide( $V{AMOUNT_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).abs().multip
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
 				<textElement>
-					<font size="11" isBold="true"/>
+					<font size="11" isBold="false"/>
 				</textElement>
 				<text><![CDATA[Secondary Filters:]]></text>
 			</staticText>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesXLS.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesXLS.jrxml
@@ -2,6 +2,7 @@
 <!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
 <!-- 2017-03-02T13:16:17 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportInvoiceCustomerDimensionalAnalysesXLS" pageWidth="1900" pageHeight="842" orientation="Landscape" columnWidth="1900" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" isIgnorePagination="true" uuid="59be190b-97b3-4951-842b-79d4e9d2d71b">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.5"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalyses_srpt_doctypecount.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalyses_srpt_doctypecount.jrxml
@@ -2,6 +2,7 @@
 <!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
 <!-- 2018-02-27T16:45:13 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportInvoiceCustomerDimensionalAnalyses_srpt_doctypecount" pageWidth="400" pageHeight="802" whenNoDataType="AllSectionsNoDetail" columnWidth="400" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" whenResourceMissingType="Error" uuid="dcc54a6a-4fa7-4363-918c-1e721f63d8f0">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="si"/>
 	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true"/>
 	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9" isBold="true"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalyses_srpt_doctypecount.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalyses_srpt_doctypecount.jrxml
@@ -5,8 +5,8 @@
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="si"/>
 	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="SansSerif" fontSize="9" isBold="true"/>
+	<style name="Detail_Line" fontName="SansSerif" fontSize="8" isBold="false">
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
 			<style mode="Opaque" backcolor="#CCCCCC"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerJR.jrxml
@@ -2,6 +2,7 @@
 <!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
 <!-- 2016-07-13T11:53:22 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportInvoiceCustomerJR" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="4df7acd1-be6d-4c1a-9aff-94a5421b9a97">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceDiscountJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceDiscountJR.jrxml
@@ -2,6 +2,7 @@
 <!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
 <!-- 2016-07-12T15:04:28 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportInvoiceDiscountJR" pageWidth="930" pageHeight="595" orientation="Landscape" columnWidth="870" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="143e2f91-13e7-4c3a-ac89-f630de85c5f4">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceVendorDimensionalAnalysesXLS.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceVendorDimensionalAnalysesXLS.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="eportInvoiceVendorDimensionalAnalysesXLS" pageWidth="1720" pageHeight="842" orientation="Landscape" columnWidth="1720" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" isIgnorePagination="true" uuid="40dc54a6-0046-4a72-8725-73936874bae9">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.5"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceVendorJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceVendorJR.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportInvoiceVendorJR" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="ddd3ad5f-4204-433a-bac3-9932a093c47f">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoicesEditJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoicesEditJR.jrxml
@@ -2,6 +2,7 @@
 <!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
 <!-- 2016-12-26T16:04:35 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportInvoicesEditJR" pageWidth="930" pageHeight="595" orientation="Landscape" columnWidth="870" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="d47540dd-b79e-4355-811f-a0b9f6886e2b">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportMaterialTransactionEditionJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportMaterialTransactionEditionJR.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportMaterialTransactionEditionJR" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="5d9f80d7-9a05-47eb-b2e4-4f40c42ab02b">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportOrderNotInvoiceJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportOrderNotInvoiceJR.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportOrderNotInvoiceJR" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="4e35e7d6-9d9f-424c-aa14-e29210dbe636">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportPendingProductionJr.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportPendingProductionJr.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportPendingProductionJr" pageWidth="595" pageHeight="842" columnWidth="595" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="0bdfad47-abfb-49cb-ba61-39148e3fd3ca">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportProductionRun.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportProductionRun.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportProductionRun" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="756c6650-814d-4daf-ad52-183a7df51014">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportProjectBuildingSiteJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportProjectBuildingSiteJR.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportProjectBuildingSiteJR" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="8e5abae8-2672-4583-b80f-770a1b4f70fd">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportProjectProfitabilityJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportProjectProfitabilityJR.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportProjectProfitabilityJR" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="f900737c-ab48-488b-88a7-ef101d1a9b29">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportProjectProgress.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportProjectProgress.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportProjectProgress" pageWidth="850" pageHeight="595" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="c1fc9d13-cc94-42ec-b54f-2cd84d921e72">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportSalesOrderInvoicedJasper.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportSalesOrderInvoicedJasper.jrxml
@@ -2,6 +2,7 @@
 <!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
 <!-- 2016-12-26T15:35:27 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportSalesOrderInvoicedJasper" pageWidth="920" pageHeight="595" orientation="Landscape" columnWidth="860" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="69316ac0-b6f7-469e-a008-b44e0006499c">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportSalesOrderJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportSalesOrderJR.jrxml
@@ -2,6 +2,7 @@
 <!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
 <!-- 2016-07-12T15:15:42 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportSalesOrderJR" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="bfa4f89a-03b7-4f2e-a3be-00d6a95ae2b0">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportSalesOrderProvidedJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportSalesOrderProvidedJR.jrxml
@@ -2,6 +2,7 @@
 <!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
 <!-- 2016-12-26T16:03:14 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportSalesOrderProvidedJR" pageWidth="920" pageHeight="595" orientation="Landscape" columnWidth="860" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="764f59d0-b626-4a6a-bf2f-036b80c04677">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportShipmentEdition.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportShipmentEdition.jrxml
@@ -2,6 +2,7 @@
 <!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
 <!-- 2016-12-26T15:52:57 -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportShipmentEdition" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="03915ee5-7c7b-45a2-9519-6fc1230d6340">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportStandardCostsJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportStandardCostsJR.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportStandardCostsJR" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="e22dd576-aa7d-474a-91f8-bb5d2120f249">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportStandardCostsJR_srptcosts.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportStandardCostsJR_srptcosts.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportStandardCostsJR_srptcosts" pageWidth="505" pageHeight="46" orientation="Landscape" columnWidth="505" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="e57394df-d49a-40a1-bc76-39968066d58a">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportStandardCostsJR_subreport0.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportStandardCostsJR_subreport0.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportStandardCostsJR_subreport0" pageWidth="505" pageHeight="46" orientation="Landscape" columnWidth="505" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="54f1ea59-9c12-430b-bc59-fa978c453b90">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportTaxInvoice.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportTaxInvoice.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportTaxInvoice" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="509319a5-55ea-42a3-9075-594e130174a0">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportTaxInvoicePurchase.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportTaxInvoicePurchase.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportTaxInvoicePurchase" pageWidth="535" pageHeight="842" columnWidth="535" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="4cdce3bc-ac34-47d4-922d-5b04e341e2ef">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportTaxInvoicePurchaseForeign.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportTaxInvoicePurchaseForeign.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportTaxInvoicePurchaseForeign" pageWidth="535" pageHeight="842" columnWidth="535" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="ca5c867b-f5e6-4ea7-a416-fb91ed037816">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportTaxInvoiceSale.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportTaxInvoiceSale.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportTaxInvoiceSale" pageWidth="535" pageHeight="842" columnWidth="535" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="58fc11f9-1212-48e2-97bf-ff1126396715">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportTaxInvoiceSaleForeign.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportTaxInvoiceSaleForeign.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportTaxInvoiceSaleForeign" pageWidth="535" pageHeight="842" columnWidth="535" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="c5939522-8a73-4367-b4cd-43484e8ddcba">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportToInvoiceConsignmentJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportToInvoiceConsignmentJR.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportToInvoiceConsignmentJR" pageWidth="842" pageHeight="595" orientation="Landscape" whenNoDataType="AllSectionsNoDetail" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="a5c625d1-9d06-426a-8d36-85c089385be1">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportTrialBalanceExcel.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportTrialBalanceExcel.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportTrialBalanceExcel" pageWidth="1430" pageHeight="842" orientation="Landscape" columnWidth="1430" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" isIgnorePagination="true" uuid="d73c9057-b2b2-4024-ad3d-89ef81bae8bf">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportTrialBalancePDF.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportTrialBalancePDF.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportTrialBalancePDF" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="94f73212-0a4e-4d01-a77d-7c1011919e14">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="7.59499667166483"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportWarehousePartnerJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportWarehousePartnerJR.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportWarehousePartnerJR" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="7761643a-888d-4085-bd65-842b0ef65ab1">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportWorkRequirementDailyEdit.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportWorkRequirementDailyEdit.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportWorkRequirementDailyEdit" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="cbbcad5d-b527-4b67-9019-9bad04e9ae3d">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportWorkRequirementJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportWorkRequirementJR.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportWorkRequirementJR" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="66e7cffd-a0f8-4b81-a5dc-7105fb95028b">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/SimpleDimensionalComparative.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/SimpleDimensionalComparative.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="SimpleDimensionalComparative" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="730" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="998085fe-979c-4a42-ad9f-592a626f2da5">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/SimpleDimensionalNoComparative.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/SimpleDimensionalNoComparative.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="SimpleDimensionalNoComparative" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="561cda02-49ee-459a-9225-b5d1e5db8cbb">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpCommon/ad_reports/SimpleDimensionalNoComparative.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/SimpleDimensionalNoComparative.jrxml
@@ -6,85 +6,85 @@
 	<import value="net.sf.jasperreports.engine.*"/>
 	<import value="java.util.*"/>
 	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<style name="default" isDefault="true" vAlign="Middle" fontName="SansSerif" fontSize="11"/>
+	<style name="Report_Title" fontName="SansSerif" fontSize="18">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="SansSerif" fontSize="14">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Data_Label" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true">
+	<style name="Report_Data_Label" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
+	<style name="Report_Data_Field" fontName="SansSerif" fontSize="11" isBold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="10" isBold="false">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="SansSerif" fontSize="10" isBold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8" isBold="true">
+	<style name="Detail_Line" fontName="SansSerif" fontSize="8" isBold="true">
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
 			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level1_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="true">
+	<style name="Level1_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="true">
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==1)&&($V{NIVEL1_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
+			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==1)&&($V{NIVEL1_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
+			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level2_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="true">
+	<style name="Level2_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="true">
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==2)&&($V{NIVEL1_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
+			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==2)&&($V{NIVEL1_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
+			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level3_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="true">
+	<style name="Level3_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="true">
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==3)&&($V{NIVEL2_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
+			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==3)&&($V{NIVEL2_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
+			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level4_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="true">
+	<style name="Level4_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="true">
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==4)&&($V{NIVEL3_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
+			<style backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==4)&&($V{NIVEL3_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
+			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level5_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="true">
+	<style name="Level5_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="true">
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==5)&&($V{NIVEL4_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
+			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==5)&&($V{NIVEL4_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
+			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level6_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="true"/>
-	<style name="Level7_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="true"/>
-	<style name="Level8_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="true"/>
-	<style name="Level9_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="true"/>
-	<style name="Report_Footer" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
+	<style name="Level6_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="true"/>
+	<style name="Level7_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="true"/>
+	<style name="Level8_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="true"/>
+	<style name="Level9_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="true"/>
+	<style name="Report_Footer" vAlign="Middle" fontName="SansSerif" fontSize="11"/>
 	<style name="Detail_Border" forecolor="#8A8A8A">
 		<pen lineWidth="0.25" lineStyle="Solid"/>
 	</style>

--- a/src/org/openbravo/erpCommon/ad_reports/WeightDimensionalComparative.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/WeightDimensionalComparative.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="WeightDimensionalComparative" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="730" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="c336158b-5039-4b91-a548-7d71b338fad6">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="3.138428376721006"/>

--- a/src/org/openbravo/erpCommon/ad_reports/WeightDimensionalNoComparative.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/WeightDimensionalNoComparative.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="WeightDimensionalNoComparative" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="730" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="ace3ae64-07eb-4915-a6f0-85c6e9228f21">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="11.918176537727245"/>

--- a/src/org/openbravo/erpCommon/ad_reports/WeightDimensionalNoComparative.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/WeightDimensionalNoComparative.jrxml
@@ -10,42 +10,42 @@
 	<import value="net.sf.jasperreports.engine.*"/>
 	<import value="java.util.*"/>
 	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<style name="default" isDefault="true" vAlign="Middle" fontName="SansSerif" fontSize="11"/>
+	<style name="Report_Title" fontName="SansSerif" fontSize="18">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="SansSerif" fontSize="14">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Report_Data_Label" fontName="SansSerif" fontSize="11" isBold="false"/>
+	<style name="Report_Data_Field" fontName="SansSerif" fontSize="11" isBold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="SansSerif" fontSize="10" isBold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8" isBold="true">
+	<style name="Detail_Line" fontName="SansSerif" fontSize="8" isBold="true">
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
 			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level1_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Level2_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Level3_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Level4_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Level5_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Level6_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Level7_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Level8_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Level9_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Level10_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Level11_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
+	<style name="Level1_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
+	<style name="Level2_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
+	<style name="Level3_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
+	<style name="Level4_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
+	<style name="Level5_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
+	<style name="Level6_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
+	<style name="Level7_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
+	<style name="Level8_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
+	<style name="Level9_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
+	<style name="Level10_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
+	<style name="Level11_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
+	<style name="Report_Footer" vAlign="Middle" fontName="SansSerif" fontSize="11"/>
 	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
 		<defaultValueExpression><![CDATA["0,1000000"]]></defaultValueExpression>
 	</parameter>

--- a/src/org/openbravo/erpCommon/ad_reports/productionReport.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/productionReport.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="productionReport" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="8c121782-d590-487f-b029-6edf1317475c">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpCommon/ad_reports/productionSubReport.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/productionSubReport.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="productionSubReport" pageWidth="421" pageHeight="595" columnWidth="421" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="ed90010f-a284-4d7a-b41c-9a785c9beff3">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="2.5937424601000023"/>

--- a/src/org/openbravo/erpReports/C_OrderJR.jrxml
+++ b/src/org/openbravo/erpReports/C_OrderJR.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="C_OrderJR" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="b8c38fdf-cd0f-434d-9f80-06408d31ee33">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpReports/C_OrderJR_new.jrxml
+++ b/src/org/openbravo/erpReports/C_OrderJR_new.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="C_OrderJR_new" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="b3f285ed-96c8-4c04-9e91-d9172b1f71ef">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpReports/C_OrderLinesJR.jrxml
+++ b/src/org/openbravo/erpReports/C_OrderLinesJR.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="C_OrderLinesJR" pageWidth="477" pageHeight="802" columnWidth="477" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="5e43318e-b337-416e-8b13-60f71161338c">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpReports/C_OrderLinesJR_new.jrxml
+++ b/src/org/openbravo/erpReports/C_OrderLinesJR_new.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="C_OrderLinesJR_new" pageWidth="477" pageHeight="802" columnWidth="477" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="6adf6da8-eb81-443d-8699-e1e24140b799">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.5"/>

--- a/src/org/openbravo/erpReports/C_OrderLinesTaxIncludedJR.jrxml
+++ b/src/org/openbravo/erpReports/C_OrderLinesTaxIncludedJR.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="C_OrderLinesTaxIncludedJR" pageWidth="477" pageHeight="802" columnWidth="477" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="34705d46-7514-4753-935c-78f1d9dfbbd4">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpReports/C_OrderLinesTaxIncludedJR_new.jrxml
+++ b/src/org/openbravo/erpReports/C_OrderLinesTaxIncludedJR_new.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="C_OrderLinesTaxIncludedJR_new" pageWidth="477" pageHeight="802" columnWidth="477" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="3a786c24-2240-4fab-ba17-60a530e8f3d1">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.5"/>

--- a/src/org/openbravo/erpReports/C_QuotationJR.jrxml
+++ b/src/org/openbravo/erpReports/C_QuotationJR.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="C_OrderJR" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="e75eaaf1-7e11-4001-877a-b481cec96428">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpReports/C_RMOrderJR.jrxml
+++ b/src/org/openbravo/erpReports/C_RMOrderJR.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="C_OrderJR" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="ac503a95-16da-4471-91ac-4e3c6e42c41b">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpReports/C_RMOrderLinesJR.jrxml
+++ b/src/org/openbravo/erpReports/C_RMOrderLinesJR.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="C_OrderLinesJR" pageWidth="482" pageHeight="802" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="ed28d8ce-8cee-4a66-9809-b422098bf614">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpReports/RptC_Invoice.jrxml
+++ b/src/org/openbravo/erpReports/RptC_Invoice.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptC_Invoice" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="52d15ca7-c92a-4919-99b9-90d43b194bbd">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpReports/RptC_Invoice_Lines.jrxml
+++ b/src/org/openbravo/erpReports/RptC_Invoice_Lines.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptC_Invoice_Lines" pageWidth="482" pageHeight="842" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="914f920f-ee82-4deb-a352-2a441707699d">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpReports/RptC_Invoice_Lines_new.jrxml
+++ b/src/org/openbravo/erpReports/RptC_Invoice_Lines_new.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptC_Invoice_Lines_new" pageWidth="482" pageHeight="842" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="ba4d8f44-3c1b-454b-bcd0-f125d06a7071">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.5"/>

--- a/src/org/openbravo/erpReports/RptC_Invoice_TaxLines.jrxml
+++ b/src/org/openbravo/erpReports/RptC_Invoice_TaxLines.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptC_Invoice_TaxLines" pageWidth="482" pageHeight="842" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="9d194431-1513-4b4e-9cb7-66fdacf30268">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpReports/RptC_Invoice_TaxLines_new.jrxml
+++ b/src/org/openbravo/erpReports/RptC_Invoice_TaxLines_new.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptC_Invoice_TaxLines_new" pageWidth="482" pageHeight="842" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="30435b90-1203-4280-bc9c-7050905cab87">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.5"/>

--- a/src/org/openbravo/erpReports/RptC_Invoice_new.jrxml
+++ b/src/org/openbravo/erpReports/RptC_Invoice_new.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptC_Invoice_new" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="f2b40577-1272-4849-ad1a-f97e1bd41b41">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="136"/>

--- a/src/org/openbravo/erpReports/RptC_Order_TaxLines.jrxml
+++ b/src/org/openbravo/erpReports/RptC_Order_TaxLines.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptC_Invoice_TaxLines" pageWidth="477" pageHeight="842" columnWidth="477" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d50afc0b-3968-43b0-aef7-067dd7188433">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpReports/RptC_Order_TaxLines_new.jrxml
+++ b/src/org/openbravo/erpReports/RptC_Order_TaxLines_new.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptC_Order_TaxLines_new" pageWidth="477" pageHeight="842" columnWidth="477" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="de218178-592d-49dc-9d13-5adf61b856d4">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.5"/>

--- a/src/org/openbravo/erpReports/RptC_ProposalJr.jrxml
+++ b/src/org/openbravo/erpReports/RptC_ProposalJr.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptC_ProposalJr" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="28b4a0d6-1dd4-4ec8-b30c-c2b1c8977b27">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpReports/RptC_Remittance.jrxml
+++ b/src/org/openbravo/erpReports/RptC_Remittance.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptC_Remittance" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="01ea3c5d-131a-403c-a8ed-a27b41cf0f4c">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpReports/RptC_Remittance_Lines.jrxml
+++ b/src/org/openbravo/erpReports/RptC_Remittance_Lines.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptC_Remittance_Lines" pageWidth="524" pageHeight="842" columnWidth="524" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d905da12-5f12-4447-b9f6-959e2eca8a31">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpReports/RptFIN_PaymentLines.jrxml
+++ b/src/org/openbravo/erpReports/RptFIN_PaymentLines.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptFIN_PaymentLines" pageWidth="483" pageHeight="802" columnWidth="483" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="8ff0fb53-ffd8-4a35-a22c-2d1b2defed19">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpReports/RptMA_ProcessPlan.jrxml
+++ b/src/org/openbravo/erpReports/RptMA_ProcessPlan.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptMA_ProcessPlan" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="fc05e8ca-705f-4a94-b629-affee9f7cfd8">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpReports/RptM_InOut.jrxml
+++ b/src/org/openbravo/erpReports/RptM_InOut.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptM_InOut" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="d5dfe95f-ae06-4f79-81e9-d0b17882de12">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpReports/RptM_InOut_new.jrxml
+++ b/src/org/openbravo/erpReports/RptM_InOut_new.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptM_InOut_new" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="d6963708-dc40-4b85-aab0-775de682be29">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpReports/RptM_RMInOut.jrxml
+++ b/src/org/openbravo/erpReports/RptM_RMInOut.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptM_InOut" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="fc7ba0c1-1bf9-4c95-8069-b6d4fa637b88">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpReports/RptM_RMInOut_Lines.jrxml
+++ b/src/org/openbravo/erpReports/RptM_RMInOut_Lines.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Rptm_InOut_Lines" pageWidth="482" pageHeight="842" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="27655561-7568-4958-8021-a69a0b19e797">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpReports/RptM_Requisition.jrxml
+++ b/src/org/openbravo/erpReports/RptM_Requisition.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptM_Requisition" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="6be99697-9c45-4a7c-92c2-903e691d1041">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>

--- a/src/org/openbravo/erpReports/RptM_Requisition_Lines.jrxml
+++ b/src/org/openbravo/erpReports/RptM_Requisition_Lines.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptM_Requisition_Lines" pageWidth="483" pageHeight="842" columnWidth="483" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="5b3bd9f3-8d27-41ab-9a65-993f1b0760f6">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpReports/Rptm_InOut_Lines.jrxml
+++ b/src/org/openbravo/erpReports/Rptm_InOut_Lines.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Rptm_InOut_Lines" pageWidth="482" pageHeight="842" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="1a92b8dd-038c-4fa0-9510-01b7f14a60d3">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>

--- a/src/org/openbravo/erpReports/Rptm_InOut_Lines_new.jrxml
+++ b/src/org/openbravo/erpReports/Rptm_InOut_Lines_new.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Rptm_InOut_Lines_new" pageWidth="482" pageHeight="842" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="a4a06de8-2715-48bf-92dd-590febb0d7eb">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.5"/>

--- a/src/org/openbravo/erpReports/SubreportLines.jrxml
+++ b/src/org/openbravo/erpReports/SubreportLines.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="SubreportLines" pageWidth="595" pageHeight="842" columnWidth="595" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="a11d1452-2b4d-4e72-8314-c3c1a4dbceb5">
+	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<import value="net.sf.jasperreports.engine.*"/>


### PR DESCRIPTION
This pull request includes updates to multiple JasperReports files to handle missing fonts gracefully and an addition to the dependencies list. The most important changes include adding a property to ignore missing fonts in various JasperReports files and updating the dependencies list in the `artifacts.list.COMPILATION.gradle` file.

### Handling missing fonts in JasperReports:

* Added the property `net.sf.jasperreports.awt.ignore.missing.font` to ignore missing fonts in the following files:
  - `modules_core/com.etendoerp.reportvaluationstock/src/com/etendoerp/reportvaluationstock/erpCommon/ad_reports/ReportValuationStockExcel.jrxml`
  - `modules_core/com.etendoerp.reportvaluationstock/src/com/etendoerp/reportvaluationstock/erpCommon/ad_reports/ReportValuationStockPDF.jrxml`
  - `modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/ad_reports/ReportReconciliation.jrxml`
  - `modules_core/org.openbravo.financial.paymentreport/src/org/openbravo/financial/paymentreport/erpCommon/ad_reports/PaymentReportExcel.jrxml`
  - `modules_core/org.openbravo.financial.paymentreport/src/org/openbravo/financial/paymentreport/erpCommon/ad_reports/PaymentReportPDF.jrxml`
  - `modules_core/org.openbravo.reports.ordersawaitingdelivery/src/org/openbravo/reports/ordersawaitingdelivery/erpCommon/ad_reports/ReportOrderNotShipped.jrxml`
  - `src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailHTML.jrxml`
  - `src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailPDF.jrxml`
  - `src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailPDFDoubtfulDebt.jrxml`
  - `src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailXLS.jrxml`
  - `src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailXLSDoubtfulDebt.jrxml`
  - `src/org/openbravo/erpCommon/ad_reports/AgingScheduleHTML.jrxml`
  - `src/org/openbravo/erpCommon/ad_reports/AgingSchedulePDF.jrxml`
  - `src/org/openbravo/erpCommon/ad_reports/AgingSchedulePDFDoubtfulDebt.jrxml`
  - `src/org/openbravo/erpCommon/ad_reports/AgingScheduleXLS.jrxml`
  - `src/org/openbravo/erpCommon/ad_reports/CashflowForecast.jrxml`
  - `src/org/openbravo/erpCommon/ad_reports/CashflowForecastExcel.jrxml`
  - `src/org/openbravo/erpCommon/ad_reports/CashflowForecastLines.jrxml`
  - `src/org/openbravo/erpCommon/ad_reports/CashflowForecastLinesByDate.jrxml`

### Dependencies update:

* Added `com.etendoerp:font.bitstreamverasans:1.0.0` to the dependencies list in `artifacts.list.COMPILATION.gradle`