### PR TITLE
Issue #719: Calculate taxbaseamt when creating order lines from returns

### DIFF
--- a/src/org/openbravo/common/actionhandler/SRMOPickEditLines.java
+++ b/src/org/openbravo/common/actionhandler/SRMOPickEditLines.java
@@ -304,6 +304,18 @@ public class SRMOPickEditLines extends BaseProcessActionHandler {
       newOrderLine.setLineGrossAmount(grossAmt);
       newOrderLine.setBaseGrossUnitPrice(baseGrossUnitPrice);
 
+      BigDecimal taxBaseAmt;
+      if (order.getPriceList().isPriceIncludesTax()) {
+        BigDecimal grossAmount = grossPrice.multiply(qtyReturned)
+            .setScale(stdPrecision, RoundingMode.HALF_UP);
+        taxBaseAmt = FinancialUtils.calculateNetAmtFromGross(
+            tax.getId(), grossAmount, stdPrecision, BigDecimal.ZERO);
+      } else {
+        taxBaseAmt = netPrice.multiply(qtyReturned)
+            .setScale(stdPrecision, RoundingMode.HALF_UP);
+      }
+      newOrderLine.setTaxableAmount(taxBaseAmt);
+
       if (!selectedLine.get("returnReason").equals(null)) {
         newOrderLine.setReturnReason(
             OBDal.getInstance().get(ReturnReason.class, selectedLine.getString("returnReason")));


### PR DESCRIPTION
ETP-1666: Manually calculate taxbaseamt during order line creation in SRMOPickEditLines, since the database trigger does not fire in this context. Ensures taxbaseamt reflects correct net amount based on whether the price list includes taxes or not, replicating SL_Order_Amt callout logic.