### PR TITLE
Issue #759: Fix parameters load in Actions

### DIFF
--- a/modules_core/com.smf.jobs/src/com/smf/jobs/Action.java
+++ b/modules_core/com.smf.jobs/src/com/smf/jobs/Action.java
@@ -72,7 +72,7 @@ public abstract class Action extends BaseProcessActionHandler {
       }
       for (Iterator<String> it = allParams.keys(); it.hasNext(); ) {
         String key = it.next();
-        jsonContent.put(key, parameters.get(key));
+        jsonContent.put(key, allParams.get(key));
       }
       runPreActionHooks(jsonContent);
       var result = action(jsonContent, new MutableBoolean(false));


### PR DESCRIPTION
ETP-1862
This pull request includes a small but significant change to the `Action.java` file. The change modifies the way keys and values are retrieved and added to the `jsonContent` object, ensuring they come directly from `allParams` instead of `parameters`.