### PR TITLE
Issue #763: Adding a validation to check if the document is already shown.

### DIFF
--- a/src/org/openbravo/erpCommon/utility/reporting/printing/PrintController.java
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/PrintController.java
@@ -43,6 +43,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.mutable.MutableBoolean;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
@@ -1191,7 +1192,7 @@ public class PrintController extends HttpSecureAppServlet {
         log4j.debug(" Filling report location with: " + documentData.reportLocation);
       }
 
-      if (onlyOneAttachedDoc) {
+      if (onlyOneAttachedDoc && !StringUtils.equals(attachedContent.getDocName(), report.getFilename())) {
         attachedContent.setDocName(report.getFilename());
         attachedContent.setVisible("checkbox");
         clonedAttachemnts.add(attachedContent);


### PR DESCRIPTION
ETP-1894: In order to avoid duplicating the attached files, we've added a validation to check if the docName was already added.