### PR TITLE
Issue #829: Avoid NPE by adding null checks for property and column

### DIFF
--- a/modules_core/org.openbravo.client.application/src/org/openbravo/client/application/WindowSettingsActionHandler.java
+++ b/modules_core/org.openbravo.client.application/src/org/openbravo/client/application/WindowSettingsActionHandler.java
@@ -176,7 +176,7 @@ public class WindowSettingsActionHandler extends BaseActionHandler {
       final Set<String> fields = new TreeSet<String>();
       List<Field> tabFields = tab.getADFieldList();
       for (Field field : tabFields) {
-        if (!field.isReadOnly() && !field.isShownInStatusBar() && field.getColumn().isUpdatable()) {
+        if (!field.isReadOnly() && !field.isShownInStatusBar() && field.getColumn() != null && field.getColumn().isUpdatable()) {
           final Property property = KernelUtils.getProperty(entity, field);
           if (property != null) {
             fields.add(property.getName());

--- a/modules_core/org.openbravo.service.datasource/src/org/openbravo/service/datasource/DefaultDataSourceService.java
+++ b/modules_core/org.openbravo.service.datasource/src/org/openbravo/service/datasource/DefaultDataSourceService.java
@@ -297,7 +297,7 @@ public class DefaultDataSourceService extends BaseDataSourceService {
       fieldQuery.setNamedParameter("roleId", roleId);
       for (Field f : fieldQuery.list()) {
         Property property = KernelUtils.getProperty(f);
-        if (property.isAuditInfo()) {
+        if (property == null || property.isAuditInfo()) {
           continue;
         }
         String key = property.getName();


### PR DESCRIPTION
ETP-2840
---
This pull request addresses potential null pointer exceptions in field-level access logic by adding necessary null checks before accessing properties. The changes ensure that fields with missing columns or properties are safely skipped, improving robustness and preventing runtime errors.

Field-level access safety improvements:

* In `WindowSettingsActionHandler.java`, added a null check for `field.getColumn()` before calling `isUpdatable()` to prevent possible null pointer exceptions when processing tab fields.
* In `DefaultDataSourceService.java`, added a null check for `property` before accessing its attributes, ensuring that fields without a valid property are skipped during access permission testing.