### PR TITLE
Issue #829: Avoid NPE by adding null checks for property and column

### DIFF
--- a/modules_core/org.openbravo.client.application/src/org/openbravo/client/application/WindowSettingsActionHandler.java
+++ b/modules_core/org.openbravo.client.application/src/org/openbravo/client/application/WindowSettingsActionHandler.java
@@ -176,7 +176,7 @@ public class WindowSettingsActionHandler extends BaseActionHandler {
       final Set<String> fields = new TreeSet<String>();
       List<Field> tabFields = tab.getADFieldList();
       for (Field field : tabFields) {
-        if (!field.isReadOnly() && !field.isShownInStatusBar() && field.getColumn().isUpdatable()) {
+        if (!field.isReadOnly() && !field.isShownInStatusBar() && field.getColumn() != null && field.getColumn().isUpdatable()) {
           final Property property = KernelUtils.getProperty(entity, field);
           if (property != null) {
             fields.add(property.getName());

--- a/modules_core/org.openbravo.service.datasource/src/org/openbravo/service/datasource/DefaultDataSourceService.java
+++ b/modules_core/org.openbravo.service.datasource/src/org/openbravo/service/datasource/DefaultDataSourceService.java
@@ -297,7 +297,7 @@ public class DefaultDataSourceService extends BaseDataSourceService {
       fieldQuery.setNamedParameter("roleId", roleId);
       for (Field f : fieldQuery.list()) {
         Property property = KernelUtils.getProperty(f);
-        if (property.isAuditInfo()) {
+        if (property == null || property.isAuditInfo()) {
           continue;
         }
         String key = property.getName();


### PR DESCRIPTION
ETP-2840
---
This pull request introduces minor but important improvements to the handling of fields and properties in the window settings and data source services. The changes add necessary null checks to prevent potential null pointer exceptions and ensure more robust code execution.

Field/property null safety improvements:

* Added a null check for `field.getColumn()` in the field-level roles logic in `WindowSettingsActionHandler.java` to prevent errors when a field's column is missing.
* Added a null check for the `property` returned by `KernelUtils.getProperty(f)` in `DefaultDataSourceService.java` to skip processing when the property is null, avoiding possible exceptions.