### PR TITLE
Issue #847: Prevent duplicate fetch on record selection in P&E grids

### DIFF
--- a/modules_core/org.openbravo.client.application/web/org.openbravo.client.application/js/form/formitem/ob-formitem-fk-filter.js
+++ b/modules_core/org.openbravo.client.application/web/org.openbravo.client.application/js/form/formitem/ob-formitem-fk-filter.js
@@ -324,6 +324,29 @@ isc.OBFKFilterTextItem.addProperties({
   },
 
   blur: function() {
+    // Check if blur is caused by clicking on the grid
+    // In that case, skip performAction to prevent duplicate fetch
+    var isGridClick = false;
+    try {
+      var target = isc.EH.getTarget();
+      var grid = this.grid && this.grid.sourceWidget;
+      
+      // Check if the event target is the grid or one of its components
+      if (target && grid) {
+        // Walk up the component hierarchy to see if we're clicking on the grid
+        var current = target;
+        while (current) {
+          if (current === grid || current === grid.body || current === grid.header) {
+            isGridClick = true;
+            break;
+          }
+          current = current.parentElement;
+        }
+      }
+    } catch (e) {
+      // If we can't determine, allow the action (safer default)
+    }
+    
     if (this._hasChanged && this.allowFkFilterByIdentifier === false) {
       // close the picklist if the item is due to a user tab action
       if (isc.EH.getKeyName() === 'Tab') {
@@ -335,7 +358,7 @@ isc.OBFKFilterTextItem.addProperties({
         this.setCriterion(this.getAppliedCriteria());
       }
       // do not perform a filter action on blur if the filtering by identifier is not allowed
-    } else if (this._hasChanged && this.allowFkFilterByIdentifier !== false) {
+    } else if (this._hasChanged && this.allowFkFilterByIdentifier !== false && !isGridClick) {
       this.form.grid.performAction();
     }
     delete this._hasChanged;


### PR DESCRIPTION
ETP-2960
---
This pull request improves the user experience and prevents unnecessary data fetching when interacting with grid components in the foreign key filter form item. The main change is to avoid triggering a filter action when the blur event is caused by clicking on the grid, which helps prevent duplicate fetches.

Enhancements to blur event handling in foreign key filter:

* Added logic to detect if the blur event was triggered by a click on the grid or its components, and skip the filter action in that case to prevent duplicate fetches. (`ob-formitem-fk-filter.js`)
* Updated the condition for performing a filter action on blur to ensure it does not execute when the blur is due to a grid click. (`ob-formitem-fk-filter.js`)