### PR TITLE
Issue #847: Prevent duplicate fetch on record selection in P&E grids

### DIFF
--- a/modules_core/org.openbravo.client.application/web/org.openbravo.client.application/js/form/formitem/ob-formitem-fk-filter.js
+++ b/modules_core/org.openbravo.client.application/web/org.openbravo.client.application/js/form/formitem/ob-formitem-fk-filter.js
@@ -324,6 +324,29 @@ isc.OBFKFilterTextItem.addProperties({
   },
 
   blur: function() {
+    // Check if blur is caused by clicking on the grid
+    // In that case, skip performAction to prevent duplicate fetch
+    var isGridClick = false;
+    try {
+      var target = isc.EH.getTarget();
+      var grid = this.grid && this.grid.sourceWidget;
+
+      // Check if the event target is the grid or one of its components
+      if (target && grid) {
+        // Walk up the component hierarchy to see if we're clicking on the grid
+        var current = target;
+        while (current) {
+          if (current === grid || current === grid.body || current === grid.header) {
+            isGridClick = true;
+            break;
+          }
+          current = current.parentElement;
+        }
+      }
+    } catch (e) {
+      // If we can't determine, allow the action (safer default)
+    }
+
     if (this._hasChanged && this.allowFkFilterByIdentifier === false) {
       // close the picklist if the item is due to a user tab action
       if (isc.EH.getKeyName() === 'Tab') {
@@ -335,7 +358,7 @@ isc.OBFKFilterTextItem.addProperties({
         this.setCriterion(this.getAppliedCriteria());
       }
       // do not perform a filter action on blur if the filtering by identifier is not allowed
-    } else if (this._hasChanged && this.allowFkFilterByIdentifier !== false) {
+    } else if (this._hasChanged && this.allowFkFilterByIdentifier !== false && !isGridClick) {
       this.form.grid.performAction();
     }
     delete this._hasChanged;


### PR DESCRIPTION
ETP-2960
---
This pull request addresses an issue where unnecessary data fetches were triggered when a blur event was caused by clicking on the grid in the foreign key filter form item. The main change ensures that the filter action is not performed in this scenario, preventing duplicate fetches and improving performance.

**Event handling improvements:**

* Added logic in the `blur` method of `OBFKFilterTextItem` to detect if the blur event was caused by a click on the grid or its components, and to skip performing the filter action in that case. [[1]](diffhunk://#diff-35ecef78c138baf3221685cf7102bd1020cc0d71e46a06a64ee65fde37eab7a1R327-R349) [[2]](diffhunk://#diff-35ecef78c138baf3221685cf7102bd1020cc0d71e46a06a64ee65fde37eab7a1L338-R361)