### PR TITLE
Feature ETP-3146: Removed commons-compress lib.

### DIFF
--- a/artifacts.list.COMPILATION.gradle
+++ b/artifacts.list.COMPILATION.gradle
@@ -28,7 +28,6 @@ List<String> _dependenciesListCOMPILATION = [
   'commons-logging:commons-logging:1.2',
   'commons-pool:commons-pool:1.5.6',
   'org.apache.commons:commons-collections4:4.4',
-  'org.apache.commons:commons-compress:1.21',
   'org.apache.commons:commons-lang3:3.17.0',
   'org.apache.commons:commons-math3:3.6.1',
   'org.apache.commons:commons-text:1.10.0',


### PR DESCRIPTION
This pull request makes a minor update to the dependencies list by removing an unused dependency from the compilation artifacts.

* Removed `org.apache.commons:commons-compress:1.21` from the `_dependenciesListCOMPILATION` in `artifacts.list.COMPILATION.gradle` to clean up unused dependencies.