### PR TITLE
Issue #877: Add a transformer to correct the filter and sorting in the Accounting tab of the End Year Close window

### DIFF
--- a/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/hqlinjections/AccountingFactEndYearTransformer.java
+++ b/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/hqlinjections/AccountingFactEndYearTransformer.java
@@ -9,7 +9,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codehaus.jettison.json.JSONArray;
@@ -230,9 +230,6 @@ public class AccountingFactEndYearTransformer extends HqlQueryTransformer {
     queryNamedParameters.put(paramName, paramValue);
     
     switch (operator.toLowerCase()) {
-      case "equals":
-      case "iequals":
-        return expr + " = :" + paramName;
       case "notequal":
         return expr + " <> :" + paramName;
       case "greaterthan":

--- a/src-test/src/org/openbravo/advpaymentmngt/hqlinjections/AccountingFactEndYearTransformerTest.java
+++ b/src-test/src/org/openbravo/advpaymentmngt/hqlinjections/AccountingFactEndYearTransformerTest.java
@@ -8,25 +8,28 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * Unit tests for AccountingFactEndYearTransformer
  * Tests the HQL query transformation for End Year Close table
  */
+@RunWith(MockitoJUnitRunner.class)
 public class AccountingFactEndYearTransformerTest {
 
-  public static final String CLIENT_ID = "clientId";
-  public static final String UPPER_MAX_FA_DESCRIPTION = "upper(Max(fa.description))";
-  public static final String HAVING_PARAM_0 = "havingParam_0";
-  public static final String TEST = "%test%";
-  public static final String TEST_CLIENT = "test-client";
-  public static final String FIELD_NAME_DEBIT_OPERATOR_GREATER_THAN_VALUE_100_0 = "{\"fieldName\":\"debit\",\"operator\":\"greaterThan\",\"value\":100.0}";
-  public static final String HAVING = "HAVING";
-  public static final String CRITERIA = "criteria";
-  public static final String ALIAS_0 = "alias_0";
-  public static final String ALIAS_1 = "alias_1";
-  public static final String FIELD_NAME_DESCRIPTION_OPERATOR_I_CONTAINS_VALUE_TEST = "{\"fieldName\":\"description\",\"operator\":\"iContains\",\"value\":\"test\"}";
-  public static final String HAVING_PARAM = "havingParam_";
+  private static final String CLIENT_ID = "clientId";
+  private static final String UPPER_MAX_FA_DESCRIPTION = "upper(Max(fa.description))";
+  private static final String HAVING_PARAM_0 = "havingParam_0";
+  private static final String TEST = "%test%";
+  private static final String TEST_CLIENT = "test-client";
+  private static final String FIELD_NAME_DEBIT_OPERATOR_GREATER_THAN_VALUE_100_0 = "{\"fieldName\":\"debit\",\"operator\":\"greaterThan\",\"value\":100.0}";
+  private static final String HAVING = "HAVING";
+  private static final String CRITERIA = "criteria";
+  private static final String ALIAS_0 = "alias_0";
+  private static final String ALIAS_1 = "alias_1";
+  private static final String FIELD_NAME_DESCRIPTION_OPERATOR_I_CONTAINS_VALUE_TEST = "{\"fieldName\":\"description\",\"operator\":\"iContains\",\"value\":\"test\"}";
+  private static final String HAVING_PARAM = "havingParam_";
   private AccountingFactEndYearTransformer transformer;
   private Map<String, String> requestParameters;
   private Map<String, Object> queryNamedParameters;

--- a/src-test/src/org/openbravo/advpaymentmngt/hqlinjections/AddPaymentGLItemInjectorTest.java
+++ b/src-test/src/org/openbravo/advpaymentmngt/hqlinjections/AddPaymentGLItemInjectorTest.java
@@ -1,0 +1,201 @@
+package org.openbravo.advpaymentmngt.hqlinjections;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Unit tests for AddPaymentGLItemInjector
+ * Tests the HQL injection for Payment GL Item table filtering
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AddPaymentGLItemInjectorTest {
+
+  private static final String FIN_PAYMENT_ID = "fin_payment_id";
+  private static final String PID = "pid";
+  private static final String EXPECTED_HQL = "p.id = :pid";
+  public static final String PID_PARAMETER = "Should add pid parameter";
+  public static final String CORRECT_HQL_CONDITION = "Should return correct HQL condition";
+
+  private AddPaymentGLItemInjector injector;
+  private Map<String, String> requestParameters;
+  private Map<String, Object> queryNamedParameters;
+
+  /**
+   * Set up test fixtures before each test.
+   * Initializes injector instance and parameter maps.
+   */
+  @Before
+  public void setUp() {
+    injector = new AddPaymentGLItemInjector();
+    requestParameters = new HashMap<>();
+    queryNamedParameters = new HashMap<>();
+  }
+
+  /**
+   * Verifies that valid payment ID is correctly inserted into HQL.
+   */
+  @Test
+  public void testInsertHqlWithValidPaymentId() {
+    String paymentId = "ABC123";
+    requestParameters.put(FIN_PAYMENT_ID, paymentId);
+    
+    String result = injector.insertHql(requestParameters, queryNamedParameters);
+    
+    assertEquals(CORRECT_HQL_CONDITION, EXPECTED_HQL, result);
+    assertTrue(PID_PARAMETER, queryNamedParameters.containsKey(PID));
+    assertEquals("Parameter value should match", paymentId, queryNamedParameters.get(PID));
+  }
+
+  /**
+   * Verifies that different payment ID values are handled correctly.
+   */
+  @Test
+  public void testInsertHqlWithDifferentPaymentIds() {
+    String[] paymentIds = {
+        "12345",
+        "PAYMENT-001",
+        "abc-def-ghi",
+        "00000000-0000-0000-0000-000000000000"
+    };
+    
+    for (String paymentId : paymentIds) {
+      requestParameters.clear();
+      queryNamedParameters.clear();
+      requestParameters.put(FIN_PAYMENT_ID, paymentId);
+      
+      String result = injector.insertHql(requestParameters, queryNamedParameters);
+      
+      assertEquals(CORRECT_HQL_CONDITION, EXPECTED_HQL, result);
+      assertEquals("Parameter value should match for " + paymentId, 
+          paymentId, queryNamedParameters.get(PID));
+    }
+  }
+
+  /**
+   * Verifies behavior when payment ID is null.
+   */
+  @Test
+  public void testInsertHqlWithNullPaymentId() {
+    requestParameters.put(FIN_PAYMENT_ID, null);
+    
+    String result = injector.insertHql(requestParameters, queryNamedParameters);
+    
+    assertEquals(CORRECT_HQL_CONDITION, EXPECTED_HQL, result);
+    assertTrue(PID_PARAMETER, queryNamedParameters.containsKey(PID));
+    assertNull("Parameter value should be null", queryNamedParameters.get(PID));
+  }
+
+  /**
+   * Verifies behavior when payment ID is empty string.
+   */
+  @Test
+  public void testInsertHqlWithEmptyPaymentId() {
+    String emptyId = "";
+    requestParameters.put(FIN_PAYMENT_ID, emptyId);
+    
+    String result = injector.insertHql(requestParameters, queryNamedParameters);
+    
+    assertEquals(CORRECT_HQL_CONDITION, EXPECTED_HQL, result);
+    assertEquals("Parameter value should be empty string", emptyId, queryNamedParameters.get(PID));
+  }
+
+  /**
+   * Verifies behavior when payment ID parameter is missing.
+   */
+  @Test
+  public void testInsertHqlWithMissingPaymentIdParameter() {
+    // Don't put any fin_payment_id in requestParameters
+    
+    String result = injector.insertHql(requestParameters, queryNamedParameters);
+    
+    assertEquals(CORRECT_HQL_CONDITION, EXPECTED_HQL, result);
+    assertTrue(PID_PARAMETER, queryNamedParameters.containsKey(PID));
+    assertNull("Parameter value should be null when missing", queryNamedParameters.get(PID));
+  }
+
+  /**
+   * Verifies that the returned HQL string format is always consistent.
+   */
+  @Test
+  public void testReturnedHqlStringFormat() {
+    requestParameters.put(FIN_PAYMENT_ID, "test-payment");
+    
+    String result = injector.insertHql(requestParameters, queryNamedParameters);
+    
+    assertNotNull("Result should not be null", result);
+    assertTrue("Should start with 'p.id'", result.startsWith("p.id"));
+    assertTrue("Should contain '='", result.contains("="));
+    assertTrue("Should contain ':pid'", result.contains(":pid"));
+    assertEquals("Should match exact format", EXPECTED_HQL, result);
+  }
+
+  /**
+   * Verifies that multiple calls with different values update the parameter correctly.
+   */
+  @Test
+  public void testMultipleCallsUpdateParameter() {
+    // First call
+    requestParameters.put(FIN_PAYMENT_ID, "first-payment");
+    injector.insertHql(requestParameters, queryNamedParameters);
+    assertEquals("First value should be set", "first-payment", queryNamedParameters.get(PID));
+    
+    // Second call with different value
+    requestParameters.put(FIN_PAYMENT_ID, "second-payment");
+    injector.insertHql(requestParameters, queryNamedParameters);
+    assertEquals("Second value should replace first", "second-payment", queryNamedParameters.get(PID));
+  }
+
+  /**
+   * Verifies that existing parameters in the map are not affected.
+   */
+  @Test
+  public void testExistingParametersPreserved() {
+    queryNamedParameters.put("existingParam1", "value1");
+    queryNamedParameters.put("existingParam2", 123);
+    
+    requestParameters.put(FIN_PAYMENT_ID, "new-payment");
+    injector.insertHql(requestParameters, queryNamedParameters);
+    
+    assertEquals("Existing param 1 should be preserved", "value1", queryNamedParameters.get("existingParam1"));
+    assertEquals("Existing param 2 should be preserved", 123, queryNamedParameters.get("existingParam2"));
+    assertEquals("New param should be added", "new-payment", queryNamedParameters.get(PID));
+    assertEquals("Should have 3 parameters", 3, queryNamedParameters.size());
+  }
+
+  /**
+   * Verifies handling of whitespace in payment ID.
+   */
+  @Test
+  public void testPaymentIdWithWhitespace() {
+    String paymentIdWithSpaces = "  payment-id-with-spaces  ";
+    requestParameters.put(FIN_PAYMENT_ID, paymentIdWithSpaces);
+    
+    String result = injector.insertHql(requestParameters, queryNamedParameters);
+    
+    assertEquals(CORRECT_HQL_CONDITION, EXPECTED_HQL, result);
+    assertEquals("Parameter value should preserve whitespace", 
+        paymentIdWithSpaces, queryNamedParameters.get(PID));
+  }
+
+  /**
+   * Verifies handling of special characters in payment ID.
+   */
+  @Test
+  public void testPaymentIdWithSpecialCharacters() {
+    String paymentIdWithSpecialChars = "payment#123!@$%";
+    requestParameters.put(FIN_PAYMENT_ID, paymentIdWithSpecialChars);
+    
+    String result = injector.insertHql(requestParameters, queryNamedParameters);
+    
+    assertEquals(CORRECT_HQL_CONDITION, EXPECTED_HQL, result);
+    assertEquals("Parameter value should preserve special characters", 
+        paymentIdWithSpecialChars, queryNamedParameters.get(PID));
+  }
+}

--- a/src-test/src/org/openbravo/advpaymentmngt/hqlinjections/AddPaymentOrderInvoicesTransformerTest.java
+++ b/src-test/src/org/openbravo/advpaymentmngt/hqlinjections/AddPaymentOrderInvoicesTransformerTest.java
@@ -1,0 +1,521 @@
+package org.openbravo.advpaymentmngt.hqlinjections;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Unit tests for AddPaymentOrderInvoicesTransformer
+ * Tests the HQL query transformation for payment order/invoice selection
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AddPaymentOrderInvoicesTransformerTest {
+
+  private static final String TRANSACTION_TYPE_INVOICE = "I";
+  private static final String TRANSACTION_TYPE_ORDER = "O";
+  private static final String RECEIVED_FROM = "received_from";
+  private static final String FIN_PAYMENT_ID = "fin_payment_id";
+  private static final String AD_ORG_ID = "ad_org_id";
+  private static final String C_CURRENCY_ID = "c_currency_id";
+  private static final String ISSOTRX = "issotrx";
+  public static final String ORD_DOCUMENT_NO = "ord.documentNo";
+  public static final String CRITERIA = "criteria";
+  public static final String INV_ID = "inv.id";
+  public static final String TRANSACTION_IS_SALES_TRANSACTION = "ord.salesTransaction = :isSalesTransaction";
+  public static final String MIXED = "MIXED";
+  public static final String SALES_TRANSACTION_IS_SALES_TRANSACTION = "inv.salesTransaction = :isSalesTransaction";
+  public static final String RESULT_SHOULD_NOT_BE_NULL = "Result should not be null";
+  public static final String FIELD_NAME = "fieldName";
+  public static final String VALUE = "value";
+
+  private AddPaymentOrderInvoicesTransformer transformer;
+  private Map<String, String> requestParameters;
+
+  /**
+   * Set up test fixtures before each test.
+   * Initializes transformer instance and parameter maps.
+   */
+  @Before
+  public void setUp() {
+    transformer = new AddPaymentOrderInvoicesTransformer();
+    requestParameters = new HashMap<>();
+
+    // Set default required parameters
+    requestParameters.put(C_CURRENCY_ID, "test-currency");
+    requestParameters.put(ISSOTRX, "true");
+    requestParameters.put(RECEIVED_FROM, "test-bp");
+    requestParameters.put(AD_ORG_ID, "test-org");
+  }
+
+  /**
+   * Verifies that getSelectClause generates correct clause for Invoice transaction type.
+   */
+  @Test
+  public void testGetSelectClauseForInvoiceType() {
+    StringBuffer result = transformer.getSelectClause(TRANSACTION_TYPE_INVOICE, false);
+    
+    assertNotNull(RESULT_SHOULD_NOT_BE_NULL, result);
+    assertTrue("Should contain paymentScheduleDetail", result.toString().contains("paymentScheduleDetail"));
+    assertTrue("Should contain salesOrderNo", result.toString().contains("salesOrderNo"));
+    assertTrue("Should contain invoiceNo", result.toString().contains("invoiceNo"));
+    assertTrue("Should contain paymentMethod", result.toString().contains("paymentMethod"));
+    assertTrue("Should contain expectedAmount", result.toString().contains("expectedAmount"));
+    assertTrue("Should contain outstandingAmount", result.toString().contains("outstandingAmount"));
+    assertTrue("Should contain max for invoice", result.toString().contains("max(COALESCE(inv.grandTotalAmount"));
+  }
+
+  /**
+   * Verifies that getSelectClause generates correct clause for Order transaction type.
+   */
+  @Test
+  public void testGetSelectClauseForOrderType() {
+    StringBuffer result = transformer.getSelectClause(TRANSACTION_TYPE_ORDER, false);
+    
+    assertNotNull(RESULT_SHOULD_NOT_BE_NULL, result);
+    assertTrue("Should contain salesOrderNo", result.toString().contains("salesOrderNo"));
+    assertTrue("Should contain sum for order", result.toString().contains("sum(COALESCE(inv.grandTotalAmount"));
+    assertTrue("Should contain order fields", result.toString().contains(ORD_DOCUMENT_NO));
+  }
+
+  /**
+   * Verifies that getSelectClause handles mixed type (neither I nor O).
+   */
+  @Test
+  public void testGetSelectClauseForMixedType() {
+    StringBuffer result = transformer.getSelectClause(MIXED, false);
+    
+    assertNotNull(RESULT_SHOULD_NOT_BE_NULL, result);
+    assertTrue("Should contain COALESCE for createdBy", result.toString().contains("COALESCE(invCreatedBy"));
+    assertTrue("Should contain COALESCE for updatedBy", result.toString().contains("COALESCE(invUpdatedBy"));
+  }
+
+  /**
+   * Verifies that getSelectClause includes selection flag when hasSelectedIds is false.
+   */
+  @Test
+  public void testGetSelectClauseWithoutSelectedIds() {
+    StringBuffer result = transformer.getSelectClause(TRANSACTION_TYPE_INVOICE, false);
+    
+    assertTrue("Should check max(fp.id) for selection", result.toString().contains("max(fp.id) is not null"));
+  }
+
+  /**
+   * Verifies that getSelectClause includes different selection logic when hasSelectedIds is true.
+   */
+  @Test
+  public void testGetSelectClauseWithSelectedIds() {
+    StringBuffer result = transformer.getSelectClause(TRANSACTION_TYPE_INVOICE, true);
+    
+    assertTrue("Should use client-side selection", result.toString().contains("1 < 0"));
+  }
+
+  /**
+   * Verifies that getJoinClauseOrder includes business partner filter when provided.
+   */
+  @Test
+  public void testGetJoinClauseOrderWithBusinessPartner() {
+    requestParameters.put(RECEIVED_FROM, "BP123");
+    
+    StringBuffer result = transformer.getJoinClauseOrder(requestParameters);
+    
+    assertTrue("Should include businessPartnerId filter", 
+        result.toString().contains("ord.businessPartner.id = :businessPartnerId"));
+    assertTrue("Should include currency filter", result.toString().contains("ord.currency.id = :currencyId"));
+    assertTrue("Should include sales transaction filter", 
+        result.toString().contains(TRANSACTION_IS_SALES_TRANSACTION));
+  }
+
+  /**
+   * Verifies that getJoinClauseOrder excludes business partner filter when null.
+   */
+  @Test
+  public void testGetJoinClauseOrderWithoutBusinessPartner() {
+    requestParameters.put(RECEIVED_FROM, null);
+    
+    StringBuffer result = transformer.getJoinClauseOrder(requestParameters);
+    
+    assertFalse("Should not include businessPartnerId filter", 
+        result.toString().contains("businessPartner.id"));
+  }
+
+  /**
+   * Verifies that getJoinClauseOrder excludes business partner filter when value is "null" string.
+   */
+  @Test
+  public void testGetJoinClauseOrderWithNullString() {
+    requestParameters.put(RECEIVED_FROM, "null");
+    
+    StringBuffer result = transformer.getJoinClauseOrder(requestParameters);
+    
+    assertFalse("Should not include businessPartnerId filter for 'null' string", 
+        result.toString().contains("businessPartner.id"));
+  }
+
+  /**
+   * Verifies that getJoinClauseInvoice includes business partner filter when provided.
+   */
+  @Test
+  public void testGetJoinClauseInvoiceWithBusinessPartner() {
+    requestParameters.put(RECEIVED_FROM, "BP456");
+    
+    StringBuffer result = transformer.getJoinClauseInvoice(requestParameters);
+    
+    assertTrue("Should include businessPartnerId filter", 
+        result.toString().contains("inv.businessPartner.id = :businessPartnerId"));
+    assertTrue("Should include currency filter", result.toString().contains("inv.currency.id = :currencyId"));
+    assertTrue("Should include sales transaction filter", 
+        result.toString().contains(SALES_TRANSACTION_IS_SALES_TRANSACTION));
+  }
+
+  /**
+   * Verifies that getWhereClause handles payment ID parameter correctly.
+   */
+  @Test
+  public void testGetWhereClauseWithPaymentId() {
+    requestParameters.put(FIN_PAYMENT_ID, "PAYMENT123");
+    
+    StringBuffer result = transformer.getWhereClause(TRANSACTION_TYPE_INVOICE, requestParameters, 
+        new ArrayList<String>());
+    
+    assertTrue("Should include payment condition", 
+        result.toString().contains("psd.paymentDetails is null or fp.id = :paymentId"));
+  }
+
+  /**
+   * Verifies that getWhereClause handles null payment ID correctly.
+   */
+  @Test
+  public void testGetWhereClauseWithoutPaymentId() {
+    requestParameters.put(FIN_PAYMENT_ID, null);
+    
+    StringBuffer result = transformer.getWhereClause(TRANSACTION_TYPE_INVOICE, requestParameters, 
+        new ArrayList<String>());
+    
+    assertTrue("Should only check null payment details", 
+        result.toString().contains("psd.paymentDetails is null"));
+    assertFalse("Should not include fp.id condition", result.toString().contains("fp.id = :paymentId"));
+  }
+
+  /**
+   * Verifies that getWhereClause includes organization filter when provided.
+   */
+  @Test
+  public void testGetWhereClauseWithOrganization() {
+    requestParameters.put(AD_ORG_ID, "ORG123");
+    
+    StringBuffer result = transformer.getWhereClause(TRANSACTION_TYPE_INVOICE, requestParameters, 
+        new ArrayList<String>());
+    
+    assertTrue("Should include organization filter", 
+        result.toString().contains("psd.organization.id in :orgIds"));
+  }
+
+  /**
+   * Verifies that getWhereClause includes selected PSDs when provided.
+   */
+  @Test
+  public void testGetWhereClauseWithSelectedPSDs() {
+    List<String> selectedPSDs = new ArrayList<>();
+    selectedPSDs.add("PSD1");
+    selectedPSDs.add("PSD2");
+    selectedPSDs.add("PSD3");
+    
+    StringBuffer result = transformer.getWhereClause(TRANSACTION_TYPE_INVOICE, requestParameters, 
+        selectedPSDs);
+    
+    assertTrue("Should include psd.id in clause", result.toString().contains("psd.id in ("));
+    assertTrue("Should include PSD1", result.toString().contains("'PSD1'"));
+    assertTrue("Should include PSD2", result.toString().contains("'PSD2'"));
+    assertTrue("Should include PSD3", result.toString().contains("'PSD3'"));
+  }
+
+  /**
+   * Verifies that getWhereClause handles Invoice transaction type conditions.
+   */
+  @Test
+  public void testGetWhereClauseForInvoiceType() {
+    StringBuffer result = transformer.getWhereClause(TRANSACTION_TYPE_INVOICE, requestParameters, 
+        new ArrayList<String>());
+    
+    assertTrue("Should include invoice sales transaction", 
+        result.toString().contains(SALES_TRANSACTION_IS_SALES_TRANSACTION));
+    assertTrue("Should include invoice currency", result.toString().contains("inv.currency.id = :currencyId"));
+  }
+
+  /**
+   * Verifies that getWhereClause handles Order transaction type conditions.
+   */
+  @Test
+  public void testGetWhereClauseForOrderType() {
+    StringBuffer result = transformer.getWhereClause(TRANSACTION_TYPE_ORDER, requestParameters, 
+        new ArrayList<String>());
+    
+    assertTrue("Should include order sales transaction", 
+        result.toString().contains(TRANSACTION_IS_SALES_TRANSACTION));
+    assertTrue("Should include order currency", result.toString().contains("ord.currency.id = :currencyId"));
+  }
+
+  /**
+   * Verifies that getWhereClause handles mixed type with both invoice and order conditions.
+   */
+  @Test
+  public void testGetWhereClauseForMixedType() {
+    StringBuffer result = transformer.getWhereClause(MIXED, requestParameters,
+        new ArrayList<String>());
+    
+    assertTrue("Should include invoice conditions", 
+        result.toString().contains(SALES_TRANSACTION_IS_SALES_TRANSACTION));
+    assertTrue("Should include order conditions", 
+        result.toString().contains(TRANSACTION_IS_SALES_TRANSACTION));
+    assertTrue("Should use OR between conditions", result.toString().contains("or ("));
+  }
+
+  /**
+   * Verifies that getGroupByClause generates correct grouping for Invoice type.
+   */
+  @Test
+  public void testGetGroupByClauseForInvoiceType() {
+    StringBuffer result = transformer.getGroupByClause(TRANSACTION_TYPE_INVOICE);
+    
+    assertNotNull(RESULT_SHOULD_NOT_BE_NULL, result);
+    assertTrue("Should group by invoice id", result.toString().contains(INV_ID));
+    assertTrue("Should group by invoice documentNo", result.toString().contains("inv.documentNo"));
+    assertTrue("Should group by business partner", result.toString().contains("bp.id"));
+    assertTrue("Should group by payment method", result.toString().contains("finPaymentmethod.id"));
+  }
+
+  /**
+   * Verifies that getGroupByClause generates correct grouping for Order type.
+   */
+  @Test
+  public void testGetGroupByClauseForOrderType() {
+    StringBuffer result = transformer.getGroupByClause(TRANSACTION_TYPE_ORDER);
+    
+    assertNotNull(RESULT_SHOULD_NOT_BE_NULL, result);
+    assertTrue("Should group by order id", result.toString().contains("ord.id"));
+    assertTrue("Should group by order documentNo", result.toString().contains(ORD_DOCUMENT_NO));
+    assertFalse("Should not group by invoice fields", result.toString().contains(INV_ID));
+  }
+
+  /**
+   * Verifies that getGroupByClause generates correct grouping for mixed type.
+   */
+  @Test
+  public void testGetGroupByClauseForMixedType() {
+    StringBuffer result = transformer.getGroupByClause(MIXED);
+    
+    assertNotNull(RESULT_SHOULD_NOT_BE_NULL, result);
+    assertTrue("Should group by invoice id", result.toString().contains(INV_ID));
+    assertTrue("Should group by order id", result.toString().contains("ord.id"));
+    assertTrue("Should group by both document types", result.toString().contains("inv.documentNo"));
+    assertTrue("Should group by both document types", result.toString().contains(ORD_DOCUMENT_NO));
+  }
+
+  /**
+   * Verifies that removeGridFilters removes filters between AND and whereClause placeholder.
+   */
+  @Test
+  public void testRemoveGridFilters() {
+    String hqlQuery = "SELECT ... FROM ... where x = 1 AND psd.organization in (:org) AND filter1 = 'test' " +
+        "AND filter2 = 'test2' and @whereClause@";
+    
+    String result = transformer.removeGridFilters(hqlQuery);
+    
+    assertFalse("Should remove grid filters", result.contains("filter1 = 'test'"));
+    assertTrue("Should keep organization filter", result.contains("psd.organization in (:org)"));
+    assertTrue("Should keep whereClause placeholder", result.contains("@whereClause@"));
+  }
+
+  /**
+   * Verifies that removeGridFilters handles query without grid filters.
+   */
+  @Test
+  public void testRemoveGridFiltersWithoutFilters() {
+    String hqlQuery = "SELECT ... FROM ... where x = 1 AND psd.organization in (:org) and @whereClause@";
+    
+    String result = transformer.removeGridFilters(hqlQuery);
+    
+    assertEquals(hqlQuery, result, "Should return same query");
+  }
+
+  /**
+   * Verifies that transformCriteria extracts selected PSDs from id field.
+   * 
+   * @throws JSONException if JSON parsing fails
+   */
+  @Test
+  public void testTransformCriteriaWithIdField() throws JSONException {
+    JSONObject criteria = new JSONObject();
+    JSONArray criteriaArray = new JSONArray();
+    
+    JSONObject idCriteria = new JSONObject();
+    idCriteria.put(FIELD_NAME, "id");
+    idCriteria.put(VALUE, "PSD1,PSD2,PSD3");
+    criteriaArray.put(idCriteria);
+    
+    criteria.put(CRITERIA, criteriaArray);
+    
+    List<String> selectedPSDs = new ArrayList<>();
+    transformer.transformCriteria(criteria, selectedPSDs);
+    
+    assertEquals(3, selectedPSDs.size(), "Should extract 3 PSDs");
+    assertTrue("Should contain PSD1", selectedPSDs.contains("PSD1"));
+    assertTrue("Should contain PSD2", selectedPSDs.contains("PSD2"));
+    assertTrue("Should contain PSD3", selectedPSDs.contains("PSD3"));
+  }
+
+  /**
+   * Verifies that transformCriteria handles whitespace in comma-separated values.
+   * 
+   * @throws JSONException if JSON parsing fails
+   */
+  @Test
+  public void testTransformCriteriaTrimsWhitespace() throws JSONException {
+    JSONObject criteria = new JSONObject();
+    JSONArray criteriaArray = new JSONArray();
+    
+    JSONObject idCriteria = new JSONObject();
+    idCriteria.put(FIELD_NAME, "id");
+    idCriteria.put(VALUE, "PSD1 , PSD2 , PSD3");
+    criteriaArray.put(idCriteria);
+    
+    criteria.put(CRITERIA, criteriaArray);
+    
+    List<String> selectedPSDs = new ArrayList<>();
+    transformer.transformCriteria(criteria, selectedPSDs);
+    
+    assertTrue("Should trim whitespace from PSD1", selectedPSDs.contains("PSD1"));
+    assertFalse("Should not contain value with spaces", selectedPSDs.contains(" PSD2 "));
+  }
+
+  /**
+   * Verifies that transformCriteria preserves non-id criteria.
+   * 
+   * @throws JSONException if JSON parsing fails
+   */
+  @Test
+  public void testTransformCriteriaPreservesOtherFields() throws JSONException {
+    JSONObject criteria = new JSONObject();
+    JSONArray criteriaArray = new JSONArray();
+    
+    JSONObject otherCriteria = new JSONObject();
+    otherCriteria.put(FIELD_NAME, "amount");
+    otherCriteria.put(VALUE, "100");
+    criteriaArray.put(otherCriteria);
+    
+    criteria.put(CRITERIA, criteriaArray);
+    
+    List<String> selectedPSDs = new ArrayList<>();
+    transformer.transformCriteria(criteria, selectedPSDs);
+    
+    assertTrue("Should not extract from non-id fields", selectedPSDs.isEmpty());
+    JSONArray resultArray = criteria.getJSONArray(CRITERIA);
+    assertEquals(1, resultArray.length(), "Should preserve original criteria");
+  }
+
+  /**
+   * Verifies that getAggregatorFunction wraps expression correctly.
+   */
+  @Test
+  public void testGetAggregatorFunction() {
+    String result = transformer.getAggregatorFunction("test.field");
+    
+    assertEquals(" hqlagg(test.field)", result, "Should wrap in hqlagg function");
+  }
+
+  /**
+   * Verifies that getAggregatorFunction handles complex expressions.
+   */
+  @Test
+  public void testGetAggregatorFunctionWithComplexExpression() {
+    String result = transformer.getAggregatorFunction("CASE WHEN x > 0 THEN x ELSE 0 END");
+    
+    assertEquals(" hqlagg(CASE WHEN x > 0 THEN x ELSE 0 END)", result, "Should wrap complex expression");
+  }
+
+  /**
+   * Verifies that transformCriteria handles empty criteria array.
+   * 
+   * @throws JSONException if JSON parsing fails
+   */
+  @Test
+  public void testTransformCriteriaWithEmptyArray() throws JSONException {
+    JSONObject criteria = new JSONObject();
+    criteria.put(CRITERIA, new JSONArray());
+    
+    List<String> selectedPSDs = new ArrayList<>();
+    transformer.transformCriteria(criteria, selectedPSDs);
+    
+    assertTrue("Should return empty list", selectedPSDs.isEmpty());
+  }
+
+  /**
+   * Verifies that transformCriteria handles single PSD value (no comma).
+   * 
+   * @throws JSONException if JSON parsing fails
+   */
+  @Test
+  public void testTransformCriteriaWithSingleValue() throws JSONException {
+    JSONObject criteria = new JSONObject();
+    JSONArray criteriaArray = new JSONArray();
+    
+    JSONObject idCriteria = new JSONObject();
+    idCriteria.put(FIELD_NAME, "id");
+    idCriteria.put(VALUE, "PSD1");
+    criteriaArray.put(idCriteria);
+    
+    criteria.put(CRITERIA, criteriaArray);
+    
+    List<String> selectedPSDs = new ArrayList<>();
+    transformer.transformCriteria(criteria, selectedPSDs);
+    
+    assertEquals(1, selectedPSDs.size(),"Should extract single PSD");
+    assertEquals("PSD1", selectedPSDs.get(0), "Should be PSD1");
+  }
+
+  /**
+   * Verifies that getWhereClause handles large number of PSDs with batching.
+   */
+  @Test
+  public void testGetWhereClauseWithManyPSDs() {
+    List<String> selectedPSDs = new ArrayList<>();
+    for (int i = 0; i < 3000; i++) {
+      selectedPSDs.add("PSD" + i);
+    }
+    
+    StringBuffer result = transformer.getWhereClause(TRANSACTION_TYPE_INVOICE, requestParameters, 
+        selectedPSDs);
+    
+    String resultStr = result.toString();
+    assertTrue("Should contain multiple psd.id in clauses for batching", 
+        resultStr.contains("psd.id in (") && resultStr.contains("or psd.id in ("));
+  }
+
+  /**
+   * Verifies that getWhereClause includes business partner filter when provided.
+   */
+  @Test
+  public void testGetWhereClauseWithBusinessPartner() {
+    requestParameters.put(RECEIVED_FROM, "BP789");
+    
+    StringBuffer result = transformer.getWhereClause(TRANSACTION_TYPE_INVOICE, requestParameters, 
+        new ArrayList<String>());
+    
+    assertTrue("Should include business partner filter", 
+        result.toString().contains("bp.id = :businessPartnerId"));
+  }
+}

--- a/src-test/src/org/openbravo/advpaymentmngt/suite/AdvPaymentMngtTestSuite.java
+++ b/src-test/src/org/openbravo/advpaymentmngt/suite/AdvPaymentMngtTestSuite.java
@@ -59,7 +59,10 @@ import org.openbravo.advpaymentmngt.filterexpression.TransactionAddPaymentDefaul
 import org.openbravo.advpaymentmngt.filterexpression.TransactionAddPaymentDisplayLogicsTest;
 import org.openbravo.advpaymentmngt.filterexpression.TransactionAddPaymentReadOnlyLogicsTest;
 import org.openbravo.advpaymentmngt.hook.PaymentProcessOrderHookTest;
+import org.openbravo.advpaymentmngt.hqlinjections.AccountingFactEndYearTransformerTest;
 import org.openbravo.advpaymentmngt.hqlinjections.AddPaymentCreditToUseInjectorTest;
+import org.openbravo.advpaymentmngt.hqlinjections.AddPaymentGLItemInjectorTest;
+import org.openbravo.advpaymentmngt.hqlinjections.AddPaymentOrderInvoicesTransformerTest;
 import org.openbravo.advpaymentmngt.hqlinjections.CreditToUseTransformerTest;
 import org.openbravo.advpaymentmngt.hqlinjections.MatchStatementTransformerTest;
 import org.openbravo.advpaymentmngt.hqlinjections.TransactionsToMatchTransformerTest;
@@ -115,7 +118,10 @@ import org.openbravo.advpaymentmngt.utility.ValueTest;
     MatchStatementActionHandlerTest.class,
 
     // tests hqlinjections
+    AccountingFactEndYearTransformerTest.class,
     AddPaymentCreditToUseInjectorTest.class,
+    AddPaymentGLItemInjectorTest.class,
+    AddPaymentOrderInvoicesTransformerTest.class,
     CreditToUseTransformerTest.class,
     MatchStatementTransformerTest.class,
     TransactionsToMatchTransformerTest.class,


### PR DESCRIPTION
ETP-3159
---
This pull request introduces a new HQL query transformer for the FinancialMgmtAccountingFactEndYear table, designed to correctly handle filters on aggregated columns such as debit and credit. The transformer ensures that filters on these aggregated fields are moved from the WHERE clause to the HAVING clause, addressing issues caused by the DAL placing aggregate conditions in WHERE. It also robustly cleans up the query to remove any aggregate conditions from WHERE, even in complex or nested cases, and appends the appropriate HAVING clause.

**HQL Query Transformation for Aggregated Filters:**

* Added a new class `AccountingFactEndYearTransformer` that extends `HqlQueryTransformer` to process and move filters on aggregated debit/credit columns from the WHERE clause to the HAVING clause for the `FinancialMgmtAccountingFactEndYear` HQL table.
* Implemented logic to parse JSON criteria, detect filters on debit/credit fields, and construct the corresponding HAVING clause with proper parameter handling and support for various operators (equals, greaterthan, etc.).
* Developed a method to recursively remove aggregate conditions from the WHERE clause, including handling nested and complex expressions, and cleaning up the resulting query to ensure syntactic correctness.
* Ensured that only parameters associated with removed aggregate conditions are deleted from the query parameters map, preventing potential parameter mismatches. (F28c4a01