### PR TITLE
Feature ETP-3156: Fixed SecureWebServicesUtilsTest and TestActionHookCall tests.

### DIFF
--- a/src-test/src/com/smf/jobs/TestActionHookCall.java
+++ b/src-test/src/com/smf/jobs/TestActionHookCall.java
@@ -1,7 +1,7 @@
 package com.smf.jobs;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -9,8 +9,8 @@ import java.util.Map;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openbravo.base.weld.WeldUtils;
 import org.openbravo.base.weld.test.WeldBaseTest;
 import org.openbravo.dal.core.OBContext;
@@ -21,10 +21,8 @@ import org.openbravo.test.base.TestConstants;
  */
 public class TestActionHookCall extends WeldBaseTest {
 
-  @Before
-  public void setUp() throws Exception {
-    super.setUp();
-
+  @BeforeEach
+  public void setUpTestAction() {
     OBContext.setOBContext(TestConstants.Users.ADMIN, TestConstants.Roles.FB_GRP_ADMIN, TestConstants.Clients.FB_GRP,
         TestConstants.Orgs.ESP_NORTE);
   }


### PR DESCRIPTION
This pull request updates and improves the test codebase for the `com.smf.jobs` and `com.smf.securewebservices.utils` packages, focusing on migrating to JUnit 5 and enhancing test utility methods for better reliability and maintainability. The most important changes are summarized below.

### Migration to JUnit 5

* Updated import statements and test annotations in `TestActionHookCall.java` to use JUnit 5 (`org.junit.jupiter.api`) instead of JUnit 4, including replacing `@Before` with `@BeforeEach` and updating assertion imports. [[1]](diffhunk://#diff-8b801a97ad87b444172f0eff7cf0393f2a5490a8b074d1feaffd4267e603a49cL3-R13) [[2]](diffhunk://#diff-8b801a97ad87b444172f0eff7cf0393f2a5490a8b074d1feaffd4267e603a49cL24-R25)

### Test Utility Method Improvements

* Refactored `SecureWebServicesUtilsTest.java` to improve configuration helper methods:
  - Changed `configSWSConfig` and `configAlgorithmPreference` from static to instance methods.
  - Added logic to check for existing configuration or preference objects before creating new ones, ensuring idempotent setup.
  - Used `OBContext.setAdminMode()` and restored previous mode in a `finally` block for safer context management.
  - Replaced direct database commits with `flush()` and improved context handling for test reliability.

### Code Cleanup

* Removed unused imports and redundant code from `SecureWebServicesUtilsTest.java` for clarity and maintainability. [[1]](diffhunk://#diff-828bc901ae635bb009fe4af104cadbabd84e453748e0cf82743dad8d01cd7c6dL7) [[2]](diffhunk://#diff-828bc901ae635bb009fe4af104cadbabd84e453748e0cf82743dad8d01cd7c6dL16-L17)
* Minor formatting and whitespace cleanup at the end of `SecureWebServicesUtilsTest.java`. [[1]](diffhunk://#diff-828bc901ae635bb009fe4af104cadbabd84e453748e0cf82743dad8d01cd7c6dR206) [[2]](diffhunk://#diff-828bc901ae635bb009fe4af104cadbabd84e453748e0cf82743dad8d01cd7c6dL216)