### PR TITLE
Issue #877: Add a transformer to correct the filter and sorting in the Accounting tab of the End Year Close window

### DIFF
--- a/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/hqlinjections/AccountingFactEndYearTransformer.java
+++ b/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/hqlinjections/AccountingFactEndYearTransformer.java
@@ -1,0 +1,498 @@
+package org.openbravo.advpaymentmngt.hqlinjections;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+import org.openbravo.client.kernel.ComponentProvider;
+import org.openbravo.service.datasource.hql.HqlQueryTransformer;
+import org.openbravo.service.json.JsonUtils;
+
+/**
+ * HQL Query Transformer for the Financial Management Accounting Fact End Year table.
+ *
+ * <p>
+ * This transformer addresses a PostgreSQL limitation where aggregate functions (SUM, MAX, MIN, AVG,
+ * COUNT) cannot be used in WHERE clauses. When users filter by aggregated columns like Debit,
+ * Credit, or Description in the End Year Close grid, the Data Access Layer (DAL) generates HQL
+ * queries that place these aggregate conditions in the WHERE clause, causing SQL errors.
+ * </p>
+ *
+ * <p>
+ * <b>Problem:</b> PostgreSQL rejects queries like:
+ *
+ * <pre>
+ * WHERE Max(fa.description) LIKE :param
+ * </pre>
+ *
+ * with error "aggregate functions are not allowed in WHERE"
+ * </p>
+ *
+ * <p>
+ * <b>Solution:</b> This transformer intercepts HQL queries before execution and performs two key
+ * operations:
+ * <ol>
+ * <li>Removes all aggregate function conditions from the WHERE clause (replacing them with 1=1
+ * placeholders)</li>
+ * <li>For Debit and Credit filters, generates equivalent conditions in a HAVING clause using the
+ * proper aggregate expressions</li>
+ * </ol>
+ * </p>
+ *
+ * <p>
+ * The transformer handles complex scenarios including:
+ * <ul>
+ * <li>Nested aggregate functions: {@code upper(Max(fa.description))}</li>
+ * <li>LIKE clauses with escape characters: {@code LIKE :param escape '|'}</li>
+ * <li>Multiple filter conditions with AND/OR operators</li>
+ * <li>Nested criteria groups</li>
+ * <li>All comparison operators (equals, greater than, less than, etc.)</li>
+ * </ul>
+ * </p>
+ *
+ * <p>
+ * <b>Example Transformation:</b>
+ *
+ * <pre>
+ * Input HQL:
+ * SELECT ... WHERE ... AND CASE WHEN Sum(...) > 0 THEN Sum(...) ELSE 0 END > :alias_0
+ *
+ * Output HQL:
+ * SELECT ... WHERE ... AND 1=1 HAVING CASE WHEN Sum(...) > 0 THEN Sum(...) ELSE 0 END > :havingParam_0
+ * </pre>
+ * </p>
+ *
+ * @see HqlQueryTransformer
+ * @see ComponentProvider.Qualifier
+ */
+@ComponentProvider.Qualifier("A45FDE07216C40FBA472E7B91F7273E4")
+public class AccountingFactEndYearTransformer extends HqlQueryTransformer {
+
+  private static final Logger log = LogManager.getLogger();
+  private static final String CRITERIA = "criteria";
+
+  @Override
+  public String transformHqlQuery(String _hqlQuery, Map<String, String> requestParameters,
+      Map<String, Object> queryNamedParameters) {
+    if (!requestParameters.containsKey(CRITERIA)) {
+      return _hqlQuery;
+    }
+
+    try {
+      JSONObject criteria = JsonUtils.buildCriteria(requestParameters);
+
+      // Build HAVING clause directly from JSON criteria for debit/credit only
+      StringBuilder havingClause = new StringBuilder();
+      int[] paramCounter = {0};
+      boolean hasAggregateFilters = processJSONCriteria(criteria, havingClause, queryNamedParameters, paramCounter);
+
+      // ALWAYS remove aggregate conditions from WHERE (even if no debit/credit filters)
+      // because other fields like description use Max() and DAL puts them in WHERE
+      String cleanedQuery = removeAggregateConditionsFromWhere(_hqlQuery, queryNamedParameters);
+
+      if (hasAggregateFilters) {
+        return insertHavingClause(cleanedQuery, havingClause.toString());
+      } else {
+        return cleanedQuery;
+      }
+
+    } catch (Exception e) {
+      log.error("Error transforming HQL query for End Year Close", e);
+      return _hqlQuery;
+    }
+  }
+
+  private boolean processJSONCriteria(JSONObject criteria, StringBuilder havingClause,
+      Map<String, Object> queryNamedParameters, int[] paramCounter) throws Exception {
+
+    if (!criteria.has(CRITERIA)) {
+      return false;
+    }
+
+    JSONArray criteriaArray = criteria.getJSONArray(CRITERIA);
+    List<String> conditions = new ArrayList<>();
+    boolean hasAggregate = processCriteriaArray(criteriaArray, conditions, queryNamedParameters, paramCounter);
+
+    if (!conditions.isEmpty()) {
+      String join = getJoinOperator(criteria);
+      havingClause.append(String.join(join, conditions));
+    }
+
+    return hasAggregate;
+  }
+
+  private boolean processCriteriaArray(JSONArray criteriaArray, List<String> conditions,
+      Map<String, Object> queryNamedParameters, int[] paramCounter) throws Exception {
+    boolean hasAggregate = false;
+
+    for (int i = 0; i < criteriaArray.length(); i++) {
+      JSONObject criterion = criteriaArray.getJSONObject(i);
+
+      if (processNestedCriteria(criterion, conditions, queryNamedParameters, paramCounter)) {
+        hasAggregate = true;
+        continue;
+      }
+
+      if (processAggregateCriterion(criterion, conditions, queryNamedParameters, paramCounter)) {
+        hasAggregate = true;
+      }
+    }
+
+    return hasAggregate;
+  }
+
+  private boolean processNestedCriteria(JSONObject criterion, List<String> conditions,
+      Map<String, Object> queryNamedParameters, int[] paramCounter) throws Exception {
+    if (!criterion.has(CRITERIA)) {
+      return false;
+    }
+
+    StringBuilder nestedHaving = new StringBuilder();
+    if (processJSONCriteria(criterion, nestedHaving, queryNamedParameters, paramCounter)) {
+      conditions.add("(" + nestedHaving.toString() + ")");
+      return true;
+    }
+
+    return false;
+  }
+
+  private boolean processAggregateCriterion(JSONObject criterion, List<String> conditions,
+      Map<String, Object> queryNamedParameters, int[] paramCounter) throws JSONException {
+    if (!criterion.has("fieldName")) {
+      return false;
+    }
+
+    String fieldName = criterion.getString("fieldName");
+    if (!isAggregateField(fieldName)) {
+      return false;
+    }
+
+    String operator = criterion.optString("operator", "equals");
+    Object value = criterion.opt("value");
+    String aggregateExpr = getAggregateExpression(fieldName);
+
+    String condition = buildCondition(aggregateExpr, operator, value, queryNamedParameters, paramCounter);
+    if (condition != null) {
+      conditions.add(condition);
+      return true;
+    }
+
+    return false;
+  }
+
+  private boolean isAggregateField(String fieldName) {
+    return StringUtils.equalsIgnoreCase("debit", fieldName)
+        || StringUtils.equalsIgnoreCase("credit", fieldName);
+  }
+
+  private String getAggregateExpression(String fieldName) {
+    if (StringUtils.equalsIgnoreCase("debit", fieldName)) {
+      return "CASE WHEN Sum(fa.debit - fa.credit) > 0 THEN Sum(fa.debit - fa.credit) ELSE 0 END";
+    } else {
+      return "CASE WHEN Sum(fa.credit - fa.debit) > 0 THEN Sum(fa.credit - fa.debit) ELSE 0 END";
+    }
+  }
+
+  private String getJoinOperator(JSONObject criteria) {
+    String operator = criteria.optString("operator", "and");
+    return StringUtils.equalsIgnoreCase("or", operator) ? " OR " : " AND ";
+  }
+
+  private String buildCondition(String expr, String operator, Object value,
+      Map<String, Object> queryNamedParameters, int[] paramCounter) {
+
+    if (value == null) {
+      return null;
+    }
+
+    // Convert Double to BigDecimal if needed (debit/credit are BigDecimal fields)
+    Object paramValue = value;
+    if (value instanceof Double) {
+      paramValue = BigDecimal.valueOf((Double) value);
+    } else if (value instanceof Integer) {
+      paramValue = BigDecimal.valueOf((Integer) value);
+    } else if (value instanceof Long) {
+      paramValue = BigDecimal.valueOf((Long) value);
+    }
+
+    String paramName = "havingParam_" + paramCounter[0]++;
+    queryNamedParameters.put(paramName, paramValue);
+
+    switch (operator.toLowerCase()) {
+      case "notequal":
+        return expr + " <> :" + paramName;
+      case "greaterthan":
+        return expr + " > :" + paramName;
+      case "lessthan":
+        return expr + " < :" + paramName;
+      case "greaterorequal":
+        return expr + " >= :" + paramName;
+      case "lessorequal":
+        return expr + " <= :" + paramName;
+      default:
+        return expr + " = :" + paramName;
+    }
+  }
+
+  private String removeAggregateConditionsFromWhere(String hqlQuery, Map<String, Object> queryNamedParameters) {
+    // Pattern to match any condition that contains aggregate functions (Sum, Max, etc.)
+    // This handles nested cases where DAL generates complex nested expressions
+    Set<String> paramsToRemove = new HashSet<>();
+    String cleaned = hqlQuery;
+
+    // Repeatedly remove any conditions containing aggregate functions
+    boolean foundMatch = true;
+    int iterations = 0;
+
+    while (foundMatch && iterations < 20) { // increased safety limit
+      iterations++;
+      foundMatch = false;
+
+      // Find any parameter :alias_N in the query, then check if its condition contains aggregates
+      // This handles cases like: upper(Max(fa.description)) like upper(:alias_0)
+      Pattern paramPattern = Pattern.compile(
+          ":(alias_\\d+)"
+      );
+      Matcher paramMatcher = paramPattern.matcher(cleaned);
+
+      while (paramMatcher.find()) {
+        String paramName = paramMatcher.group(1);
+        int paramPos = paramMatcher.start();
+
+        // Look backwards from paramPos to find the start of this condition
+        // We need to find the opening of the expression (after AND, OR, or opening paren)
+        int conditionStart = findConditionStart(cleaned, paramPos);
+        // Look forwards from paramPos to find the end of this condition
+        int conditionEnd = findConditionEnd(cleaned, paramMatcher.end());
+        String condition = cleaned.substring(conditionStart, conditionEnd);
+
+        // Check if this condition contains any aggregate function
+        if (containsAggregateFunction(condition)) {
+          paramsToRemove.add(paramName);
+
+          // Replace the entire condition with 1=1
+          cleaned = cleaned.substring(0, conditionStart) + "1=1" + cleaned.substring(conditionEnd);
+          foundMatch = true;
+          break; // Restart the search after modification
+        }
+      }
+    }
+
+    if (iterations >= 20) {
+      log.warn("Reached maximum iterations while removing aggregate conditions");
+    }
+    // Clean up dangling AND/OR operators and empty conditions
+    // Handle "and1=1" or "1=1and" (missing space)
+    cleaned = cleaned.replace("and1=1", "and 1=1");
+    cleaned = cleaned.replace("1=1and", "1=1 and");
+
+    // Handle multiple 1=1 with AND between them
+    cleaned = cleaned.replace("1=1\\s+and\\s+1=1", "1=1");
+    cleaned = cleaned.replace("AND\\s+1=1\\s+AND", "AND");
+    cleaned = cleaned.replace("\\s+AND\\s+1=1\\s*\\)", ")");
+    cleaned = cleaned.replace("\\(\\s*1=1\\s+AND\\s+", "(");
+    cleaned = cleaned.replace("\\s+AND\\s+1=1\\s+GROUP", " GROUP");
+    cleaned = cleaned.replace("WHERE\\s+1=1\\s+AND\\s+", "WHERE ");
+    cleaned = cleaned.replace("\\(\\(\\s*1=1\\s+and\\s+", "((");
+    cleaned = cleaned.replace("\\s+and\\s+1=1\\s+and\\s+", " and ");
+    cleaned = cleaned.replace("\\(\\s*1=1\\s+and\\s+", "(");
+
+    // Final cleanup: remove standalone 1=1 in parentheses
+    cleaned = cleaned.replace("\\(\\s*1=1\\s*\\)", "");
+    cleaned = cleaned.replace("\\(\\(\\s*\\)", "((");
+    cleaned = cleaned.replace("\\(\\s*and\\s+", "(");
+
+    // Remove only the parameters that were used in the removed aggregate conditions
+    for (String paramName : paramsToRemove) {
+      queryNamedParameters.remove(paramName);
+    }
+
+    return cleaned;
+  }
+
+  private boolean containsAggregateFunction(String expression) {
+    // Check if expression contains common aggregate functions
+    String upper = expression.toUpperCase();
+    return upper.contains("SUM(") ||
+        upper.contains("MAX(") ||
+        upper.contains("MIN(") ||
+        upper.contains("AVG(") ||
+        upper.contains("COUNT(");
+  }
+
+  private int findConditionStart(String query, int fromPos) {
+    // Look backwards to find where this condition starts
+    // Condition starts after: AND, OR, WHERE
+    // We DON'T stop at parentheses because they might be part of functions like upper(:param)
+    int pos = fromPos - 1;
+
+    while (pos >= 0) {
+      // Check for AND, OR, WHERE at current position
+      if (pos >= 4 && StringUtils.equalsIgnoreCase(" AND", query.substring(pos - 4, pos))) {
+        return pos;
+      }
+      if (pos >= 3 && StringUtils.equalsIgnoreCase(" OR", query.substring(pos - 3, pos))) {
+        return pos;
+      }
+      if (pos >= 6 && StringUtils.equalsIgnoreCase("WHERE ", query.substring(pos - 6, pos))) {
+        return pos;
+      }
+      // Check for opening double parenthesis which marks start of filter conditions: ((
+      if (pos >= 2 && StringUtils.equalsIgnoreCase("((", query.substring(pos - 2, pos))) {
+        return pos;
+      }
+      pos--;
+    }
+
+    return 0; // Start of string
+  }
+
+  private int findConditionEnd(String query, int fromPos) {
+    int pos = fromPos;
+    int parenDepth = 0;
+
+    while (pos < query.length()) {
+      char c = query.charAt(pos);
+
+      if (c == '(') {
+        parenDepth++;
+      } else if (c == ')') {
+        int endPos = handleClosingParen(query, pos, parenDepth);
+        if (endPos != -1) {
+          return endPos;
+        }
+        parenDepth--;
+      } else if (parenDepth == 0) {
+        int keywordPos = checkForTerminatingKeyword(query, pos);
+        if (keywordPos != -1) {
+          return keywordPos;
+        }
+      }
+      pos++;
+    }
+
+    return query.length();
+  }
+
+  private int handleClosingParen(String query, int pos, int parenDepth) {
+    if (parenDepth != 0) {
+      return -1;
+    }
+
+    int escapeEndPos = checkForEscapeClause(query, pos);
+    if (escapeEndPos != -1) {
+      return escapeEndPos;
+    }
+
+    return pos;
+  }
+
+  private int checkForEscapeClause(String query, int closingParenPos) {
+    int checkPos = skipWhitespace(query, closingParenPos + 1);
+
+    if (!hasEscapeKeyword(query, checkPos)) {
+      return -1;
+    }
+
+    checkPos = skipWhitespace(query, checkPos + 6); // Skip "escape"
+    return skipEscapeValue(query, checkPos);
+  }
+
+  private int skipWhitespace(String query, int startPos) {
+    int pos = startPos;
+    while (pos < query.length() && Character.isWhitespace(query.charAt(pos))) {
+      pos++;
+    }
+    return pos;
+  }
+
+  private boolean hasEscapeKeyword(String query, int pos) {
+    return pos + 6 <= query.length()
+        && StringUtils.equalsIgnoreCase("escape", query.substring(pos, pos + 6));
+  }
+
+  private int skipEscapeValue(String query, int startPos) {
+    if (startPos >= query.length() || query.charAt(startPos) != '\'') {
+      return startPos;
+    }
+
+    int pos = startPos + 1; // Skip opening quote
+    while (pos < query.length() && query.charAt(pos) != '\'') {
+      pos++;
+    }
+
+    return pos < query.length() ? pos + 1 : pos; // Skip closing quote if present
+  }
+
+  private int checkForTerminatingKeyword(String query, int pos) {
+    if (matchesKeywordAtPosition(query, pos, " AND", 4)) {
+      return pos;
+    }
+    if (matchesKeywordAtPosition(query, pos, " OR", 3)) {
+      return pos;
+    }
+    if (matchesKeywordAtPosition(query, pos, " GROUP", 6)) {
+      return pos;
+    }
+    if (matchesKeywordAtPosition(query, pos, " HAVING", 7)) {
+      return pos;
+    }
+    if (matchesKeywordAtPosition(query, pos, " ORDER", 6)) {
+      return pos;
+    }
+    return -1;
+  }
+
+  private boolean matchesKeywordAtPosition(String query, int pos, String keyword, int length) {
+    return pos + length <= query.length()
+        && StringUtils.equalsIgnoreCase(keyword, query.substring(pos, pos + length));
+  }
+
+  private String insertHavingClause(String hqlQuery, String havingClause) {
+    if (havingClause == null || havingClause.trim().isEmpty()) {
+      return hqlQuery;
+    }
+
+    String upperHql = hqlQuery.toUpperCase();
+    int havingPos = upperHql.indexOf("HAVING");
+    int orderByPos = upperHql.indexOf("ORDER BY");
+
+    if (havingPos != -1) {
+      // There's already a HAVING clause, append with AND
+      String beforeHaving = hqlQuery.substring(0, havingPos + 6); // +6 for "HAVING"
+      String existingHaving;
+      String afterHaving;
+
+      if (orderByPos != -1 && orderByPos > havingPos) {
+        existingHaving = hqlQuery.substring(havingPos + 6, orderByPos).trim();
+        afterHaving = hqlQuery.substring(orderByPos);
+      } else {
+        existingHaving = hqlQuery.substring(havingPos + 6).trim();
+        afterHaving = "";
+      }
+
+      return beforeHaving + " (" + existingHaving + ") AND (" + havingClause + ") " + afterHaving;
+
+    } else if (orderByPos != -1) {
+      // No HAVING, insert before ORDER BY
+      String beforeOrder = hqlQuery.substring(0, orderByPos);
+      String afterOrder = hqlQuery.substring(orderByPos);
+      return beforeOrder + " HAVING " + havingClause + " " + afterOrder;
+
+    } else {
+      // No HAVING, no ORDER BY, append at end
+      return hqlQuery + " HAVING " + havingClause;
+    }
+  }
+}

--- a/src-test/src/org/openbravo/advpaymentmngt/hqlinjections/AccountingFactEndYearTransformerTest.java
+++ b/src-test/src/org/openbravo/advpaymentmngt/hqlinjections/AccountingFactEndYearTransformerTest.java
@@ -1,0 +1,555 @@
+package org.openbravo.advpaymentmngt.hqlinjections;
+
+import static org.junit.Assert.*;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Unit tests for AccountingFactEndYearTransformer
+ * Tests the HQL query transformation for End Year Close table
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AccountingFactEndYearTransformerTest {
+
+  private static final String CLIENT_ID = "clientId";
+  private static final String UPPER_MAX_FA_DESCRIPTION = "upper(Max(fa.description))";
+  private static final String HAVING_PARAM_0 = "havingParam_0";
+  private static final String TEST = "%test%";
+  private static final String TEST_CLIENT = "test-client";
+  private static final String FIELD_NAME_DEBIT_OPERATOR_GREATER_THAN_VALUE_100_0 = "{\"fieldName\":\"debit\",\"operator\":\"greaterThan\",\"value\":100.0}";
+  private static final String HAVING = "HAVING";
+  private static final String CRITERIA = "criteria";
+  private static final String ALIAS_0 = "alias_0";
+  private static final String ALIAS_1 = "alias_1";
+  private static final String FIELD_NAME_DESCRIPTION_OPERATOR_I_CONTAINS_VALUE_TEST = "{\"fieldName\":\"description\",\"operator\":\"iContains\",\"value\":\"test\"}";
+  private static final String HAVING_PARAM = "havingParam_";
+  private AccountingFactEndYearTransformer transformer;
+  private Map<String, String> requestParameters;
+  private Map<String, Object> queryNamedParameters;
+  private String baseHqlQuery;
+
+  /**
+   * Set up test fixtures before each test.
+   * Initializes transformer instance, parameter maps, and base HQL query.
+   */
+  @Before
+  public void setUp() {
+    transformer = new AccountingFactEndYearTransformer();
+    requestParameters = new HashMap<>();
+    queryNamedParameters = new HashMap<>();
+
+    // Base HQL query similar to the real one
+    baseHqlQuery = "SELECT max(fa.id) AS Fact_Acct_End_Year_V_ID, "
+        + "fa.client.id AS AD_Client_ID, "
+        + "pc.organization.id AS AD_Org_ID, "
+        + "Max(fa.creationDate) AS Created, "
+        + "Max(fa.description) as Description, "
+        + "CASE WHEN Sum(fa.debit - fa.credit) > 0 THEN Sum(fa.debit - fa.credit) ELSE 0 END AS Debit, "
+        + "CASE WHEN Sum(fa.credit - fa.debit) > 0 THEN Sum(fa.credit - fa.debit) ELSE 0 END AS Credit "
+        + "FROM FinancialMgmtAccountingFact fa "
+        + "JOIN fa.period p "
+        + "WHERE fa.type IN ('O', 'C') "
+        + "and fa.client.id in ('0', :clientId) "
+        + "GROUP BY fa.client.id, pc.id "
+        + "HAVING Sum(fa.credit - fa.debit) <> 0 "
+        + "ORDER BY fa.type DESC";
+  }
+
+  /**
+   * Verifies that query is returned unchanged when no criteria parameter is provided.
+   */
+  @Test
+  public void testNoCriteriaParameterReturnsOriginalQuery() {
+    // No criteria parameter in request
+    String result = transformer.transformHqlQuery(baseHqlQuery, requestParameters, queryNamedParameters);
+
+    assertEquals("Should return original query when no criteria", baseHqlQuery, result);
+  }
+
+  /**
+   * Verifies that empty criteria parameter returns a valid result.
+   */
+  @Test
+  public void testEmptyCriteriaReturnsOriginalQuery() {
+    requestParameters.put(CRITERIA, "");
+
+    String result = transformer.transformHqlQuery(baseHqlQuery, requestParameters, queryNamedParameters);
+
+    assertNotNull("Result should not be null", result);
+  }
+
+  /**
+   * Verifies that filtering by debit adds a HAVING clause with the correct aggregate expression.
+   */
+  @Test
+  public void testDebitFilterOnlyAddsHavingClause() {
+    // Criteria with debit filter
+    requestParameters.put(CRITERIA, FIELD_NAME_DEBIT_OPERATOR_GREATER_THAN_VALUE_100_0);
+    queryNamedParameters.put(CLIENT_ID, TEST_CLIENT);
+
+    String result = transformer.transformHqlQuery(baseHqlQuery, requestParameters, queryNamedParameters);
+
+    assertTrue("Should contain HAVING clause", result.contains(HAVING));
+    assertTrue("Should contain debit condition", result.contains("CASE WHEN Sum(fa.debit - fa.credit)"));
+    assertTrue("Should contain havingParam", result.contains(HAVING_PARAM));
+    assertTrue("Should have added parameter", queryNamedParameters.containsKey(HAVING_PARAM_0));
+    assertEquals("Parameter should be BigDecimal", BigDecimal.valueOf(100.0), queryNamedParameters.get(HAVING_PARAM_0));
+  }
+
+  /**
+   * Verifies that filtering by credit adds a HAVING clause with the correct aggregate expression.
+   */
+  @Test
+  public void testCreditFilterOnlyAddsHavingClause() {
+    requestParameters.put(CRITERIA, "{\"fieldName\":\"credit\",\"operator\":\"lessThan\",\"value\":500.0}");
+
+    String result = transformer.transformHqlQuery(baseHqlQuery, requestParameters, queryNamedParameters);
+
+    assertTrue("Should contain HAVING clause", result.contains(HAVING));
+    assertTrue("Should contain credit condition", result.contains("CASE WHEN Sum(fa.credit - fa.debit)"));
+    assertTrue("Should have added parameter", queryNamedParameters.containsKey(HAVING_PARAM_0));
+  }
+
+  /**
+   * Verifies that multiple debit and credit filters are combined with AND operator.
+   */
+  @Test
+  public void testDebitAndCreditFiltersCombinesWithAnd() {
+    requestParameters.put(CRITERIA,
+        "{\"operator\":\"and\",\"_constructor\":\"AdvancedCriteria\",\"criteria\":["
+            + FIELD_NAME_DEBIT_OPERATOR_GREATER_THAN_VALUE_100_0 + ","
+            + "{\"fieldName\":\"credit\",\"operator\":\"lessThan\",\"value\":500.0}"
+            + "]}");
+
+    String result = transformer.transformHqlQuery(baseHqlQuery, requestParameters, queryNamedParameters);
+
+    assertTrue("Should contain AND operator", result.contains(" AND "));
+    assertTrue("Should have two parameters", queryNamedParameters.size() >= 2);
+    assertTrue("Should have havingParam_0", queryNamedParameters.containsKey(HAVING_PARAM_0));
+    assertTrue("Should have havingParam_1", queryNamedParameters.containsKey("havingParam_1"));
+  }
+
+  /**
+   * Verifies that multiple debit and credit filters are combined with OR operator.
+   */
+  @Test
+  public void testDebitOrCreditFiltersCombinesWithOr() {
+    requestParameters.put(CRITERIA,
+        "{\"operator\":\"or\",\"_constructor\":\"AdvancedCriteria\",\"criteria\":["
+            + "{\"fieldName\":\"debit\",\"operator\":\"equals\",\"value\":100.0},"
+            + "{\"fieldName\":\"credit\",\"operator\":\"equals\",\"value\":500.0}"
+            + "]}");
+
+    String result = transformer.transformHqlQuery(baseHqlQuery, requestParameters, queryNamedParameters);
+
+    assertTrue("Should contain OR operator", result.contains(" OR "));
+  }
+
+  /**
+   * Verifies that aggregate conditions on description field are removed from WHERE clause.
+   */
+  @Test
+  public void testDescriptionFilterWithAggregateRemovesFromWhere() {
+    String queryWithAggregateFilter = "SELECT max(fa.id), Max(fa.description) as Description "
+        + "FROM FinancialMgmtAccountingFact fa "
+        + "WHERE fa.client.id in (:clientId) AND (( upper(Max(fa.description)) like upper(:alias_0) escape '|' )) "
+        + "GROUP BY fa.client.id";
+
+    queryNamedParameters.put(CLIENT_ID, TEST_CLIENT);
+    queryNamedParameters.put(ALIAS_0, TEST);
+    requestParameters.put(CRITERIA, FIELD_NAME_DESCRIPTION_OPERATOR_I_CONTAINS_VALUE_TEST);
+
+    String result = transformer.transformHqlQuery(queryWithAggregateFilter, requestParameters, queryNamedParameters);
+
+    // Verify the aggregate condition was removed from WHERE
+    assertFalse("Should not contain upper(Max(fa.description)) in result", result.contains(UPPER_MAX_FA_DESCRIPTION));
+    assertFalse("Should have removed alias_0 parameter", queryNamedParameters.containsKey(ALIAS_0));
+    assertTrue("Should keep clientId parameter", queryNamedParameters.containsKey(CLIENT_ID));
+    // The WHERE clause should still exist with clientId condition
+    assertTrue("Should contain WHERE clause", result.contains("WHERE"));
+    assertTrue("Should contain clientId condition", result.contains("fa.client.id in (:clientId)"));
+  }
+
+  /**
+   * Verifies that multiple aggregate conditions are all removed from WHERE clause.
+   */
+  @Test
+  public void testMultipleAggregateConditionsRemovesAll() {
+    String queryWithMultipleAggregates = "SELECT max(fa.id), Max(fa.description), Max(fa.creationDate) "
+        + "FROM FinancialMgmtAccountingFact fa "
+        + "WHERE fa.client.id in (:clientId) AND upper(Max(fa.description)) like upper(:alias_0) escape '|' "
+        + "AND Max(fa.creationDate) > :alias_1 "
+        + "GROUP BY fa.client.id";
+
+    queryNamedParameters.put(ALIAS_0, TEST);
+    queryNamedParameters.put(ALIAS_1, "2024-01-01");
+    requestParameters.put(CRITERIA,
+        "{\"operator\":\"and\",\"criteria\":["
+            + FIELD_NAME_DESCRIPTION_OPERATOR_I_CONTAINS_VALUE_TEST + ","
+            + "{\"fieldName\":\"creationDate\",\"operator\":\"greaterThan\",\"value\":\"2024-01-01\"}"
+            + "]}");
+
+    String result = transformer.transformHqlQuery(queryWithMultipleAggregates, requestParameters, queryNamedParameters);
+
+    // Extract the WHERE clause to verify aggregate removal (not SELECT clause)
+    int whereIndex = result.indexOf("WHERE");
+    int groupByIndex = result.indexOf("GROUP BY");
+    String whereClause = result.substring(whereIndex, groupByIndex);
+
+    assertFalse("Should not contain upper(Max(fa.description)) in WHERE", whereClause.contains(UPPER_MAX_FA_DESCRIPTION));
+    assertFalse("Should not contain Max(fa.creationDate) > in WHERE", whereClause.contains("Max(fa.creationDate) >"));
+    assertFalse("Should have removed alias_0", queryNamedParameters.containsKey(ALIAS_0));
+    assertFalse("Should have removed alias_1", queryNamedParameters.containsKey(ALIAS_1));
+    assertTrue("Should contain 1=1 replacements", whereClause.contains("1=1"));
+  }
+
+  /**
+   * Verifies that nested criteria groups are handled correctly with proper parentheses.
+   */
+  @Test
+  public void testNestedCriteriaHandlesCorrectly() {
+    requestParameters.put(CRITERIA,
+        "{\"operator\":\"and\",\"criteria\":["
+            + "{\"operator\":\"or\",\"criteria\":["
+            + FIELD_NAME_DEBIT_OPERATOR_GREATER_THAN_VALUE_100_0 + ","
+            + "{\"fieldName\":\"debit\",\"operator\":\"lessThan\",\"value\":50.0}"
+            + "]},"
+            + "{\"fieldName\":\"credit\",\"operator\":\"equals\",\"value\":200.0}"
+            + "]}");
+
+    String result = transformer.transformHqlQuery(baseHqlQuery, requestParameters, queryNamedParameters);
+
+    assertTrue("Should contain parentheses for nesting", result.contains("(") && result.contains(")"));
+    assertTrue("Should have multiple parameters", queryNamedParameters.size() >= 3);
+  }
+
+  /**
+   * Verifies that all comparison operators (equals, notEqual, greaterOrEqual, lessOrEqual) work correctly.
+   */
+  @Test
+  public void testDifferentOperatorsAllHandled() {
+    // Test equals operator
+    requestParameters.put(CRITERIA, "{\"fieldName\":\"debit\",\"operator\":\"equals\",\"value\":100.0}");
+    String result1 = transformer.transformHqlQuery(baseHqlQuery, requestParameters, queryNamedParameters);
+    assertTrue("Should handle equals", result1.contains(" = :"));
+
+    // Test notEqual operator
+    queryNamedParameters.clear();
+    requestParameters.put(CRITERIA, "{\"fieldName\":\"debit\",\"operator\":\"notEqual\",\"value\":100.0}");
+    String result2 = transformer.transformHqlQuery(baseHqlQuery, requestParameters, queryNamedParameters);
+    assertTrue("Should handle notEqual", result2.contains(" <> :"));
+
+    // Test greaterOrEqual operator
+    queryNamedParameters.clear();
+    requestParameters.put(CRITERIA, "{\"fieldName\":\"debit\",\"operator\":\"greaterOrEqual\",\"value\":100.0}");
+    String result3 = transformer.transformHqlQuery(baseHqlQuery, requestParameters, queryNamedParameters);
+    assertTrue("Should handle greaterOrEqual", result3.contains(" >= :"));
+
+    // Test lessOrEqual operator
+    queryNamedParameters.clear();
+    requestParameters.put(CRITERIA, "{\"fieldName\":\"debit\",\"operator\":\"lessOrEqual\",\"value\":100.0}");
+    String result4 = transformer.transformHqlQuery(baseHqlQuery, requestParameters, queryNamedParameters);
+    assertTrue("Should handle lessOrEqual", result4.contains(" <= :"));
+  }
+
+  /**
+   * Verifies that Integer values are properly converted to BigDecimal for parameter binding.
+   */
+  @Test
+  public void testIntegerValueConvertsToBigDecimal() {
+    requestParameters.put(CRITERIA, "{\"fieldName\":\"debit\",\"operator\":\"equals\",\"value\":100}");
+
+    transformer.transformHqlQuery(baseHqlQuery, requestParameters, queryNamedParameters);
+
+    Object paramValue = queryNamedParameters.get(HAVING_PARAM_0);
+    assertTrue("Should convert Integer to BigDecimal", paramValue instanceof BigDecimal);
+    assertEquals("Value should match", BigDecimal.valueOf(100), paramValue);
+  }
+
+  /**
+   * Verifies that Long values are properly converted to BigDecimal for parameter binding.
+   */
+  @Test
+  public void testLongValueConvertsToBigDecimal() {
+    requestParameters.put(CRITERIA, "{\"fieldName\":\"credit\",\"operator\":\"equals\",\"value\":9999999999}");
+
+    transformer.transformHqlQuery(baseHqlQuery, requestParameters, queryNamedParameters);
+
+    Object paramValue = queryNamedParameters.get(HAVING_PARAM_0);
+    assertTrue("Should convert Long to BigDecimal", paramValue instanceof BigDecimal);
+  }
+
+  /**
+   * Verifies that non-aggregate fields do not add HAVING parameters.
+   */
+  @Test
+  public void testNullValueSkipsCondition() {
+    // Null values in JSON are parsed as missing, not as null objects
+    // Test with a query that has no debit/credit filters (only other fields)
+    requestParameters.put(CRITERIA, "{\"fieldName\":\"clientId\",\"operator\":\"equals\",\"value\":\"test\"}");
+    queryNamedParameters.put(CLIENT_ID, TEST_CLIENT);
+
+    String result = transformer.transformHqlQuery(baseHqlQuery, requestParameters, queryNamedParameters);
+
+    // Should not add HAVING clause since clientId is not debit/credit
+    assertFalse("Should not add havingParam for non-aggregate field", result.contains(HAVING_PARAM));
+    assertTrue("Should keep clientId parameter", queryNamedParameters.containsKey(CLIENT_ID));
+  }
+
+  /**
+   * Verifies that new conditions are appended to existing HAVING clause with AND operator.
+   */
+  @Test
+  public void testExistingHavingClauseAppendsWithAnd() {
+    String queryWithHaving = baseHqlQuery; // Already has HAVING clause
+    requestParameters.put(CRITERIA, FIELD_NAME_DEBIT_OPERATOR_GREATER_THAN_VALUE_100_0);
+
+    String result = transformer.transformHqlQuery(queryWithHaving, requestParameters, queryNamedParameters);
+
+    assertTrue("Should append to existing HAVING", result.contains(HAVING));
+    assertTrue("Should use AND to combine", result.contains(" AND "));
+  }
+
+  /**
+   * Verifies that HAVING clause is added even when query has no GROUP BY.
+   */
+  @Test
+  public void testNoGroupByStillProcesses() {
+    String simpleQuery = "SELECT fa.id FROM FinancialMgmtAccountingFact fa WHERE fa.client.id = :clientId";
+    requestParameters.put(CRITERIA, "{\"fieldName\":\"debit\",\"operator\":\"equals\",\"value\":100.0}");
+
+    String result = transformer.transformHqlQuery(simpleQuery, requestParameters, queryNamedParameters);
+
+    assertTrue("Should add HAVING even without GROUP BY", result.contains(HAVING));
+  }
+
+  /**
+   * Verifies that LIKE conditions with escape clauses are properly removed including the escape part.
+   */
+  @Test
+  public void testEscapeClauseInLikeHandledCorrectly() {
+    String queryWithEscape = "SELECT max(fa.id), Max(fa.description) "
+        + "FROM FinancialMgmtAccountingFact fa "
+        + "WHERE upper(Max(fa.description)) like upper(:alias_0) escape '|' and fa.client.id = :clientId "
+        + "GROUP BY fa.client.id";
+
+    queryNamedParameters.put(ALIAS_0, TEST);
+    queryNamedParameters.put(CLIENT_ID, "test");
+    requestParameters.put(CRITERIA, FIELD_NAME_DESCRIPTION_OPERATOR_I_CONTAINS_VALUE_TEST);
+
+    String result = transformer.transformHqlQuery(queryWithEscape, requestParameters, queryNamedParameters);
+
+    assertFalse("Should remove entire condition including escape", result.contains("escape '|'"));
+    assertFalse("Should not have standalone escape keyword", result.matches(".*\\s+escape\\s+.*"));
+  }
+
+  /**
+   * Verifies that complex queries with nested parentheses maintain correct structure after transformation.
+   */
+  @Test
+  public void testComplexNestedParenthesesHandledCorrectly() {
+    String complexQuery = "SELECT max(fa.id), Max(fa.description) "
+        + "FROM FinancialMgmtAccountingFact fa "
+        + "WHERE fa.client.id in (:clientId) AND (( upper(Max(fa.description)) like upper(:alias_0) escape '|' and fa.type = :alias_1 )) "
+        + "GROUP BY fa.client.id";
+
+    queryNamedParameters.put(ALIAS_0, TEST);
+    queryNamedParameters.put(ALIAS_1, "O");
+    requestParameters.put(CRITERIA,
+        "{\"operator\":\"and\",\"criteria\":["
+            + FIELD_NAME_DESCRIPTION_OPERATOR_I_CONTAINS_VALUE_TEST + ","
+            + "{\"fieldName\":\"type\",\"operator\":\"equals\",\"value\":\"O\"}"
+            + "]}");
+
+    String result = transformer.transformHqlQuery(complexQuery, requestParameters, queryNamedParameters);
+
+    assertFalse("Should remove Max aggregate condition", result.contains(UPPER_MAX_FA_DESCRIPTION));
+    assertTrue("Should keep non-aggregate condition", result.contains("fa.type = :alias_1"));
+    assertFalse("Should have removed alias_0", queryNamedParameters.containsKey(ALIAS_0));
+    assertTrue("Should keep alias_1", queryNamedParameters.containsKey(ALIAS_1));
+  }
+
+  /**
+   * Verifies that SUM aggregate function is removed from WHERE clause.
+   */
+  @Test
+  public void testSumAggregateInWhereRemoved() {
+    String queryWithSum = "SELECT Sum(fa.amount) "
+        + "FROM FinancialMgmtAccountingFact fa "
+        + "WHERE Sum(fa.amount) > :alias_0 "
+        + "GROUP BY fa.client.id";
+
+    queryNamedParameters.put(ALIAS_0, "100");
+    requestParameters.put(CRITERIA, "{\"fieldName\":\"amount\",\"operator\":\"greaterThan\",\"value\":100}");
+
+    String result = transformer.transformHqlQuery(queryWithSum, requestParameters, queryNamedParameters);
+
+    assertFalse("Should remove Sum from WHERE", result.contains("WHERE Sum(fa.amount)"));
+    assertFalse("Should remove alias_0", queryNamedParameters.containsKey(ALIAS_0));
+  }
+
+  /**
+   * Verifies that AVG aggregate function is removed from WHERE clause.
+   */
+  @Test
+  public void testAvgAggregateInWhereRemoved() {
+    String queryWithAvg = "SELECT Avg(fa.amount) "
+        + "FROM FinancialMgmtAccountingFact fa "
+        + "WHERE Avg(fa.amount) < :alias_0 "
+        + "GROUP BY fa.client.id";
+
+    queryNamedParameters.put(ALIAS_0, "50");
+    requestParameters.put(CRITERIA, "{\"fieldName\":\"avgAmount\",\"operator\":\"lessThan\",\"value\":50}");
+
+    String result = transformer.transformHqlQuery(queryWithAvg, requestParameters, queryNamedParameters);
+
+    assertFalse("Should remove Avg from WHERE", result.contains("WHERE Avg(fa.amount)"));
+  }
+
+  /**
+   * Verifies that MIN, MAX, and COUNT aggregate functions are all removed from WHERE clause.
+   */
+  @Test
+  public void testMinMaxCountAggregatesAllRemoved() {
+    String queryWithMultiple = "SELECT Min(fa.id), Max(fa.id), Count(fa.id) "
+        + "FROM FinancialMgmtAccountingFact fa "
+        + "WHERE Min(fa.id) > :alias_0 and Max(fa.id) < :alias_1 and Count(fa.id) = :alias_2 "
+        + "GROUP BY fa.client.id";
+
+    queryNamedParameters.put(ALIAS_0, "1");
+    queryNamedParameters.put(ALIAS_1, "100");
+    queryNamedParameters.put("alias_2", "10");
+    requestParameters.put(CRITERIA, "{\"fieldName\":\"id\",\"operator\":\"equals\",\"value\":1}");
+
+    String result = transformer.transformHqlQuery(queryWithMultiple, requestParameters, queryNamedParameters);
+
+    assertFalse("Should remove Min", result.contains("Min(fa.id) >"));
+    assertFalse("Should remove Max", result.contains("Max(fa.id) <"));
+    assertFalse("Should remove Count", result.contains("Count(fa.id) ="));
+    assertEquals("Should remove all alias parameters", 0, queryNamedParameters.size());
+  }
+
+  /**
+   * Verifies that malformed JSON criteria returns the original query without throwing exceptions.
+   */
+  @Test
+  public void testMalformedJSONHandlesGracefully() {
+    requestParameters.put(CRITERIA, "{malformed json");
+
+    String result = transformer.transformHqlQuery(baseHqlQuery, requestParameters, queryNamedParameters);
+
+    assertEquals("Should return original query on error", baseHqlQuery, result);
+  }
+
+  /**
+   * Verifies that criteria without fieldName property are skipped gracefully.
+   */
+  @Test
+  public void testCriteriaWithoutFieldNameSkipped() {
+    requestParameters.put(CRITERIA, "{\"operator\":\"equals\",\"value\":100}");
+
+    String result = transformer.transformHqlQuery(baseHqlQuery, requestParameters, queryNamedParameters);
+
+    assertFalse("Should not add HAVING", result.contains(HAVING_PARAM));
+  }
+
+  /**
+   * Verifies that non-aggregate fields do not trigger HAVING clause generation.
+   */
+  @Test
+  public void testNonDebitCreditFieldNoHavingAdded() {
+    requestParameters.put(CRITERIA, "{\"fieldName\":\"clientId\",\"operator\":\"equals\",\"value\":\"test\"}");
+
+    String result = transformer.transformHqlQuery(baseHqlQuery, requestParameters, queryNamedParameters);
+
+    assertFalse("Should not add HAVING for non-aggregate fields", result.contains(HAVING_PARAM));
+  }
+
+  /**
+   * Verifies that ORDER BY clause is preserved and placed after HAVING clause.
+   */
+  @Test
+  public void testOrderByPreservedWhenAddingHaving() {
+    requestParameters.put(CRITERIA, FIELD_NAME_DEBIT_OPERATOR_GREATER_THAN_VALUE_100_0);
+
+    String result = transformer.transformHqlQuery(baseHqlQuery, requestParameters, queryNamedParameters);
+
+    assertTrue("Should preserve ORDER BY", result.contains("ORDER BY"));
+    int havingIndex = result.indexOf(HAVING);
+    int orderByIndex = result.indexOf("ORDER BY");
+    assertTrue("HAVING should come before ORDER BY", havingIndex < orderByIndex);
+  }
+
+  /**
+   * Verifies that operators are handled case-insensitively.
+   */
+  @Test
+  public void testCaseInsensitiveOperatorsWork() {
+    requestParameters.put(CRITERIA, "{\"fieldName\":\"debit\",\"operator\":\"GREATERTHAN\",\"value\":100.0}");
+
+    String result = transformer.transformHqlQuery(baseHqlQuery, requestParameters, queryNamedParameters);
+
+    assertTrue("Should handle uppercase operators", result.contains(" > :"));
+  }
+
+  /**
+   * Verifies that iEquals operator is translated to equals (=) in SQL.
+   */
+  @Test
+  public void testIEqualsOperatorUsesEquals() {
+    requestParameters.put(CRITERIA, "{\"fieldName\":\"debit\",\"operator\":\"iEquals\",\"value\":100.0}");
+
+    String result = transformer.transformHqlQuery(baseHqlQuery, requestParameters, queryNamedParameters);
+
+    assertTrue("Should use = for iEquals", result.contains(" = :"));
+  }
+
+  /**
+   * Verifies that empty parentheses are removed during query cleanup.
+   */
+  @Test
+  public void testEmptyParenthesesCleanedUp() {
+    String queryWithEmptyParens = "SELECT max(fa.id) "
+        + "FROM FinancialMgmtAccountingFact fa "
+        + "WHERE fa.client.id = :clientId AND (( upper(Max(fa.description)) like upper(:alias_0) )) "
+        + "GROUP BY fa.client.id";
+
+    queryNamedParameters.put(ALIAS_0, TEST);
+    requestParameters.put(CRITERIA, FIELD_NAME_DESCRIPTION_OPERATOR_I_CONTAINS_VALUE_TEST);
+
+    String result = transformer.transformHqlQuery(queryWithEmptyParens, requestParameters, queryNamedParameters);
+
+    assertFalse("Should not have empty double parentheses", result.contains("(())"));
+  }
+
+  /**
+   * Verifies that multiple aggregate conditions are handled correctly across iterations.
+   */
+  @Test
+  public void testMultipleIterationsHandlesCorrectly() {
+    // Create a query with many aggregate conditions to test iteration logic
+    StringBuilder query = new StringBuilder("SELECT max(fa.id) FROM FinancialMgmtAccountingFact fa WHERE ");
+    for (int i = 0; i < 5; i++) {
+      if (i > 0) query.append(" and ");
+      query.append("Max(fa.field").append(i).append(") = :alias_").append(i);
+      queryNamedParameters.put("alias_" + i, "value" + i);
+    }
+    query.append(" GROUP BY fa.client.id");
+
+    requestParameters.put(CRITERIA, "{\"fieldName\":\"test\",\"operator\":\"equals\",\"value\":\"test\"}");
+
+    String result = transformer.transformHqlQuery(query.toString(), requestParameters, queryNamedParameters);
+
+    for (int i = 0; i < 5; i++) {
+      assertFalse("Should remove all aggregate conditions", result.contains("Max(fa.field" + i + ")"));
+      assertFalse("Should remove all alias parameters", queryNamedParameters.containsKey("alias_" + i));
+    }
+  }
+}

--- a/src-test/src/org/openbravo/advpaymentmngt/hqlinjections/AddPaymentGLItemInjectorTest.java
+++ b/src-test/src/org/openbravo/advpaymentmngt/hqlinjections/AddPaymentGLItemInjectorTest.java
@@ -1,0 +1,205 @@
+package org.openbravo.advpaymentmngt.hqlinjections;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Unit tests for AddPaymentGLItemInjector
+ * Tests the HQL injection for Payment GL Item table filtering
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AddPaymentGLItemInjectorTest {
+
+  private static final String FIN_PAYMENT_ID = "fin_payment_id";
+  private static final String PID = "pid";
+  private static final String EXPECTED_HQL = "p.id = :pid";
+  public static final String PID_PARAMETER = "Should add pid parameter";
+  public static final String CORRECT_HQL_CONDITION = "Should return correct HQL condition";
+
+  private AddPaymentGLItemInjector injector;
+  private Map<String, String> requestParameters;
+  private Map<String, Object> queryNamedParameters;
+
+  /**
+   * Set up test fixtures before each test.
+   * Initializes injector instance and parameter maps.
+   */
+  @Before
+  public void setUp() {
+    injector = new AddPaymentGLItemInjector();
+    requestParameters = new HashMap<>();
+    queryNamedParameters = new HashMap<>();
+  }
+
+  /**
+   * Verifies that valid payment ID is correctly inserted into HQL.
+   */
+  @Test
+  public void testInsertHqlWithValidPaymentId() {
+    String paymentId = "ABC123";
+    requestParameters.put(FIN_PAYMENT_ID, paymentId);
+
+    String result = injector.insertHql(requestParameters, queryNamedParameters);
+
+    assertEquals(CORRECT_HQL_CONDITION, EXPECTED_HQL, result);
+    assertTrue(PID_PARAMETER, queryNamedParameters.containsKey(PID));
+    assertEquals("Parameter value should match", paymentId, queryNamedParameters.get(PID));
+  }
+
+  /**
+   * Verifies that different payment ID values are handled correctly.
+   */
+  @Test
+  public void testInsertHqlWithDifferentPaymentIds() {
+    String[] paymentIds = {
+        "12345",
+        "PAYMENT-001",
+        "abc-def-ghi",
+        "00000000-0000-0000-0000-000000000000"
+    };
+
+    for (String paymentId : paymentIds) {
+      requestParameters.clear();
+      queryNamedParameters.clear();
+      requestParameters.put(FIN_PAYMENT_ID, paymentId);
+
+      String result = injector.insertHql(requestParameters, queryNamedParameters);
+
+      assertEquals(CORRECT_HQL_CONDITION, EXPECTED_HQL, result);
+      assertEquals("Parameter value should match for " + paymentId,
+          paymentId, queryNamedParameters.get(PID));
+    }
+  }
+
+  /**
+   * Verifies behavior when payment ID is null.
+   */
+  @Test
+  public void testInsertHqlWithNullPaymentId() {
+    requestParameters.put(FIN_PAYMENT_ID, null);
+
+    String result = injector.insertHql(requestParameters, queryNamedParameters);
+
+    assertEquals(CORRECT_HQL_CONDITION, EXPECTED_HQL, result);
+    assertTrue(PID_PARAMETER, queryNamedParameters.containsKey(PID));
+    assertNull("Parameter value should be null", queryNamedParameters.get(PID));
+  }
+
+  /**
+   * Verifies behavior when payment ID is empty string.
+   */
+  @Test
+  public void testInsertHqlWithEmptyPaymentId() {
+    String emptyId = "";
+    requestParameters.put(FIN_PAYMENT_ID, emptyId);
+
+    String result = injector.insertHql(requestParameters, queryNamedParameters);
+
+    assertEquals(CORRECT_HQL_CONDITION, EXPECTED_HQL, result);
+    assertEquals("Parameter value should be empty string", emptyId, queryNamedParameters.get(PID));
+  }
+
+  /**
+   * Verifies behavior when payment ID parameter is missing.
+   */
+  @Test
+  public void testInsertHqlWithMissingPaymentIdParameter() {
+    // Don't put any fin_payment_id in requestParameters
+
+    String result = injector.insertHql(requestParameters, queryNamedParameters);
+
+    assertEquals(CORRECT_HQL_CONDITION, EXPECTED_HQL, result);
+    assertTrue(PID_PARAMETER, queryNamedParameters.containsKey(PID));
+    assertNull("Parameter value should be null when missing", queryNamedParameters.get(PID));
+  }
+
+  /**
+   * Verifies that the returned HQL string format is always consistent.
+   */
+  @Test
+  public void testReturnedHqlStringFormat() {
+    requestParameters.put(FIN_PAYMENT_ID, "test-payment");
+
+    String result = injector.insertHql(requestParameters, queryNamedParameters);
+
+    assertNotNull("Result should not be null", result);
+    assertTrue("Should start with 'p.id'", result.startsWith("p.id"));
+    assertTrue("Should contain '='", result.contains("="));
+    assertTrue("Should contain ':pid'", result.contains(":pid"));
+    assertEquals("Should match exact format", EXPECTED_HQL, result);
+  }
+
+  /**
+   * Verifies that multiple calls with different values update the parameter correctly.
+   */
+  @Test
+  public void testMultipleCallsUpdateParameter() {
+    // First call
+    requestParameters.put(FIN_PAYMENT_ID, "first-payment");
+    injector.insertHql(requestParameters, queryNamedParameters);
+    assertEquals("First value should be set", "first-payment", queryNamedParameters.get(PID));
+
+    // Second call with different value
+    requestParameters.put(FIN_PAYMENT_ID, "second-payment");
+    injector.insertHql(requestParameters, queryNamedParameters);
+    assertEquals("Second value should replace first", "second-payment", queryNamedParameters.get(PID));
+  }
+
+  /**
+   * Verifies that existing parameters in the map are not affected.
+   */
+  @Test
+  public void testExistingParametersPreserved() {
+    queryNamedParameters.put("existingParam1", "value1");
+    queryNamedParameters.put("existingParam2", 123);
+
+    requestParameters.put(FIN_PAYMENT_ID, "new-payment");
+    injector.insertHql(requestParameters, queryNamedParameters);
+
+    assertEquals("Existing param 1 should be preserved", "value1", queryNamedParameters.get("existingParam1"));
+    assertEquals("Existing param 2 should be preserved", 123, queryNamedParameters.get("existingParam2"));
+    assertEquals("New param should be added", "new-payment", queryNamedParameters.get(PID));
+    assertEquals("Should have 3 parameters", 3, queryNamedParameters.size());
+  }
+
+  /**
+   * Verifies handling of whitespace in payment ID.
+   */
+  @Test
+  public void testPaymentIdWithWhitespace() {
+    String paymentIdWithSpaces = "  payment-id-with-spaces  ";
+    requestParameters.put(FIN_PAYMENT_ID, paymentIdWithSpaces);
+
+    String result = injector.insertHql(requestParameters, queryNamedParameters);
+
+    assertEquals(CORRECT_HQL_CONDITION, EXPECTED_HQL, result);
+    assertEquals("Parameter value should preserve whitespace",
+        paymentIdWithSpaces, queryNamedParameters.get(PID));
+  }
+
+  /**
+   * Verifies handling of special characters in payment ID.
+   */
+  @Test
+  public void testPaymentIdWithSpecialCharacters() {
+    String paymentIdWithSpecialChars = "payment#123!@$%";
+    requestParameters.put(FIN_PAYMENT_ID, paymentIdWithSpecialChars);
+
+    String result = injector.insertHql(requestParameters, queryNamedParameters);
+
+    assertEquals(CORRECT_HQL_CONDITION, EXPECTED_HQL, result);
+    assertEquals("Parameter value should preserve special characters",
+        paymentIdWithSpecialChars, queryNamedParameters.get(PID));
+  }
+}

--- a/src-test/src/org/openbravo/advpaymentmngt/hqlinjections/AddPaymentOrderInvoicesTransformerTest.java
+++ b/src-test/src/org/openbravo/advpaymentmngt/hqlinjections/AddPaymentOrderInvoicesTransformerTest.java
@@ -1,0 +1,521 @@
+package org.openbravo.advpaymentmngt.hqlinjections;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Unit tests for AddPaymentOrderInvoicesTransformer
+ * Tests the HQL query transformation for payment order/invoice selection
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AddPaymentOrderInvoicesTransformerTest {
+
+  private static final String TRANSACTION_TYPE_INVOICE = "I";
+  private static final String TRANSACTION_TYPE_ORDER = "O";
+  private static final String RECEIVED_FROM = "received_from";
+  private static final String FIN_PAYMENT_ID = "fin_payment_id";
+  private static final String AD_ORG_ID = "ad_org_id";
+  private static final String C_CURRENCY_ID = "c_currency_id";
+  private static final String ISSOTRX = "issotrx";
+  public static final String ORD_DOCUMENT_NO = "ord.documentNo";
+  public static final String CRITERIA = "criteria";
+  public static final String INV_ID = "inv.id";
+  public static final String TRANSACTION_IS_SALES_TRANSACTION = "ord.salesTransaction = :isSalesTransaction";
+  public static final String MIXED = "MIXED";
+  public static final String SALES_TRANSACTION_IS_SALES_TRANSACTION = "inv.salesTransaction = :isSalesTransaction";
+  public static final String RESULT_SHOULD_NOT_BE_NULL = "Result should not be null";
+  public static final String FIELD_NAME = "fieldName";
+  public static final String VALUE = "value";
+
+  private AddPaymentOrderInvoicesTransformer transformer;
+  private Map<String, String> requestParameters;
+
+  /**
+   * Set up test fixtures before each test.
+   * Initializes transformer instance and parameter maps.
+   */
+  @Before
+  public void setUp() {
+    transformer = new AddPaymentOrderInvoicesTransformer();
+    requestParameters = new HashMap<>();
+
+    // Set default required parameters
+    requestParameters.put(C_CURRENCY_ID, "test-currency");
+    requestParameters.put(ISSOTRX, "true");
+    requestParameters.put(RECEIVED_FROM, "test-bp");
+    requestParameters.put(AD_ORG_ID, "test-org");
+  }
+
+  /**
+   * Verifies that getSelectClause generates correct clause for Invoice transaction type.
+   */
+  @Test
+  public void testGetSelectClauseForInvoiceType() {
+    StringBuffer result = transformer.getSelectClause(TRANSACTION_TYPE_INVOICE, false);
+
+    assertNotNull(RESULT_SHOULD_NOT_BE_NULL, result);
+    assertTrue("Should contain paymentScheduleDetail", result.toString().contains("paymentScheduleDetail"));
+    assertTrue("Should contain salesOrderNo", result.toString().contains("salesOrderNo"));
+    assertTrue("Should contain invoiceNo", result.toString().contains("invoiceNo"));
+    assertTrue("Should contain paymentMethod", result.toString().contains("paymentMethod"));
+    assertTrue("Should contain expectedAmount", result.toString().contains("expectedAmount"));
+    assertTrue("Should contain outstandingAmount", result.toString().contains("outstandingAmount"));
+    assertTrue("Should contain max for invoice", result.toString().contains("max(COALESCE(inv.grandTotalAmount"));
+  }
+
+  /**
+   * Verifies that getSelectClause generates correct clause for Order transaction type.
+   */
+  @Test
+  public void testGetSelectClauseForOrderType() {
+    StringBuffer result = transformer.getSelectClause(TRANSACTION_TYPE_ORDER, false);
+
+    assertNotNull(RESULT_SHOULD_NOT_BE_NULL, result);
+    assertTrue("Should contain salesOrderNo", result.toString().contains("salesOrderNo"));
+    assertTrue("Should contain sum for order", result.toString().contains("sum(COALESCE(inv.grandTotalAmount"));
+    assertTrue("Should contain order fields", result.toString().contains(ORD_DOCUMENT_NO));
+  }
+
+  /**
+   * Verifies that getSelectClause handles mixed type (neither I nor O).
+   */
+  @Test
+  public void testGetSelectClauseForMixedType() {
+    StringBuffer result = transformer.getSelectClause(MIXED, false);
+
+    assertNotNull(RESULT_SHOULD_NOT_BE_NULL, result);
+    assertTrue("Should contain COALESCE for createdBy", result.toString().contains("COALESCE(invCreatedBy"));
+    assertTrue("Should contain COALESCE for updatedBy", result.toString().contains("COALESCE(invUpdatedBy"));
+  }
+
+  /**
+   * Verifies that getSelectClause includes selection flag when hasSelectedIds is false.
+   */
+  @Test
+  public void testGetSelectClauseWithoutSelectedIds() {
+    StringBuffer result = transformer.getSelectClause(TRANSACTION_TYPE_INVOICE, false);
+
+    assertTrue("Should check max(fp.id) for selection", result.toString().contains("max(fp.id) is not null"));
+  }
+
+  /**
+   * Verifies that getSelectClause includes different selection logic when hasSelectedIds is true.
+   */
+  @Test
+  public void testGetSelectClauseWithSelectedIds() {
+    StringBuffer result = transformer.getSelectClause(TRANSACTION_TYPE_INVOICE, true);
+
+    assertTrue("Should use client-side selection", result.toString().contains("1 < 0"));
+  }
+
+  /**
+   * Verifies that getJoinClauseOrder includes business partner filter when provided.
+   */
+  @Test
+  public void testGetJoinClauseOrderWithBusinessPartner() {
+    requestParameters.put(RECEIVED_FROM, "BP123");
+
+    StringBuffer result = transformer.getJoinClauseOrder(requestParameters);
+
+    assertTrue("Should include businessPartnerId filter",
+        result.toString().contains("ord.businessPartner.id = :businessPartnerId"));
+    assertTrue("Should include currency filter", result.toString().contains("ord.currency.id = :currencyId"));
+    assertTrue("Should include sales transaction filter",
+        result.toString().contains(TRANSACTION_IS_SALES_TRANSACTION));
+  }
+
+  /**
+   * Verifies that getJoinClauseOrder excludes business partner filter when null.
+   */
+  @Test
+  public void testGetJoinClauseOrderWithoutBusinessPartner() {
+    requestParameters.put(RECEIVED_FROM, null);
+
+    StringBuffer result = transformer.getJoinClauseOrder(requestParameters);
+
+    assertFalse("Should not include businessPartnerId filter",
+        result.toString().contains("businessPartner.id"));
+  }
+
+  /**
+   * Verifies that getJoinClauseOrder excludes business partner filter when value is "null" string.
+   */
+  @Test
+  public void testGetJoinClauseOrderWithNullString() {
+    requestParameters.put(RECEIVED_FROM, "null");
+
+    StringBuffer result = transformer.getJoinClauseOrder(requestParameters);
+
+    assertFalse("Should not include businessPartnerId filter for 'null' string",
+        result.toString().contains("businessPartner.id"));
+  }
+
+  /**
+   * Verifies that getJoinClauseInvoice includes business partner filter when provided.
+   */
+  @Test
+  public void testGetJoinClauseInvoiceWithBusinessPartner() {
+    requestParameters.put(RECEIVED_FROM, "BP456");
+
+    StringBuffer result = transformer.getJoinClauseInvoice(requestParameters);
+
+    assertTrue("Should include businessPartnerId filter",
+        result.toString().contains("inv.businessPartner.id = :businessPartnerId"));
+    assertTrue("Should include currency filter", result.toString().contains("inv.currency.id = :currencyId"));
+    assertTrue("Should include sales transaction filter",
+        result.toString().contains(SALES_TRANSACTION_IS_SALES_TRANSACTION));
+  }
+
+  /**
+   * Verifies that getWhereClause handles payment ID parameter correctly.
+   */
+  @Test
+  public void testGetWhereClauseWithPaymentId() {
+    requestParameters.put(FIN_PAYMENT_ID, "PAYMENT123");
+
+    StringBuffer result = transformer.getWhereClause(TRANSACTION_TYPE_INVOICE, requestParameters,
+        new ArrayList<String>());
+
+    assertTrue("Should include payment condition",
+        result.toString().contains("psd.paymentDetails is null or fp.id = :paymentId"));
+  }
+
+  /**
+   * Verifies that getWhereClause handles null payment ID correctly.
+   */
+  @Test
+  public void testGetWhereClauseWithoutPaymentId() {
+    requestParameters.put(FIN_PAYMENT_ID, null);
+
+    StringBuffer result = transformer.getWhereClause(TRANSACTION_TYPE_INVOICE, requestParameters,
+        new ArrayList<String>());
+
+    assertTrue("Should only check null payment details",
+        result.toString().contains("psd.paymentDetails is null"));
+    assertFalse("Should not include fp.id condition", result.toString().contains("fp.id = :paymentId"));
+  }
+
+  /**
+   * Verifies that getWhereClause includes organization filter when provided.
+   */
+  @Test
+  public void testGetWhereClauseWithOrganization() {
+    requestParameters.put(AD_ORG_ID, "ORG123");
+
+    StringBuffer result = transformer.getWhereClause(TRANSACTION_TYPE_INVOICE, requestParameters,
+        new ArrayList<String>());
+
+    assertTrue("Should include organization filter",
+        result.toString().contains("psd.organization.id in :orgIds"));
+  }
+
+  /**
+   * Verifies that getWhereClause includes selected PSDs when provided.
+   */
+  @Test
+  public void testGetWhereClauseWithSelectedPSDs() {
+    List<String> selectedPSDs = new ArrayList<>();
+    selectedPSDs.add("PSD1");
+    selectedPSDs.add("PSD2");
+    selectedPSDs.add("PSD3");
+
+    StringBuffer result = transformer.getWhereClause(TRANSACTION_TYPE_INVOICE, requestParameters,
+        selectedPSDs);
+
+    assertTrue("Should include psd.id in clause", result.toString().contains("psd.id in ("));
+    assertTrue("Should include PSD1", result.toString().contains("'PSD1'"));
+    assertTrue("Should include PSD2", result.toString().contains("'PSD2'"));
+    assertTrue("Should include PSD3", result.toString().contains("'PSD3'"));
+  }
+
+  /**
+   * Verifies that getWhereClause handles Invoice transaction type conditions.
+   */
+  @Test
+  public void testGetWhereClauseForInvoiceType() {
+    StringBuffer result = transformer.getWhereClause(TRANSACTION_TYPE_INVOICE, requestParameters,
+        new ArrayList<String>());
+
+    assertTrue("Should include invoice sales transaction",
+        result.toString().contains(SALES_TRANSACTION_IS_SALES_TRANSACTION));
+    assertTrue("Should include invoice currency", result.toString().contains("inv.currency.id = :currencyId"));
+  }
+
+  /**
+   * Verifies that getWhereClause handles Order transaction type conditions.
+   */
+  @Test
+  public void testGetWhereClauseForOrderType() {
+    StringBuffer result = transformer.getWhereClause(TRANSACTION_TYPE_ORDER, requestParameters,
+        new ArrayList<String>());
+
+    assertTrue("Should include order sales transaction",
+        result.toString().contains(TRANSACTION_IS_SALES_TRANSACTION));
+    assertTrue("Should include order currency", result.toString().contains("ord.currency.id = :currencyId"));
+  }
+
+  /**
+   * Verifies that getWhereClause handles mixed type with both invoice and order conditions.
+   */
+  @Test
+  public void testGetWhereClauseForMixedType() {
+    StringBuffer result = transformer.getWhereClause(MIXED, requestParameters,
+        new ArrayList<String>());
+
+    assertTrue("Should include invoice conditions",
+        result.toString().contains(SALES_TRANSACTION_IS_SALES_TRANSACTION));
+    assertTrue("Should include order conditions",
+        result.toString().contains(TRANSACTION_IS_SALES_TRANSACTION));
+    assertTrue("Should use OR between conditions", result.toString().contains("or ("));
+  }
+
+  /**
+   * Verifies that getGroupByClause generates correct grouping for Invoice type.
+   */
+  @Test
+  public void testGetGroupByClauseForInvoiceType() {
+    StringBuffer result = transformer.getGroupByClause(TRANSACTION_TYPE_INVOICE);
+
+    assertNotNull(RESULT_SHOULD_NOT_BE_NULL, result);
+    assertTrue("Should group by invoice id", result.toString().contains(INV_ID));
+    assertTrue("Should group by invoice documentNo", result.toString().contains("inv.documentNo"));
+    assertTrue("Should group by business partner", result.toString().contains("bp.id"));
+    assertTrue("Should group by payment method", result.toString().contains("finPaymentmethod.id"));
+  }
+
+  /**
+   * Verifies that getGroupByClause generates correct grouping for Order type.
+   */
+  @Test
+  public void testGetGroupByClauseForOrderType() {
+    StringBuffer result = transformer.getGroupByClause(TRANSACTION_TYPE_ORDER);
+
+    assertNotNull(RESULT_SHOULD_NOT_BE_NULL, result);
+    assertTrue("Should group by order id", result.toString().contains("ord.id"));
+    assertTrue("Should group by order documentNo", result.toString().contains(ORD_DOCUMENT_NO));
+    assertFalse("Should not group by invoice fields", result.toString().contains(INV_ID));
+  }
+
+  /**
+   * Verifies that getGroupByClause generates correct grouping for mixed type.
+   */
+  @Test
+  public void testGetGroupByClauseForMixedType() {
+    StringBuffer result = transformer.getGroupByClause(MIXED);
+
+    assertNotNull(RESULT_SHOULD_NOT_BE_NULL, result);
+    assertTrue("Should group by invoice id", result.toString().contains(INV_ID));
+    assertTrue("Should group by order id", result.toString().contains("ord.id"));
+    assertTrue("Should group by both document types", result.toString().contains("inv.documentNo"));
+    assertTrue("Should group by both document types", result.toString().contains(ORD_DOCUMENT_NO));
+  }
+
+  /**
+   * Verifies that removeGridFilters removes filters between AND and whereClause placeholder.
+   */
+  @Test
+  public void testRemoveGridFilters() {
+    String hqlQuery = "SELECT ... FROM ... where x = 1 AND psd.organization in (:org) AND filter1 = 'test' " +
+        "AND filter2 = 'test2' and @whereClause@";
+
+    String result = transformer.removeGridFilters(hqlQuery);
+
+    assertFalse("Should remove grid filters", result.contains("filter1 = 'test'"));
+    assertTrue("Should keep organization filter", result.contains("psd.organization in (:org)"));
+    assertTrue("Should keep whereClause placeholder", result.contains("@whereClause@"));
+  }
+
+  /**
+   * Verifies that removeGridFilters handles query without grid filters.
+   */
+  @Test
+  public void testRemoveGridFiltersWithoutFilters() {
+    String hqlQuery = "SELECT ... FROM ... where x = 1 AND psd.organization in (:org) and @whereClause@";
+
+    String result = transformer.removeGridFilters(hqlQuery);
+
+    assertEquals(hqlQuery, result, "Should return same query");
+  }
+
+  /**
+   * Verifies that transformCriteria extracts selected PSDs from id field.
+   *
+   * @throws JSONException if JSON parsing fails
+   */
+  @Test
+  public void testTransformCriteriaWithIdField() throws JSONException {
+    JSONObject criteria = new JSONObject();
+    JSONArray criteriaArray = new JSONArray();
+
+    JSONObject idCriteria = new JSONObject();
+    idCriteria.put(FIELD_NAME, "id");
+    idCriteria.put(VALUE, "PSD1,PSD2,PSD3");
+    criteriaArray.put(idCriteria);
+
+    criteria.put(CRITERIA, criteriaArray);
+
+    List<String> selectedPSDs = new ArrayList<>();
+    transformer.transformCriteria(criteria, selectedPSDs);
+
+    assertEquals(3, selectedPSDs.size(), "Should extract 3 PSDs");
+    assertTrue("Should contain PSD1", selectedPSDs.contains("PSD1"));
+    assertTrue("Should contain PSD2", selectedPSDs.contains("PSD2"));
+    assertTrue("Should contain PSD3", selectedPSDs.contains("PSD3"));
+  }
+
+  /**
+   * Verifies that transformCriteria handles whitespace in comma-separated values.
+   *
+   * @throws JSONException if JSON parsing fails
+   */
+  @Test
+  public void testTransformCriteriaTrimsWhitespace() throws JSONException {
+    JSONObject criteria = new JSONObject();
+    JSONArray criteriaArray = new JSONArray();
+
+    JSONObject idCriteria = new JSONObject();
+    idCriteria.put(FIELD_NAME, "id");
+    idCriteria.put(VALUE, "PSD1 , PSD2 , PSD3");
+    criteriaArray.put(idCriteria);
+
+    criteria.put(CRITERIA, criteriaArray);
+
+    List<String> selectedPSDs = new ArrayList<>();
+    transformer.transformCriteria(criteria, selectedPSDs);
+
+    assertTrue("Should trim whitespace from PSD1", selectedPSDs.contains("PSD1"));
+    assertFalse("Should not contain value with spaces", selectedPSDs.contains(" PSD2 "));
+  }
+
+  /**
+   * Verifies that transformCriteria preserves non-id criteria.
+   *
+   * @throws JSONException if JSON parsing fails
+   */
+  @Test
+  public void testTransformCriteriaPreservesOtherFields() throws JSONException {
+    JSONObject criteria = new JSONObject();
+    JSONArray criteriaArray = new JSONArray();
+
+    JSONObject otherCriteria = new JSONObject();
+    otherCriteria.put(FIELD_NAME, "amount");
+    otherCriteria.put(VALUE, "100");
+    criteriaArray.put(otherCriteria);
+
+    criteria.put(CRITERIA, criteriaArray);
+
+    List<String> selectedPSDs = new ArrayList<>();
+    transformer.transformCriteria(criteria, selectedPSDs);
+
+    assertTrue("Should not extract from non-id fields", selectedPSDs.isEmpty());
+    JSONArray resultArray = criteria.getJSONArray(CRITERIA);
+    assertEquals(1, resultArray.length(), "Should preserve original criteria");
+  }
+
+  /**
+   * Verifies that getAggregatorFunction wraps expression correctly.
+   */
+  @Test
+  public void testGetAggregatorFunction() {
+    String result = transformer.getAggregatorFunction("test.field");
+
+    assertEquals(" hqlagg(test.field)", result, "Should wrap in hqlagg function");
+  }
+
+  /**
+   * Verifies that getAggregatorFunction handles complex expressions.
+   */
+  @Test
+  public void testGetAggregatorFunctionWithComplexExpression() {
+    String result = transformer.getAggregatorFunction("CASE WHEN x > 0 THEN x ELSE 0 END");
+
+    assertEquals(" hqlagg(CASE WHEN x > 0 THEN x ELSE 0 END)", result, "Should wrap complex expression");
+  }
+
+  /**
+   * Verifies that transformCriteria handles empty criteria array.
+   *
+   * @throws JSONException if JSON parsing fails
+   */
+  @Test
+  public void testTransformCriteriaWithEmptyArray() throws JSONException {
+    JSONObject criteria = new JSONObject();
+    criteria.put(CRITERIA, new JSONArray());
+
+    List<String> selectedPSDs = new ArrayList<>();
+    transformer.transformCriteria(criteria, selectedPSDs);
+
+    assertTrue("Should return empty list", selectedPSDs.isEmpty());
+  }
+
+  /**
+   * Verifies that transformCriteria handles single PSD value (no comma).
+   *
+   * @throws JSONException if JSON parsing fails
+   */
+  @Test
+  public void testTransformCriteriaWithSingleValue() throws JSONException {
+    JSONObject criteria = new JSONObject();
+    JSONArray criteriaArray = new JSONArray();
+
+    JSONObject idCriteria = new JSONObject();
+    idCriteria.put(FIELD_NAME, "id");
+    idCriteria.put(VALUE, "PSD1");
+    criteriaArray.put(idCriteria);
+
+    criteria.put(CRITERIA, criteriaArray);
+
+    List<String> selectedPSDs = new ArrayList<>();
+    transformer.transformCriteria(criteria, selectedPSDs);
+
+    assertEquals(1, selectedPSDs.size(),"Should extract single PSD");
+    assertEquals("PSD1", selectedPSDs.get(0), "Should be PSD1");
+  }
+
+  /**
+   * Verifies that getWhereClause handles large number of PSDs with batching.
+   */
+  @Test
+  public void testGetWhereClauseWithManyPSDs() {
+    List<String> selectedPSDs = new ArrayList<>();
+    for (int i = 0; i < 3000; i++) {
+      selectedPSDs.add("PSD" + i);
+    }
+
+    StringBuffer result = transformer.getWhereClause(TRANSACTION_TYPE_INVOICE, requestParameters,
+        selectedPSDs);
+
+    String resultStr = result.toString();
+    assertTrue("Should contain multiple psd.id in clauses for batching",
+        resultStr.contains("psd.id in (") && resultStr.contains("or psd.id in ("));
+  }
+
+  /**
+   * Verifies that getWhereClause includes business partner filter when provided.
+   */
+  @Test
+  public void testGetWhereClauseWithBusinessPartner() {
+    requestParameters.put(RECEIVED_FROM, "BP789");
+
+    StringBuffer result = transformer.getWhereClause(TRANSACTION_TYPE_INVOICE, requestParameters,
+        new ArrayList<String>());
+
+    assertTrue("Should include business partner filter",
+        result.toString().contains("bp.id = :businessPartnerId"));
+  }
+}

--- a/src-test/src/org/openbravo/advpaymentmngt/suite/AdvPaymentMngtTestSuite.java
+++ b/src-test/src/org/openbravo/advpaymentmngt/suite/AdvPaymentMngtTestSuite.java
@@ -1,0 +1,27 @@
+package org.openbravo.advpaymentmngt.suite;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.openbravo.advpaymentmngt.hqlinjections.AccountingFactEndYearTransformerTest;
+import org.openbravo.advpaymentmngt.hqlinjections.AddPaymentGLItemInjectorTest;
+import org.openbravo.advpaymentmngt.hqlinjections.AddPaymentOrderInvoicesTransformerTest;
+
+/**
+ * Test suite for the Advanced Payment Management module.
+ * <p>
+ * This suite aggregates all test classes related to the Advanced Payment Management
+ * functionalities, ensuring comprehensive testing of the module's components.
+ * </p>
+ * <p>
+ * The suite includes tests for action handlers, application providers, and HQL injections.
+ * </p>
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+    // tests hqlinjections
+    AccountingFactEndYearTransformerTest.class,
+    AddPaymentGLItemInjectorTest.class,
+    AddPaymentOrderInvoicesTransformerTest.class,
+})
+public class AdvPaymentMngtTestSuite {
+}

--- a/src-test/src/org/openbravo/test/StandaloneTestSuite.java
+++ b/src-test/src/org/openbravo/test/StandaloneTestSuite.java
@@ -21,6 +21,7 @@ package org.openbravo.test;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
+import org.openbravo.advpaymentmngt.suite.AdvPaymentMngtTestSuite;
 import org.openbravo.advpaymentmngt.test.DocumentNumberGeneration;
 import org.openbravo.advpaymentmngt.test.ReversePaymentTest;
 import org.openbravo.authentication.hashing.PasswordHashing;
@@ -304,6 +305,8 @@ import org.openbravo.userinterface.selectors.test.ExpressionsTest;
     RecordID2Test.class, //
     PostDocumentTest.class, //
 
+    // AdvPayment
+    AdvPaymentMngtTestSuite.class, //
 
     // Inventory Status
     InventoryStatusTest.class, //


### PR DESCRIPTION
ETP-3159
---
This pull request adds a comprehensive unit test class for the `AddPaymentGLItemInjector` component, ensuring its correct behavior when generating HQL conditions and handling various payment ID inputs. The new tests cover a wide range of scenarios to verify robustness and correctness.

**Testing improvements:**

* Added a new test class `AddPaymentGLItemInjectorTest` with multiple unit tests to validate the behavior of `AddPaymentGLItemInjector`, including handling of valid, null, empty, missing, whitespace, and special character payment IDs, as well as preservation of existing parameters and consistency of the returned HQL string.