### PR TITLE
Feature ETP-3155: Fixed webservices test initialization

### DIFF
--- a/src-test/src/org/openbravo/test/security/CrossOrganizationReference.java
+++ b/src-test/src/org/openbravo/test/security/CrossOrganizationReference.java
@@ -30,10 +30,8 @@ import java.util.Map.Entry;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.openbravo.base.model.ModelProvider;
 import org.openbravo.base.model.Property;
 import org.openbravo.base.provider.OBProvider;
@@ -165,13 +163,13 @@ public class CrossOrganizationReference extends BaseDataSourceTestDal {
     }
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setRole() {
     ensureDalInitialized();
     setQAAdminContext();
   }
 
-  @AfterClass
+  @AfterAll
   public static void removeCreatedObjects() {
     OBContext.setOBContext("0");
     OBContext.setAdminMode(false);
@@ -197,8 +195,7 @@ public class CrossOrganizationReference extends BaseDataSourceTestDal {
    * @param allowCrossOrgColumns
    *          value to set
    */
-  static void setUpAllowedCrossOrg(List<String> colIds, boolean allowCrossOrgColumns)
-      throws Exception {
+  static void setUpAllowedCrossOrg(List<String> colIds, boolean allowCrossOrgColumns) {
     OBContext.setOBContext("0");
     for (String colId : colIds) {
       Column col = OBDal.getInstance().get(Column.class, colId);


### PR DESCRIPTION
This pull request updates the test class `CrossOrganizationReference.java` to use JUnit 5 annotations and conventions, replacing older JUnit 4 usages. The changes improve consistency and compatibility with modern testing practices.

**Migration to JUnit 5:**

* Replaced `@BeforeClass` and `@AfterClass` annotations with `@BeforeAll` and `@AfterAll` to conform to JUnit 5 standards. [[1]](diffhunk://#diff-5c00917e59e5901ef8a63f6116e1fceb40189ee4ce8c236b22e7036f3a15a9fdL33-R34) [[2]](diffhunk://#diff-5c00917e59e5901ef8a63f6116e1fceb40189ee4ce8c236b22e7036f3a15a9fdL168-R172)
* Updated import statements to use JUnit 5 classes, removing JUnit 4 imports.

**Code cleanup:**

* Removed unnecessary `throws Exception` declaration from the `setUpAllowedCrossOrg` method signature, as it is no longer required.