### PR TITLE
Feature ETP-3260: Fix AllJrxmlCompilation test

### DIFF
--- a/artifacts.list.COMPILATION.gradle
+++ b/artifacts.list.COMPILATION.gradle
@@ -12,6 +12,7 @@ List<String> _dependenciesListCOMPILATION = [
   'com.fasterxml.jackson.core:jackson-annotations:2.11.2',
   'com.fasterxml.jackson.core:jackson-core:2.11.2',
   'com.fasterxml.jackson.core:jackson-databind:2.11.2',
+  'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.18.2',
   'com.fasterxml:classmate:1.3.4',
   'org.codehaus.jettison:jettison:1.3',
 
@@ -34,7 +35,10 @@ List<String> _dependenciesListCOMPILATION = [
   // Reporting and Document Generation
   'com.lowagie:itext:2.1.7',
   'jfree:jfreechart:1.0.12',
+  'net.sf.jasperreports:jasperreports:7.0.3',
   'net.sf.jasperreports:jasperreports-servlets:7.0.3',
+  'net.sf.jasperreports:jasperreports-chart-themes:7.0.3',
+  'net.sf.jasperreports:jasperreports-jdt:7.0.0',
 
   // Database Drivers and Persistence Connectors
   'com.oracle.database.jdbc:ojdbc8:23.9.0.25.07',

--- a/src-test/src/org/openbravo/test/reporting/AllJrxmlCompilation.java
+++ b/src-test/src/org/openbravo/test/reporting/AllJrxmlCompilation.java
@@ -1,24 +1,15 @@
-/*
- *************************************************************************
- * The contents of this file are subject to the Openbravo  Public  License
- * Version  1.1  (the  "License"),  being   the  Mozilla   Public  License
- * Version 1.1  with a permitted attribution clause; you may not  use this
- * file except in compliance with the License. You  may  obtain  a copy of
- * the License at http://www.openbravo.com/legal/license.html 
- * Software distributed under the License  is  distributed  on  an "AS IS"
- * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
- * License for the specific  language  governing  rights  and  limitations
- * under the License. 
- * The Original Code is Openbravo ERP. 
- * The Initial Developer of the Original Code is Openbravo SLU 
- * All portions are Copyright (C) 2017-2018 Openbravo SLU 
- * All Rights Reserved. 
- * Contributor(s):  ______________________________________.
- ************************************************************************
- */
 package org.openbravo.test.reporting;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -32,20 +23,24 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.openbravo.base.session.OBPropertiesProvider;
 import org.openbravo.base.weld.test.WeldBaseTest;
-import org.openbravo.client.application.report.ReportingUtils;
+import org.openbravo.dal.core.DalContextListener;
 
+import jakarta.servlet.ServletContext;
 import net.sf.jasperreports.engine.JRException;
+import net.sf.jasperreports.engine.JasperCompileManager;
+import net.sf.jasperreports.engine.design.JasperDesign;
+import net.sf.jasperreports.engine.xml.JRXmlLoader;
 
 /**
  * Compiles all jrxml templates present in the sources directory ensuring they can be compiled with
- * the current combination of jdk + ejc.
- * 
- * @author alostale
+ * the current combination of jdk + jasperreports.
  *
+ * Adapted for JasperReports 7.x which uses Jackson XML parser.
  */
 public class AllJrxmlCompilation extends WeldBaseTest {
 
@@ -54,20 +49,70 @@ public class AllJrxmlCompilation extends WeldBaseTest {
     return true;
   }
 
-  @ParameterizedTest(name = "{0}")
-  @MethodSource("parameters")
-  public void jrxmlShouldCompile(Path report) throws JRException {
-    ReportingUtils.compileReport(report.toString());
+  @BeforeEach
+  public void setupServletContext() {
+    ServletContext ctx = createMockedServletContext();
+    DalContextListener.setServletContext(ctx);
+    Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
   }
 
-  private static Stream<Path> parameters() {
-    final List<Path> allJasperFiles = new ArrayList<>();
-    try {
-      allJasperFiles.addAll(getJrxmlTemplates("src"));
-      allJasperFiles.addAll(getJrxmlTemplates("modules"));
-    } catch (IOException ioex) {
+  private ServletContext createMockedServletContext() {
+    ServletContext ctx = mock(ServletContext.class);
 
+    String basePath = OBPropertiesProvider.getInstance()
+        .getOpenbravoProperties()
+        .getProperty("source.path");
+
+    when(ctx.getRealPath(anyString())).thenAnswer(invocation -> {
+      String path = invocation.getArgument(0);
+      if ("/".equals(path)) {
+        return basePath;
+      }
+      return Paths.get(basePath, path).toString();
+    });
+
+    when(ctx.getInitParameter(eq("BaseConfigPath"))).thenReturn("config");
+    when(ctx.getInitParameter(eq("BaseDesignPath"))).thenReturn("src");
+    when(ctx.getInitParameter(eq("DefaultDesignPath")))
+        .thenReturn("org/openbravo/erpCommon/reportCache");
+    when(ctx.getInitParameter(eq("AttachmentDirectory"))).thenReturn(basePath + "/attachments");
+
+    return ctx;
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void jrxmlShouldCompile(Path report) throws JRException, IOException {
+    if (DalContextListener.getServletContext() == null) {
+      setupServletContext();
     }
+
+    ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
+
+      File file = report.toFile();
+      if (!file.exists()) {
+        throw new JRException(report + " (No such jasper template file)");
+      }
+      String xmlContent = Files.readString(file.toPath(), StandardCharsets.UTF_8);
+
+      try (InputStream is = new ByteArrayInputStream(xmlContent.getBytes(StandardCharsets.UTF_8))) {
+        JasperDesign jasperDesign = JRXmlLoader.load(is);
+        JasperCompileManager.compileReport(jasperDesign);
+      }
+
+    } catch (JRException e) {
+      throw new JRException("Failed to compile: " + report.getFileName(), e);
+    } finally {
+      Thread.currentThread().setContextClassLoader(originalClassLoader);
+    }
+  }
+
+  private static Stream<Path> parameters() throws IOException {
+    final List<Path> allJasperFiles = new ArrayList<>();
+    allJasperFiles.addAll(getJrxmlTemplates("src"));
+    allJasperFiles.addAll(getJrxmlTemplates("modules"));
     return allJasperFiles.stream();
   }
 

--- a/src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailHTML.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailHTML.jrxml
@@ -1,37 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
-<!-- 2016-11-02T09:12:28 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="PaymentReportPDF" pageWidth="1100" pageHeight="595" orientation="Landscape" whenNoDataType="NoDataSection" columnWidth="1040" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="f73cd4f8-17ca-4505-866b-7b88e67c1d99">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="PaymentReportPDF" language="java" pageWidth="1100" pageHeight="595" orientation="Landscape" whenNoDataType="NoDataSection" columnWidth="1040" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="f73cd4f8-17ca-4505-866b-7b88e67c1d99">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.5"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
 	<parameter name="AMOUNTFORMAT" class="java.text.DecimalFormat"/>
 	<parameter name="DATEFORMATTER" class="java.text.DateFormat">
 		<defaultValueExpression><![CDATA[$P{REPORT_FORMAT_FACTORY}.createDateFormat("", $P{REPORT_LOCALE}, $P{REPORT_TIME_ZONE})]]></defaultValueExpression>
@@ -64,22 +61,20 @@
 	<parameter name="reversed" class="java.lang.String">
 		<defaultValueExpression><![CDATA["true"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="processId" class="java.lang.String" isForPrompting="false">
-		<parameterDescription><![CDATA[]]></parameterDescription>
+	<parameter name="processId" forPrompting="false" class="java.lang.String">
+		<description><![CDATA[]]></description>
 	</parameter>
-	<parameter name="reportId" class="java.lang.String" isForPrompting="false">
-		<parameterDescription><![CDATA[]]></parameterDescription>
+	<parameter name="reportId" forPrompting="false" class="java.lang.String">
+		<description><![CDATA[]]></description>
 	</parameter>
-	<parameter name="dateFromUI" class="java.lang.String" isForPrompting="false">
-		<parameterDescription><![CDATA[]]></parameterDescription>
+	<parameter name="dateFromUI" forPrompting="false" class="java.lang.String">
+		<description><![CDATA[]]></description>
 	</parameter>
 	<parameter name="warning" class="java.lang.String"/>
-	<queryString>
-		<![CDATA[SELECT 'hello' AS BP_GROUP, 'hello' AS BPARTNER, 'hello' AS PROJECT, 'hello' AS PAYMENT, 'hello' AS SALES_PERSON, 1234 AS INVOICE_NUMBER, to_Date('01/01/2010') AS INVOICE_DATE,
+	<query language="sql"><![CDATA[SELECT 'hello' AS BP_GROUP, 'hello' AS BPARTNER, 'hello' AS PROJECT, 'hello' AS PAYMENT, 'hello' AS SALES_PERSON, 1234 AS INVOICE_NUMBER, to_Date('01/01/2010') AS INVOICE_DATE,
        to_Date('01/03/2010') AS DUE_DATE, 1234 AS PLANNED_DSO, 1234 AS CURRENT_DSO, 1234 AS OVERDUE, 1234 AS DAYS_OVERDUE, 1234 AS AMOUNT,
        'hello' AS CURRENCY, 1234 AS BASE_AMOUNT, 'hello' AS BASE_CURRENCY, 'hello' AS PAYMENT_METHOD, 'hello' AS FINANCIAL_ACCOUNT
-FROM DUAL]]>
-	</queryString>
+FROM DUAL]]></query>
 	<field name="INVOICE_NUMBER" class="java.lang.String"/>
 	<field name="INVOICE_ID" class="java.lang.String"/>
 	<field name="AMOUNT0" class="java.math.BigDecimal"/>
@@ -97,356 +92,220 @@ FROM DUAL]]>
 	<field name="SHOW_NETDUE" class="java.math.BigDecimal"/>
 	<field name="DOUBTFUL_DEBT" class="java.math.BigDecimal"/>
 	<field name="PERCENTAGE" class="java.math.BigDecimal"/>
-	<variable name="SUMAMT0" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT0}]]></variableExpression>
+	<variable name="SUMAMT0" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT0}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMNET" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{NETDUE} != null ? $F{NETDUE} : new BigDecimal("0")]]></variableExpression>
+	<variable name="SUMNET" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{NETDUE} != null ? $F{NETDUE} : new BigDecimal("0")]]></expression>
 	</variable>
-	<variable name="SUMAMT1" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT1}]]></variableExpression>
+	<variable name="SUMAMT1" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT1}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT2" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT2}]]></variableExpression>
+	<variable name="SUMAMT2" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT2}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT3" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT3}]]></variableExpression>
+	<variable name="SUMAMT3" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT3}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT4" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT4}]]></variableExpression>
+	<variable name="SUMAMT4" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT4}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT5" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT5}]]></variableExpression>
+	<variable name="SUMAMT5" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT5}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT0TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT0}]]></variableExpression>
+	<variable name="SUMAMT0TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT0}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMNETTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{NETDUE}]]></variableExpression>
+	<variable name="SUMNETTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{NETDUE}]]></expression>
 	</variable>
-	<variable name="SUMAMT1TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT1}]]></variableExpression>
+	<variable name="SUMAMT1TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT1}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT2TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT2}]]></variableExpression>
+	<variable name="SUMAMT2TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT2}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT3TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT3}]]></variableExpression>
+	<variable name="SUMAMT3TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT3}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT4TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT4}]]></variableExpression>
+	<variable name="SUMAMT4TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT4}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT5TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT5}]]></variableExpression>
+	<variable name="SUMAMT5TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT5}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMCREDIT" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT6}]]></variableExpression>
+	<variable name="SUMCREDIT" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT6}]]></expression>
 		<initialValueExpression><![CDATA[]]></initialValueExpression>
 	</variable>
-	<variable name="SUMCREDITSTOTAL" class="java.math.BigDecimal" incrementType="Group" incrementGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$V{SUMCREDIT}]]></variableExpression>
+	<variable name="SUMCREDITSTOTAL" incrementType="Group" calculation="Sum" incrementGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{SUMCREDIT}]]></expression>
 	</variable>
-	<variable name="SUMDOUBTFULDEBT" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{DOUBTFUL_DEBT} != null ? $F{DOUBTFUL_DEBT} : new BigDecimal("0")]]></variableExpression>
+	<variable name="SUMDOUBTFULDEBT" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{DOUBTFUL_DEBT} != null ? $F{DOUBTFUL_DEBT} : new BigDecimal("0")]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMPERCENTAGE" class="java.math.BigDecimal" resetType="Group" resetGroup="Group">
-		<variableExpression><![CDATA[$V{SUMDOUBTFULDEBT}.divide($V{SUMNET}.doubleValue() == 0 ? new BigDecimal("1"):$V{SUMNET}, 5, RoundingMode.HALF_UP ).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="SUMPERCENTAGE" resetType="Group" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{SUMDOUBTFULDEBT}.divide($V{SUMNET}.doubleValue() == 0 ? new BigDecimal("1"):$V{SUMNET}, 5, RoundingMode.HALF_UP ).multiply(new BigDecimal("100"))]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMDOUBTFULTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{DOUBTFUL_DEBT}]]></variableExpression>
+	<variable name="SUMDOUBTFULTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{DOUBTFUL_DEBT}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
 	<variable name="PERCENTAGETOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{SUMDOUBTFULTOTAL}.divide( $V{SUMNETTOTAL}.doubleValue() == 0 ? new BigDecimal("1"):$V{SUMNETTOTAL}, 5, RoundingMode.HALF_UP ).multiply(new BigDecimal("100"))]]></variableExpression>
+		<expression><![CDATA[$V{SUMDOUBTFULTOTAL}.divide( $V{SUMNETTOTAL}.doubleValue() == 0 ? new BigDecimal("1"):$V{SUMNETTOTAL}, 5, RoundingMode.HALF_UP ).multiply(new BigDecimal("100"))]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
 	<group name="Group" keepTogether="true">
-		<groupExpression><![CDATA[$F{BPARTNER}]]></groupExpression>
+		<expression><![CDATA[$F{BPARTNER}]]></expression>
 		<groupHeader>
 			<band height="23">
-				<textField>
-					<reportElement x="1" y="2" width="1025" height="19" uuid="a141b137-fe53-4603-bb3c-b0258b6afdd5">
-						<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-					</reportElement>
-					<textElement>
-						<font size="12"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{BPARTNERNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="0" y="22" width="1027" height="1" uuid="80d2bc60-64d0-4a89-a13c-2aeb03f54a7e">
-						<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-					</reportElement>
-				</line>
-				<textField>
-					<reportElement x="1" y="2" width="857" height="19" uuid="779d1bfc-1d4e-4a35-92bd-396d1455dbba">
-						<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
-					</reportElement>
-					<textElement>
-						<font size="12"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{BPARTNERNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="0" y="22" width="858" height="1" uuid="6fbe995f-df4e-440e-ae6f-2157527c7123">
-						<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
-					</reportElement>
-				</line>
+				<element kind="textField" uuid="a141b137-fe53-4603-bb3c-b0258b6afdd5" x="1" y="2" width="1025" height="19" fontSize="12.0">
+					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+					<expression><![CDATA[$F{BPARTNERNAME}]]></expression>
+				</element>
+				<element kind="line" uuid="80d2bc60-64d0-4a89-a13c-2aeb03f54a7e" key="line-33" x="0" y="22" width="1027" height="1" style="Report_Footer">
+					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+				</element>
+				<element kind="textField" uuid="779d1bfc-1d4e-4a35-92bd-396d1455dbba" x="1" y="2" width="857" height="19" fontSize="12.0">
+					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
+					<expression><![CDATA[$F{BPARTNERNAME}]]></expression>
+				</element>
+				<element kind="line" uuid="6fbe995f-df4e-440e-ae6f-2157527c7123" key="line-33" x="0" y="22" width="858" height="1" style="Report_Footer">
+					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="29">
-				<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-					<reportElement key="textField-22" style="Report_Footer" stretchType="RelativeToTallestObject" x="928" y="4" width="91" height="18" uuid="8b6862d7-e3c1-4431-bc4a-12369ab64a99">
-						<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2"/>
-					<textElement textAlignment="Right">
-						<font size="10" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$P{AMOUNTFORMAT}.format(($V{SUMNET}==null ? BigDecimal.ZERO : $V{SUMNET}).subtract($V{SUMCREDIT}==null ? BigDecimal.ZERO : $V{SUMCREDIT}))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="563" y="25" width="71" height="1" uuid="c6795428-9a80-4dc9-a28d-3fa141eab4b7"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="263" y="23" width="71" height="1" uuid="23ffad35-170e-409d-914e-76085e4cd32a"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="413" y="2" width="71" height="1" uuid="58a5fc07-67e1-4d22-a87b-f324f04becbb"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="263" y="2" width="71" height="1" uuid="4104f97b-6e97-40f4-bf43-fb99e14f5a6b"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="479" y="5" width="74" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="89ee4528-0b2e-472f-aebf-2d5f7057b840"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{SUMAMT3} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT3}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="413" y="23" width="71" height="1" uuid="33264572-fdfe-48fd-827d-e5b07a10169a"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="637" y="25" width="72" height="1" uuid="851fc223-70e3-49c7-b542-3d99094e798d"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="338" y="2" width="71" height="1" uuid="8162b580-e114-4026-914c-60b00a8854a1"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="553" y="5" width="76" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="95c4b5f0-b70d-4849-8c8a-bdcfa40384d9"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{SUMAMT4} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT4}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="563" y="2" width="71" height="1" uuid="faec19f8-40f0-45a1-8176-c8aadfa23518"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="563" y="23" width="71" height="1" uuid="0bc446cb-634c-4181-977f-59e352ab07d6"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="413" y="25" width="71" height="1" uuid="124a2bec-9d74-4e73-b635-00257c5e86fe"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="254" y="5" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="845b1491-7a8e-49fb-934e-10b0e28d1f31"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{SUMAMT0} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT0}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="938" y="23" width="89" height="1" uuid="6cef69a7-54de-4944-922d-e99b480814b7">
-						<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-					</reportElement>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="488" y="23" width="71" height="1" uuid="f52c1a97-98a1-4472-82a3-2b83a74b95c1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="938" y="2" width="89" height="1" uuid="eecdfb57-d80c-4e2a-ae3b-6a9352dbe120">
-						<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-					</reportElement>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="338" y="25" width="71" height="1" uuid="a0014dad-1ba5-448b-8b96-5646dcd85340"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="637" y="2" width="72" height="1" uuid="96d24014-f2d4-45b9-ac57-1312e0db22c4"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="488" y="25" width="71" height="1" uuid="552b5cbf-5be8-48dc-9df4-a63fcc7aeab2"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="263" y="25" width="71" height="1" uuid="587c0ad1-75e9-4ac3-b6e1-39e2520a2987"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="403" y="5" width="76" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="14bc892a-1426-4695-9e31-889d587fe31b"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{SUMAMT2} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT2}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="329" y="5" width="74" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="86f6cbde-bf5d-44f2-9421-47822158b019"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{SUMAMT1} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT1}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="488" y="2" width="71" height="1" uuid="71a9a036-0419-49a8-89dd-8418d32108cd"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="629" y="5" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="40b741fa-24e2-4590-a820-397c2f0ebe99"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{SUMAMT5} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT5}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="338" y="23" width="71" height="1" uuid="5075ec55-571b-48f8-b3ca-c0305bf8d9a8"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="637" y="23" width="72" height="1" uuid="ba27f724-41e2-4798-840c-69d380e639b9"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="712" y="2" width="72" height="1" uuid="903fc661-3b54-459b-a679-50ec6fb843fb"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="712" y="25" width="72" height="1" uuid="73521388-262f-4568-8894-076ffb3a2d9e"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="712" y="23" width="72" height="1" uuid="af9b3a1e-aae3-44c5-a968-442fbe34d69c"/>
-				</line>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" stretchType="RelativeToTallestObject" x="704" y="5" width="74" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="4e42bba2-3a96-4c0e-b53b-51325116f3b9"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{SUMCREDIT} != null ? "(" + $P{AMOUNTFORMAT}.format($V{SUMCREDIT}) + ")" : "(" + $P{AMOUNTFORMAT}.format(new BigDecimal("0")) + ")"]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="938" y="25" width="89" height="1" uuid="3795eb66-0986-460c-9276-0dddc618f645">
-						<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-					</reportElement>
-				</line>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" stretchType="RelativeToTallestObject" x="778" y="5" width="74" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="4344de4e-2051-41f5-bd81-20008632277a"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" ) ?
+				<element kind="textField" uuid="8b6862d7-e3c1-4431-bc4a-12369ab64a99" key="textField-22" stretchType="ElementGroupHeight" x="928" y="4" width="91" height="18" fontSize="10.0" textAdjust="StretchHeight" blankWhenNull="false" bold="false" hTextAlign="Right" style="Report_Footer">
+					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+					<expression><![CDATA[$P{AMOUNTFORMAT}.format(($V{SUMNET}==null ? BigDecimal.ZERO : $V{SUMNET}).subtract($V{SUMCREDIT}==null ? BigDecimal.ZERO : $V{SUMCREDIT}))]]></expression>
+					<box rightPadding="2" style="Report_Footer"/>
+				</element>
+				<element kind="line" uuid="c6795428-9a80-4dc9-a28d-3fa141eab4b7" key="line-33" x="563" y="25" width="71" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="23ffad35-170e-409d-914e-76085e4cd32a" key="line-33" x="263" y="23" width="71" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="58a5fc07-67e1-4d22-a87b-f324f04becbb" key="line-33" x="413" y="2" width="71" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="4104f97b-6e97-40f4-bf43-fb99e14f5a6b" key="line-33" x="263" y="2" width="71" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="89ee4528-0b2e-472f-aebf-2d5f7057b840" key="textField-6" x="479" y="5" width="74" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT3} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT3}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="33264572-fdfe-48fd-827d-e5b07a10169a" key="line-33" x="413" y="23" width="71" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="851fc223-70e3-49c7-b542-3d99094e798d" key="line-33" x="637" y="25" width="72" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="8162b580-e114-4026-914c-60b00a8854a1" key="line-33" x="338" y="2" width="71" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="95c4b5f0-b70d-4849-8c8a-bdcfa40384d9" key="textField-6" x="553" y="5" width="76" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT4} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT4}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="faec19f8-40f0-45a1-8176-c8aadfa23518" key="line-33" x="563" y="2" width="71" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="0bc446cb-634c-4181-977f-59e352ab07d6" key="line-33" x="563" y="23" width="71" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="124a2bec-9d74-4e73-b635-00257c5e86fe" key="line-33" x="413" y="25" width="71" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="845b1491-7a8e-49fb-934e-10b0e28d1f31" key="textField-6" x="254" y="5" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT0} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT0}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="6cef69a7-54de-4944-922d-e99b480814b7" key="line-33" x="938" y="23" width="89" height="1" style="Report_Footer">
+					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+				</element>
+				<element kind="line" uuid="f52c1a97-98a1-4472-82a3-2b83a74b95c1" key="line-33" x="488" y="23" width="71" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="eecdfb57-d80c-4e2a-ae3b-6a9352dbe120" key="line-33" x="938" y="2" width="89" height="1" style="Report_Footer">
+					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+				</element>
+				<element kind="line" uuid="a0014dad-1ba5-448b-8b96-5646dcd85340" key="line-33" x="338" y="25" width="71" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="96d24014-f2d4-45b9-ac57-1312e0db22c4" key="line-33" x="637" y="2" width="72" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="552b5cbf-5be8-48dc-9df4-a63fcc7aeab2" key="line-33" x="488" y="25" width="71" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="587c0ad1-75e9-4ac3-b6e1-39e2520a2987" key="line-33" x="263" y="25" width="71" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="14bc892a-1426-4695-9e31-889d587fe31b" key="textField-6" x="403" y="5" width="76" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT2} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT2}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="textField" uuid="86f6cbde-bf5d-44f2-9421-47822158b019" key="textField-6" x="329" y="5" width="74" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT1} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT1}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="71a9a036-0419-49a8-89dd-8418d32108cd" key="line-33" x="488" y="2" width="71" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="40b741fa-24e2-4590-a820-397c2f0ebe99" key="textField-6" x="629" y="5" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT5} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT5}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="5075ec55-571b-48f8-b3ca-c0305bf8d9a8" key="line-33" x="338" y="23" width="71" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="ba27f724-41e2-4798-840c-69d380e639b9" key="line-33" x="637" y="23" width="72" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="903fc661-3b54-459b-a679-50ec6fb843fb" key="line-33" x="712" y="2" width="72" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="73521388-262f-4568-8894-076ffb3a2d9e" key="line-33" x="712" y="25" width="72" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="af9b3a1e-aae3-44c5-a968-442fbe34d69c" key="line-33" x="712" y="23" width="72" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="4e42bba2-3a96-4c0e-b53b-51325116f3b9" key="textField-6" stretchType="ElementGroupHeight" x="704" y="5" width="74" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMCREDIT} != null ? "(" + $P{AMOUNTFORMAT}.format($V{SUMCREDIT}) + ")" : "(" + $P{AMOUNTFORMAT}.format(new BigDecimal("0")) + ")"]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="3795eb66-0986-460c-9276-0dddc618f645" key="line-33" x="938" y="25" width="89" height="1" style="Report_Footer">
+					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+				</element>
+				<element kind="textField" uuid="4344de4e-2051-41f5-bd81-20008632277a" key="textField-6" stretchType="ElementGroupHeight" x="778" y="5" width="74" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$P{showDoubtfulDebt}.equals( "true" ) ?
 $V{SUMDOUBTFULDEBT} != null ? $P{AMOUNTFORMAT}.format($V{SUMDOUBTFULDEBT}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))
-: $P{AMOUNTFORMAT}.format(($V{SUMNET}==null ? BigDecimal.ZERO : $V{SUMNET}).subtract($V{SUMCREDIT}==null ? BigDecimal.ZERO : $V{SUMCREDIT}))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="786" y="2" width="72" height="1" uuid="a65f316f-da76-461b-8eb7-0bf5ce84d5fa"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="786" y="23" width="72" height="1" uuid="fc668f89-a72b-4f37-8d98-f4c4c98eb2ca"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="786" y="25" width="72" height="1" uuid="eda1fe60-90c5-4beb-865c-484030bc29fd"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="861" y="23" width="72" height="1" uuid="d87b8280-912f-44f2-aced-ab9f66c28425">
-						<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-					</reportElement>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="861" y="25" width="72" height="1" uuid="60ed16da-8a6b-4d85-8a91-877a003fdad2">
-						<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-					</reportElement>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="861" y="2" width="72" height="1" uuid="fe7aad94-4aac-4b83-bfc5-3ba93e8a5d6c">
-						<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-					</reportElement>
-				</line>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" stretchType="RelativeToTallestObject" x="853" y="5" width="74" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="8f1ae3e8-d959-4877-8a43-91b8d37337e7">
-						<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{SUMPERCENTAGE} != null ? $P{AMOUNTFORMAT}.format($V{SUMPERCENTAGE}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))) + " %"]]></textFieldExpression>
-				</textField>
+: $P{AMOUNTFORMAT}.format(($V{SUMNET}==null ? BigDecimal.ZERO : $V{SUMNET}).subtract($V{SUMCREDIT}==null ? BigDecimal.ZERO : $V{SUMCREDIT}))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="a65f316f-da76-461b-8eb7-0bf5ce84d5fa" key="line-33" x="786" y="2" width="72" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="fc668f89-a72b-4f37-8d98-f4c4c98eb2ca" key="line-33" x="786" y="23" width="72" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="eda1fe60-90c5-4beb-865c-484030bc29fd" key="line-33" x="786" y="25" width="72" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="d87b8280-912f-44f2-aced-ab9f66c28425" key="line-33" x="861" y="23" width="72" height="1" style="Report_Footer">
+					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+				</element>
+				<element kind="line" uuid="60ed16da-8a6b-4d85-8a91-877a003fdad2" key="line-33" x="861" y="25" width="72" height="1" style="Report_Footer">
+					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+				</element>
+				<element kind="line" uuid="fe7aad94-4aac-4b83-bfc5-3ba93e8a5d6c" key="line-33" x="861" y="2" width="72" height="1" style="Report_Footer">
+					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+				</element>
+				<element kind="textField" uuid="8f1ae3e8-d959-4877-8a43-91b8d37337e7" key="textField-6" stretchType="ElementGroupHeight" x="853" y="5" width="74" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+					<expression><![CDATA[($V{SUMPERCENTAGE} != null ? $P{AMOUNTFORMAT}.format($V{SUMPERCENTAGE}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))) + " %"]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="85" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-24" style="Report_Footer" x="1" y="61" width="118" height="18" uuid="e07db061-6cf3-488c-93ec-23705d2fe00a"/>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Organization:]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-26" style="Report_Footer" x="299" y="61" width="118" height="19" uuid="c987e0e8-33ce-4dad-9eae-8df8c9b042ed"/>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[As Of Date:]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-27" style="Report_Footer" x="532" y="61" width="160" height="20" uuid="448f68e3-9309-474e-8576-7da6d885835a"/>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[General Ledger:]]></text>
-			</staticText>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="125" y="61" width="168" height="18" uuid="987f8147-4975-4d22-a7dc-ddf0ea9378ca"/>
-				<textFieldExpression><![CDATA[$P{Organization}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="423" y="61" width="100" height="19" uuid="6c7b8ca6-7df8-4126-b41b-001d663d261a"/>
-				<textFieldExpression><![CDATA[$P{currentDate}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="698" y="61" width="179" height="20" uuid="971b8815-79be-464c-adf2-0f785d0dbb12"/>
-				<textFieldExpression><![CDATA[$P{AccSchema}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="11" y="11" width="500" height="28" uuid="f7b46b64-ef9b-4f8f-8626-62df17b66264"/>
-				<textElement>
-					<font size="18"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{title}]]></textFieldExpression>
-			</textField>
-			<textField hyperlinkType="Reference">
-				<reportElement key="staticText-25" style="Report_Footer" mode="Transparent" x="795" y="21" width="38" height="18" forecolor="#0000FF" uuid="f9707200-2ffb-44c6-b627-05ebd5e9d881"/>
-				<textElement textAlignment="Center" markup="none">
-					<font isUnderline="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA["PDF"]]></textFieldExpression>
-				<hyperlinkReferenceExpression><![CDATA["javascript:top.OB.RemoteCallManager.call(\'org.openbravo.common.actionhandler.AgingBalanceReportActionHandler\',"
+	<background splitType="Stretch"/>
+	<title height="85" splitType="Stretch">
+		<element kind="staticText" uuid="e07db061-6cf3-488c-93ec-23705d2fe00a" key="staticText-24" x="1" y="61" width="118" height="18" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Organization:]]></text>
+		</element>
+		<element kind="staticText" uuid="c987e0e8-33ce-4dad-9eae-8df8c9b042ed" key="staticText-26" x="299" y="61" width="118" height="19" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[As Of Date:]]></text>
+		</element>
+		<element kind="staticText" uuid="448f68e3-9309-474e-8576-7da6d885835a" key="staticText-27" x="532" y="61" width="160" height="20" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[General Ledger:]]></text>
+		</element>
+		<element kind="textField" uuid="987f8147-4975-4d22-a7dc-ddf0ea9378ca" key="textField-25" x="125" y="61" width="168" height="18" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{Organization}]]></expression>
+		</element>
+		<element kind="textField" uuid="6c7b8ca6-7df8-4126-b41b-001d663d261a" key="textField-25" x="423" y="61" width="100" height="19" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{currentDate}]]></expression>
+		</element>
+		<element kind="textField" uuid="971b8815-79be-464c-adf2-0f785d0dbb12" key="textField-25" x="698" y="61" width="179" height="20" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{AccSchema}]]></expression>
+		</element>
+		<element kind="textField" uuid="f7b46b64-ef9b-4f8f-8626-62df17b66264" x="11" y="11" width="500" height="28" fontSize="18.0">
+			<expression><![CDATA[$P{title}]]></expression>
+		</element>
+		<element kind="textField" uuid="f9707200-2ffb-44c6-b627-05ebd5e9d881" key="staticText-25" mode="Transparent" x="795" y="21" width="38" height="18" forecolor="#0000FF" markup="none" linkType="Reference" underline="true" hTextAlign="Center" style="Report_Footer">
+			<expression><![CDATA["PDF"]]></expression>
+			<hyperlinkReferenceExpression><![CDATA["javascript:top.OB.RemoteCallManager.call(\'org.openbravo.common.actionhandler.AgingBalanceReportActionHandler\',"
     +"{"
     +"  _buttonValue:\'PDF\',"
     +"  _params:{"
@@ -475,14 +334,10 @@ $V{SUMDOUBTFULDEBT} != null ? $P{AMOUNTFORMAT}.format($V{SUMDOUBTFULDEBT}) : $P{
 		+"  top.OB.Utilities.Action.executeJSON(data.responseActions, null, null, null);"
 		+"}"
 		+");"]]></hyperlinkReferenceExpression>
-			</textField>
-			<textField hyperlinkType="Reference">
-				<reportElement key="staticText-25" style="Report_Footer" x="837" y="21" width="39" height="18" forecolor="#0000FF" uuid="9e08f837-0b79-4074-9cd9-7fc880fa5421"/>
-				<textElement textAlignment="Center" markup="none">
-					<font isUnderline="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA["XLS"]]></textFieldExpression>
-				<hyperlinkReferenceExpression><![CDATA["javascript:top.OB.RemoteCallManager.call(\'org.openbravo.common.actionhandler.AgingBalanceReportActionHandler\',"
+		</element>
+		<element kind="textField" uuid="9e08f837-0b79-4074-9cd9-7fc880fa5421" key="staticText-25" x="837" y="21" width="39" height="18" forecolor="#0000FF" markup="none" linkType="Reference" underline="true" hTextAlign="Center" style="Report_Footer">
+			<expression><![CDATA["XLS"]]></expression>
+			<hyperlinkReferenceExpression><![CDATA["javascript:top.OB.RemoteCallManager.call(\'org.openbravo.common.actionhandler.AgingBalanceReportActionHandler\',"
     +"{"
     +"  _buttonValue:\'XLS\',"
     +"  _params:{"
@@ -511,603 +366,323 @@ $V{SUMDOUBTFULDEBT} != null ? $P{AMOUNTFORMAT}.format($V{SUMDOUBTFULDEBT}) : $P{
 		+"  top.OB.Utilities.Action.executeJSON(data.responseActions, null, null, null);"
 		+"}"
 		+");"]]></hyperlinkReferenceExpression>
-			</textField>
-			<line>
-				<reportElement key="line-25" style="Report_Footer" stretchType="RelativeToBandHeight" x="833" y="21" width="1" height="18" uuid="54e47736-e70d-4eb7-b585-44bd053cd37e"/>
-			</line>
-			<line>
-				<reportElement key="line-25" style="Report_Footer" stretchType="RelativeToBandHeight" x="794" y="21" width="1" height="18" uuid="0916a5c9-2cc6-49d9-86cd-8c1aff4bab48"/>
-			</line>
-			<line>
-				<reportElement key="line-32" style="Report_Footer" x="794" y="20" width="40" height="1" uuid="585800cd-91d5-4e62-a8c0-0b02c64aaf50"/>
-			</line>
-			<line>
-				<reportElement key="line-32" style="Report_Footer" x="794" y="39" width="40" height="1" uuid="433a30eb-b414-437e-a0ae-6cfd2975cf1a"/>
-			</line>
-			<line>
-				<reportElement key="line-32" style="Report_Footer" x="837" y="20" width="40" height="1" uuid="dc3c028a-c7d9-48d4-9f64-eb6b2cacdc61"/>
-			</line>
-			<line>
-				<reportElement key="line-32" style="Report_Footer" x="836" y="39" width="41" height="1" uuid="cc5ace6c-0512-4fd8-a531-7db817eebf3a"/>
-			</line>
-			<line>
-				<reportElement key="line-25" style="Report_Footer" stretchType="RelativeToBandHeight" x="876" y="21" width="1" height="18" uuid="ba23e8b7-5ffe-4cd9-ae86-e8a660e8ec1b"/>
-			</line>
-			<line>
-				<reportElement key="line-25" style="Report_Footer" stretchType="RelativeToBandHeight" x="836" y="20" width="1" height="19" uuid="3a78123c-2536-4afc-b47b-eee43885fb27"/>
-			</line>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement mode="Opaque" x="0" y="-9" width="940" height="20" isRemoveLineWhenBlank="true" isPrintInFirstWholeBand="true" forecolor="#0A0505" backcolor="#FFE79F" uuid="3496bea0-a67f-48b9-add2-25b9966bb2f5">
-					<property name="local_mesure_unitheight" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.height" value="px"/>
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					<property name="local_mesure_unitx" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.x" value="px"/>
-					<property name="local_mesure_unity" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.y" value="px"/>
-				</reportElement>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="10"/>
-					<paragraph lineSpacing="Single" lineSpacingSize="1.0"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{warning}]]></textFieldExpression>
-			</textField>
-		</band>
+		</element>
+		<element kind="line" uuid="54e47736-e70d-4eb7-b585-44bd053cd37e" key="line-25" stretchType="ContainerHeight" x="833" y="21" width="1" height="18" style="Report_Footer"/>
+		<element kind="line" uuid="0916a5c9-2cc6-49d9-86cd-8c1aff4bab48" key="line-25" stretchType="ContainerHeight" x="794" y="21" width="1" height="18" style="Report_Footer"/>
+		<element kind="line" uuid="585800cd-91d5-4e62-a8c0-0b02c64aaf50" key="line-32" x="794" y="20" width="40" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="433a30eb-b414-437e-a0ae-6cfd2975cf1a" key="line-32" x="794" y="39" width="40" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="dc3c028a-c7d9-48d4-9f64-eb6b2cacdc61" key="line-32" x="837" y="20" width="40" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="cc5ace6c-0512-4fd8-a531-7db817eebf3a" key="line-32" x="836" y="39" width="41" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="ba23e8b7-5ffe-4cd9-ae86-e8a660e8ec1b" key="line-25" stretchType="ContainerHeight" x="876" y="21" width="1" height="18" style="Report_Footer"/>
+		<element kind="line" uuid="3a78123c-2536-4afc-b47b-eee43885fb27" key="line-25" stretchType="ContainerHeight" x="836" y="20" width="1" height="19" style="Report_Footer"/>
+		<element kind="textField" uuid="3496bea0-a67f-48b9-add2-25b9966bb2f5" mode="Opaque" x="0" y="-9" width="940" height="20" forecolor="#0A0505" backcolor="#FFE79F" fontName="Bitstream Vera Sans" fontSize="10.0" textAdjust="StretchHeight" blankWhenNull="true" removeLineWhenBlank="true" printInFirstWholeBand="true" vTextAlign="Middle">
+			<paragraph lineSpacing="Single" lineSpacingSize="1.0"/>
+			<expression><![CDATA[$P{warning}]]></expression>
+			<property name="local_mesure_unitheight" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<property name="local_mesure_unitwidth" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.width" value="px"/>
+			<property name="local_mesure_unitx" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.x" value="px"/>
+			<property name="local_mesure_unity" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.y" value="px"/>
+		</element>
 	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band height="50">
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="628" y="30" width="75" height="20" uuid="68793993-ea27-4637-9be2-a186ff5cc7e9"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{inpLabel5}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="553" y="30" width="75" height="20" uuid="4101b094-8b2c-4578-bee2-9a055433aa37"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{inpLabel4}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="1018" y="30" width="9" height="20" uuid="bd41a64b-fb33-4bd3-b770-5eb815855f1a">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="928" y="30" width="90" height="20" uuid="866bda08-c8c6-4b42-ad42-c1f7136e08ad">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Net Due]]></text>
-			</staticText>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="478" y="30" width="75" height="20" uuid="2d248cf7-0ef1-4e7c-a495-0c91bebc899c"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{inpLabel3}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="253" y="30" width="75" height="20" uuid="6402f3b7-093a-4d6e-ba7f-1a1ed2f9fcc7"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Current]]></text>
-			</staticText>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="328" y="30" width="75" height="20" uuid="0e6b2c6b-325c-41c7-ba78-365c8b88c57d"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{inpLabel1}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="403" y="30" width="75" height="20" uuid="69476ab5-fddb-4bfb-bc68-6427c4cb400a"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{inpLabel2}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="98" y="30" width="80" height="20" uuid="036efc45-826f-4401-aba3-c333b75abca0"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement>
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Document No.]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="0" y="30" width="98" height="20" uuid="c2950b3c-e050-48ec-9ae6-34c4442d4b5f"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement>
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Business Partner]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="703" y="30" width="75" height="20" uuid="62b7ea28-0581-4e95-96d6-fa164cafdb81"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Credits]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="178" y="30" width="75" height="20" uuid="16aeb7b9-2c0d-4195-9f7b-2ef67aea6b2c"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Document Date]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="778" y="30" width="75" height="20" uuid="fb344430-1f3d-489e-84fe-7e66d18acbaa">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Doubtful Debt]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="853" y="30" width="75" height="20" uuid="b9b4acab-c68c-4326-9350-e0b98a795747">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Percentage]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="778" y="30" width="75" height="20" uuid="ab0b2740-2794-4939-99b3-eedb594d6095">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Net Due]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="853" y="30" width="4" height="20" uuid="11b591b4-49b1-4895-bed9-be6f8a8b5f91">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[]]></text>
-			</staticText>
-		</band>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader height="50">
+		<element kind="textField" uuid="68793993-ea27-4637-9be2-a186ff5cc7e9" key="staticText-25" x="628" y="30" width="75" height="20" markup="none" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel5}]]></expression>
+		</element>
+		<element kind="textField" uuid="4101b094-8b2c-4578-bee2-9a055433aa37" key="staticText-25" x="553" y="30" width="75" height="20" markup="none" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel4}]]></expression>
+		</element>
+		<element kind="staticText" uuid="bd41a64b-fb33-4bd3-b770-5eb815855f1a" key="staticText-25" x="1018" y="30" width="9" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+			<text><![CDATA[]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="866bda08-c8c6-4b42-ad42-c1f7136e08ad" key="staticText-25" x="928" y="30" width="90" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+			<text><![CDATA[Net Due]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="2d248cf7-0ef1-4e7c-a495-0c91bebc899c" key="staticText-25" x="478" y="30" width="75" height="20" markup="none" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel3}]]></expression>
+		</element>
+		<element kind="staticText" uuid="6402f3b7-093a-4d6e-ba7f-1a1ed2f9fcc7" key="staticText-25" x="253" y="30" width="75" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Current]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="0e6b2c6b-325c-41c7-ba78-365c8b88c57d" key="staticText-25" x="328" y="30" width="75" height="20" markup="none" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel1}]]></expression>
+		</element>
+		<element kind="textField" uuid="69476ab5-fddb-4bfb-bc68-6427c4cb400a" key="staticText-25" x="403" y="30" width="75" height="20" markup="none" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel2}]]></expression>
+		</element>
+		<element kind="staticText" uuid="036efc45-826f-4401-aba3-c333b75abca0" key="staticText-25" x="98" y="30" width="80" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" style="Detail_Header">
+			<text><![CDATA[Document No.]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="c2950b3c-e050-48ec-9ae6-34c4442d4b5f" key="staticText-25" x="0" y="30" width="98" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" style="Detail_Header">
+			<text><![CDATA[Business Partner]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="62b7ea28-0581-4e95-96d6-fa164cafdb81" key="staticText-25" x="703" y="30" width="75" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Credits]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="16aeb7b9-2c0d-4195-9f7b-2ef67aea6b2c" key="staticText-25" x="178" y="30" width="75" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Document Date]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="fb344430-1f3d-489e-84fe-7e66d18acbaa" key="staticText-25" x="778" y="30" width="75" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+			<text><![CDATA[Doubtful Debt]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="b9b4acab-c68c-4326-9350-e0b98a795747" key="staticText-25" x="853" y="30" width="75" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+			<text><![CDATA[Percentage]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="ab0b2740-2794-4939-99b3-eedb594d6095" key="staticText-25" x="778" y="30" width="75" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
+			<text><![CDATA[Net Due]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="11b591b4-49b1-4895-bed9-be6f8a8b5f91" key="staticText-25" x="853" y="30" width="4" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
+			<text><![CDATA[]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
 	</columnHeader>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField-15" style="Detail_Line" stretchType="RelativeToTallestObject" x="928" y="0" width="90" height="16" uuid="c0f6c49d-6a52-4134-9de2-e0be8ed75a31">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box rightPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{SHOW_NETDUE} == null ? null : ($F{NETDUE} == null
-    ? "(" + $P{AMOUNTFORMAT}.format($F{SHOW_NETDUE}) + ")" : $P{AMOUNTFORMAT}.format($F{SHOW_NETDUE}))]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="107" y="0" width="71" height="16" forecolor="#0000FF" uuid="8b202051-0d80-45d8-afc6-e246e2ec944c"/>
-				<box leftPadding="2"/>
-				<textElement verticalAlignment="Middle">
-					<font size="8" isUnderline="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{INVOICE_NUMBER}]]></textFieldExpression>
+			<element kind="textField" uuid="c0f6c49d-6a52-4134-9de2-e0be8ed75a31" key="textField-15" stretchType="ElementGroupHeight" x="928" y="0" width="90" height="16" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+				<expression><![CDATA[$F{SHOW_NETDUE} == null ? null : ($F{NETDUE} == null
+    ? "(" + $P{AMOUNTFORMAT}.format($F{SHOW_NETDUE}) + ")" : $P{AMOUNTFORMAT}.format($F{SHOW_NETDUE}))]]></expression>
+				<box rightPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="8b202051-0d80-45d8-afc6-e246e2ec944c" key="textField-6" x="107" y="0" width="71" height="16" forecolor="#0000FF" fontSize="8.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{INVOICE_NUMBER}]]></expression>
 				<hyperlinkReferenceExpression><![CDATA["javascript:top.OB.Utilities.openDirectTab('" + $F{TABID} + "', '" + $F{INVOICE_ID} + "');"]]></hyperlinkReferenceExpression>
 				<hyperlinkTooltipExpression><![CDATA["Invoice"]]></hyperlinkTooltipExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="253" y="0" width="75" height="16" forecolor="#000000" uuid="712a7b96-59d1-4cd8-9313-929271023042"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AMOUNT0} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT0}) : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-15" style="Detail_Line" x="99" y="0" width="8" height="16" uuid="70fc92ac-98bb-4cb4-b181-a7eab6a4ddf2"/>
-				<box rightPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-15" style="Detail_Line" x="1018" y="0" width="8" height="16" uuid="0a38002a-f20a-467a-b991-5ccecb648f07">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box rightPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="328" y="0" width="75" height="16" forecolor="#000000" uuid="698a71f1-b47b-44d5-a77f-9133af8f5ff3"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AMOUNT1} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT1}) : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="403" y="0" width="75" height="16" forecolor="#000000" uuid="3a8c65c6-a6e2-4be2-8f79-6eab4ae0856e"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AMOUNT2} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT2}) : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="478" y="0" width="75" height="16" forecolor="#000000" uuid="af6718bb-35fd-4ba8-8234-466ad4be1b30"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AMOUNT3} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT3}) : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="553" y="0" width="75" height="16" forecolor="#000000" uuid="ff0fe2e4-636a-49f0-85d9-1f63597bbe24"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AMOUNT4} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT4}) : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="628" y="0" width="75" height="16" forecolor="#000000" uuid="939462a4-27fd-4dad-83e0-c80aa37bd34a"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AMOUNT5} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT5}) : null]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" stretchType="RelativeToTallestObject" x="703" y="0" width="75" height="16" forecolor="#000000" uuid="d564af5b-cd53-413a-ab02-45c8d205b89b"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AMOUNT6} != null ? "(" + $P{AMOUNTFORMAT}.format($F{AMOUNT6}) + ")" : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="178" y="0" width="75" height="16" forecolor="#000000" uuid="ddcd9e4d-de40-4f1b-b379-fcf8df350237"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{DATEFORMATTER}.format($F{INVOICE_DATE})]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" stretchType="RelativeToTallestObject" x="778" y="0" width="75" height="16" forecolor="#000000" uuid="dc0bca82-f2f1-4268-b25f-74fa3da91e8e"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" ) ?
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="712a7b96-59d1-4cd8-9313-929271023042" key="textField-6" x="253" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{AMOUNT0} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT0}) : null]]></expression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="70fc92ac-98bb-4cb4-b181-a7eab6a4ddf2" key="textField-15" x="99" y="0" width="8" height="16" fontSize="8.0" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<box rightPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="0a38002a-f20a-467a-b991-5ccecb648f07" key="textField-15" x="1018" y="0" width="8" height="16" fontSize="8.0" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+				<box rightPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="698a71f1-b47b-44d5-a77f-9133af8f5ff3" key="textField-6" x="328" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{AMOUNT1} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT1}) : null]]></expression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="3a8c65c6-a6e2-4be2-8f79-6eab4ae0856e" key="textField-6" x="403" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{AMOUNT2} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT2}) : null]]></expression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="af6718bb-35fd-4ba8-8234-466ad4be1b30" key="textField-6" x="478" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{AMOUNT3} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT3}) : null]]></expression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="ff0fe2e4-636a-49f0-85d9-1f63597bbe24" key="textField-6" x="553" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{AMOUNT4} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT4}) : null]]></expression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="939462a4-27fd-4dad-83e0-c80aa37bd34a" key="textField-6" x="628" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{AMOUNT5} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT5}) : null]]></expression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="d564af5b-cd53-413a-ab02-45c8d205b89b" key="textField-6" stretchType="ElementGroupHeight" x="703" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{AMOUNT6} != null ? "(" + $P{AMOUNTFORMAT}.format($F{AMOUNT6}) + ")" : null]]></expression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="ddcd9e4d-de40-4f1b-b379-fcf8df350237" key="textField-6" x="178" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$P{DATEFORMATTER}.format($F{INVOICE_DATE})]]></expression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="dc0bca82-f2f1-4268-b25f-74fa3da91e8e" key="textField-6" stretchType="ElementGroupHeight" x="778" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$P{showDoubtfulDebt}.equals( "true" ) ?
 $F{DOUBTFUL_DEBT} != null ? $P{AMOUNTFORMAT}.format($F{DOUBTFUL_DEBT}): null
 : $F{SHOW_NETDUE} == null ? null : ($F{NETDUE} == null
-    ? "(" + $P{AMOUNTFORMAT}.format($F{SHOW_NETDUE}) + ")" : $P{AMOUNTFORMAT}.format($F{SHOW_NETDUE}))]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" stretchType="RelativeToTallestObject" x="853" y="0" width="75" height="16" forecolor="#000000" uuid="3440ccf8-b86b-4808-bc21-2adbf98bf9d4">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PERCENTAGE} != null ?  $P{AMOUNTFORMAT}.format($F{PERCENTAGE}) + " %" : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-15" style="Detail_Line" x="853" y="0" width="5" height="16" uuid="746099f1-a6c5-48b0-86a5-277dafef7c43">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
-				</reportElement>
-				<box rightPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-			</textField>
+    ? "(" + $P{AMOUNTFORMAT}.format($F{SHOW_NETDUE}) + ")" : $P{AMOUNTFORMAT}.format($F{SHOW_NETDUE}))]]></expression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="3440ccf8-b86b-4808-bc21-2adbf98bf9d4" key="textField-6" stretchType="ElementGroupHeight" x="853" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+				<expression><![CDATA[$F{PERCENTAGE} != null ?  $P{AMOUNTFORMAT}.format($F{PERCENTAGE}) + " %" : null]]></expression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="746099f1-a6c5-48b0-86a5-277dafef7c43" key="textField-15" x="853" y="0" width="5" height="16" fontSize="8.0" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
+				<box rightPadding="2" style="Detail_Line"/>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="73">
-			<textField>
-				<reportElement x="0" y="6" width="1026" height="28" uuid="2ea70e3e-7d5c-49e3-9424-70bbb78b54b7">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<textElement>
-					<font size="18"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Total"]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="563" y="68" width="71" height="1" uuid="f9d50bd2-036c-4029-b9f4-1a3bb90cf34b"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="263" y="66" width="71" height="1" uuid="a3843ac6-c86a-4c1c-aa9b-badc3bd05481"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="263" y="45" width="71" height="1" uuid="5545d979-4e26-41b5-9a54-b1ef5a966a87"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="413" y="45" width="71" height="1" uuid="903b5b50-c877-489d-8755-19f634e64945"/>
-			</line>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" x="479" y="48" width="74" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="b2ca8452-666d-4bbc-acd3-d0043d05b0d7"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUMAMT3TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT3TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="413" y="66" width="71" height="1" uuid="73f057a7-94ee-4b81-8d73-16af7f000eb6"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="637" y="68" width="72" height="1" uuid="6f616f05-acb8-4cb2-994a-7512b85aa4be"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="338" y="45" width="71" height="1" uuid="6c359ed2-bc04-49d3-9c1d-ae24789d21c5"/>
-			</line>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" x="553" y="48" width="76" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="d3c642c9-ca07-45d9-b223-9fb1d41fe0dc"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUMAMT4TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT4TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="563" y="45" width="71" height="1" uuid="df53e330-28fb-47a5-89b5-2ba29b3cd5ac"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="563" y="66" width="71" height="1" uuid="455c9395-bc64-40dc-bd93-04ad700b12b5"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="413" y="68" width="71" height="1" uuid="d36dd934-4ec2-4796-87e8-7cda868147c8"/>
-			</line>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" x="254" y="48" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="30c05d91-0f96-4230-a5a6-f04b94e90006"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUMAMT0TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT0TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="938" y="66" width="89" height="1" uuid="bd61c1ca-f018-4eb9-9b86-8af5cb423abf">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="488" y="66" width="71" height="1" uuid="d20ad3d5-42ed-4dbc-8a8a-939db2390462"/>
-			</line>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-22" style="Report_Footer" stretchType="RelativeToTallestObject" x="934" y="47" width="85" height="18" uuid="3249c44f-07d1-46c8-9038-8e648b730c34">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box rightPadding="2"/>
-				<textElement textAlignment="Right">
-					<font size="10" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{AMOUNTFORMAT}.format(($V{SUMNETTOTAL}==null ? BigDecimal.ZERO : $V{SUMNETTOTAL}).subtract($V{SUMCREDITSTOTAL}==null ? BigDecimal.ZERO : $V{SUMCREDITSTOTAL}))]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="338" y="68" width="71" height="1" uuid="28b6bf08-49dc-4273-9030-d2bc70de1cc3"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="938" y="45" width="89" height="1" uuid="d9fa448c-7994-4edb-af0c-e926eeee16bd">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="637" y="45" width="72" height="1" uuid="119509f2-b199-444b-abb2-d3b62302a1b5"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="488" y="68" width="71" height="1" uuid="836939c1-d9a2-4530-b922-861da014dab7"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="263" y="68" width="71" height="1" uuid="c84b0a5a-961a-4d54-b5e6-6677d6d70851"/>
-			</line>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" x="403" y="48" width="76" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="41f1bbcd-a7b2-477e-87c8-d31979b0d701"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUMAMT2TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT2TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" x="329" y="48" width="74" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="0a20434b-b9f3-40b2-af80-d41496692bf5"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUMAMT1TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT1TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="488" y="45" width="71" height="1" uuid="fc73677d-e3fd-4d09-bd82-6cdb5ac65f1a"/>
-			</line>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" x="629" y="48" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="335ad78a-dbbd-40e2-9aca-f0ae294fd2f6"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUMAMT5TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT5TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="338" y="66" width="71" height="1" uuid="e4e6d992-f352-4ae2-bdfb-847b8e777a9f"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="637" y="66" width="72" height="1" uuid="9593f8e3-033c-43c7-9531-8cd4c5496a61"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="0" y="35" width="1027" height="1" uuid="44409892-d390-4c86-9d1f-cee4a28f7f9b">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="712" y="68" width="72" height="1" uuid="d6b63212-8303-4c09-bbab-53a50306a6e7"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="712" y="66" width="72" height="1" uuid="26131af8-a68f-4fd9-b590-f9f161d0dd7a"/>
-			</line>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" stretchType="RelativeToTallestObject" x="704" y="48" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="7ceab422-9114-492b-89a2-9fde370911d4"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUMCREDITSTOTAL} != null ? "(" + $P{AMOUNTFORMAT}.format($V{SUMCREDITSTOTAL}) + ")" : "(" + $P{AMOUNTFORMAT}.format(new BigDecimal("0")) + ")"]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="712" y="45" width="72" height="1" uuid="8fdb15a6-da15-4f3d-a309-39bb7f4aa5e5"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="938" y="68" width="89" height="1" uuid="c20f91e5-bd70-47bc-9346-471d3723b30d">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="787" y="68" width="72" height="1" uuid="0295dcb2-3488-4858-814e-977062c8efb1"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="787" y="66" width="72" height="1" uuid="e200751e-fa45-4a80-beff-db6fd3f7ac00"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="787" y="45" width="72" height="1" uuid="21e6af9d-6024-468d-a1da-d36e5683818a"/>
-			</line>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" stretchType="RelativeToTallestObject" x="779" y="48" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="c48e9e07-2028-40ff-a940-b15d107802c5"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" ) ?
+	<columnFooter height="73">
+		<element kind="textField" uuid="2ea70e3e-7d5c-49e3-9424-70bbb78b54b7" x="0" y="6" width="1026" height="28" fontSize="18.0">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+			<expression><![CDATA["Total"]]></expression>
+		</element>
+		<element kind="line" uuid="f9d50bd2-036c-4029-b9f4-1a3bb90cf34b" key="line-33" x="563" y="68" width="71" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="a3843ac6-c86a-4c1c-aa9b-badc3bd05481" key="line-33" x="263" y="66" width="71" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="5545d979-4e26-41b5-9a54-b1ef5a966a87" key="line-33" x="263" y="45" width="71" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="903b5b50-c877-489d-8755-19f634e64945" key="line-33" x="413" y="45" width="71" height="1" style="Report_Footer"/>
+		<element kind="textField" uuid="b2ca8452-666d-4bbc-acd3-d0043d05b0d7" key="textField-6" x="479" y="48" width="74" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMAMT3TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT3TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="line" uuid="73f057a7-94ee-4b81-8d73-16af7f000eb6" key="line-33" x="413" y="66" width="71" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="6f616f05-acb8-4cb2-994a-7512b85aa4be" key="line-33" x="637" y="68" width="72" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="6c359ed2-bc04-49d3-9c1d-ae24789d21c5" key="line-33" x="338" y="45" width="71" height="1" style="Report_Footer"/>
+		<element kind="textField" uuid="d3c642c9-ca07-45d9-b223-9fb1d41fe0dc" key="textField-6" x="553" y="48" width="76" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMAMT4TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT4TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="line" uuid="df53e330-28fb-47a5-89b5-2ba29b3cd5ac" key="line-33" x="563" y="45" width="71" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="455c9395-bc64-40dc-bd93-04ad700b12b5" key="line-33" x="563" y="66" width="71" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="d36dd934-4ec2-4796-87e8-7cda868147c8" key="line-33" x="413" y="68" width="71" height="1" style="Report_Footer"/>
+		<element kind="textField" uuid="30c05d91-0f96-4230-a5a6-f04b94e90006" key="textField-6" x="254" y="48" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMAMT0TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT0TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="line" uuid="bd61c1ca-f018-4eb9-9b86-8af5cb423abf" key="line-33" x="938" y="66" width="89" height="1" style="Report_Footer">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+		</element>
+		<element kind="line" uuid="d20ad3d5-42ed-4dbc-8a8a-939db2390462" key="line-33" x="488" y="66" width="71" height="1" style="Report_Footer"/>
+		<element kind="textField" uuid="3249c44f-07d1-46c8-9038-8e648b730c34" key="textField-22" stretchType="ElementGroupHeight" x="934" y="47" width="85" height="18" fontSize="10.0" textAdjust="StretchHeight" blankWhenNull="false" bold="false" hTextAlign="Right" style="Report_Footer">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+			<expression><![CDATA[$P{AMOUNTFORMAT}.format(($V{SUMNETTOTAL}==null ? BigDecimal.ZERO : $V{SUMNETTOTAL}).subtract($V{SUMCREDITSTOTAL}==null ? BigDecimal.ZERO : $V{SUMCREDITSTOTAL}))]]></expression>
+			<box rightPadding="2" style="Report_Footer"/>
+		</element>
+		<element kind="line" uuid="28b6bf08-49dc-4273-9030-d2bc70de1cc3" key="line-33" x="338" y="68" width="71" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="d9fa448c-7994-4edb-af0c-e926eeee16bd" key="line-33" x="938" y="45" width="89" height="1" style="Report_Footer">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+		</element>
+		<element kind="line" uuid="119509f2-b199-444b-abb2-d3b62302a1b5" key="line-33" x="637" y="45" width="72" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="836939c1-d9a2-4530-b922-861da014dab7" key="line-33" x="488" y="68" width="71" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="c84b0a5a-961a-4d54-b5e6-6677d6d70851" key="line-33" x="263" y="68" width="71" height="1" style="Report_Footer"/>
+		<element kind="textField" uuid="41f1bbcd-a7b2-477e-87c8-d31979b0d701" key="textField-6" x="403" y="48" width="76" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMAMT2TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT2TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="textField" uuid="0a20434b-b9f3-40b2-af80-d41496692bf5" key="textField-6" x="329" y="48" width="74" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMAMT1TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT1TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="line" uuid="fc73677d-e3fd-4d09-bd82-6cdb5ac65f1a" key="line-33" x="488" y="45" width="71" height="1" style="Report_Footer"/>
+		<element kind="textField" uuid="335ad78a-dbbd-40e2-9aca-f0ae294fd2f6" key="textField-6" x="629" y="48" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMAMT5TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT5TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="line" uuid="e4e6d992-f352-4ae2-bdfb-847b8e777a9f" key="line-33" x="338" y="66" width="71" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="9593f8e3-033c-43c7-9531-8cd4c5496a61" key="line-33" x="637" y="66" width="72" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="44409892-d390-4c86-9d1f-cee4a28f7f9b" key="line-33" x="0" y="35" width="1027" height="1" style="Report_Footer">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+		</element>
+		<element kind="line" uuid="d6b63212-8303-4c09-bbab-53a50306a6e7" key="line-33" x="712" y="68" width="72" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="26131af8-a68f-4fd9-b590-f9f161d0dd7a" key="line-33" x="712" y="66" width="72" height="1" style="Report_Footer"/>
+		<element kind="textField" uuid="7ceab422-9114-492b-89a2-9fde370911d4" key="textField-6" stretchType="ElementGroupHeight" x="704" y="48" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMCREDITSTOTAL} != null ? "(" + $P{AMOUNTFORMAT}.format($V{SUMCREDITSTOTAL}) + ")" : "(" + $P{AMOUNTFORMAT}.format(new BigDecimal("0")) + ")"]]></expression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="line" uuid="8fdb15a6-da15-4f3d-a309-39bb7f4aa5e5" key="line-33" x="712" y="45" width="72" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="c20f91e5-bd70-47bc-9346-471d3723b30d" key="line-33" x="938" y="68" width="89" height="1" style="Report_Footer">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+		</element>
+		<element kind="line" uuid="0295dcb2-3488-4858-814e-977062c8efb1" key="line-33" x="787" y="68" width="72" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="e200751e-fa45-4a80-beff-db6fd3f7ac00" key="line-33" x="787" y="66" width="72" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="21e6af9d-6024-468d-a1da-d36e5683818a" key="line-33" x="787" y="45" width="72" height="1" style="Report_Footer"/>
+		<element kind="textField" uuid="c48e9e07-2028-40ff-a940-b15d107802c5" key="textField-6" stretchType="ElementGroupHeight" x="779" y="48" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{showDoubtfulDebt}.equals( "true" ) ?
 $V{SUMDOUBTFULTOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMDOUBTFULTOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))
-: $P{AMOUNTFORMAT}.format(($V{SUMNETTOTAL}==null ? BigDecimal.ZERO : $V{SUMNETTOTAL}).subtract($V{SUMCREDITSTOTAL}==null ? BigDecimal.ZERO : $V{SUMCREDITSTOTAL}))]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="862" y="68" width="72" height="1" uuid="b5da38f6-8a1e-4c1c-91f0-79ced645b325">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="862" y="66" width="72" height="1" uuid="34a39d2f-4655-496b-9f3b-aaff8329490e">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="862" y="45" width="72" height="1" uuid="075cd612-d726-4ddd-b8ac-3fb64772fc4f">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-			</line>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" stretchType="RelativeToTallestObject" x="854" y="48" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="95112442-c842-400d-9860-974919db4399">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{PERCENTAGETOTAL} != null ? $P{AMOUNTFORMAT}.format($V{PERCENTAGETOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))) + " %"]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="0" y="6" width="858" height="28" uuid="b7f281e3-289d-46dd-95ff-cf1ccc3efef2">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
-				</reportElement>
-				<textElement>
-					<font size="18"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Total"]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="0" y="35" width="858" height="1" uuid="97bdad2d-fac3-4633-9bd9-65073f56d511">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
-				</reportElement>
-			</line>
-		</band>
+: $P{AMOUNTFORMAT}.format(($V{SUMNETTOTAL}==null ? BigDecimal.ZERO : $V{SUMNETTOTAL}).subtract($V{SUMCREDITSTOTAL}==null ? BigDecimal.ZERO : $V{SUMCREDITSTOTAL}))]]></expression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="line" uuid="b5da38f6-8a1e-4c1c-91f0-79ced645b325" key="line-33" x="862" y="68" width="72" height="1" style="Report_Footer">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+		</element>
+		<element kind="line" uuid="34a39d2f-4655-496b-9f3b-aaff8329490e" key="line-33" x="862" y="66" width="72" height="1" style="Report_Footer">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+		</element>
+		<element kind="line" uuid="075cd612-d726-4ddd-b8ac-3fb64772fc4f" key="line-33" x="862" y="45" width="72" height="1" style="Report_Footer">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+		</element>
+		<element kind="textField" uuid="95112442-c842-400d-9860-974919db4399" key="textField-6" stretchType="ElementGroupHeight" x="854" y="48" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+			<expression><![CDATA[($V{PERCENTAGETOTAL} != null ? $P{AMOUNTFORMAT}.format($V{PERCENTAGETOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))) + " %"]]></expression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="textField" uuid="b7f281e3-289d-46dd-95ff-cf1ccc3efef2" x="0" y="6" width="858" height="28" fontSize="18.0">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
+			<expression><![CDATA["Total"]]></expression>
+		</element>
+		<element kind="line" uuid="97bdad2d-fac3-4633-9bd9-65073f56d511" key="line-33" x="0" y="35" width="858" height="1" style="Report_Footer">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
+		</element>
 	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
+	<pageFooter splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailPDF.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailPDF.jrxml
@@ -1,35 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="PaymentReportPDF" pageWidth="670" pageHeight="842" columnWidth="610" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="PaymentReportPDF" language="java" pageWidth="670" pageHeight="842" columnWidth="610" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="702c1b52-c51e-47b9-9b6a-3f1858f0e416">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
 	<parameter name="AMOUNTFORMAT" class="java.text.DecimalFormat"/>
 	<parameter name="DATEFORMATTER" class="java.text.DateFormat">
 		<defaultValueExpression><![CDATA[$P{REPORT_FORMAT_FACTORY}.createDateFormat("", $P{REPORT_LOCALE}, $P{REPORT_TIME_ZONE})]]></defaultValueExpression>
@@ -55,12 +54,10 @@
 	<parameter name="inpLabel3" class="java.lang.String"/>
 	<parameter name="inpLabel4" class="java.lang.String"/>
 	<parameter name="inpLabel5" class="java.lang.String"/>
-	<queryString>
-		<![CDATA[SELECT 'hello' AS BP_GROUP, 'hello' AS BPARTNER, 'hello' AS PROJECT, 'hello' AS PAYMENT, 'hello' AS SALES_PERSON, 1234 AS INVOICE_NUMBER, to_Date('01/01/2010') AS INVOICE_DATE,
+	<query language="sql"><![CDATA[SELECT 'hello' AS BP_GROUP, 'hello' AS BPARTNER, 'hello' AS PROJECT, 'hello' AS PAYMENT, 'hello' AS SALES_PERSON, 1234 AS INVOICE_NUMBER, to_Date('01/01/2010') AS INVOICE_DATE,
        to_Date('01/03/2010') AS DUE_DATE, 1234 AS PLANNED_DSO, 1234 AS CURRENT_DSO, 1234 AS OVERDUE, 1234 AS DAYS_OVERDUE, 1234 AS AMOUNT,
        'hello' AS CURRENCY, 1234 AS BASE_AMOUNT, 'hello' AS BASE_CURRENCY, 'hello' AS PAYMENT_METHOD, 'hello' AS FINANCIAL_ACCOUNT
-FROM DUAL]]>
-	</queryString>
+FROM DUAL]]></query>
 	<field name="INVOICE_NUMBER" class="java.lang.String"/>
 	<field name="INVOICE_ID" class="java.lang.String"/>
 	<field name="AMOUNT0" class="java.math.BigDecimal"/>
@@ -76,711 +73,393 @@ FROM DUAL]]>
 	<field name="TABID" class="java.lang.String"/>
 	<field name="INVOICE_DATE" class="java.util.Date"/>
 	<field name="SHOW_NETDUE" class="java.math.BigDecimal"/>
-	<variable name="SUMAMT0" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT0}]]></variableExpression>
+	<variable name="SUMAMT0" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT0}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMNET" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{NETDUE}]]></variableExpression>
+	<variable name="SUMNET" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{NETDUE}]]></expression>
 	</variable>
-	<variable name="SUMAMT1" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT1}]]></variableExpression>
+	<variable name="SUMAMT1" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT1}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT2" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT2}]]></variableExpression>
+	<variable name="SUMAMT2" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT2}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT3" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT3}]]></variableExpression>
+	<variable name="SUMAMT3" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT3}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT4" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT4}]]></variableExpression>
+	<variable name="SUMAMT4" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT4}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT5" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT5}]]></variableExpression>
+	<variable name="SUMAMT5" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT5}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT0TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT0}]]></variableExpression>
+	<variable name="SUMAMT0TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT0}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMNETTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{NETDUE}]]></variableExpression>
+	<variable name="SUMNETTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{NETDUE}]]></expression>
 	</variable>
-	<variable name="SUMAMT1TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT1}]]></variableExpression>
+	<variable name="SUMAMT1TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT1}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT2TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT2}]]></variableExpression>
+	<variable name="SUMAMT2TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT2}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT3TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT3}]]></variableExpression>
+	<variable name="SUMAMT3TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT3}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT4TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT4}]]></variableExpression>
+	<variable name="SUMAMT4TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT4}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT5TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT5}]]></variableExpression>
+	<variable name="SUMAMT5TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT5}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMCREDIT" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT6}]]></variableExpression>
+	<variable name="SUMCREDIT" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT6}]]></expression>
 		<initialValueExpression><![CDATA[]]></initialValueExpression>
 	</variable>
-	<variable name="SUMCREDITSTOTAL" class="java.math.BigDecimal" incrementType="Group" incrementGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$V{SUMCREDIT}]]></variableExpression>
+	<variable name="SUMCREDITSTOTAL" incrementType="Group" calculation="Sum" incrementGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{SUMCREDIT}]]></expression>
 	</variable>
 	<group name="Totals">
 		<groupFooter>
 			<band height="63">
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="364" y="58" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="178" y="39" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="426" y="58" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="178" y="58" width="58" height="1"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="109" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT0TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT0TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="302" y="58" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="552" y="39" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="364" y="60" width="58" height="1"/>
-				</line>
-				<textField>
-					<reportElement x="0" y="0" width="610" height="28"/>
-					<textElement>
-						<font size="16"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA["Total"]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="116" y="39" width="58" height="1"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="171" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT1TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT1TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="302" y="60" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="240" y="39" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="116" y="58" width="58" height="1"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="233" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT2TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT2TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="426" y="39" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="302" y="39" width="58" height="1"/>
-				</line>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-22" style="Report_Footer" x="543" y="42" width="64" height="14"/>
-					<box rightPadding="2"/>
-					<textElement textAlignment="Right">
-						<font size="6" isBold="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$P{AMOUNTFORMAT}.format(($V{SUMNETTOTAL}==null ? BigDecimal.ZERO : $V{SUMNETTOTAL}).subtract($V{SUMCREDITSTOTAL}==null ? BigDecimal.ZERO : $V{SUMCREDITSTOTAL}))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="364" y="39" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="116" y="60" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="552" y="58" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="426" y="60" width="58" height="1"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="419" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT5TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT5TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="0" y="29" width="610" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="552" y="60" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="178" y="60" width="58" height="1"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="295" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT3TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT3TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="240" y="58" width="58" height="1"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="357" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT4TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT4TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="240" y="60" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="488" y="60" width="58" height="1"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="481" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMCREDITSTOTAL} != null ? "(" + $P{AMOUNTFORMAT}.format($V{SUMCREDITSTOTAL}) + ")" : "(" + $P{AMOUNTFORMAT}.format(new BigDecimal("0")) + ")"]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="488" y="58" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="488" y="39" width="58" height="1"/>
-				</line>
+				<element kind="line" uuid="b439ab6a-f834-40f7-8559-c68792bd9068" key="line-33" x="364" y="58" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="40bf9150-2148-465d-87e1-3bba660211bb" key="line-33" x="178" y="39" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="a79577d4-c46f-4dee-9221-790affe43913" key="line-33" x="426" y="58" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="e45ce410-b4f0-4a51-b7ee-e05b5d103d5a" key="line-33" x="178" y="58" width="58" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="6c07d1be-1645-4729-be75-0af10f4f47a9" key="textField-6" x="109" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT0TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT0TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="41c54531-de5f-4242-9fcd-66860c017521" key="line-33" x="302" y="58" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="830c4edc-ed7c-493d-99ce-c0fdc31f63d7" key="line-33" x="552" y="39" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="e556f068-23f8-4743-a9c4-526e290ce975" key="line-33" x="364" y="60" width="58" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="ede15dbf-1caa-4a54-8a30-af96eb39d1ad" x="0" y="0" width="610" height="28" fontSize="16.0">
+					<expression><![CDATA["Total"]]></expression>
+				</element>
+				<element kind="line" uuid="6757317f-65c3-4f2d-a9ff-92bc70916fa5" key="line-33" x="116" y="39" width="58" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="3911fd88-852f-46fe-b0e9-b0536df7b626" key="textField-6" x="171" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT1TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT1TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="dd27b900-727a-4631-b588-e4db2603f56f" key="line-33" x="302" y="60" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="608ec4a1-3a58-46eb-b21e-a0daa088d6e6" key="line-33" x="240" y="39" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="a38ce0e0-f948-4785-aa7e-4dfbd34240fe" key="line-33" x="116" y="58" width="58" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="3c61c0fb-220c-425f-a235-c3102972d44f" key="textField-6" x="233" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT2TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT2TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="97a037c1-36f0-463f-96b2-aa98ac2c2586" key="line-33" x="426" y="39" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="ce87450b-7290-4be4-bf97-16ef07b22334" key="line-33" x="302" y="39" width="58" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="2a1197f5-0ef1-42ca-befb-2e91432fe3c6" key="textField-22" x="543" y="42" width="64" height="14" fontSize="6.0" blankWhenNull="false" bold="false" hTextAlign="Right" style="Report_Footer">
+					<expression><![CDATA[$P{AMOUNTFORMAT}.format(($V{SUMNETTOTAL}==null ? BigDecimal.ZERO : $V{SUMNETTOTAL}).subtract($V{SUMCREDITSTOTAL}==null ? BigDecimal.ZERO : $V{SUMCREDITSTOTAL}))]]></expression>
+					<box rightPadding="2" style="Report_Footer"/>
+				</element>
+				<element kind="line" uuid="42fd84b5-35ea-4e4b-a5b9-2cd3be4eebb8" key="line-33" x="364" y="39" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="cc8dc0fc-b9f9-4b0a-8ecd-1885c26b4b77" key="line-33" x="116" y="60" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="48db295a-ca75-432c-9358-35e835a81a7e" key="line-33" x="552" y="58" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="4975a6d0-d265-4b9b-a5be-199fa01c8747" key="line-33" x="426" y="60" width="58" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="6ffa484a-c909-4d6c-8e93-2def93da3fe1" key="textField-6" x="419" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT5TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT5TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="a397ab01-c239-4dba-a6ab-64ea6e959d0e" key="line-33" x="0" y="29" width="610" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="85702488-1ba9-43d3-aec6-d416ac2c7478" key="line-33" x="552" y="60" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="2c3e4f5f-99e9-4dc1-98e2-74af68facd54" key="line-33" x="178" y="60" width="58" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="2c3323e9-c871-4e9e-a68c-96b5e3424a32" key="textField-6" x="295" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT3TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT3TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="602e1449-daf6-4925-84a4-3930d4853baf" key="line-33" x="240" y="58" width="58" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="72fa7f44-b1dd-4962-b3ec-0f4d3793c087" key="textField-6" x="357" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT4TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT4TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="c994dead-bda8-41f5-886b-78f86cf73283" key="line-33" x="240" y="60" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="d914aa56-7f2e-429a-b53a-1c460a6bc252" key="line-33" x="488" y="60" width="58" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="d3271d0c-379c-49cd-8ee2-5f9925c352f9" key="textField-6" x="481" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMCREDITSTOTAL} != null ? "(" + $P{AMOUNTFORMAT}.format($V{SUMCREDITSTOTAL}) + ")" : "(" + $P{AMOUNTFORMAT}.format(new BigDecimal("0")) + ")"]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="3552b1ab-a1a8-4aca-a543-9d626217a151" key="line-33" x="488" y="58" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="2fcdf693-adb3-41e5-9bf3-d7c252cb9201" key="line-33" x="488" y="39" width="58" height="1" style="Report_Footer"/>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="Group" keepTogether="true">
-		<groupExpression><![CDATA[$F{BPARTNER}]]></groupExpression>
+		<expression><![CDATA[$F{BPARTNER}]]></expression>
 		<groupHeader>
 			<band height="19" splitType="Stretch">
-				<textField>
-					<reportElement x="0" y="0" width="610" height="18"/>
-					<textElement>
-						<font size="10"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$F{BPARTNERNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="0" y="18" width="610" height="1"/>
-				</line>
+				<element kind="textField" uuid="2b2dc421-bbd2-4bd0-9d34-11d8407b3b50" x="0" y="0" width="610" height="18" fontSize="10.0">
+					<expression><![CDATA[$F{BPARTNERNAME}]]></expression>
+				</element>
+				<element kind="line" uuid="4d4afaa4-f54e-4c7b-838a-7978f351e5a6" key="line-33" x="0" y="18" width="610" height="1" style="Report_Footer"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="27" splitType="Stretch">
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-22" style="Report_Footer" x="539" y="5" width="68" height="14"/>
-					<box rightPadding="2"/>
-					<textElement textAlignment="Right">
-						<font size="6" isBold="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$P{AMOUNTFORMAT}.format(($V{SUMNET}==null ? BigDecimal.ZERO : $V{SUMNET}).subtract($V{SUMCREDIT}==null ? BigDecimal.ZERO : $V{SUMCREDIT}))]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="291" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT3} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT3}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="353" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT4} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT4}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="105" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT0} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT0}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="229" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT2} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT2}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="167" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT1} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT1}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="415" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT5} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT5}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="364" y="21" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="302" y="2" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="552" y="23" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="426" y="21" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="552" y="2" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="302" y="21" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="552" y="21" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="178" y="2" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="240" y="23" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="364" y="23" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="178" y="21" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="302" y="23" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="116" y="2" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="426" y="23" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="426" y="2" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="240" y="2" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="240" y="21" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="116" y="21" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="364" y="2" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="178" y="23" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="116" y="23" width="58" height="1"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="477" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMCREDIT} != null ? "(" + $P{AMOUNTFORMAT}.format($V{SUMCREDIT}) + ")" : "(" + $P{AMOUNTFORMAT}.format(new BigDecimal("0")) + ")"]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="488" y="21" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="488" y="23" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="488" y="2" width="58" height="1"/>
-				</line>
+				<element kind="textField" uuid="2f91c171-3b9d-40ae-b1e3-dcc46c3ff81e" key="textField-22" x="539" y="5" width="68" height="14" fontSize="6.0" blankWhenNull="false" bold="false" hTextAlign="Right" style="Report_Footer">
+					<expression><![CDATA[$P{AMOUNTFORMAT}.format(($V{SUMNET}==null ? BigDecimal.ZERO : $V{SUMNET}).subtract($V{SUMCREDIT}==null ? BigDecimal.ZERO : $V{SUMCREDIT}))]]></expression>
+					<box rightPadding="2" style="Report_Footer"/>
+				</element>
+				<element kind="textField" uuid="de2d3b43-f108-4892-b3a1-64f9475bb220" key="textField-6" x="291" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT3} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT3}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="textField" uuid="717ca8f1-718b-4700-9a1c-95ed760b2d5b" key="textField-6" x="353" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT4} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT4}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="textField" uuid="4bc3085e-6687-48c7-a56e-3627db972019" key="textField-6" x="105" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT0} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT0}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="textField" uuid="69becf48-7da8-46b6-b855-5a39d6ace128" key="textField-6" x="229" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT2} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT2}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="textField" uuid="3c30283b-230f-4dff-8d84-11600e66bebe" key="textField-6" x="167" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT1} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT1}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="textField" uuid="5d335d4f-ec19-416f-9cc2-b63d12b6c9c6" key="textField-6" x="415" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT5} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT5}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="73a94b20-9cd8-429b-8cd3-2eab65a9d3c1" key="line-33" x="364" y="21" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="ef7265f9-5f5f-4685-9563-0ecfcced10dd" key="line-33" x="302" y="2" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="0300f961-5518-4bab-ae96-9c55692c1905" key="line-33" x="552" y="23" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="b9e35aa2-3439-44ce-a8a6-193e327ce1f8" key="line-33" x="426" y="21" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="0438a151-ce71-4c9e-a82a-8ea1b7d78164" key="line-33" x="552" y="2" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="298c5145-b4cd-4a54-80f0-888919c69906" key="line-33" x="302" y="21" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="59c1bff7-af71-4d19-bd86-78a6ed9f2bf4" key="line-33" x="552" y="21" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="b3c7ff02-58b3-4a56-a094-6d55d5097e53" key="line-33" x="178" y="2" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="d6f4d371-7b4e-41b0-8f3d-2cb5c1656dcd" key="line-33" x="240" y="23" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="76255121-2f84-4161-9088-93531e1cf4bd" key="line-33" x="364" y="23" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="9a3d893e-a706-4d5d-a403-e4047f2cc796" key="line-33" x="178" y="21" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="800a4bb1-17b1-4518-a235-d41e1d2b04d7" key="line-33" x="302" y="23" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="0a6e1306-c984-4122-9343-1709bcc8adb8" key="line-33" x="116" y="2" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="8e7888c4-a7f9-46a0-8c8f-588d4972a0fb" key="line-33" x="426" y="23" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="3cbe234a-2164-4d39-9b59-bcb93e15ca41" key="line-33" x="426" y="2" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="ff98f400-4dae-4b10-88be-8d6abde61a46" key="line-33" x="240" y="2" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="7eea60a5-1877-4f85-9dc5-e73fa9d71223" key="line-33" x="240" y="21" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="631a90c7-a0ac-42f2-b3ed-aac38080bcd4" key="line-33" x="116" y="21" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="209ab389-42d3-41e1-a2f9-08d99b3c0b15" key="line-33" x="364" y="2" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="bc8c62c7-f223-4e03-9181-e93231d1c956" key="line-33" x="178" y="23" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="a8007beb-2121-4889-8f7f-58a8c25be308" key="line-33" x="116" y="23" width="58" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="c24d153a-0c8e-4aaf-b034-683c243ffdc8" key="textField-6" x="477" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMCREDIT} != null ? "(" + $P{AMOUNTFORMAT}.format($V{SUMCREDIT}) + ")" : "(" + $P{AMOUNTFORMAT}.format(new BigDecimal("0")) + ")"]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="a4c0d296-77ae-4c6f-87f0-19412544c550" key="line-33" x="488" y="21" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="6a6f29e1-de90-4129-98f1-4009a9d9cc5a" key="line-33" x="488" y="23" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="df728895-b7af-47b9-8fd1-9055b74325c1" key="line-33" x="488" y="2" width="58" height="1" style="Report_Footer"/>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="137" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-24" style="Report_Footer" x="0" y="73" width="108" height="18"/>
-				<textElement textAlignment="Right">
-					<font size="9"/>
-				</textElement>
-				<text><![CDATA[Organization:]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-26" style="Report_Footer" x="0" y="93" width="108" height="18"/>
-				<textElement textAlignment="Right">
-					<font size="9"/>
-				</textElement>
-				<text><![CDATA[As Of Date:]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-27" style="Report_Footer" x="277" y="73" width="136" height="18"/>
-				<textElement textAlignment="Right">
-					<font size="9"/>
-				</textElement>
-				<text><![CDATA[General Ledger:]]></text>
-			</staticText>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="113" y="73" width="152" height="18"/>
-				<textElement>
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{Organization}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="113" y="93" width="152" height="18"/>
-				<textElement>
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{currentDate}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="418" y="73" width="179" height="18"/>
-				<textElement>
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{AccSchema}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="11" y="11" width="400" height="28"/>
-				<textElement>
-					<font size="16"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{title}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="137" splitType="Stretch">
+		<element kind="staticText" uuid="6462258b-df73-48a7-9a6a-4eae3677a8e1" key="staticText-24" x="0" y="73" width="108" height="18" fontSize="9.0" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Organization:]]></text>
+		</element>
+		<element kind="staticText" uuid="ededb7fb-9934-4116-85ca-d269c5490622" key="staticText-26" x="0" y="93" width="108" height="18" fontSize="9.0" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[As Of Date:]]></text>
+		</element>
+		<element kind="staticText" uuid="1654d45a-23fd-4e86-a3c3-415ef7a14e0b" key="staticText-27" x="277" y="73" width="136" height="18" fontSize="9.0" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[General Ledger:]]></text>
+		</element>
+		<element kind="textField" uuid="b75f33b8-81da-4291-8595-1a2120e46420" key="textField-25" x="113" y="73" width="152" height="18" fontSize="9.0" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{Organization}]]></expression>
+		</element>
+		<element kind="textField" uuid="0cc2e8b0-6bd3-404e-9111-c14af321bc6c" key="textField-25" x="113" y="93" width="152" height="18" fontSize="9.0" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{currentDate}]]></expression>
+		</element>
+		<element kind="textField" uuid="c16e390c-a8b8-4d2f-9782-91a64a5f9b2b" key="textField-25" x="418" y="73" width="179" height="18" fontSize="9.0" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{AccSchema}]]></expression>
+		</element>
+		<element kind="textField" uuid="f80508fa-05a6-4795-be3e-c42767424c1e" x="11" y="11" width="400" height="28" fontSize="16.0">
+			<expression><![CDATA[$P{title}]]></expression>
+		</element>
 	</title>
-	<pageHeader>
-		<band height="18" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="0" y="0" width="5" height="18"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="601" y="0" width="9" height="18"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[]]></text>
-			</staticText>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="291" y="0" width="62" height="18"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{inpLabel3}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="229" y="0" width="62" height="18"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{inpLabel2}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="105" y="0" width="62" height="18"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Current]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="5" y="0" width="50" height="18"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement>
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Document No.]]></text>
-			</staticText>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="353" y="0" width="62" height="18"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{inpLabel4}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="415" y="0" width="62" height="18"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{inpLabel5}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="167" y="0" width="62" height="18"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{inpLabel1}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="539" y="0" width="62" height="18"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Net Due]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="477" y="0" width="62" height="18"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Credits]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="55" y="0" width="50" height="18"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Document Date]]></text>
-			</staticText>
-		</band>
+	<pageHeader height="18" splitType="Stretch">
+		<element kind="staticText" uuid="294dd5f3-0ea4-4606-a6d9-fcbb16f85413" key="staticText-25" x="0" y="0" width="5" height="18" fontSize="6.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="12c9ff49-3548-4b1e-ac42-7ffe10fbb831" key="staticText-25" x="601" y="0" width="9" height="18" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="947ae3ef-eb3b-4414-ab93-eefd032cc4c3" key="staticText-25" x="291" y="0" width="62" height="18" markup="none" fontSize="6.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel3}]]></expression>
+		</element>
+		<element kind="textField" uuid="f42c1ca4-711a-4da6-9f6e-c1357cbc3bd6" key="staticText-25" x="229" y="0" width="62" height="18" markup="none" fontSize="6.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel2}]]></expression>
+		</element>
+		<element kind="staticText" uuid="eff1fd8f-7a8a-4a11-bcf5-66bf28461c00" key="staticText-25" x="105" y="0" width="62" height="18" fontSize="6.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Current]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="66d278fa-25b6-4ac3-9381-68cca163b0a9" key="staticText-25" x="5" y="0" width="50" height="18" fontSize="6.0" pdfFontName="Helvetica-Bold" style="Detail_Header">
+			<text><![CDATA[Document No.]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="35f7de64-f42a-4b1e-9c9b-b28e0aed6fee" key="staticText-25" x="353" y="0" width="62" height="18" markup="none" fontSize="6.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel4}]]></expression>
+		</element>
+		<element kind="textField" uuid="a8b9c3e8-d692-4098-8bad-68554f564ec1" key="staticText-25" x="415" y="0" width="62" height="18" markup="none" fontSize="6.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel5}]]></expression>
+		</element>
+		<element kind="textField" uuid="e5dcb783-cc9f-4fb8-bfee-8a726fe10e38" key="staticText-25" x="167" y="0" width="62" height="18" markup="none" fontSize="6.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel1}]]></expression>
+		</element>
+		<element kind="staticText" uuid="e9d39a3f-4b6c-492d-8683-fa626c575051" key="staticText-25" x="539" y="0" width="62" height="18" fontSize="6.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Net Due]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="70a0a919-7f37-4460-b6a7-9717a37d026a" key="staticText-25" x="477" y="0" width="62" height="18" fontSize="6.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Credits]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="b5ec9203-cd16-4308-949e-f12a819af983" key="staticText-25" x="55" y="0" width="50" height="18" fontSize="6.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Document Date]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="14" splitType="Stretch">
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-15" x="539" y="0" width="62" height="14"/>
+			<element kind="textField" uuid="4c2fece7-70fd-43ad-853f-04645ccf00a6" key="textField-15" x="539" y="0" width="62" height="14" fontSize="6.0" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{SHOW_NETDUE} == null ? null : ($F{NETDUE} == null
+    ? "(" + $P{AMOUNTFORMAT}.format($F{SHOW_NETDUE}) + ")" : $P{AMOUNTFORMAT}.format($F{SHOW_NETDUE}))]]></expression>
 				<box rightPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{SHOW_NETDUE} == null ? null : ($F{NETDUE} == null
-    ? "(" + $P{AMOUNTFORMAT}.format($F{SHOW_NETDUE}) + ")" : $P{AMOUNTFORMAT}.format($F{SHOW_NETDUE}))]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" x="5" y="0" width="50" height="14" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="6e7efdf4-ccf8-4790-8e3c-efa882d914ce" key="textField-6" x="5" y="0" width="50" height="14" forecolor="#000000" fontSize="6.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" vTextAlign="Middle">
+				<expression><![CDATA[$F{INVOICE_NUMBER}]]></expression>
 				<box leftPadding="2"/>
-				<textElement verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{INVOICE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" x="105" y="0" width="62" height="14" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="e8c8f086-698e-45dd-9643-db214db330c3" key="textField-6" x="105" y="0" width="62" height="14" forecolor="#000000" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{AMOUNT0} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT0}) : null]]></expression>
 				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{AMOUNT0} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT0}) : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-15" x="601" y="0" width="8" height="14"/>
+			</element>
+			<element kind="textField" uuid="0fec0488-14df-4f07-b3c8-ba2b06d72429" key="textField-15" x="601" y="0" width="8" height="14" fontSize="8.0" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
 				<box rightPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" x="167" y="0" width="62" height="14" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="515457b7-4eb1-47ef-bb4c-05b9796aa53f" key="textField-6" x="167" y="0" width="62" height="14" forecolor="#000000" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{AMOUNT1} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT1}) : null]]></expression>
 				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{AMOUNT1} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT1}) : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" x="229" y="0" width="62" height="14" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="845b1a22-4538-4ac2-bdd5-47143ed999dc" key="textField-6" x="229" y="0" width="62" height="14" forecolor="#000000" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{AMOUNT2} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT2}) : null]]></expression>
 				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{AMOUNT2} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT2}) : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" x="291" y="0" width="62" height="14" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="1076489a-b040-4a32-ae00-d97950aa2b07" key="textField-6" x="291" y="0" width="62" height="14" forecolor="#000000" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{AMOUNT3} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT3}) : null]]></expression>
 				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{AMOUNT3} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT3}) : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" x="353" y="0" width="62" height="14" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="f0a7d3ce-6e58-4cf3-a76a-faa1f33ef9b2" key="textField-6" x="353" y="0" width="62" height="14" forecolor="#000000" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{AMOUNT4} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT4}) : null]]></expression>
 				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{AMOUNT4} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT4}) : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" x="415" y="0" width="62" height="14" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="b9d02a37-f3d4-4f03-998e-66b21846f4a2" key="textField-6" x="415" y="0" width="62" height="14" forecolor="#000000" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{AMOUNT5} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT5}) : null]]></expression>
 				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{AMOUNT5} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT5}) : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" x="477" y="0" width="62" height="14" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="77a96dd4-d78b-4962-9627-ff89d2741257" key="textField-6" x="477" y="0" width="62" height="14" forecolor="#000000" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{AMOUNT6} != null ? "(" + $P{AMOUNTFORMAT}.format($F{AMOUNT6}) + ")" : null]]></expression>
 				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{AMOUNT6} != null ? "(" + $P{AMOUNTFORMAT}.format($F{AMOUNT6}) + ")" : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" x="55" y="0" width="50" height="14" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="b374715b-4f27-452c-85d7-886e13b10bc2" key="textField-6" x="55" y="0" width="50" height="14" forecolor="#000000" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Center" vTextAlign="Middle">
+				<expression><![CDATA[$P{DATEFORMATTER}.format($F{INVOICE_DATE})]]></expression>
 				<box leftPadding="2"/>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{DATEFORMATTER}.format($F{INVOICE_DATE})]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<pageFooter>
-		<band height="14" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="475" y="0" width="95" height="14"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="6"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="298" y="0" width="113" height="14"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="6"/>
-				</textElement>
-				<textFieldExpression class="java.util.Date"><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" x="216" y="0" width="78" height="14"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="6"/>
-				</textElement>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="574" y="0" width="36" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="6"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-		</band>
+	<pageFooter height="14" splitType="Stretch">
+		<element kind="textField" uuid="92a596b1-f7fa-4258-b953-15c5d649ccb8" key="textField" x="475" y="0" width="95" height="14" fontSize="6.0" pattern="" blankWhenNull="false" hTextAlign="Right">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="9e8adecc-fdf2-4bdd-8fdd-dc89cf5fa451" key="textField" x="298" y="0" width="113" height="14" fontName="Times-Roman" fontSize="6.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="0667ce08-d7f3-42a8-b836-0494a92f69f0" key="staticText-1" x="216" y="0" width="78" height="14" fontName="Bitstream Vera Sans" fontSize="6.0" hTextAlign="Right" vTextAlign="Middle">
+			<text><![CDATA[Generated on]]></text>
+			<box leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="65e2b44e-dde3-4ac0-a944-2456d9844647" key="textField" x="574" y="0" width="36" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" evaluationTime="Report" pattern="" blankWhenNull="false">
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailPDFDoubtfulDebt.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailPDFDoubtfulDebt.jrxml
@@ -1,35 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="PaymentReportPDF" pageWidth="842" pageHeight="670" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="PaymentReportPDF" language="java" pageWidth="842" pageHeight="670" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="627bb3d1-cd42-4427-b16e-7102cf7ed47e">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
 	<parameter name="AMOUNTFORMAT" class="java.text.DecimalFormat"/>
 	<parameter name="DATEFORMATTER" class="java.text.DateFormat">
 		<defaultValueExpression><![CDATA[$P{REPORT_FORMAT_FACTORY}.createDateFormat("", $P{REPORT_LOCALE}, $P{REPORT_TIME_ZONE})]]></defaultValueExpression>
@@ -55,12 +54,10 @@
 	<parameter name="inpLabel3" class="java.lang.String"/>
 	<parameter name="inpLabel4" class="java.lang.String"/>
 	<parameter name="inpLabel5" class="java.lang.String"/>
-	<queryString>
-		<![CDATA[SELECT 'hello' AS BP_GROUP, 'hello' AS BPARTNER, 'hello' AS PROJECT, 'hello' AS PAYMENT, 'hello' AS SALES_PERSON, 1234 AS INVOICE_NUMBER, to_Date('01/01/2010') AS INVOICE_DATE,
+	<query language="sql"><![CDATA[SELECT 'hello' AS BP_GROUP, 'hello' AS BPARTNER, 'hello' AS PROJECT, 'hello' AS PAYMENT, 'hello' AS SALES_PERSON, 1234 AS INVOICE_NUMBER, to_Date('01/01/2010') AS INVOICE_DATE,
        to_Date('01/03/2010') AS DUE_DATE, 1234 AS PLANNED_DSO, 1234 AS CURRENT_DSO, 1234 AS OVERDUE, 1234 AS DAYS_OVERDUE, 1234 AS AMOUNT,
        'hello' AS CURRENCY, 1234 AS BASE_AMOUNT, 'hello' AS BASE_CURRENCY, 'hello' AS PAYMENT_METHOD, 'hello' AS FINANCIAL_ACCOUNT
-FROM DUAL]]>
-	</queryString>
+FROM DUAL]]></query>
 	<field name="INVOICE_NUMBER" class="java.lang.String"/>
 	<field name="INVOICE_ID" class="java.lang.String"/>
 	<field name="AMOUNT0" class="java.math.BigDecimal"/>
@@ -78,837 +75,463 @@ FROM DUAL]]>
 	<field name="SHOW_NETDUE" class="java.math.BigDecimal"/>
 	<field name="DOUBTFUL_DEBT" class="java.math.BigDecimal"/>
 	<field name="PERCENTAGE" class="java.math.BigDecimal"/>
-	<variable name="SUMAMT0" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT0}]]></variableExpression>
+	<variable name="SUMAMT0" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT0}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMNET" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{NETDUE} != null ? $F{NETDUE} : new BigDecimal("0")]]></variableExpression>
+	<variable name="SUMNET" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{NETDUE} != null ? $F{NETDUE} : new BigDecimal("0")]]></expression>
 	</variable>
-	<variable name="SUMAMT1" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT1}]]></variableExpression>
+	<variable name="SUMAMT1" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT1}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT2" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT2}]]></variableExpression>
+	<variable name="SUMAMT2" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT2}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT3" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT3}]]></variableExpression>
+	<variable name="SUMAMT3" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT3}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT4" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT4}]]></variableExpression>
+	<variable name="SUMAMT4" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT4}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT5" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT5}]]></variableExpression>
+	<variable name="SUMAMT5" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT5}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT0TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT0}]]></variableExpression>
+	<variable name="SUMAMT0TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT0}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMNETTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{NETDUE}]]></variableExpression>
+	<variable name="SUMNETTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{NETDUE}]]></expression>
 	</variable>
-	<variable name="SUMAMT1TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT1}]]></variableExpression>
+	<variable name="SUMAMT1TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT1}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT2TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT2}]]></variableExpression>
+	<variable name="SUMAMT2TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT2}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT3TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT3}]]></variableExpression>
+	<variable name="SUMAMT3TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT3}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT4TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT4}]]></variableExpression>
+	<variable name="SUMAMT4TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT4}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT5TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT5}]]></variableExpression>
+	<variable name="SUMAMT5TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT5}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMCREDIT" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT6}]]></variableExpression>
+	<variable name="SUMCREDIT" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT6}]]></expression>
 		<initialValueExpression><![CDATA[]]></initialValueExpression>
 	</variable>
-	<variable name="SUMCREDITSTOTAL" class="java.math.BigDecimal" incrementType="Group" incrementGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$V{SUMCREDIT}]]></variableExpression>
+	<variable name="SUMCREDITSTOTAL" incrementType="Group" calculation="Sum" incrementGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{SUMCREDIT}]]></expression>
 	</variable>
-	<variable name="SUMDOUBTFULDEBT" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{DOUBTFUL_DEBT} == null ? new BigDecimal("0") : $F{DOUBTFUL_DEBT}]]></variableExpression>
+	<variable name="SUMDOUBTFULDEBT" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{DOUBTFUL_DEBT} == null ? new BigDecimal("0") : $F{DOUBTFUL_DEBT}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMPERCENTAGE" class="java.math.BigDecimal" resetType="Group" resetGroup="Group">
-		<variableExpression><![CDATA[$V{SUMDOUBTFULDEBT}.divide($V{SUMNET}.doubleValue() == 0 ? new BigDecimal("1"):$V{SUMNET} , 5, RoundingMode.HALF_UP ).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="SUMPERCENTAGE" resetType="Group" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{SUMDOUBTFULDEBT}.divide($V{SUMNET}.doubleValue() == 0 ? new BigDecimal("1"):$V{SUMNET} , 5, RoundingMode.HALF_UP ).multiply(new BigDecimal("100"))]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMDOUBTFULTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{DOUBTFUL_DEBT}]]></variableExpression>
+	<variable name="SUMDOUBTFULTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{DOUBTFUL_DEBT}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
 	<variable name="PERCENTAGETOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{SUMDOUBTFULTOTAL}.divide( $V{SUMNETTOTAL}.doubleValue() == 0 ? new BigDecimal("1"):$V{SUMNETTOTAL}, 5, RoundingMode.HALF_UP ).multiply(new BigDecimal("100"))]]></variableExpression>
+		<expression><![CDATA[$V{SUMDOUBTFULTOTAL}.divide( $V{SUMNETTOTAL}.doubleValue() == 0 ? new BigDecimal("1"):$V{SUMNETTOTAL}, 5, RoundingMode.HALF_UP ).multiply(new BigDecimal("100"))]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
 	<group name="Totals">
 		<groupFooter>
 			<band height="63">
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="364" y="58" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="178" y="39" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="426" y="58" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="178" y="58" width="58" height="1"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="109" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT0TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT0TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="302" y="58" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="685" y="39" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="364" y="60" width="58" height="1"/>
-				</line>
-				<textField>
-					<reportElement x="0" y="0" width="743" height="28"/>
-					<textElement>
-						<font size="16"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA["Total"]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="116" y="39" width="58" height="1"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="171" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT1TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT1TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="302" y="60" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="240" y="39" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="116" y="58" width="58" height="1"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="233" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT2TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT2TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="426" y="39" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="302" y="39" width="58" height="1"/>
-				</line>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-22" style="Report_Footer" x="676" y="42" width="64" height="14"/>
-					<box rightPadding="2"/>
-					<textElement textAlignment="Right">
-						<font size="6" isBold="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$P{AMOUNTFORMAT}.format(($V{SUMNETTOTAL}==null ? BigDecimal.ZERO : $V{SUMNETTOTAL}).subtract($V{SUMCREDITSTOTAL}==null ? BigDecimal.ZERO : $V{SUMCREDITSTOTAL}))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="364" y="39" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="116" y="60" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="685" y="58" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="426" y="60" width="58" height="1"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="419" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT5TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT5TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="0" y="28" width="743" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="685" y="60" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="178" y="60" width="58" height="1"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="295" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT3TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT3TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="240" y="58" width="58" height="1"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="357" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT4TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT4TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="240" y="60" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="488" y="60" width="58" height="1"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="481" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMCREDITSTOTAL} != null ? "(" + $P{AMOUNTFORMAT}.format($V{SUMCREDITSTOTAL}) + ")" : "(" + $P{AMOUNTFORMAT}.format(new BigDecimal("0")) + ")"]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="488" y="58" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="488" y="39" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="621" y="58" width="58" height="1"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="614" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[($V{PERCENTAGETOTAL} != null ? $P{AMOUNTFORMAT}.format($V{PERCENTAGETOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))) + " %"]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="621" y="39" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="621" y="60" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="550" y="58" width="67" height="1"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="543" y="42" width="71" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMDOUBTFULTOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMDOUBTFULTOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="550" y="39" width="67" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="550" y="60" width="67" height="1"/>
-				</line>
+				<element kind="line" uuid="73e8e43b-1dec-4da2-8f41-2e0921051422" key="line-33" x="364" y="58" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="5d86bf9b-d717-40dc-ad35-a3ec6b0a3be4" key="line-33" x="178" y="39" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="7baee58c-a396-4072-ac47-5ac30a38f442" key="line-33" x="426" y="58" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="8421ca0d-4536-4a2b-937c-b0116b2a700e" key="line-33" x="178" y="58" width="58" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="4fdd55ea-77cd-4c7d-9450-906269749c76" key="textField-6" x="109" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT0TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT0TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="84360d77-5d89-460b-8cb5-f446958c2854" key="line-33" x="302" y="58" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="051ced04-fcf6-41f7-a0f1-30277ce8d88f" key="line-33" x="685" y="39" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="b03dab73-153d-4d5a-8b36-46120d29a837" key="line-33" x="364" y="60" width="58" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="b95811cb-eb1f-447a-8138-2335c13c7aa1" x="0" y="0" width="743" height="28" fontSize="16.0">
+					<expression><![CDATA["Total"]]></expression>
+				</element>
+				<element kind="line" uuid="c5e38278-5495-4098-ac59-3acac916906c" key="line-33" x="116" y="39" width="58" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="89c0ceed-f0bf-4e4f-bd77-40497a4d1170" key="textField-6" x="171" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT1TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT1TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="cbe465d1-49bf-4d0e-bd22-e56601c971fa" key="line-33" x="302" y="60" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="eec38e35-f500-4c9d-9b44-576dccbc7de2" key="line-33" x="240" y="39" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="d30d5cd0-74e3-496b-9e7b-762104270d90" key="line-33" x="116" y="58" width="58" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="229035cd-8a66-498a-ac9a-1c2764e11818" key="textField-6" x="233" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT2TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT2TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="90d2f544-f5c4-43fd-a673-67aa7cf77e61" key="line-33" x="426" y="39" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="dc9cb8c5-ec93-4844-a439-a1bb2a9d51ba" key="line-33" x="302" y="39" width="58" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="43995c65-74ee-4ade-9180-52a90256eaf4" key="textField-22" x="676" y="42" width="64" height="14" fontSize="6.0" blankWhenNull="false" bold="false" hTextAlign="Right" style="Report_Footer">
+					<expression><![CDATA[$P{AMOUNTFORMAT}.format(($V{SUMNETTOTAL}==null ? BigDecimal.ZERO : $V{SUMNETTOTAL}).subtract($V{SUMCREDITSTOTAL}==null ? BigDecimal.ZERO : $V{SUMCREDITSTOTAL}))]]></expression>
+					<box rightPadding="2" style="Report_Footer"/>
+				</element>
+				<element kind="line" uuid="0f39d02f-db9d-48e6-8375-d07974e7768e" key="line-33" x="364" y="39" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="5c1c8b18-2ccd-4322-b6ca-44a1f9366977" key="line-33" x="116" y="60" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="84512ab7-4a38-4cf9-b7f8-79cb61a35e38" key="line-33" x="685" y="58" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="299c62c6-41a4-44e9-b087-fb63d281440e" key="line-33" x="426" y="60" width="58" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="5cf0c1e7-446a-4ca7-8eff-7d8cfca5c188" key="textField-6" x="419" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT5TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT5TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="ddc14a03-c08e-419e-a345-0198648b68c4" key="line-33" x="0" y="28" width="743" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="cfd20593-c6d4-4cf2-9655-5213c83dda84" key="line-33" x="685" y="60" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="549087e0-b720-412c-be19-2aaaca0a45ed" key="line-33" x="178" y="60" width="58" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="f47366ee-778b-4a62-8b4c-54c91e2d1d87" key="textField-6" x="295" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT3TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT3TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="e418800b-708e-4ccf-a2ff-4dc4eddfc579" key="line-33" x="240" y="58" width="58" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="4434e5dd-19c9-463e-b9fe-4239450a97b5" key="textField-6" x="357" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT4TOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT4TOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="c84f6f9e-3e29-4cda-9662-558b46642bac" key="line-33" x="240" y="60" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="cdc8516c-93ee-4952-aebf-3d446f1729c3" key="line-33" x="488" y="60" width="58" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="c58ccf75-548d-4154-b98e-63ab81be4936" key="textField-6" x="481" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMCREDITSTOTAL} != null ? "(" + $P{AMOUNTFORMAT}.format($V{SUMCREDITSTOTAL}) + ")" : "(" + $P{AMOUNTFORMAT}.format(new BigDecimal("0")) + ")"]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="2f16d5ba-4d86-427e-85e3-20454ab4668b" key="line-33" x="488" y="58" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="3b584824-1d5a-425f-900b-1255ee6c1cb8" key="line-33" x="488" y="39" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="58f63c5e-40f0-4572-9211-036761dd727a" key="line-33" x="621" y="58" width="58" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="b0f89190-7821-44bb-8fb7-9832e3d31025" key="textField-6" x="614" y="42" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[($V{PERCENTAGETOTAL} != null ? $P{AMOUNTFORMAT}.format($V{PERCENTAGETOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))) + " %"]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="b7ac1dbe-f114-4111-88b5-04672032932b" key="line-33" x="621" y="39" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="b4943534-0fb0-45cc-a738-147cf5d6df2c" key="line-33" x="621" y="60" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="75ae9b8e-b77b-429a-b32d-73c94f3292f4" key="line-33" x="550" y="58" width="67" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="f67bdadd-716d-4d9a-8f08-fbdb79d54c69" key="textField-6" x="543" y="42" width="71" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMDOUBTFULTOTAL} != null ? $P{AMOUNTFORMAT}.format($V{SUMDOUBTFULTOTAL}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="02f746da-8e40-47ea-ad26-0c1e13cdc257" key="line-33" x="550" y="39" width="67" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="30fc05aa-2356-4e1b-bb12-91b8bd5ddb79" key="line-33" x="550" y="60" width="67" height="1" style="Report_Footer"/>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="Group" keepTogether="true">
-		<groupExpression><![CDATA[$F{BPARTNER}]]></groupExpression>
+		<expression><![CDATA[$F{BPARTNER}]]></expression>
 		<groupHeader>
 			<band height="19" splitType="Stretch">
-				<textField>
-					<reportElement x="0" y="0" width="742" height="18"/>
-					<textElement>
-						<font size="10"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$F{BPARTNERNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="0" y="18" width="743" height="1"/>
-				</line>
+				<element kind="textField" uuid="7d9a2ec9-2d8b-4b6f-81ba-b93f33bc9802" x="0" y="0" width="742" height="18" fontSize="10.0">
+					<expression><![CDATA[$F{BPARTNERNAME}]]></expression>
+				</element>
+				<element kind="line" uuid="9fd0c5f2-11a3-409a-8c95-6966c98cf0fd" key="line-33" x="0" y="18" width="743" height="1" style="Report_Footer"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="27" splitType="Stretch">
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-22" style="Report_Footer" x="672" y="5" width="68" height="14"/>
-					<box rightPadding="2"/>
-					<textElement textAlignment="Right">
-						<font size="6" isBold="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$P{AMOUNTFORMAT}.format(($V{SUMNET}==null ? BigDecimal.ZERO : $V{SUMNET}).subtract($V{SUMCREDIT}==null ? BigDecimal.ZERO : $V{SUMCREDIT}))]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="291" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT3} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT3}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="353" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT4} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT4}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="105" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT0} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT0}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="229" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT2} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT2}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="167" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT1} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT1}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="415" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMAMT5} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT5}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="364" y="21" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="302" y="2" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="685" y="23" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="426" y="21" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="685" y="2" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="302" y="21" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="685" y="21" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="178" y="2" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="240" y="23" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="364" y="23" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="178" y="21" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="302" y="23" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="116" y="2" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="426" y="23" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="426" y="2" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="240" y="2" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="240" y="21" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="116" y="21" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="364" y="2" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="178" y="23" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="116" y="23" width="58" height="1"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="477" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMCREDIT} != null ? "(" + $P{AMOUNTFORMAT}.format($V{SUMCREDIT}) + ")" : "(" + $P{AMOUNTFORMAT}.format(new BigDecimal("0")) + ")"]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="488" y="21" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="488" y="23" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="488" y="2" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="623" y="2" width="58" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="550" y="2" width="69" height="1"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="610" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[($V{SUMPERCENTAGE} != null ? $P{AMOUNTFORMAT}.format($V{SUMPERCENTAGE}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))) + " %"]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="621" y="21" width="58" height="1"/>
-				</line>
-				<textField isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField-6" style="Detail_Header" x="539" y="5" width="71" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isBold="false" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$V{SUMDOUBTFULDEBT} != null ? $P{AMOUNTFORMAT}.format($V{SUMDOUBTFULDEBT}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="550" y="21" width="67" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="550" y="23" width="67" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="621" y="23" width="58" height="1"/>
-				</line>
+				<element kind="textField" uuid="6ed89003-1f50-4404-8e78-d5f82a2e92ea" key="textField-22" x="672" y="5" width="68" height="14" fontSize="6.0" blankWhenNull="false" bold="false" hTextAlign="Right" style="Report_Footer">
+					<expression><![CDATA[$P{AMOUNTFORMAT}.format(($V{SUMNET}==null ? BigDecimal.ZERO : $V{SUMNET}).subtract($V{SUMCREDIT}==null ? BigDecimal.ZERO : $V{SUMCREDIT}))]]></expression>
+					<box rightPadding="2" style="Report_Footer"/>
+				</element>
+				<element kind="textField" uuid="53c41eb6-5e02-4195-b61d-66c28386dccc" key="textField-6" x="291" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT3} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT3}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="textField" uuid="6e261ea8-92fe-477c-8731-32c18968a256" key="textField-6" x="353" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT4} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT4}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="textField" uuid="b0cbbbaa-3ed4-4841-b8fa-0840cb00df50" key="textField-6" x="105" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT0} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT0}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="textField" uuid="7445b559-25af-4fd2-9fc2-0c7de294d5ef" key="textField-6" x="229" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT2} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT2}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="textField" uuid="9ea3d7f4-2e6b-4ca8-bc26-72304b73911f" key="textField-6" x="167" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT1} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT1}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="textField" uuid="b24e0517-740e-480d-9c96-2cc41fbc6c20" key="textField-6" x="415" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMAMT5} != null ? $P{AMOUNTFORMAT}.format($V{SUMAMT5}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="1f7d6fd3-68a0-409f-87a4-435874ee9b3b" key="line-33" x="364" y="21" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="3cf9bbbf-69d6-4994-bca6-6767ef5c2107" key="line-33" x="302" y="2" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="61f82cd6-1c23-4e51-9cda-008ed717184b" key="line-33" x="685" y="23" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="21e310a1-ede6-42bf-998b-e65c16116150" key="line-33" x="426" y="21" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="659db6aa-d050-4934-814c-806a43978c73" key="line-33" x="685" y="2" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="419d868e-6352-48a5-99ab-c715a7da3eb9" key="line-33" x="302" y="21" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="c5886f64-09a6-4e94-8059-ee4966919be0" key="line-33" x="685" y="21" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="046a994d-bbd0-4e6d-8514-bc91aa397839" key="line-33" x="178" y="2" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="d5b74582-8068-4552-b435-1c72136be4bf" key="line-33" x="240" y="23" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="0dc2a976-7a5c-4ff5-b164-e4e4010cdb3c" key="line-33" x="364" y="23" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="ecba9d85-2ad2-4944-b85b-2c7e1dbc0714" key="line-33" x="178" y="21" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="7cac5c05-e3f5-46a0-998c-48165167f66b" key="line-33" x="302" y="23" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="fa7d0c8b-09ea-488e-b05d-88ae3a3feaeb" key="line-33" x="116" y="2" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="d4320cc8-8daa-46df-8eba-0bfbd79d6595" key="line-33" x="426" y="23" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="b3dd5af7-98f7-4037-b92c-07c02c0a6673" key="line-33" x="426" y="2" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="35936337-f336-4991-b516-ea344fc7fe40" key="line-33" x="240" y="2" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="e81064f3-9e04-408c-a8b7-defbd82a1c9f" key="line-33" x="240" y="21" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="9f81d990-3562-4268-a0d0-4e6ed8523e36" key="line-33" x="116" y="21" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="2becea49-b714-47bb-9030-78d4be6b8c0a" key="line-33" x="364" y="2" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="6573327b-559c-4135-bd78-f175f1ed9212" key="line-33" x="178" y="23" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="3f97703f-1dc2-462c-8b0a-e505ebc8019b" key="line-33" x="116" y="23" width="58" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="dfd95423-85c5-4a49-85a9-8e0e8dfd8482" key="textField-6" x="477" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMCREDIT} != null ? "(" + $P{AMOUNTFORMAT}.format($V{SUMCREDIT}) + ")" : "(" + $P{AMOUNTFORMAT}.format(new BigDecimal("0")) + ")"]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="09637295-379d-4c56-801a-25bfe52d9ae4" key="line-33" x="488" y="21" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="f741e102-7ea2-4e84-a556-0bf8879f8b4f" key="line-33" x="488" y="23" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="2980193c-53dc-4d27-a29d-f9587d66f1b1" key="line-33" x="488" y="2" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="b1194058-01cf-43eb-9f1e-022659256388" key="line-33" x="623" y="2" width="58" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="808f715f-19bf-4626-90ad-381d367ec307" key="line-33" x="550" y="2" width="69" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="dc585144-4a6f-44fa-9203-94e56d27e291" key="textField-6" x="610" y="5" width="62" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[($V{SUMPERCENTAGE} != null ? $P{AMOUNTFORMAT}.format($V{SUMPERCENTAGE}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))) + " %"]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="d1cbf32c-de5a-4fd3-b710-33c0f29975b0" key="line-33" x="621" y="21" width="58" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="0a5f726b-6716-454e-a954-d2c5b4826cb8" key="textField-6" x="539" y="5" width="71" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUMDOUBTFULDEBT} != null ? $P{AMOUNTFORMAT}.format($V{SUMDOUBTFULDEBT}) : $P{AMOUNTFORMAT}.format(new BigDecimal("0"))]]></expression>
+					<box leftPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="3ee3c1f7-4807-4cdf-ad09-446ceb78bcf0" key="line-33" x="550" y="21" width="67" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="06995ade-139e-423d-9e9f-9b43f0c71f12" key="line-33" x="550" y="23" width="67" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="63bfb867-cbc1-458c-a5ec-d3df8e27b681" key="line-33" x="621" y="23" width="58" height="1" style="Report_Footer"/>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="137" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-24" style="Report_Footer" x="0" y="73" width="108" height="18"/>
-				<textElement textAlignment="Right">
-					<font size="9"/>
-				</textElement>
-				<text><![CDATA[Organization:]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-26" style="Report_Footer" x="0" y="93" width="108" height="18"/>
-				<textElement textAlignment="Right">
-					<font size="9"/>
-				</textElement>
-				<text><![CDATA[As Of Date:]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-27" style="Report_Footer" x="277" y="73" width="136" height="18"/>
-				<textElement textAlignment="Right">
-					<font size="9"/>
-				</textElement>
-				<text><![CDATA[General Ledger:]]></text>
-			</staticText>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="113" y="73" width="152" height="18"/>
-				<textElement>
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{Organization}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="113" y="93" width="152" height="18"/>
-				<textElement>
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{currentDate}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="418" y="73" width="179" height="18"/>
-				<textElement>
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{AccSchema}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="11" y="11" width="400" height="28"/>
-				<textElement>
-					<font size="16"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{title}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="137" splitType="Stretch">
+		<element kind="staticText" uuid="1750ef7c-14e2-4c56-b67d-43f2a1596518" key="staticText-24" x="0" y="73" width="108" height="18" fontSize="9.0" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Organization:]]></text>
+		</element>
+		<element kind="staticText" uuid="1c9b2f96-00d7-448a-88f4-38e07885afc6" key="staticText-26" x="0" y="93" width="108" height="18" fontSize="9.0" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[As Of Date:]]></text>
+		</element>
+		<element kind="staticText" uuid="648b6d3a-de65-40dd-bb9d-9324f272d7d2" key="staticText-27" x="277" y="73" width="136" height="18" fontSize="9.0" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[General Ledger:]]></text>
+		</element>
+		<element kind="textField" uuid="244771ce-3e44-4c8a-a742-fe771d3192ea" key="textField-25" x="113" y="73" width="152" height="18" fontSize="9.0" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{Organization}]]></expression>
+		</element>
+		<element kind="textField" uuid="a71c3402-4637-4413-acfa-15ba2bdd96c0" key="textField-25" x="113" y="93" width="152" height="18" fontSize="9.0" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{currentDate}]]></expression>
+		</element>
+		<element kind="textField" uuid="7a0c840e-975a-4225-b900-696b47beb600" key="textField-25" x="418" y="73" width="179" height="18" fontSize="9.0" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{AccSchema}]]></expression>
+		</element>
+		<element kind="textField" uuid="ed42be48-94e7-4f6e-ae29-d6bde01de720" x="11" y="11" width="400" height="28" fontSize="16.0">
+			<expression><![CDATA[$P{title}]]></expression>
+		</element>
 	</title>
-	<pageHeader>
-		<band height="18" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="0" y="0" width="5" height="18"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="734" y="0" width="9" height="18"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[]]></text>
-			</staticText>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="291" y="0" width="62" height="18"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{inpLabel3}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="229" y="0" width="62" height="18"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{inpLabel2}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="105" y="0" width="62" height="18"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Current]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="5" y="0" width="50" height="18"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement>
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Document No.]]></text>
-			</staticText>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="353" y="0" width="62" height="18"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{inpLabel4}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="415" y="0" width="62" height="18"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{inpLabel5}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="167" y="0" width="62" height="18"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{inpLabel1}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="672" y="0" width="62" height="18"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Net Due]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="477" y="0" width="62" height="18"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Credits]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="55" y="0" width="50" height="18"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Document Date]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="539" y="0" width="71" height="18"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Doubtful Debt]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="610" y="0" width="62" height="18"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="6" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Percentage]]></text>
-			</staticText>
-		</band>
+	<pageHeader height="18" splitType="Stretch">
+		<element kind="staticText" uuid="f4598711-6508-4a28-bce5-c3ac07266967" key="staticText-25" x="0" y="0" width="5" height="18" fontSize="6.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="8d0d1595-2035-4d35-9e98-8bb71592dd16" key="staticText-25" x="734" y="0" width="9" height="18" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="a3a46111-3ec6-4879-94da-e7195ae7ed0b" key="staticText-25" x="291" y="0" width="62" height="18" markup="none" fontSize="6.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel3}]]></expression>
+		</element>
+		<element kind="textField" uuid="387c55b6-a105-4f26-862f-b23c09f6da1a" key="staticText-25" x="229" y="0" width="62" height="18" markup="none" fontSize="6.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel2}]]></expression>
+		</element>
+		<element kind="staticText" uuid="f532e33c-6350-413f-8a5c-f32c66ef7874" key="staticText-25" x="105" y="0" width="62" height="18" fontSize="6.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Current]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="22b745ae-9e5e-4b98-b4e2-f634b28d8e51" key="staticText-25" x="5" y="0" width="50" height="18" fontSize="6.0" pdfFontName="Helvetica-Bold" style="Detail_Header">
+			<text><![CDATA[Document No.]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="10e3c599-30e8-493d-8529-1f8b6a9914de" key="staticText-25" x="353" y="0" width="62" height="18" markup="none" fontSize="6.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel4}]]></expression>
+		</element>
+		<element kind="textField" uuid="007a113c-919b-4226-add3-6b93238dad76" key="staticText-25" x="415" y="0" width="62" height="18" markup="none" fontSize="6.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel5}]]></expression>
+		</element>
+		<element kind="textField" uuid="eacba659-0b58-4d0f-84d1-8da5bc6c134d" key="staticText-25" x="167" y="0" width="62" height="18" markup="none" fontSize="6.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel1}]]></expression>
+		</element>
+		<element kind="staticText" uuid="6c1c42f4-63ae-48b4-a472-d89e6e2b4bf0" key="staticText-25" x="672" y="0" width="62" height="18" fontSize="6.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Net Due]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="9e3d1d5e-d0f8-48fd-90cf-d8a748323270" key="staticText-25" x="477" y="0" width="62" height="18" fontSize="6.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Credits]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="65e0b0b7-9905-4b8e-bc4e-56a2090c020d" key="staticText-25" x="55" y="0" width="50" height="18" fontSize="6.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Document Date]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="9bdb9fb0-a250-4c8e-9652-9a9f16e66b3d" key="staticText-25" x="539" y="0" width="71" height="18" fontSize="6.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Doubtful Debt]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="41c3b3ad-5e58-4eb4-80ab-dc7caec50217" key="staticText-25" x="610" y="0" width="62" height="18" fontSize="6.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Percentage]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="14" splitType="Stretch">
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-15" x="672" y="0" width="62" height="14"/>
+			<element kind="textField" uuid="f564b01d-b942-4e3b-a716-fb1b4d423001" key="textField-15" x="672" y="0" width="62" height="14" fontSize="6.0" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{SHOW_NETDUE} == null ? null : ($F{NETDUE} == null
+    ? "(" + $P{AMOUNTFORMAT}.format($F{SHOW_NETDUE}) + ")" : $P{AMOUNTFORMAT}.format($F{SHOW_NETDUE}))]]></expression>
 				<box rightPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{SHOW_NETDUE} == null ? null : ($F{NETDUE} == null
-    ? "(" + $P{AMOUNTFORMAT}.format($F{SHOW_NETDUE}) + ")" : $P{AMOUNTFORMAT}.format($F{SHOW_NETDUE}))]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" x="5" y="0" width="50" height="14" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="b0b4f90a-83f1-482a-9711-b8cebe9a9dab" key="textField-6" x="5" y="0" width="50" height="14" forecolor="#000000" fontSize="6.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" vTextAlign="Middle">
+				<expression><![CDATA[$F{INVOICE_NUMBER}]]></expression>
 				<box leftPadding="2"/>
-				<textElement verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{INVOICE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" x="105" y="0" width="62" height="14" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="d10f7c85-eb17-498c-b321-99b5114a3734" key="textField-6" x="105" y="0" width="62" height="14" forecolor="#000000" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{AMOUNT0} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT0}) : null]]></expression>
 				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{AMOUNT0} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT0}) : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-15" x="734" y="0" width="8" height="14"/>
+			</element>
+			<element kind="textField" uuid="ed481474-0d07-42ec-848c-5333b73b2299" key="textField-15" x="734" y="0" width="8" height="14" fontSize="8.0" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
 				<box rightPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" x="167" y="0" width="62" height="14" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="d95d40d0-4bc4-4fd2-8bb4-3ec88020a55c" key="textField-6" x="167" y="0" width="62" height="14" forecolor="#000000" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{AMOUNT1} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT1}) : null]]></expression>
 				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{AMOUNT1} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT1}) : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" x="229" y="0" width="62" height="14" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="68248eaf-c05c-4ab0-8d46-faa4273e9cf4" key="textField-6" x="229" y="0" width="62" height="14" forecolor="#000000" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{AMOUNT2} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT2}) : null]]></expression>
 				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{AMOUNT2} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT2}) : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" x="291" y="0" width="62" height="14" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="3ff814df-02dd-44e7-bf27-e4617843333d" key="textField-6" x="291" y="0" width="62" height="14" forecolor="#000000" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{AMOUNT3} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT3}) : null]]></expression>
 				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{AMOUNT3} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT3}) : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" x="353" y="0" width="62" height="14" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="44725ea2-f96d-403d-8e4f-a5b4c887405a" key="textField-6" x="353" y="0" width="62" height="14" forecolor="#000000" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{AMOUNT4} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT4}) : null]]></expression>
 				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{AMOUNT4} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT4}) : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" x="415" y="0" width="62" height="14" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="85c7af93-8294-4ef1-a898-07627fe1e371" key="textField-6" x="415" y="0" width="62" height="14" forecolor="#000000" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{AMOUNT5} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT5}) : null]]></expression>
 				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{AMOUNT5} != null ? $P{AMOUNTFORMAT}.format($F{AMOUNT5}) : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" x="477" y="0" width="62" height="14" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="ac1afd9c-4744-43da-afbc-4664903e5640" key="textField-6" x="477" y="0" width="62" height="14" forecolor="#000000" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{AMOUNT6} != null ? "(" + $P{AMOUNTFORMAT}.format($F{AMOUNT6}) + ")" : null]]></expression>
 				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{AMOUNT6} != null ? "(" + $P{AMOUNTFORMAT}.format($F{AMOUNT6}) + ")" : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" x="55" y="0" width="50" height="14" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="94eff7a2-0791-4de4-9ffb-6fe637541ea0" key="textField-6" x="55" y="0" width="50" height="14" forecolor="#000000" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Center" vTextAlign="Middle">
+				<expression><![CDATA[$P{DATEFORMATTER}.format($F{INVOICE_DATE})]]></expression>
 				<box leftPadding="2"/>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{DATEFORMATTER}.format($F{INVOICE_DATE})]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" x="539" y="0" width="71" height="14" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="0d6c2544-7bb1-4d30-8cda-56e9f084df8e" key="textField-6" x="539" y="0" width="71" height="14" forecolor="#000000" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{DOUBTFUL_DEBT} != null ? $P{AMOUNTFORMAT}.format($F{DOUBTFUL_DEBT}) : null]]></expression>
 				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{DOUBTFUL_DEBT} != null ? $P{AMOUNTFORMAT}.format($F{DOUBTFUL_DEBT}) : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" x="610" y="0" width="62" height="14" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="b81505aa-9ecf-4cb8-b27c-182502aa483b" key="textField-6" x="610" y="0" width="62" height="14" forecolor="#000000" fontSize="6.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{PERCENTAGE} != null ? $P{AMOUNTFORMAT}.format($F{PERCENTAGE}) + " %" : null]]></expression>
 				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{PERCENTAGE} != null ? $P{AMOUNTFORMAT}.format($F{PERCENTAGE}) + " %" : null]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<pageFooter>
-		<band height="14" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="612" y="0" width="95" height="14"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="6"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="361" y="0" width="113" height="14"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="6"/>
-				</textElement>
-				<textFieldExpression class="java.util.Date"><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" x="279" y="0" width="78" height="14"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="6"/>
-				</textElement>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="707" y="0" width="36" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="6"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-		</band>
+	<pageFooter height="14" splitType="Stretch">
+		<element kind="textField" uuid="5b4c4465-d5c6-4e9a-9894-24612acfed5d" key="textField" x="612" y="0" width="95" height="14" fontSize="6.0" pattern="" blankWhenNull="false" hTextAlign="Right">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="fb81d698-d78d-4bb4-8da6-1cc92b22a401" key="textField" x="361" y="0" width="113" height="14" fontName="Times-Roman" fontSize="6.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="f382c1e8-b362-45e0-bb93-b4541a5922bb" key="staticText-1" x="279" y="0" width="78" height="14" fontName="Bitstream Vera Sans" fontSize="6.0" hTextAlign="Right" vTextAlign="Middle">
+			<text><![CDATA[Generated on]]></text>
+			<box leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="7828be03-b251-4ad4-bf3a-bef6f357df98" key="textField" x="707" y="0" width="36" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" evaluationTime="Report" pattern="" blankWhenNull="false">
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailXLS.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailXLS.jrxml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="PaymentReportPDF" pageWidth="983" pageHeight="842" columnWidth="983" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="1db8947f-ba8e-4a27-9a66-99f493df8411">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="PaymentReportPDF" language="java" pageWidth="983" pageHeight="842" columnWidth="983" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="1db8947f-ba8e-4a27-9a66-99f493df8411">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
@@ -7,30 +7,29 @@
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
 	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
 	<parameter name="AMOUNTFORMAT" class="java.text.DecimalFormat"/>
 	<parameter name="DATEFORMATTER" class="java.text.DateFormat">
 		<defaultValueExpression><![CDATA[$P{REPORT_FORMAT_FACTORY}.createDateFormat("", $P{REPORT_LOCALE}, $P{REPORT_TIME_ZONE})]]></defaultValueExpression>
@@ -56,12 +55,10 @@
 	<parameter name="inpLabel3" class="java.lang.String"/>
 	<parameter name="inpLabel4" class="java.lang.String"/>
 	<parameter name="inpLabel5" class="java.lang.String"/>
-	<queryString>
-		<![CDATA[SELECT 'hello' AS BP_GROUP, 'hello' AS BPARTNER, 'hello' AS PROJECT, 'hello' AS PAYMENT, 'hello' AS SALES_PERSON, 1234 AS INVOICE_NUMBER, to_Date('01/01/2010') AS INVOICE_DATE,
+	<query language="sql"><![CDATA[SELECT 'hello' AS BP_GROUP, 'hello' AS BPARTNER, 'hello' AS PROJECT, 'hello' AS PAYMENT, 'hello' AS SALES_PERSON, 1234 AS INVOICE_NUMBER, to_Date('01/01/2010') AS INVOICE_DATE,
        to_Date('01/03/2010') AS DUE_DATE, 1234 AS PLANNED_DSO, 1234 AS CURRENT_DSO, 1234 AS OVERDUE, 1234 AS DAYS_OVERDUE, 1234 AS AMOUNT,
        'hello' AS CURRENCY, 1234 AS BASE_AMOUNT, 'hello' AS BASE_CURRENCY, 'hello' AS PAYMENT_METHOD, 'hello' AS FINANCIAL_ACCOUNT
-FROM DUAL]]>
-	</queryString>
+FROM DUAL]]></query>
 	<field name="INVOICE_NUMBER" class="java.lang.String"/>
 	<field name="INVOICE_ID" class="java.lang.String"/>
 	<field name="AMOUNT0" class="java.math.BigDecimal"/>
@@ -77,494 +74,309 @@ FROM DUAL]]>
 	<field name="TABID" class="java.lang.String"/>
 	<field name="INVOICE_DATE" class="java.util.Date"/>
 	<field name="SHOW_NETDUE" class="java.math.BigDecimal"/>
-	<variable name="SUMAMT0" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT0}]]></variableExpression>
+	<variable name="SUMAMT0" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT0}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMNET" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{NETDUE}]]></variableExpression>
+	<variable name="SUMNET" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{NETDUE}]]></expression>
 	</variable>
-	<variable name="SUMAMT1" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT1}]]></variableExpression>
+	<variable name="SUMAMT1" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT1}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT2" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT2}]]></variableExpression>
+	<variable name="SUMAMT2" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT2}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT3" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT3}]]></variableExpression>
+	<variable name="SUMAMT3" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT3}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT4" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT4}]]></variableExpression>
+	<variable name="SUMAMT4" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT4}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT5" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT5}]]></variableExpression>
+	<variable name="SUMAMT5" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT5}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT0TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT0}]]></variableExpression>
+	<variable name="SUMAMT0TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT0}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMNETTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{NETDUE}]]></variableExpression>
+	<variable name="SUMNETTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{NETDUE}]]></expression>
 	</variable>
-	<variable name="SUMAMT1TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT1}]]></variableExpression>
+	<variable name="SUMAMT1TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT1}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT2TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT2}]]></variableExpression>
+	<variable name="SUMAMT2TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT2}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT3TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT3}]]></variableExpression>
+	<variable name="SUMAMT3TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT3}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT4TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT4}]]></variableExpression>
+	<variable name="SUMAMT4TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT4}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT5TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT5}]]></variableExpression>
+	<variable name="SUMAMT5TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT5}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMCREDIT" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT6}.negate()]]></variableExpression>
+	<variable name="SUMCREDIT" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT6}.negate()]]></expression>
 		<initialValueExpression><![CDATA[]]></initialValueExpression>
 	</variable>
-	<variable name="SUMCREDITSTOTAL" class="java.math.BigDecimal" incrementType="Group" incrementGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$V{SUMCREDIT}]]></variableExpression>
+	<variable name="SUMCREDITSTOTAL" incrementType="Group" calculation="Sum" incrementGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{SUMCREDIT}]]></expression>
 	</variable>
 	<group name="Totals"/>
 	<group name="Group">
-		<groupExpression><![CDATA[$F{BPARTNER}]]></groupExpression>
+		<expression><![CDATA[$F{BPARTNER}]]></expression>
 		<groupHeader>
 			<band height="22" splitType="Stretch">
-				<textField>
-					<reportElement x="0" y="0" width="983" height="19" uuid="75a5d049-76ba-41c9-964f-d2b2a96cf135"/>
-					<textElement>
-						<font size="12"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{BPARTNERNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="0" y="20" width="983" height="1" uuid="3c618a7f-9055-4936-94b0-75da2cbbd63a"/>
-				</line>
+				<element kind="textField" uuid="75a5d049-76ba-41c9-964f-d2b2a96cf135" x="0" y="0" width="983" height="19" fontSize="12.0">
+					<expression><![CDATA[$F{BPARTNERNAME}]]></expression>
+				</element>
+				<element kind="line" uuid="3c618a7f-9055-4936-94b0-75da2cbbd63a" key="line-33" x="0" y="20" width="983" height="1" style="Report_Footer"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="28">
-				<staticText>
-					<reportElement key="staticText-21" style="Report_Footer" x="0" y="1" width="883" height="19" uuid="32949d86-9201-46e1-97d3-5412409510a1"/>
-					<textElement>
-						<font size="12" isBold="false" isItalic="false"/>
-					</textElement>
+				<element kind="staticText" uuid="32949d86-9201-46e1-97d3-5412409510a1" key="staticText-21" x="0" y="1" width="883" height="19" fontSize="12.0" bold="false" italic="false" style="Report_Footer">
 					<text><![CDATA[Balance]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="883" y="0" width="100" height="1" uuid="d5252031-0324-4e27-88bc-69718c7389c6"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="883" y="22" width="100" height="1" uuid="31d79717-8977-4040-977b-5330bd54a06e"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="883" y="25" width="100" height="1" uuid="7a7db1be-a2df-4635-95c4-8af219c54c52"/>
-				</line>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-					<reportElement key="textField-22" style="Report_Footer" x="883" y="1" width="100" height="19" uuid="82ec0731-e20c-438b-837f-fc8650a71cc0"/>
-					<box rightPadding="2"/>
-					<textElement textAlignment="Right">
-						<font size="10" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{SUMNET}==null ? BigDecimal.ZERO : $V{SUMNET}).add($V{SUMCREDIT}==null ? BigDecimal.ZERO : $V{SUMCREDIT})]]></textFieldExpression>
+				</element>
+				<element kind="line" uuid="d5252031-0324-4e27-88bc-69718c7389c6" key="line-33" x="883" y="0" width="100" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="31d79717-8977-4040-977b-5330bd54a06e" key="line-33" x="883" y="22" width="100" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="7a7db1be-a2df-4635-95c4-8af219c54c52" key="line-33" x="883" y="25" width="100" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="82ec0731-e20c-438b-837f-fc8650a71cc0" key="textField-22" x="883" y="1" width="100" height="19" fontSize="10.0" textAdjust="StretchHeight" blankWhenNull="false" bold="false" hTextAlign="Right" style="Report_Footer">
+					<expression><![CDATA[($V{SUMNET}==null ? BigDecimal.ZERO : $V{SUMNET}).add($V{SUMCREDIT}==null ? BigDecimal.ZERO : $V{SUMCREDIT})]]></expression>
 					<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-				</textField>
+					<box rightPadding="2" style="Report_Footer"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="47" splitType="Stretch">
-			<textField>
-				<reportElement x="0" y="0" width="983" height="29" uuid="c55b5b7a-0b83-49a4-8416-80de6f0200ea"/>
-				<textElement>
-					<font size="18"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{title}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="783" y="29" width="200" height="18" uuid="47b90b43-313e-4879-b316-37f5b0bd709d"/>
-				<textFieldExpression><![CDATA[$P{AccSchema}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-26" style="Report_Footer" x="333" y="29" width="150" height="18" uuid="ef0c2628-09fa-434a-bb3f-94686f570eb6"/>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[As Of Date:]]></text>
-			</staticText>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="483" y="29" width="150" height="18" uuid="3b8e77ea-ead5-4e9a-a473-94a660b8b43c"/>
-				<textFieldExpression><![CDATA[$P{currentDate}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="99" y="29" width="234" height="18" uuid="e2629eec-2e05-4b1f-a0f8-41bfb7366968"/>
-				<textFieldExpression><![CDATA[$P{Organization}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-27" style="Report_Footer" x="633" y="29" width="150" height="18" uuid="25548c57-990d-4546-86ce-b246f5679bda"/>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[General Ledger:]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-24" style="Report_Footer" x="0" y="29" width="99" height="18" uuid="d4511bb2-3744-4e95-a9c3-f796083d3788"/>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Organization:]]></text>
-			</staticText>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="47" splitType="Stretch">
+		<element kind="textField" uuid="c55b5b7a-0b83-49a4-8416-80de6f0200ea" x="0" y="0" width="983" height="29" fontSize="18.0">
+			<expression><![CDATA[$P{title}]]></expression>
+		</element>
+		<element kind="textField" uuid="47b90b43-313e-4879-b316-37f5b0bd709d" key="textField-25" x="783" y="29" width="200" height="18" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{AccSchema}]]></expression>
+		</element>
+		<element kind="staticText" uuid="ef0c2628-09fa-434a-bb3f-94686f570eb6" key="staticText-26" x="333" y="29" width="150" height="18" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[As Of Date:]]></text>
+		</element>
+		<element kind="textField" uuid="3b8e77ea-ead5-4e9a-a473-94a660b8b43c" key="textField-25" x="483" y="29" width="150" height="18" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{currentDate}]]></expression>
+		</element>
+		<element kind="textField" uuid="e2629eec-2e05-4b1f-a0f8-41bfb7366968" key="textField-25" x="99" y="29" width="234" height="18" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{Organization}]]></expression>
+		</element>
+		<element kind="staticText" uuid="25548c57-990d-4546-86ce-b246f5679bda" key="staticText-27" x="633" y="29" width="150" height="18" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[General Ledger:]]></text>
+		</element>
+		<element kind="staticText" uuid="d4511bb2-3744-4e95-a9c3-f796083d3788" key="staticText-24" x="0" y="29" width="99" height="18" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Organization:]]></text>
+		</element>
 	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band height="20" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="783" y="0" width="100" height="20" uuid="f17b9fe4-3443-4624-aa6d-5c11eab3653d"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Net Due]]></text>
-			</staticText>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="483" y="0" width="75" height="20" uuid="e5ee696b-0d60-4c15-ad8d-83dcef1833db"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{inpLabel3}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="258" y="0" width="75" height="20" uuid="2eb85510-3ed0-4ba0-88a2-11a3a7e9986b"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Current]]></text>
-			</staticText>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="333" y="0" width="75" height="20" uuid="5e9f4533-03d9-4eb9-a6a9-1f91cf921689"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{inpLabel1}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="408" y="0" width="75" height="20" uuid="4d7f6735-e32d-40cd-ad31-403d87a0eb51"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{inpLabel2}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="99" y="0" width="80" height="20" uuid="5cb5473e-6f76-49b9-904c-d6dfd32f06f4"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement>
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Document No.]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="1" y="0" width="98" height="20" uuid="0dfd8a38-4180-4daa-8e96-df246858fba8"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement>
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Business Partner]]></text>
-			</staticText>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="633" y="0" width="75" height="20" uuid="260a25c3-767e-45ca-9bfd-2bfbd0a2bb13"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{inpLabel5}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="558" y="0" width="75" height="20" uuid="e5b3a94d-a2d7-421b-9ff1-2ad4a51a7459"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{inpLabel4}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="708" y="0" width="75" height="20" uuid="28a3e28b-d12b-480d-bbd3-0bdf7f097b22"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Credits]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="179" y="0" width="79" height="20" uuid="428340b1-34f5-4124-b62b-701256c7191e"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Document Date]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="883" y="0" width="100" height="20" uuid="be5287de-118e-4063-87fc-9e24ab28a3a2"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Total]]></text>
-			</staticText>
-		</band>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader height="20" splitType="Stretch">
+		<element kind="staticText" uuid="f17b9fe4-3443-4624-aa6d-5c11eab3653d" key="staticText-25" x="783" y="0" width="100" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Net Due]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="e5ee696b-0d60-4c15-ad8d-83dcef1833db" key="staticText-25" x="483" y="0" width="75" height="20" markup="none" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel3}]]></expression>
+		</element>
+		<element kind="staticText" uuid="2eb85510-3ed0-4ba0-88a2-11a3a7e9986b" key="staticText-25" x="258" y="0" width="75" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Current]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="5e9f4533-03d9-4eb9-a6a9-1f91cf921689" key="staticText-25" x="333" y="0" width="75" height="20" markup="none" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel1}]]></expression>
+		</element>
+		<element kind="textField" uuid="4d7f6735-e32d-40cd-ad31-403d87a0eb51" key="staticText-25" x="408" y="0" width="75" height="20" markup="none" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel2}]]></expression>
+		</element>
+		<element kind="staticText" uuid="5cb5473e-6f76-49b9-904c-d6dfd32f06f4" key="staticText-25" x="99" y="0" width="80" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" style="Detail_Header">
+			<text><![CDATA[Document No.]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="0dfd8a38-4180-4daa-8e96-df246858fba8" key="staticText-25" x="1" y="0" width="98" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" style="Detail_Header">
+			<text><![CDATA[Business Partner]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="260a25c3-767e-45ca-9bfd-2bfbd0a2bb13" key="staticText-25" x="633" y="0" width="75" height="20" markup="none" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel5}]]></expression>
+		</element>
+		<element kind="textField" uuid="e5b3a94d-a2d7-421b-9ff1-2ad4a51a7459" key="staticText-25" x="558" y="0" width="75" height="20" markup="none" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel4}]]></expression>
+		</element>
+		<element kind="staticText" uuid="28a3e28b-d12b-480d-bbd3-0bdf7f097b22" key="staticText-25" x="708" y="0" width="75" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Credits]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="428340b1-34f5-4124-b62b-701256c7191e" key="staticText-25" x="179" y="0" width="79" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Document Date]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="be5287de-118e-4063-87fc-9e24ab28a3a2" key="staticText-25" x="883" y="0" width="100" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Total]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
 	</columnHeader>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="99" y="0" width="80" height="16" forecolor="#000000" uuid="8152fa9b-67cd-490b-9129-d68a3243800d"/>
-				<box leftPadding="2"/>
-				<textElement verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{INVOICE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="258" y="0" width="75" height="16" forecolor="#000000" uuid="e5135476-8709-480a-a862-8567c34a0c9a"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AMOUNT0} != null ? $F{AMOUNT0} : BigDecimal.ZERO]]></textFieldExpression>
+			<element kind="textField" uuid="8152fa9b-67cd-490b-9129-d68a3243800d" key="textField-6" x="99" y="0" width="80" height="16" forecolor="#000000" fontSize="8.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{INVOICE_NUMBER}]]></expression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="e5135476-8709-480a-a862-8567c34a0c9a" key="textField-6" x="258" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{AMOUNT0} != null ? $F{AMOUNT0} : BigDecimal.ZERO]]></expression>
 				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="333" y="0" width="75" height="16" forecolor="#000000" uuid="ca05c0d9-c251-4703-87c5-82cd29d66169"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AMOUNT1} != null ? $F{AMOUNT1} : BigDecimal.ZERO]]></textFieldExpression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="ca05c0d9-c251-4703-87c5-82cd29d66169" key="textField-6" x="333" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{AMOUNT1} != null ? $F{AMOUNT1} : BigDecimal.ZERO]]></expression>
 				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="408" y="0" width="75" height="16" forecolor="#000000" uuid="98d56916-c6f7-4e51-aec7-9f0ad9713c95"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AMOUNT2} != null ? $F{AMOUNT2} : BigDecimal.ZERO]]></textFieldExpression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="98d56916-c6f7-4e51-aec7-9f0ad9713c95" key="textField-6" x="408" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{AMOUNT2} != null ? $F{AMOUNT2} : BigDecimal.ZERO]]></expression>
 				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="483" y="0" width="75" height="16" forecolor="#000000" uuid="c4eca720-b800-4fd3-894a-312afc7bf258"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AMOUNT3} != null ? $F{AMOUNT3} : BigDecimal.ZERO]]></textFieldExpression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="c4eca720-b800-4fd3-894a-312afc7bf258" key="textField-6" x="483" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{AMOUNT3} != null ? $F{AMOUNT3} : BigDecimal.ZERO]]></expression>
 				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="558" y="0" width="75" height="16" forecolor="#000000" uuid="60c7d6f1-5f5c-4c80-b85a-5044aceacd7c"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AMOUNT4} != null ? $F{AMOUNT4} : BigDecimal.ZERO]]></textFieldExpression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="60c7d6f1-5f5c-4c80-b85a-5044aceacd7c" key="textField-6" x="558" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{AMOUNT4} != null ? $F{AMOUNT4} : BigDecimal.ZERO]]></expression>
 				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="179" y="0" width="79" height="16" forecolor="#000000" uuid="67dd8d34-d7e6-44e3-b40e-50d4cf6e81ed"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{DATEFORMATTER}.format($F{INVOICE_DATE})]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-15" style="Detail_Line" x="883" y="0" width="100" height="16" uuid="c47f14a6-4b1f-4540-8ea7-2d47895427af"/>
-				<box rightPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-15" style="Detail_Line" x="783" y="0" width="100" height="16" uuid="38ce54c6-d938-46e1-9f9f-49bd5564b90b"/>
-				<box rightPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{SHOW_NETDUE} == null ? BigDecimal.ZERO : ($F{NETDUE} == null
-    ? $F{SHOW_NETDUE}.negate() : $F{SHOW_NETDUE})]]></textFieldExpression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="67dd8d34-d7e6-44e3-b40e-50d4cf6e81ed" key="textField-6" x="179" y="0" width="79" height="16" forecolor="#000000" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$P{DATEFORMATTER}.format($F{INVOICE_DATE})]]></expression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="c47f14a6-4b1f-4540-8ea7-2d47895427af" key="textField-15" x="883" y="0" width="100" height="16" fontSize="8.0" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[]]></expression>
+				<box rightPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="38ce54c6-d938-46e1-9f9f-49bd5564b90b" key="textField-15" x="783" y="0" width="100" height="16" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{SHOW_NETDUE} == null ? BigDecimal.ZERO : ($F{NETDUE} == null
+    ? $F{SHOW_NETDUE}.negate() : $F{SHOW_NETDUE})]]></expression>
 				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="633" y="0" width="75" height="16" forecolor="#000000" uuid="16b6e4ef-8617-4a3d-8809-6fc2f3b281a0"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AMOUNT5} != null ? $F{AMOUNT5} : BigDecimal.ZERO]]></textFieldExpression>
+				<box rightPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="16b6e4ef-8617-4a3d-8809-6fc2f3b281a0" key="textField-6" x="633" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{AMOUNT5} != null ? $F{AMOUNT5} : BigDecimal.ZERO]]></expression>
 				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="708" y="0" width="75" height="16" forecolor="#000000" uuid="b7fbaa8e-7cf2-4a3a-83a4-ceb1ff1edd7a"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AMOUNT6} != null ? $F{AMOUNT6}.negate() : BigDecimal.ZERO]]></textFieldExpression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="b7fbaa8e-7cf2-4a3a-83a4-ceb1ff1edd7a" key="textField-6" x="708" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{AMOUNT6} != null ? $F{AMOUNT6}.negate() : BigDecimal.ZERO]]></expression>
 				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="72">
-			<staticText>
-				<reportElement x="0" y="0" width="983" height="28" uuid="c1ae44a7-998a-4376-ab95-3484073e0042"/>
-				<textElement markup="none">
-					<font size="18"/>
-				</textElement>
-				<text><![CDATA[Total]]></text>
-			</staticText>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="258" y="60" width="725" height="1" uuid="c7978ca3-c5a4-4286-8a34-270ed0cbba2d"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="258" y="39" width="725" height="1" uuid="446732ae-d6a5-4e29-8cf5-8456d6d3ddf4"/>
-			</line>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" x="483" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="8920e958-46f7-419a-9364-f20205b85e08"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUMAMT3TOTAL} != null ? $V{SUMAMT3TOTAL} : BigDecimal.ZERO]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" x="558" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="99ed2b1b-c40c-4e85-9c4e-8b38142b2ced"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUMAMT4TOTAL} != null ? $V{SUMAMT4TOTAL} : BigDecimal.ZERO]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="258" y="63" width="725" height="1" uuid="309e6d12-dee1-4cdb-bc5f-4a8e760a5a07"/>
-			</line>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" x="408" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="ad96ed9c-f46f-4d56-b917-933f7e5c3dd1"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUMAMT2TOTAL} != null ? $V{SUMAMT2TOTAL} : BigDecimal.ZERO]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" x="633" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="88771801-5c2a-44a9-b89a-3d8f957bc269"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUMAMT5TOTAL} != null ? $V{SUMAMT5TOTAL} : BigDecimal.ZERO]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="0" y="29" width="983" height="1" uuid="7907ca16-6f6c-461e-8abb-371b16ddfdc7"/>
-			</line>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" x="783" y="42" width="100" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="2869faa0-1a50-4323-b93a-f4d1c33ee2c4"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="10" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUMNETTOTAL}.add($V{SUMCREDITSTOTAL}==null ? BigDecimal.ZERO : $V{SUMCREDITSTOTAL})]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-22" style="Report_Footer" x="883" y="42" width="100" height="16" uuid="90d286d5-7b7c-4513-ae71-643a3eecbde9"/>
-				<box rightPadding="2"/>
-				<textElement textAlignment="Right">
-					<font size="10" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUMNETTOTAL}==null ? BigDecimal.ZERO : $V{SUMNETTOTAL}).add($V{SUMCREDITSTOTAL}==null ? BigDecimal.ZERO : $V{SUMCREDITSTOTAL})]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" x="708" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="158ebc81-bb7c-4935-8cb1-abf922a9eff2"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUMCREDITSTOTAL} != null ? $V{SUMCREDITSTOTAL} : BigDecimal.ZERO]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" x="258" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="e2c279ce-75ec-48a1-89bf-08ecaf5f229f"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUMAMT0TOTAL} != null ? $V{SUMAMT0TOTAL} : BigDecimal.ZERO]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" x="333" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="bf136791-a710-4443-aac7-075eb28a9c61"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUMAMT1TOTAL} != null ? $V{SUMAMT1TOTAL} : BigDecimal.ZERO]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-		</band>
+	<columnFooter height="72">
+		<element kind="staticText" uuid="c1ae44a7-998a-4376-ab95-3484073e0042" x="0" y="0" width="983" height="28" markup="none" fontSize="18.0">
+			<text><![CDATA[Total]]></text>
+		</element>
+		<element kind="line" uuid="c7978ca3-c5a4-4286-8a34-270ed0cbba2d" key="line-33" x="258" y="60" width="725" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="446732ae-d6a5-4e29-8cf5-8456d6d3ddf4" key="line-33" x="258" y="39" width="725" height="1" style="Report_Footer"/>
+		<element kind="textField" uuid="8920e958-46f7-419a-9364-f20205b85e08" key="textField-6" x="483" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMAMT3TOTAL} != null ? $V{SUMAMT3TOTAL} : BigDecimal.ZERO]]></expression>
+			<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="textField" uuid="99ed2b1b-c40c-4e85-9c4e-8b38142b2ced" key="textField-6" x="558" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMAMT4TOTAL} != null ? $V{SUMAMT4TOTAL} : BigDecimal.ZERO]]></expression>
+			<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="line" uuid="309e6d12-dee1-4cdb-bc5f-4a8e760a5a07" key="line-33" x="258" y="63" width="725" height="1" style="Report_Footer"/>
+		<element kind="textField" uuid="ad96ed9c-f46f-4d56-b917-933f7e5c3dd1" key="textField-6" x="408" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMAMT2TOTAL} != null ? $V{SUMAMT2TOTAL} : BigDecimal.ZERO]]></expression>
+			<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="textField" uuid="88771801-5c2a-44a9-b89a-3d8f957bc269" key="textField-6" x="633" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMAMT5TOTAL} != null ? $V{SUMAMT5TOTAL} : BigDecimal.ZERO]]></expression>
+			<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="line" uuid="7907ca16-6f6c-461e-8abb-371b16ddfdc7" key="line-33" x="0" y="29" width="983" height="1" style="Report_Footer"/>
+		<element kind="textField" uuid="2869faa0-1a50-4323-b93a-f4d1c33ee2c4" key="textField-6" x="783" y="42" width="100" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="10.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMNETTOTAL}.add($V{SUMCREDITSTOTAL}==null ? BigDecimal.ZERO : $V{SUMCREDITSTOTAL})]]></expression>
+			<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="textField" uuid="90d286d5-7b7c-4513-ae71-643a3eecbde9" key="textField-22" x="883" y="42" width="100" height="16" fontSize="10.0" textAdjust="StretchHeight" blankWhenNull="false" bold="false" hTextAlign="Right" style="Report_Footer">
+			<expression><![CDATA[($V{SUMNETTOTAL}==null ? BigDecimal.ZERO : $V{SUMNETTOTAL}).add($V{SUMCREDITSTOTAL}==null ? BigDecimal.ZERO : $V{SUMCREDITSTOTAL})]]></expression>
+			<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
+			<box rightPadding="2" style="Report_Footer"/>
+		</element>
+		<element kind="textField" uuid="158ebc81-bb7c-4935-8cb1-abf922a9eff2" key="textField-6" x="708" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMCREDITSTOTAL} != null ? $V{SUMCREDITSTOTAL} : BigDecimal.ZERO]]></expression>
+			<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="textField" uuid="e2c279ce-75ec-48a1-89bf-08ecaf5f229f" key="textField-6" x="258" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMAMT0TOTAL} != null ? $V{SUMAMT0TOTAL} : BigDecimal.ZERO]]></expression>
+			<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="textField" uuid="bf136791-a710-4443-aac7-075eb28a9c61" key="textField-6" x="333" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMAMT1TOTAL} != null ? $V{SUMAMT1TOTAL} : BigDecimal.ZERO]]></expression>
+			<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
 	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
+	<pageFooter splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailXLSDoubtfulDebt.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/AgingScheduleDetailXLSDoubtfulDebt.jrxml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="PaymentReportPDF" pageWidth="1138" pageHeight="842" columnWidth="1138" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="PaymentReportPDF" language="java" pageWidth="1138" pageHeight="842" columnWidth="1138" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="e7a0e6ef-f401-4086-bc89-ad836adcaebf">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
@@ -7,30 +7,29 @@
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
 	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
 	<parameter name="AMOUNTFORMAT" class="java.text.DecimalFormat"/>
 	<parameter name="DATEFORMATTER" class="java.text.DateFormat">
 		<defaultValueExpression><![CDATA[$P{REPORT_FORMAT_FACTORY}.createDateFormat("", $P{REPORT_LOCALE}, $P{REPORT_TIME_ZONE})]]></defaultValueExpression>
@@ -56,12 +55,10 @@
 	<parameter name="inpLabel3" class="java.lang.String"/>
 	<parameter name="inpLabel4" class="java.lang.String"/>
 	<parameter name="inpLabel5" class="java.lang.String"/>
-	<queryString>
-		<![CDATA[SELECT 'hello' AS BP_GROUP, 'hello' AS BPARTNER, 'hello' AS PROJECT, 'hello' AS PAYMENT, 'hello' AS SALES_PERSON, 1234 AS INVOICE_NUMBER, to_Date('01/01/2010') AS INVOICE_DATE,
+	<query language="sql"><![CDATA[SELECT 'hello' AS BP_GROUP, 'hello' AS BPARTNER, 'hello' AS PROJECT, 'hello' AS PAYMENT, 'hello' AS SALES_PERSON, 1234 AS INVOICE_NUMBER, to_Date('01/01/2010') AS INVOICE_DATE,
        to_Date('01/03/2010') AS DUE_DATE, 1234 AS PLANNED_DSO, 1234 AS CURRENT_DSO, 1234 AS OVERDUE, 1234 AS DAYS_OVERDUE, 1234 AS AMOUNT,
        'hello' AS CURRENCY, 1234 AS BASE_AMOUNT, 'hello' AS BASE_CURRENCY, 'hello' AS PAYMENT_METHOD, 'hello' AS FINANCIAL_ACCOUNT
-FROM DUAL]]>
-	</queryString>
+FROM DUAL]]></query>
 	<field name="INVOICE_NUMBER" class="java.lang.String"/>
 	<field name="INVOICE_ID" class="java.lang.String"/>
 	<field name="AMOUNT0" class="java.math.BigDecimal"/>
@@ -79,545 +76,333 @@ FROM DUAL]]>
 	<field name="SHOW_NETDUE" class="java.math.BigDecimal"/>
 	<field name="DOUBTFUL_DEBT" class="java.math.BigDecimal"/>
 	<field name="PERCENTAGE" class="java.math.BigDecimal"/>
-	<variable name="SUMAMT0" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT0}]]></variableExpression>
+	<variable name="SUMAMT0" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT0}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMNET" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{NETDUE}]]></variableExpression>
+	<variable name="SUMNET" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{NETDUE}]]></expression>
 	</variable>
-	<variable name="SUMAMT1" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT1}]]></variableExpression>
+	<variable name="SUMAMT1" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT1}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT2" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT2}]]></variableExpression>
+	<variable name="SUMAMT2" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT2}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT3" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT3}]]></variableExpression>
+	<variable name="SUMAMT3" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT3}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT4" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT4}]]></variableExpression>
+	<variable name="SUMAMT4" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT4}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT5" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT5}]]></variableExpression>
+	<variable name="SUMAMT5" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT5}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT0TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT0}]]></variableExpression>
+	<variable name="SUMAMT0TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT0}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMNETTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{NETDUE}]]></variableExpression>
+	<variable name="SUMNETTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{NETDUE}]]></expression>
 	</variable>
-	<variable name="SUMAMT1TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT1}]]></variableExpression>
+	<variable name="SUMAMT1TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT1}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT2TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT2}]]></variableExpression>
+	<variable name="SUMAMT2TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT2}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT3TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT3}]]></variableExpression>
+	<variable name="SUMAMT3TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT3}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT4TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT4}]]></variableExpression>
+	<variable name="SUMAMT4TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT4}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMAMT5TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT5}]]></variableExpression>
+	<variable name="SUMAMT5TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT5}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="SUMCREDIT" class="java.math.BigDecimal" resetType="Group" resetGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT6}.negate()]]></variableExpression>
+	<variable name="SUMCREDIT" resetType="Group" calculation="Sum" resetGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT6}.negate()]]></expression>
 		<initialValueExpression><![CDATA[]]></initialValueExpression>
 	</variable>
-	<variable name="SUMCREDITSTOTAL" class="java.math.BigDecimal" incrementType="Group" incrementGroup="Group" calculation="Sum">
-		<variableExpression><![CDATA[$V{SUMCREDIT}]]></variableExpression>
+	<variable name="SUMCREDITSTOTAL" incrementType="Group" calculation="Sum" incrementGroup="Group" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{SUMCREDIT}]]></expression>
 	</variable>
-	<variable name="SUMDOUBTFULTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{DOUBTFUL_DEBT}]]></variableExpression>
+	<variable name="SUMDOUBTFULTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{DOUBTFUL_DEBT}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
 	<variable name="PERCENTAGETOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{SUMDOUBTFULTOTAL}.divide( $V{SUMNETTOTAL}.doubleValue() == 0 ? new BigDecimal("1"):$V{SUMNETTOTAL}, 5, RoundingMode.HALF_UP ).multiply(new BigDecimal("100"))]]></variableExpression>
+		<expression><![CDATA[$V{SUMDOUBTFULTOTAL}.divide( $V{SUMNETTOTAL}.doubleValue() == 0 ? new BigDecimal("1"):$V{SUMNETTOTAL}, 5, RoundingMode.HALF_UP ).multiply(new BigDecimal("100"))]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
 	<group name="Totals"/>
 	<group name="Group">
-		<groupExpression><![CDATA[$F{BPARTNER}]]></groupExpression>
+		<expression><![CDATA[$F{BPARTNER}]]></expression>
 		<groupHeader>
 			<band height="22" splitType="Stretch">
-				<textField>
-					<reportElement x="0" y="0" width="1138" height="19"/>
-					<textElement>
-						<font size="12"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[$F{BPARTNERNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="1" y="20" width="1137" height="1"/>
-				</line>
+				<element kind="textField" uuid="fb2b3204-24d7-4f01-b9db-9a6088593765" x="0" y="0" width="1138" height="19" fontSize="12.0">
+					<expression><![CDATA[$F{BPARTNERNAME}]]></expression>
+				</element>
+				<element kind="line" uuid="42532757-34db-41eb-b59e-293d9ab4d8fc" key="line-33" x="1" y="20" width="1137" height="1" style="Report_Footer"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="28">
-				<staticText>
-					<reportElement key="staticText-21" style="Report_Footer" x="0" y="1" width="1038" height="19"/>
-					<textElement>
-						<font size="12" isBold="false" isItalic="false"/>
-					</textElement>
+				<element kind="staticText" uuid="9224f6d6-d05a-4b96-9af2-49ac46911c28" key="staticText-21" x="0" y="1" width="1038" height="19" fontSize="12.0" bold="false" italic="false" style="Report_Footer">
 					<text><![CDATA[Balance]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="1038" y="0" width="100" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="1038" y="22" width="100" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="1038" y="25" width="100" height="1"/>
-				</line>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-					<reportElement key="textField-22" style="Report_Footer" x="1038" y="1" width="100" height="19"/>
-					<box rightPadding="2"/>
-					<textElement textAlignment="Right">
-						<font size="10" isBold="false"/>
-					</textElement>
-					<textFieldExpression class="java.math.BigDecimal"><![CDATA[($V{SUMNET}==null ? BigDecimal.ZERO : $V{SUMNET}).add($V{SUMCREDIT}==null ? BigDecimal.ZERO : $V{SUMCREDIT})]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="line" uuid="7d7b797a-a9c7-40e1-8655-bb41ec342428" key="line-33" x="1038" y="0" width="100" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="4eda3e14-637c-4858-8976-70ef1149d295" key="line-33" x="1038" y="22" width="100" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="3e83fb73-8ac1-416e-bb31-401aade75843" key="line-33" x="1038" y="25" width="100" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="07ec3b86-8b6b-4a53-ad66-c3aa5e72e192" key="textField-22" x="1038" y="1" width="100" height="19" fontSize="10.0" textAdjust="StretchHeight" blankWhenNull="false" bold="false" hTextAlign="Right" style="Report_Footer">
+					<expression><![CDATA[($V{SUMNET}==null ? BigDecimal.ZERO : $V{SUMNET}).add($V{SUMCREDIT}==null ? BigDecimal.ZERO : $V{SUMCREDIT})]]></expression>
+					<box rightPadding="2" style="Report_Footer"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="47" splitType="Stretch">
-			<textField>
-				<reportElement x="0" y="0" width="1138" height="29"/>
-				<textElement>
-					<font size="18"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{title}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="783" y="29" width="355" height="18"/>
-				<textElement/>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{AccSchema}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-26" style="Report_Footer" x="333" y="29" width="150" height="18"/>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[As Of Date:]]></text>
-			</staticText>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="483" y="29" width="150" height="18"/>
-				<textElement/>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{currentDate}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="99" y="29" width="234" height="18"/>
-				<textElement/>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{Organization}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-27" style="Report_Footer" x="633" y="29" width="150" height="18"/>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[General Ledger:]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-24" style="Report_Footer" x="0" y="29" width="99" height="18"/>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Organization:]]></text>
-			</staticText>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="47" splitType="Stretch">
+		<element kind="textField" uuid="b8129a02-9c8d-4518-88b0-5801aec2fa80" x="0" y="0" width="1138" height="29" fontSize="18.0">
+			<expression><![CDATA[$P{title}]]></expression>
+		</element>
+		<element kind="textField" uuid="723cdc4e-6a83-4d8c-990f-2487ccc0a533" key="textField-25" x="783" y="29" width="355" height="18" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{AccSchema}]]></expression>
+		</element>
+		<element kind="staticText" uuid="582197c6-d8e7-4302-8728-fc0b6644ddf0" key="staticText-26" x="333" y="29" width="150" height="18" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[As Of Date:]]></text>
+		</element>
+		<element kind="textField" uuid="e915000e-1b1e-4b6a-926b-d25554db2b3d" key="textField-25" x="483" y="29" width="150" height="18" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{currentDate}]]></expression>
+		</element>
+		<element kind="textField" uuid="153a7666-5f0f-4ff5-9f87-4d755b595023" key="textField-25" x="99" y="29" width="234" height="18" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{Organization}]]></expression>
+		</element>
+		<element kind="staticText" uuid="ce156b77-c1f7-4313-a1c6-139bc0465229" key="staticText-27" x="633" y="29" width="150" height="18" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[General Ledger:]]></text>
+		</element>
+		<element kind="staticText" uuid="8c2f2fc6-53bf-4290-8310-e13560e8e551" key="staticText-24" x="0" y="29" width="99" height="18" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Organization:]]></text>
+		</element>
 	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band height="20" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="938" y="0" width="100" height="20"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Net Due]]></text>
-			</staticText>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="483" y="0" width="75" height="20"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{inpLabel3}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="258" y="0" width="75" height="20"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Current]]></text>
-			</staticText>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="333" y="0" width="75" height="20"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{inpLabel1}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="408" y="0" width="75" height="20"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{inpLabel2}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="99" y="0" width="80" height="20"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement>
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Document No.]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="1" y="0" width="98" height="20"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement>
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Business Partner]]></text>
-			</staticText>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="633" y="0" width="75" height="20"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{inpLabel5}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-25" style="Detail_Header" x="558" y="0" width="75" height="20"/>
-				<textElement textAlignment="Right" markup="none">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{inpLabel4}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="708" y="0" width="75" height="20"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Credits]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="179" y="0" width="79" height="20"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Document Date]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="1038" y="0" width="100" height="20"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Total]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="783" y="0" width="85" height="20"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Doubtful Debt]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="868" y="0" width="70" height="20"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Percentage]]></text>
-			</staticText>
-		</band>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader height="20" splitType="Stretch">
+		<element kind="staticText" uuid="eafcc144-d71f-4fc0-adfb-d5390917fb45" key="staticText-25" x="938" y="0" width="100" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Net Due]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="22261e4a-e70d-4fa6-878c-c66f9d125d0c" key="staticText-25" x="483" y="0" width="75" height="20" markup="none" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel3}]]></expression>
+		</element>
+		<element kind="staticText" uuid="f554a100-6df4-4cea-9f9f-a7a466aa2ca0" key="staticText-25" x="258" y="0" width="75" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Current]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="d8b950d4-de42-42c1-9ddf-e03c513d3881" key="staticText-25" x="333" y="0" width="75" height="20" markup="none" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel1}]]></expression>
+		</element>
+		<element kind="textField" uuid="b95950be-54cc-4c08-a046-927b5d5e5639" key="staticText-25" x="408" y="0" width="75" height="20" markup="none" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel2}]]></expression>
+		</element>
+		<element kind="staticText" uuid="c19437bc-9146-433a-bd72-8011ce7d05ce" key="staticText-25" x="99" y="0" width="80" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" style="Detail_Header">
+			<text><![CDATA[Document No.]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="d6e40936-87a7-43e9-8bc1-19044c830bbf" key="staticText-25" x="1" y="0" width="98" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" style="Detail_Header">
+			<text><![CDATA[Business Partner]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="ad155a73-e053-4feb-aa29-fd2af55487f5" key="staticText-25" x="633" y="0" width="75" height="20" markup="none" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel5}]]></expression>
+		</element>
+		<element kind="textField" uuid="e50a2705-5560-4520-adc3-d550cc3964ca" key="staticText-25" x="558" y="0" width="75" height="20" markup="none" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<expression><![CDATA[$P{inpLabel4}]]></expression>
+		</element>
+		<element kind="staticText" uuid="30bfcdbd-6a85-4670-9f44-87366205e91d" key="staticText-25" x="708" y="0" width="75" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Credits]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="3c66f2ec-885d-450b-8382-bb3a16edb1f5" key="staticText-25" x="179" y="0" width="79" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Document Date]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="6c25e063-b871-448f-8ba3-92a6a53a0ee0" key="staticText-25" x="1038" y="0" width="100" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Total]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="b5ed8c44-840c-4e84-b92e-a3167f02e8f9" key="staticText-25" x="783" y="0" width="85" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Doubtful Debt]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="a91bf59c-5000-411e-9223-cba246ab351a" key="staticText-25" x="868" y="0" width="70" height="20" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Percentage]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
 	</columnHeader>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="99" y="0" width="80" height="16" forecolor="#000000"/>
-				<box leftPadding="2"/>
-				<textElement verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{INVOICE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="258" y="0" width="75" height="16" forecolor="#000000"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$F{AMOUNT0} != null ? $F{AMOUNT0} : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="333" y="0" width="75" height="16" forecolor="#000000"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$F{AMOUNT1} != null ? $F{AMOUNT1} : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="408" y="0" width="75" height="16" forecolor="#000000"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$F{AMOUNT2} != null ? $F{AMOUNT2} : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="483" y="0" width="75" height="16" forecolor="#000000"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$F{AMOUNT3} != null ? $F{AMOUNT3} : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="558" y="0" width="75" height="16" forecolor="#000000"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$F{AMOUNT4} != null ? $F{AMOUNT4} : null]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="179" y="0" width="79" height="16" forecolor="#000000"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{DATEFORMATTER}.format($F{INVOICE_DATE})]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-15" style="Detail_Line" x="1038" y="0" width="100" height="16"/>
-				<box rightPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression class="java.math.BigDecimal"><![CDATA[]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-15" style="Detail_Line" x="938" y="0" width="100" height="16"/>
-				<box rightPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$F{SHOW_NETDUE} == null ? null : ($F{NETDUE} == null
-    ? $F{SHOW_NETDUE}.negate() : $F{SHOW_NETDUE})]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="633" y="0" width="75" height="16" forecolor="#000000"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$F{AMOUNT5} != null ? $F{AMOUNT5} : null]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="708" y="0" width="75" height="16" forecolor="#000000"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$F{AMOUNT6} != null ? $F{AMOUNT6}.negate() : null]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="783" y="0" width="85" height="16" forecolor="#000000"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$F{DOUBTFUL_DEBT} != null ? $F{DOUBTFUL_DEBT}: null]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Line" x="868" y="0" width="70" height="16" forecolor="#000000"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PERCENTAGE} != null ?  $F{PERCENTAGE} : null]]></textFieldExpression>
-			</textField>
+			<element kind="textField" uuid="ea2a09a2-c7f6-4157-9c76-18c30b6fc13e" key="textField-6" x="99" y="0" width="80" height="16" forecolor="#000000" fontSize="8.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{INVOICE_NUMBER}]]></expression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="2276a115-1830-4caa-b4d7-d9f7159dd3b2" key="textField-6" x="258" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{AMOUNT0} != null ? $F{AMOUNT0} : null]]></expression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="519cb9d9-aa0b-4d8f-bd18-3f1321ce11e3" key="textField-6" x="333" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{AMOUNT1} != null ? $F{AMOUNT1} : null]]></expression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="b3583584-6938-455d-8661-74475879c5b7" key="textField-6" x="408" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{AMOUNT2} != null ? $F{AMOUNT2} : null]]></expression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="3e3a3a9f-3394-4a80-8ad6-4a9336be3ee9" key="textField-6" x="483" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{AMOUNT3} != null ? $F{AMOUNT3} : null]]></expression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="9125a36a-ddf5-4f03-a72e-705e52c15500" key="textField-6" x="558" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{AMOUNT4} != null ? $F{AMOUNT4} : null]]></expression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="36fc1af9-06a2-4c59-aa71-250fa10a557a" key="textField-6" x="179" y="0" width="79" height="16" forecolor="#000000" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$P{DATEFORMATTER}.format($F{INVOICE_DATE})]]></expression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="b46c0555-a419-4f7f-b6a8-8105773d87c4" key="textField-15" x="1038" y="0" width="100" height="16" fontSize="8.0" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[]]></expression>
+				<box rightPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="5c1f6937-95c1-4dc3-a3d0-99a0d0743e25" key="textField-15" x="938" y="0" width="100" height="16" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{SHOW_NETDUE} == null ? null : ($F{NETDUE} == null
+    ? $F{SHOW_NETDUE}.negate() : $F{SHOW_NETDUE})]]></expression>
+				<box rightPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="aa56f9bf-48b7-440a-9b0c-2463983cb7e8" key="textField-6" x="633" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{AMOUNT5} != null ? $F{AMOUNT5} : null]]></expression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="fd1819ec-b03c-4d51-ae3c-57bf8aa20af2" key="textField-6" x="708" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{AMOUNT6} != null ? $F{AMOUNT6}.negate() : null]]></expression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="421cec4c-ec99-4d28-854a-0ef1a40b729e" key="textField-6" x="783" y="0" width="85" height="16" forecolor="#000000" fontSize="8.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{DOUBTFUL_DEBT} != null ? $F{DOUBTFUL_DEBT}: null]]></expression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
+			<element kind="textField" uuid="f3c190dc-7162-4214-a3e7-789663846898" key="textField-6" x="868" y="0" width="70" height="16" forecolor="#000000" fontSize="8.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{PERCENTAGE} != null ?  $F{PERCENTAGE} : null]]></expression>
+				<box leftPadding="2" style="Detail_Line"/>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="72">
-			<staticText>
-				<reportElement x="0" y="0" width="1138" height="28"/>
-				<textElement markup="none">
-					<font size="18"/>
-				</textElement>
-				<text><![CDATA[Total]]></text>
-			</staticText>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="1" y="60" width="1137" height="1"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="1" y="39" width="1137" height="1"/>
-			</line>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" x="483" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$V{SUMAMT3TOTAL} != null ? $V{SUMAMT3TOTAL} : BigDecimal.ZERO]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" x="558" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$V{SUMAMT4TOTAL} != null ? $V{SUMAMT4TOTAL} : BigDecimal.ZERO]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="1" y="63" width="1137" height="1"/>
-			</line>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" x="408" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$V{SUMAMT2TOTAL} != null ? $V{SUMAMT2TOTAL} : BigDecimal.ZERO]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" x="633" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$V{SUMAMT5TOTAL} != null ? $V{SUMAMT5TOTAL} : BigDecimal.ZERO]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="1" y="29" width="1137" height="1"/>
-			</line>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" x="938" y="42" width="100" height="16" forecolor="#000000" backcolor="#FFFFFF"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="10" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$V{SUMNETTOTAL}.add($V{SUMCREDITSTOTAL}==null ? BigDecimal.ZERO : $V{SUMCREDITSTOTAL})]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-22" style="Report_Footer" x="1038" y="42" width="100" height="16"/>
-				<box rightPadding="2"/>
-				<textElement textAlignment="Right">
-					<font size="10" isBold="false"/>
-				</textElement>
-				<textFieldExpression class="java.math.BigDecimal"><![CDATA[($V{SUMNETTOTAL}==null ? BigDecimal.ZERO : $V{SUMNETTOTAL}).add($V{SUMCREDITSTOTAL}==null ? BigDecimal.ZERO : $V{SUMCREDITSTOTAL})]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" x="708" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$V{SUMCREDITSTOTAL} != null ? $V{SUMCREDITSTOTAL} : BigDecimal.ZERO]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" x="258" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$V{SUMAMT0TOTAL} != null ? $V{SUMAMT0TOTAL} : BigDecimal.ZERO]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" x="333" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$V{SUMAMT1TOTAL} != null ? $V{SUMAMT1TOTAL} : BigDecimal.ZERO]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField-6" style="Detail_Header" x="783" y="42" width="85" height="16" forecolor="#000000" backcolor="#FFFFFF"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$V{SUMDOUBTFULTOTAL} != null ? $V{SUMDOUBTFULTOTAL} : BigDecimal.ZERO]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference" pattern="##0.00%">
-				<reportElement key="textField-6" style="Detail_Header" x="868" y="42" width="70" height="16" forecolor="#000000" backcolor="#FFFFFF"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{PERCENTAGETOTAL} != null ? $V{PERCENTAGETOTAL} : BigDecimal.ZERO)]]></textFieldExpression>
-			</textField>
-		</band>
+	<columnFooter height="72">
+		<element kind="staticText" uuid="4da2e716-c560-48aa-873c-20d23ca55010" x="0" y="0" width="1138" height="28" markup="none" fontSize="18.0">
+			<text><![CDATA[Total]]></text>
+		</element>
+		<element kind="line" uuid="db7ef6b4-7908-4011-963d-3c6db625646a" key="line-33" x="1" y="60" width="1137" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="35349dbd-c70c-47fc-ba99-1b30840265c0" key="line-33" x="1" y="39" width="1137" height="1" style="Report_Footer"/>
+		<element kind="textField" uuid="53e8ef88-84a5-427c-8a96-bd540732e02d" key="textField-6" x="483" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMAMT3TOTAL} != null ? $V{SUMAMT3TOTAL} : BigDecimal.ZERO]]></expression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="textField" uuid="c2f69627-758f-48ca-aef9-8acb4462d00e" key="textField-6" x="558" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMAMT4TOTAL} != null ? $V{SUMAMT4TOTAL} : BigDecimal.ZERO]]></expression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="line" uuid="cfdebd2f-8250-4440-90b7-5a8ad84ee204" key="line-33" x="1" y="63" width="1137" height="1" style="Report_Footer"/>
+		<element kind="textField" uuid="c6f68050-a348-48b0-8061-d68144e8f6af" key="textField-6" x="408" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMAMT2TOTAL} != null ? $V{SUMAMT2TOTAL} : BigDecimal.ZERO]]></expression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="textField" uuid="f58d4390-5d3c-47d2-aaaf-13ec3a7a7c65" key="textField-6" x="633" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMAMT5TOTAL} != null ? $V{SUMAMT5TOTAL} : BigDecimal.ZERO]]></expression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="line" uuid="b344ea90-4256-4383-9a01-93b5c152d4a6" key="line-33" x="1" y="29" width="1137" height="1" style="Report_Footer"/>
+		<element kind="textField" uuid="150771ae-7df2-4903-bc4c-673b52864700" key="textField-6" x="938" y="42" width="100" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="10.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMNETTOTAL}.add($V{SUMCREDITSTOTAL}==null ? BigDecimal.ZERO : $V{SUMCREDITSTOTAL})]]></expression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="textField" uuid="74a847f0-88c1-4009-94ef-8c30ba9ddcfd" key="textField-22" x="1038" y="42" width="100" height="16" fontSize="10.0" textAdjust="StretchHeight" blankWhenNull="false" bold="false" hTextAlign="Right" style="Report_Footer">
+			<expression><![CDATA[($V{SUMNETTOTAL}==null ? BigDecimal.ZERO : $V{SUMNETTOTAL}).add($V{SUMCREDITSTOTAL}==null ? BigDecimal.ZERO : $V{SUMCREDITSTOTAL})]]></expression>
+			<box rightPadding="2" style="Report_Footer"/>
+		</element>
+		<element kind="textField" uuid="6472d06d-ad6b-442e-ab73-324c02aaacc4" key="textField-6" x="708" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMCREDITSTOTAL} != null ? $V{SUMCREDITSTOTAL} : BigDecimal.ZERO]]></expression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="textField" uuid="404e491f-c8e5-4c78-9519-8e4ea427ba91" key="textField-6" x="258" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMAMT0TOTAL} != null ? $V{SUMAMT0TOTAL} : BigDecimal.ZERO]]></expression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="textField" uuid="2b60f7db-0709-41aa-b03c-e6425f8f1676" key="textField-6" x="333" y="42" width="75" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMAMT1TOTAL} != null ? $V{SUMAMT1TOTAL} : BigDecimal.ZERO]]></expression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="textField" uuid="452d7409-8bbe-4c6e-8c60-c1c0c7a2904f" key="textField-6" x="783" y="42" width="85" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$V{SUMDOUBTFULTOTAL} != null ? $V{SUMDOUBTFULTOTAL} : BigDecimal.ZERO]]></expression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
+		<element kind="textField" uuid="39b1ad1c-e263-4cc2-a081-7dddaed3b35a" key="textField-6" x="868" y="42" width="70" height="16" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" textAdjust="StretchHeight" pattern="##0.00%" linkType="Reference" blankWhenNull="true" underline="false" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[($V{PERCENTAGETOTAL} != null ? $V{PERCENTAGETOTAL} : BigDecimal.ZERO)]]></expression>
+			<box leftPadding="2" style="Detail_Header"/>
+		</element>
 	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
+	<pageFooter splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/AgingScheduleHTML.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/AgingScheduleHTML.jrxml
@@ -1,98 +1,95 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
-<!-- 2016-11-02T09:12:32 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportAgingBalance" pageWidth="975" pageHeight="842" columnWidth="915" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="bd188040-4e9b-4416-89da-8ac052697179">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportAgingBalance" language="java" pageWidth="975" pageHeight="842" columnWidth="915" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="bd188040-4e9b-4416-89da-8ac052697179">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="104"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
 		<pen lineWidth="0.0" lineStyle="Solid"/>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/home/david/workspace/trunk/openbravo/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="AMOUNTFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<parameter name="AMOUNTFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat()]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale">
 		<defaultValueExpression><![CDATA[new Locale("es", "ES")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="InitialBalance" class="java.math.BigDecimal" isForPrompting="false">
+	<parameter name="InitialBalance" forPrompting="false" class="java.math.BigDecimal">
 		<defaultValueExpression><![CDATA[new BigDecimal(1111)]]></defaultValueExpression>
 	</parameter>
 	<parameter name="SUBREPORT_DIR" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{BASE_DESIGN}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATE_FROM" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col1" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col2" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col3" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col4" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col5" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BPartners" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Date1" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Date2" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Date3" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Date4" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Date5" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Organization" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="AccSchema" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Currency" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="toCurrency" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="PayStatus" class="java.lang.String" isForPrompting="false"/>
+	<parameter name="DATE_FROM" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col1" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col2" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col3" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col4" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col5" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BPartners" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Date1" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Date2" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Date3" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Date4" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Date5" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Organization" forPrompting="false" class="java.lang.String"/>
+	<parameter name="AccSchema" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Currency" forPrompting="false" class="java.lang.String"/>
+	<parameter name="toCurrency" forPrompting="false" class="java.lang.String"/>
+	<parameter name="PayStatus" forPrompting="false" class="java.lang.String"/>
 	<parameter name="currentDate" class="java.lang.String"/>
 	<parameter name="tabTitle" class="java.lang.String"/>
 	<parameter name="title" class="java.lang.String"/>
@@ -110,17 +107,17 @@
 	<parameter name="reversed" class="java.lang.String">
 		<defaultValueExpression><![CDATA["true"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="processId" class="java.lang.String" isForPrompting="false">
-		<parameterDescription><![CDATA[]]></parameterDescription>
+	<parameter name="processId" forPrompting="false" class="java.lang.String">
+		<description><![CDATA[]]></description>
 	</parameter>
-	<parameter name="reportId" class="java.lang.String" isForPrompting="false">
-		<parameterDescription><![CDATA[]]></parameterDescription>
+	<parameter name="reportId" forPrompting="false" class="java.lang.String">
+		<description><![CDATA[]]></description>
 	</parameter>
-	<parameter name="dateFromUI" class="java.lang.String" isForPrompting="false">
-		<parameterDescription><![CDATA[]]></parameterDescription>
+	<parameter name="dateFromUI" forPrompting="false" class="java.lang.String">
+		<description><![CDATA[]]></description>
 	</parameter>
 	<parameter name="recOrPay" class="java.lang.String">
-		<parameterDescription><![CDATA[]]></parameterDescription>
+		<description><![CDATA[]]></description>
 	</parameter>
 	<parameter name="warning" class="java.lang.String"/>
 	<field name="BPartner" class="java.lang.String"/>
@@ -136,313 +133,216 @@
 	<field name="net" class="java.math.BigDecimal"/>
 	<field name="doubtfulDebt" class="java.math.BigDecimal"/>
 	<field name="percentage" class="java.math.BigDecimal"/>
-	<variable name="SUM_ZERO_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount0}]]></variableExpression>
+	<variable name="SUM_ZERO_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount0}]]></expression>
 	</variable>
-	<variable name="SUM_ONE_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount1}]]></variableExpression>
+	<variable name="SUM_ONE_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount1}]]></expression>
 	</variable>
-	<variable name="SUM_TWO_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount2}]]></variableExpression>
+	<variable name="SUM_TWO_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount2}]]></expression>
 	</variable>
-	<variable name="SUM_THREE_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount3}]]></variableExpression>
+	<variable name="SUM_THREE_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount3}]]></expression>
 	</variable>
-	<variable name="SUM_FOUR_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount4}]]></variableExpression>
+	<variable name="SUM_FOUR_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount4}]]></expression>
 	</variable>
-	<variable name="SUM_FIVE_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount5}]]></variableExpression>
+	<variable name="SUM_FIVE_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount5}]]></expression>
 	</variable>
-	<variable name="SUM_TOTAL_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{Total}]]></variableExpression>
+	<variable name="SUM_TOTAL_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{Total}]]></expression>
 	</variable>
 	<variable name="NoBPartner" class="java.lang.String">
-		<variableExpression><![CDATA[($F{BPartnerID}==null)?new String("only"):new String("exclude")]]></variableExpression>
+		<expression><![CDATA[($F{BPartnerID}==null)?new String("only"):new String("exclude")]]></expression>
 	</variable>
 	<variable name="NoBPartnerTotal" class="java.lang.String">
-		<variableExpression><![CDATA[($P{BPartners}=="")?new String("include"):new String("exclude")]]></variableExpression>
+		<expression><![CDATA[($P{BPartners}=="")?new String("include"):new String("exclude")]]></expression>
 	</variable>
-	<variable name="SUM_CREDIT" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{credit}]]></variableExpression>
+	<variable name="SUM_CREDIT" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{credit}]]></expression>
 	</variable>
-	<variable name="SUM_NET" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{net}]]></variableExpression>
+	<variable name="SUM_NET" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{net}]]></expression>
 	</variable>
-	<variable name="SUM_DOUBTFUL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{doubtfulDebt}]]></variableExpression>
+	<variable name="SUM_DOUBTFUL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{doubtfulDebt}]]></expression>
 	</variable>
 	<variable name="VAR_PERCENT" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{SUM_DOUBTFUL}.divide( $V{SUM_NET}.doubleValue() == 0 ? new BigDecimal("1"):$V{SUM_NET}, 5, RoundingMode.HALF_UP ).multiply(new BigDecimal("100"))]]></variableExpression>
+		<expression><![CDATA[$V{SUM_DOUBTFUL}.divide( $V{SUM_NET}.doubleValue() == 0 ? new BigDecimal("1"):$V{SUM_NET}, 5, RoundingMode.HALF_UP ).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="136" splitType="Stretch">
-			<textField>
-				<reportElement x="10" y="30" width="500" height="28" uuid="666e97f8-a542-4313-8ddf-06c6fa123b77"/>
-				<textElement>
-					<font size="18"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{title}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="499" y="63" width="179" height="18" uuid="a0709414-bade-4c76-ba3a-13b0945a81fc"/>
-				<textFieldExpression><![CDATA[$P{AccSchemaName}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-26" style="Report_Footer" x="10" y="83" width="118" height="18" uuid="0dfa9a37-7b70-42d0-befb-3d451e960f83"/>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[As Of Date:]]></text>
-			</staticText>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="134" y="83" width="168" height="18" uuid="3151bed2-8a25-4171-b151-2b205a22b3cf"/>
-				<textFieldExpression><![CDATA[$P{currentDate}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="134" y="63" width="168" height="18" uuid="e86ddff0-a232-458b-952e-38ea5679e948"/>
-				<textFieldExpression><![CDATA[$P{OrganizationName}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-27" style="Report_Footer" x="333" y="63" width="160" height="18" uuid="7942984d-da77-40b3-b0f1-6e845728aedf"/>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[General Ledger:]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-24" style="Report_Footer" x="10" y="63" width="118" height="18" uuid="39be6ec7-84ca-45dd-a42c-54437a37ca7d"/>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Organization:]]></text>
-			</staticText>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement mode="Opaque" x="0" y="0" width="940" height="20" isRemoveLineWhenBlank="true" isPrintInFirstWholeBand="true" forecolor="#0A0505" backcolor="#FFE79F" uuid="ea37dff9-064d-4031-9f90-196bc35782ee">
-					<property name="local_mesure_unitheight" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.height" value="px"/>
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					<property name="local_mesure_unitx" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.x" value="px"/>
-					<property name="local_mesure_unity" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.y" value="px"/>
-				</reportElement>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="10"/>
-					<paragraph lineSpacing="Single" lineSpacingSize="1.0"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{warning}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="136" splitType="Stretch">
+		<element kind="textField" uuid="666e97f8-a542-4313-8ddf-06c6fa123b77" x="10" y="30" width="500" height="28" fontSize="18.0">
+			<expression><![CDATA[$P{title}]]></expression>
+		</element>
+		<element kind="textField" uuid="a0709414-bade-4c76-ba3a-13b0945a81fc" key="textField-25" x="499" y="63" width="179" height="18" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{AccSchemaName}]]></expression>
+		</element>
+		<element kind="staticText" uuid="0dfa9a37-7b70-42d0-befb-3d451e960f83" key="staticText-26" x="10" y="83" width="118" height="18" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[As Of Date:]]></text>
+		</element>
+		<element kind="textField" uuid="3151bed2-8a25-4171-b151-2b205a22b3cf" key="textField-25" x="134" y="83" width="168" height="18" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{currentDate}]]></expression>
+		</element>
+		<element kind="textField" uuid="e86ddff0-a232-458b-952e-38ea5679e948" key="textField-25" x="134" y="63" width="168" height="18" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{OrganizationName}]]></expression>
+		</element>
+		<element kind="staticText" uuid="7942984d-da77-40b3-b0f1-6e845728aedf" key="staticText-27" x="333" y="63" width="160" height="18" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[General Ledger:]]></text>
+		</element>
+		<element kind="staticText" uuid="39be6ec7-84ca-45dd-a42c-54437a37ca7d" key="staticText-24" x="10" y="63" width="118" height="18" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Organization:]]></text>
+		</element>
+		<element kind="textField" uuid="ea37dff9-064d-4031-9f90-196bc35782ee" mode="Opaque" x="0" y="0" width="940" height="20" forecolor="#0A0505" backcolor="#FFE79F" fontName="Bitstream Vera Sans" fontSize="10.0" textAdjust="StretchHeight" blankWhenNull="true" removeLineWhenBlank="true" printInFirstWholeBand="true" vTextAlign="Middle">
+			<paragraph lineSpacing="Single" lineSpacingSize="1.0"/>
+			<expression><![CDATA[$P{warning}]]></expression>
+			<property name="local_mesure_unitheight" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<property name="local_mesure_unitwidth" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.width" value="px"/>
+			<property name="local_mesure_unitx" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.x" value="px"/>
+			<property name="local_mesure_unity" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.y" value="px"/>
+		</element>
 	</title>
-	<pageHeader>
-		<band height="5" splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band height="15" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-18" style="Detail_Header" x="0" y="0" width="151" height="15" uuid="3f6a3027-1812-4f7d-9357-d205149bbfe9"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement>
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[BUSINESS PARTNER]]></text>
-			</staticText>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Header" x="230" y="0" width="65" height="15" uuid="0b081dcc-66cc-43bb-a2c1-b38a6aa52b75"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{col1}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-3" style="Detail_Header" x="295" y="0" width="65" height="15" uuid="dc25f3fa-af04-4a29-8a0a-11e6f5239abd"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{col2}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-4" style="Detail_Header" x="360" y="0" width="65" height="15" uuid="6ec2e411-78c4-4c49-8350-090ce1920e06"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{col3}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-5" style="Detail_Header" x="425" y="0" width="65" height="15" uuid="a0498b04-4ebd-452d-b8c8-3dbcbbbf61db"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{col4}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-6" style="Detail_Header" x="490" y="0" width="65" height="15" uuid="e96cd3bc-8355-49ba-9443-c72b6e102e50"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{col5}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="844" y="0" width="70" height="15" uuid="71bfa15e-a005-4971-8d84-3f90696ad0d8">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[  NET  ]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="618" y="0" width="65" height="15" uuid="61c7c9e4-3fd8-4b6d-b1ca-8b892410481c"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[CREDITS]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="151" y="0" width="79" height="15" uuid="540b9a9a-98b1-49ff-b1ab-f5ac3d167e0e"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[CURRENT]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="555" y="0" width="63" height="15" uuid="f9f72809-46f7-41a4-8f34-00c793c32270"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[TOTAL]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="683" y="0" width="89" height="15" uuid="d3c6363a-cf15-4d04-b3cb-8d254461beed">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[DOUBTFUL DEBT]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="772" y="0" width="72" height="15" uuid="85733db2-7453-4abf-b496-5119bbf92d18">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[PERCENTAGE]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="683" y="0" width="89" height="15" uuid="f43dfb4e-5ef0-4c02-84bb-5127829417c0">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[NET]]></text>
-			</staticText>
-			<staticText>
-				<reportElement style="Detail_Line" x="772" y="0" width="6" height="15" backcolor="#5D5D5D" uuid="1c31eb4e-bcb2-4798-9379-b03eb2b2037d">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
-				</reportElement>
-				<text><![CDATA[]]></text>
-			</staticText>
-		</band>
+	<pageHeader height="5" splitType="Stretch"/>
+	<columnHeader height="15" splitType="Stretch">
+		<element kind="staticText" uuid="3f6a3027-1812-4f7d-9357-d205149bbfe9" key="staticText-18" x="0" y="0" width="151" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" style="Detail_Header">
+			<text><![CDATA[BUSINESS PARTNER]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="0b081dcc-66cc-43bb-a2c1-b38a6aa52b75" key="textField" x="230" y="0" width="65" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col1}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="dc25f3fa-af04-4a29-8a0a-11e6f5239abd" key="textField-3" x="295" y="0" width="65" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col2}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="6ec2e411-78c4-4c49-8350-090ce1920e06" key="textField-4" x="360" y="0" width="65" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col3}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="a0498b04-4ebd-452d-b8c8-3dbcbbbf61db" key="textField-5" x="425" y="0" width="65" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col4}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="e96cd3bc-8355-49ba-9443-c72b6e102e50" key="textField-6" x="490" y="0" width="65" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col5}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="71bfa15e-a005-4971-8d84-3f90696ad0d8" key="staticText-25" x="844" y="0" width="70" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+			<text><![CDATA[  NET  ]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="61c7c9e4-3fd8-4b6d-b1ca-8b892410481c" key="staticText-25" x="618" y="0" width="65" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[CREDITS]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="540b9a9a-98b1-49ff-b1ab-f5ac3d167e0e" key="staticText-25" x="151" y="0" width="79" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[CURRENT]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="f9f72809-46f7-41a4-8f34-00c793c32270" key="staticText-25" x="555" y="0" width="63" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[TOTAL]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="d3c6363a-cf15-4d04-b3cb-8d254461beed" key="staticText-25" x="683" y="0" width="89" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+			<text><![CDATA[DOUBTFUL DEBT]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="85733db2-7453-4abf-b496-5119bbf92d18" key="staticText-25" x="772" y="0" width="72" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+			<text><![CDATA[PERCENTAGE]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="f43dfb4e-5ef0-4c02-84bb-5127829417c0" key="staticText-25" x="683" y="0" width="89" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
+			<text><![CDATA[NET]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="1c31eb4e-bcb2-4798-9379-b03eb2b2037d" x="772" y="0" width="6" height="15" backcolor="#5D5D5D" style="Detail_Line">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
+			<text><![CDATA[]]></text>
+		</element>
 	</columnHeader>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="16" uuid="79d32132-766a-49f7-a751-d03c3690ed5b"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" style="Detail_Line" x="6" y="0" width="159" height="16" forecolor="#0000FF" uuid="735147e5-d85c-4dcd-b7cb-e4682db25e88"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8" isUnderline="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{BPartner}]]></textFieldExpression>
+			<element kind="line" uuid="79d32132-766a-49f7-a751-d03c3690ed5b" key="line-17" stretchType="ContainerHeight" x="1" y="0" width="1" height="16">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="735147e5-d85c-4dcd-b7cb-e4682db25e88" key="textField" x="6" y="0" width="159" height="16" forecolor="#0000FF" fontSize="8.0" linkType="Reference" blankWhenNull="false" underline="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{BPartner}]]></expression>
 				<hyperlinkReferenceExpression><![CDATA["javascript:top.OB.RemoteCallManager.call(\'org.openbravo.common.actionhandler.AgingBalanceReportActionHandler\',"
     +"{"
     +"  _buttonValue:\'HTML\',"
@@ -474,485 +374,305 @@
 		+"}"
 		+");"]]></hyperlinkReferenceExpression>
 				<hyperlinkTooltipExpression><![CDATA["Details"]]></hyperlinkTooltipExpression>
-			</textField>
-			<staticText>
-				<reportElement style="Detail_Line" x="2" y="0" width="4" height="16" uuid="9ec89087-1683-4c0b-87ea-0640e8e67ef6"/>
+				<box style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="9ec89087-1683-4c0b-87ea-0640e8e67ef6" x="2" y="0" width="4" height="16" style="Detail_Line">
 				<text><![CDATA[]]></text>
-			</staticText>
-			<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" style="Detail_Line" x="844" y="0" width="65" height="16" uuid="4bb1fbe6-d051-46da-9708-319c5468b828">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="textField" uuid="4bb1fbe6-d051-46da-9708-319c5468b828" key="textField" x="844" y="0" width="65" height="16" fontSize="8.0" textAdjust="StretchHeight" pattern="##0.00" linkType="Reference" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+				<expression><![CDATA[($F{net}!=null)?$P{AMOUNTFORMAT}.format($F{net}):new String(" ")]]></expression>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{net}!=null)?$P{AMOUNTFORMAT}.format($F{net}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" style="Detail_Line" x="618" y="0" width="65" height="16" forecolor="#000000" uuid="6a1e8208-9d9e-4767-84de-c40789e35df2"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="6a1e8208-9d9e-4767-84de-c40789e35df2" key="textField" x="618" y="0" width="65" height="16" forecolor="#000000" fontSize="8.0" textAdjust="StretchHeight" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{credit}!=null)? "(" + $P{AMOUNTFORMAT}.format($F{credit}) + ")" : "(" + $P{AMOUNTFORMAT}.format(BigDecimal.ZERO) + ")"]]></expression>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{credit}!=null)? "(" + $P{AMOUNTFORMAT}.format($F{credit}) + ")" : "(" + $P{AMOUNTFORMAT}.format(BigDecimal.ZERO) + ")"]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" style="Detail_Line" x="165" y="0" width="65" height="16" forecolor="#000000" uuid="3ced3ae5-2a6a-44c3-b205-450a0e4bc27a"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="3ced3ae5-2a6a-44c3-b205-450a0e4bc27a" key="textField" x="165" y="0" width="65" height="16" forecolor="#000000" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{amount0}!=null)?$P{AMOUNTFORMAT}.format($F{amount0}):new String(" ")]]></expression>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{amount0}!=null)?$P{AMOUNTFORMAT}.format($F{amount0}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" style="Detail_Line" x="230" y="0" width="65" height="16" forecolor="#000000" uuid="54d19e91-c240-4d36-99a5-59bef838850b"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="54d19e91-c240-4d36-99a5-59bef838850b" key="textField" x="230" y="0" width="65" height="16" forecolor="#000000" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{amount1}!=null)?$P{AMOUNTFORMAT}.format($F{amount1}):new String(" ")]]></expression>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{amount1}!=null)?$P{AMOUNTFORMAT}.format($F{amount1}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" style="Detail_Line" x="295" y="0" width="65" height="16" forecolor="#000000" uuid="5d09adfb-595b-4579-9981-1f0b5c1b99c6"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="5d09adfb-595b-4579-9981-1f0b5c1b99c6" key="textField" x="295" y="0" width="65" height="16" forecolor="#000000" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{amount2}!=null)?$P{AMOUNTFORMAT}.format($F{amount2}):new String(" ")]]></expression>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{amount2}!=null)?$P{AMOUNTFORMAT}.format($F{amount2}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" style="Detail_Line" x="360" y="0" width="65" height="16" forecolor="#000000" uuid="da123926-d89a-4074-b807-8235f173a7ec"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="da123926-d89a-4074-b807-8235f173a7ec" key="textField" x="360" y="0" width="65" height="16" forecolor="#000000" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{amount3}!=null)?$P{AMOUNTFORMAT}.format($F{amount3}):new String(" ")]]></expression>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{amount3}!=null)?$P{AMOUNTFORMAT}.format($F{amount3}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" style="Detail_Line" x="425" y="0" width="65" height="16" forecolor="#000000" uuid="6aa80ae9-f040-4cea-9e5e-421316553dcf"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="6aa80ae9-f040-4cea-9e5e-421316553dcf" key="textField" x="425" y="0" width="65" height="16" forecolor="#000000" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{amount4}!=null)?$P{AMOUNTFORMAT}.format($F{amount4}):new String(" ")]]></expression>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{amount4}!=null)?$P{AMOUNTFORMAT}.format($F{amount4}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" style="Detail_Line" x="490" y="0" width="65" height="16" forecolor="#000000" uuid="67c39c0b-845b-4345-b2d7-31c717490b62"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="67c39c0b-845b-4345-b2d7-31c717490b62" key="textField" x="490" y="0" width="65" height="16" forecolor="#000000" markup="html" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{amount5}!=null)?$P{AMOUNTFORMAT}.format($F{amount5}):new String(" ")]]></expression>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle" markup="html">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{amount5}!=null)?$P{AMOUNTFORMAT}.format($F{amount5}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement style="Detail_Line" x="909" y="0" width="4" height="16" uuid="7e396252-064b-463a-9469-dee11c899bf4">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
+			</element>
+			<element kind="staticText" uuid="7e396252-064b-463a-9469-dee11c899bf4" x="909" y="0" width="4" height="16" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
 				<text><![CDATA[]]></text>
-			</staticText>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" style="Detail_Line" x="555" y="0" width="63" height="16" forecolor="#000000" uuid="eda85746-d52c-4296-bb0d-98b1000a2c19"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="eda85746-d52c-4296-bb0d-98b1000a2c19" key="textField" x="555" y="0" width="63" height="16" forecolor="#000000" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{Total}!=null)?$P{AMOUNTFORMAT}.format($F{Total}):new String(" ")]]></expression>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{Total}!=null)?$P{AMOUNTFORMAT}.format($F{Total}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="913" y="0" width="1" height="16" uuid="2917b4ea-4c26-40e6-8d87-e67d1ee86052">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" style="Detail_Line" x="772" y="0" width="72" height="16" forecolor="#000000" uuid="afa128ce-becb-4a4e-87b1-3afc11041928">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="line" uuid="2917b4ea-4c26-40e6-8d87-e67d1ee86052" key="line-17" stretchType="ContainerHeight" x="913" y="0" width="1" height="16">
+				<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="afa128ce-becb-4a4e-87b1-3afc11041928" key="textField" x="772" y="0" width="72" height="16" forecolor="#000000" fontSize="8.0" textAdjust="StretchHeight" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+				<expression><![CDATA[(($F{percentage}!=null)? $P{AMOUNTFORMAT}.format($F{percentage}) : $P{AMOUNTFORMAT}.format(BigDecimal.ZERO)) + " %"]]></expression>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[(($F{percentage}!=null)? $P{AMOUNTFORMAT}.format($F{percentage}) : $P{AMOUNTFORMAT}.format(BigDecimal.ZERO)) + " %"]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement style="Detail_Line" x="772" y="0" width="5" height="16" uuid="b63325f8-318c-4f53-a22f-5ed9f06b4fe3">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
-				</reportElement>
+			</element>
+			<element kind="staticText" uuid="b63325f8-318c-4f53-a22f-5ed9f06b4fe3" x="772" y="0" width="5" height="16" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
 				<text><![CDATA[]]></text>
-			</staticText>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="777" y="0" width="1" height="16" uuid="ee129c69-3b9f-4739-9ce0-3ddbdd49fbd8">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
-				</reportElement>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" style="Detail_Line" x="683" y="0" width="89" height="16" forecolor="#000000" uuid="7d3564f6-9c74-4192-bcac-293833fcc038"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" ) ?
+			</element>
+			<element kind="line" uuid="ee129c69-3b9f-4739-9ce0-3ddbdd49fbd8" key="line-17" stretchType="ContainerHeight" x="777" y="0" width="1" height="16">
+				<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="7d3564f6-9c74-4192-bcac-293833fcc038" key="textField" x="683" y="0" width="89" height="16" forecolor="#000000" fontSize="8.0" textAdjust="StretchHeight" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$P{showDoubtfulDebt}.equals( "true" ) ?
 ($F{doubtfulDebt}!=null)? $P{AMOUNTFORMAT}.format($F{doubtfulDebt}) : $P{AMOUNTFORMAT}.format(BigDecimal.ZERO)
-: ($F{net}!=null)?$P{AMOUNTFORMAT}.format($F{net}):new String(" ")]]></textFieldExpression>
-			</textField>
+: ($F{net}!=null)?$P{AMOUNTFORMAT}.format($F{net}):new String(" ")]]></expression>
+				<box style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band height="22" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-26" style="Detail_Header" x="0" y="3" width="165" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="a98bac38-3505-4a39-b126-0cab254a07a8"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[TOTAL:]]></text>
-			</staticText>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" mode="Opaque" x="230" y="3" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="ce0a76f4-9f42-4c9e-afcf-f40407e3e58c"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_ONE_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_ONE_1}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" mode="Opaque" x="295" y="3" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="b4d46b4d-3e1e-4c7f-8fdf-ad696b0f306b"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_TWO_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_TWO_1}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" mode="Opaque" x="360" y="3" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="6436fbde-7c2c-4051-b579-da9ca54392ca"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_THREE_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_THREE_1}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" mode="Opaque" x="425" y="3" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="fba3e555-cbcf-48d8-9988-13ae20544e09"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_FOUR_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_FOUR_1}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" mode="Opaque" x="490" y="3" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="373c2737-6839-472a-9bbc-9edac13cee34"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_FIVE_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_FIVE_1}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" mode="Opaque" x="844" y="3" width="65" height="14" forecolor="#060D0A" backcolor="#FFFFFF" uuid="42a52617-5514-4b3e-9b1b-7495a195015a">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_NET}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_NET}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" mode="Opaque" x="618" y="3" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="7bc01cd2-39b8-4ddd-917e-12d675836d19"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_CREDIT}!=null)? "(" + $P{AMOUNTFORMAT}.format($V{SUM_CREDIT}) + ")" : "(" + $P{AMOUNTFORMAT}.format(BigDecimal.ZERO) + ")"]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement key="textField" mode="Opaque" x="909" y="2" width="4" height="12" forecolor="#060D0A" backcolor="#FFFFFF" uuid="b821c035-ab2a-47f1-a257-21d028e4887c">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField-2" mode="Opaque" x="165" y="3" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="1e217dc7-c983-440f-b4db-d0d5fbb262a8"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_ZERO_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_ZERO_1}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" mode="Opaque" x="555" y="3" width="63" height="14" forecolor="#060D0A" backcolor="#FFFFFF" uuid="41ec0047-a486-4ab5-bc67-131aace576e2"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_TOTAL_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_TOTAL_1}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="170" y="20" width="62" height="1" uuid="20ed953b-e39f-4e7b-a008-709dc05543ff"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="170" y="18" width="62" height="1" uuid="3b1a3465-c207-4f82-b33e-a569f1d1873c"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="1" y="1" width="231" height="1" uuid="de06b403-4c6b-49dc-a481-b2e5d716df59"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="235" y="18" width="62" height="1" uuid="cf279f53-c9b1-4462-b4bd-25d26bc0fee3"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="235" y="20" width="62" height="1" uuid="7a7cceb5-dcd4-4bae-8a93-161f14991b8d"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="235" y="1" width="62" height="1" uuid="08d5a2ad-485c-445c-b9e5-58baedaef8b2"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="300" y="18" width="62" height="1" uuid="4ab96a66-7b48-4ee4-b1a8-76848902dcd0"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="300" y="20" width="62" height="1" uuid="3d0c731b-0d77-41a2-95d9-eaaee691c131"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="300" y="1" width="62" height="1" uuid="6f8b3c15-4f28-4166-923f-3f16f396add6"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="365" y="18" width="62" height="1" uuid="45a4b514-e76e-400e-ad37-fa52fd7abe0f"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="365" y="20" width="62" height="1" uuid="c84e26e3-30c3-4368-bb3c-bfd36e6760d2"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="365" y="1" width="62" height="1" uuid="432d5938-e0ee-4a08-bc28-475b90ecd554"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="430" y="18" width="62" height="1" uuid="cd34978c-5b7a-4909-9b52-01c4d64f4c87"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="430" y="20" width="62" height="1" uuid="a34b95ac-6f25-4f9d-857d-97ef681685c6"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="430" y="1" width="62" height="1" uuid="34580aa3-056d-47c8-a21a-be82ed921c77"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="495" y="18" width="62" height="1" uuid="e8a4ad7d-6223-492b-97a1-1eb5bc590a76"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="495" y="20" width="62" height="1" uuid="c5e6c233-fd63-4ca6-8242-eb0139b00981"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="495" y="1" width="62" height="1" uuid="437f454f-7359-4672-b2d6-ec45d985ff30"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="560" y="18" width="62" height="1" uuid="21ff6991-c332-4234-9107-3c408cd97d9d"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="560" y="20" width="62" height="1" uuid="5351b73b-308d-4dfd-96ce-ba32286d39da"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="560" y="1" width="62" height="1" uuid="530267de-d24d-4ac4-a842-6bc6bd7af75c"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="625" y="18" width="62" height="1" uuid="bb185045-52cd-40b1-ba33-3071791b1587"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="625" y="20" width="62" height="1" uuid="07559d82-17cb-4cef-bdb4-d9d4f4e4475c"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="625" y="1" width="62" height="1" uuid="5c6be8ac-3585-4e88-ad9f-8ede82a0f678"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="851" y="18" width="63" height="1" uuid="d4d3879c-c1d7-4084-ae37-00e4ba7869a0">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="851" y="20" width="63" height="1" uuid="da424cab-783f-419b-bdf1-ca40f49856f9">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="851" y="1" width="63" height="1" uuid="7a1fba40-6674-43b5-90dc-9dedee6be40c">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="690" y="1" width="87" height="1" uuid="366f2c17-0524-4bb3-932b-d3cdf1421487"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="690" y="20" width="87" height="1" uuid="34a2622e-2d1a-42e2-bcf6-7fb66f3a33e5"/>
-			</line>
-			<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" mode="Opaque" x="683" y="3" width="89" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="5f3548b7-d73a-4dc0-9740-2aad7ffdde62"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" ) ?
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary height="22" splitType="Stretch">
+		<element kind="staticText" uuid="a98bac38-3505-4a39-b126-0cab254a07a8" key="staticText-26" x="0" y="3" width="165" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" pdfFontName="Helvetica-Bold" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[TOTAL:]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="ce0a76f4-9f42-4c9e-afcf-f40407e3e58c" key="textField" mode="Opaque" x="230" y="3" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[($V{SUM_ONE_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_ONE_1}):new String(" ")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="b4d46b4d-3e1e-4c7f-8fdf-ad696b0f306b" key="textField" mode="Opaque" x="295" y="3" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[($V{SUM_TWO_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_TWO_1}):new String(" ")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="6436fbde-7c2c-4051-b579-da9ca54392ca" key="textField" mode="Opaque" x="360" y="3" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[($V{SUM_THREE_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_THREE_1}):new String(" ")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="fba3e555-cbcf-48d8-9988-13ae20544e09" key="textField" mode="Opaque" x="425" y="3" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[($V{SUM_FOUR_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_FOUR_1}):new String(" ")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="373c2737-6839-472a-9bbc-9edac13cee34" key="textField" mode="Opaque" x="490" y="3" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[($V{SUM_FIVE_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_FIVE_1}):new String(" ")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="42a52617-5514-4b3e-9b1b-7495a195015a" key="textField" stretchType="ElementGroupHeight" mode="Opaque" x="844" y="3" width="65" height="14" forecolor="#060D0A" backcolor="#FFFFFF" fontSize="8.0" textAdjust="StretchHeight" pattern="##0.00" linkType="Reference" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+			<expression><![CDATA[($V{SUM_NET}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_NET}):new String(" ")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="7bc01cd2-39b8-4ddd-917e-12d675836d19" key="textField" stretchType="ElementGroupHeight" mode="Opaque" x="618" y="3" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" textAdjust="StretchHeight" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[($V{SUM_CREDIT}!=null)? "(" + $P{AMOUNTFORMAT}.format($V{SUM_CREDIT}) + ")" : "(" + $P{AMOUNTFORMAT}.format(BigDecimal.ZERO) + ")"]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="b821c035-ab2a-47f1-a257-21d028e4887c" key="textField" mode="Opaque" x="909" y="2" width="4" height="12" forecolor="#060D0A" backcolor="#FFFFFF" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="1e217dc7-c983-440f-b4db-d0d5fbb262a8" key="textField-2" mode="Opaque" x="165" y="3" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[($V{SUM_ZERO_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_ZERO_1}):new String(" ")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="41ec0047-a486-4ab5-bc67-131aace576e2" key="textField" mode="Opaque" x="555" y="3" width="63" height="14" forecolor="#060D0A" backcolor="#FFFFFF" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[($V{SUM_TOTAL_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_TOTAL_1}):new String(" ")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="20ed953b-e39f-4e7b-a008-709dc05543ff" key="line-33" x="170" y="20" width="62" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="3b1a3465-c207-4f82-b33e-a569f1d1873c" key="line-33" x="170" y="18" width="62" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="de06b403-4c6b-49dc-a481-b2e5d716df59" key="line-33" x="1" y="1" width="231" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="cf279f53-c9b1-4462-b4bd-25d26bc0fee3" key="line-33" x="235" y="18" width="62" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="7a7cceb5-dcd4-4bae-8a93-161f14991b8d" key="line-33" x="235" y="20" width="62" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="08d5a2ad-485c-445c-b9e5-58baedaef8b2" key="line-33" x="235" y="1" width="62" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="4ab96a66-7b48-4ee4-b1a8-76848902dcd0" key="line-33" x="300" y="18" width="62" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="3d0c731b-0d77-41a2-95d9-eaaee691c131" key="line-33" x="300" y="20" width="62" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="6f8b3c15-4f28-4166-923f-3f16f396add6" key="line-33" x="300" y="1" width="62" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="45a4b514-e76e-400e-ad37-fa52fd7abe0f" key="line-33" x="365" y="18" width="62" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="c84e26e3-30c3-4368-bb3c-bfd36e6760d2" key="line-33" x="365" y="20" width="62" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="432d5938-e0ee-4a08-bc28-475b90ecd554" key="line-33" x="365" y="1" width="62" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="cd34978c-5b7a-4909-9b52-01c4d64f4c87" key="line-33" x="430" y="18" width="62" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="a34b95ac-6f25-4f9d-857d-97ef681685c6" key="line-33" x="430" y="20" width="62" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="34580aa3-056d-47c8-a21a-be82ed921c77" key="line-33" x="430" y="1" width="62" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="e8a4ad7d-6223-492b-97a1-1eb5bc590a76" key="line-33" x="495" y="18" width="62" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="c5e6c233-fd63-4ca6-8242-eb0139b00981" key="line-33" x="495" y="20" width="62" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="437f454f-7359-4672-b2d6-ec45d985ff30" key="line-33" x="495" y="1" width="62" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="21ff6991-c332-4234-9107-3c408cd97d9d" key="line-33" x="560" y="18" width="62" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="5351b73b-308d-4dfd-96ce-ba32286d39da" key="line-33" x="560" y="20" width="62" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="530267de-d24d-4ac4-a842-6bc6bd7af75c" key="line-33" x="560" y="1" width="62" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="bb185045-52cd-40b1-ba33-3071791b1587" key="line-33" x="625" y="18" width="62" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="07559d82-17cb-4cef-bdb4-d9d4f4e4475c" key="line-33" x="625" y="20" width="62" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="5c6be8ac-3585-4e88-ad9f-8ede82a0f678" key="line-33" x="625" y="1" width="62" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="d4d3879c-c1d7-4084-ae37-00e4ba7869a0" key="line-33" x="851" y="18" width="63" height="1" style="Report_Footer">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+		</element>
+		<element kind="line" uuid="da424cab-783f-419b-bdf1-ca40f49856f9" key="line-33" x="851" y="20" width="63" height="1" style="Report_Footer">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+		</element>
+		<element kind="line" uuid="7a1fba40-6674-43b5-90dc-9dedee6be40c" key="line-33" x="851" y="1" width="63" height="1" style="Report_Footer">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+		</element>
+		<element kind="line" uuid="366f2c17-0524-4bb3-932b-d3cdf1421487" key="line-33" x="690" y="1" width="87" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="34a2622e-2d1a-42e2-bcf6-7fb66f3a33e5" key="line-33" x="690" y="20" width="87" height="1" style="Report_Footer"/>
+		<element kind="textField" uuid="5f3548b7-d73a-4dc0-9740-2aad7ffdde62" key="textField" stretchType="ElementGroupHeight" mode="Opaque" x="683" y="3" width="89" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" textAdjust="StretchHeight" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[$P{showDoubtfulDebt}.equals( "true" ) ?
 ($V{SUM_DOUBTFUL}!=null)? $P{AMOUNTFORMAT}.format($V{SUM_DOUBTFUL}) : $P{AMOUNTFORMAT}.format(BigDecimal.ZERO)
-: ($V{SUM_NET}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_NET}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="690" y="18" width="87" height="1" uuid="a0ef13e8-863b-42f2-80be-6c5b291eb5f9"/>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="780" y="1" width="68" height="1" uuid="075cca0e-3ddb-4083-99c7-8532de4cb7ea">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="780" y="20" width="68" height="1" uuid="56d7491d-8117-44ee-875a-3f6d6318c91e">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-			</line>
-			<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" mode="Opaque" x="772" y="3" width="72" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="1e4dd78d-287b-46e7-8a8c-1faf7e0a67ef">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[(($V{VAR_PERCENT}!=null)? $P{AMOUNTFORMAT}.format($V{VAR_PERCENT}) : $P{AMOUNTFORMAT}.format(BigDecimal.ZERO)) + " %"]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="780" y="18" width="68" height="1" uuid="2471c5ba-6148-4c84-b18d-bcc24c226a5f">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-			</line>
-		</band>
+: ($V{SUM_NET}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_NET}):new String(" ")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="a0ef13e8-863b-42f2-80be-6c5b291eb5f9" key="line-33" x="690" y="18" width="87" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="075cca0e-3ddb-4083-99c7-8532de4cb7ea" key="line-33" x="780" y="1" width="68" height="1" style="Report_Footer">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+		</element>
+		<element kind="line" uuid="56d7491d-8117-44ee-875a-3f6d6318c91e" key="line-33" x="780" y="20" width="68" height="1" style="Report_Footer">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+		</element>
+		<element kind="textField" uuid="1e4dd78d-287b-46e7-8a8c-1faf7e0a67ef" key="textField" stretchType="ElementGroupHeight" mode="Opaque" x="772" y="3" width="72" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" textAdjust="StretchHeight" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+			<expression><![CDATA[(($V{VAR_PERCENT}!=null)? $P{AMOUNTFORMAT}.format($V{VAR_PERCENT}) : $P{AMOUNTFORMAT}.format(BigDecimal.ZERO)) + " %"]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="2471c5ba-6148-4c84-b18d-bcc24c226a5f" key="line-33" x="780" y="18" width="68" height="1" style="Report_Footer">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+		</element>
 	</summary>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/AgingSchedulePDF.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/AgingSchedulePDF.jrxml
@@ -1,96 +1,95 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportAgingBalance" pageWidth="670" pageHeight="842" columnWidth="610" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportAgingBalance" language="java" pageWidth="670" pageHeight="842" columnWidth="610" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="beb75ecd-e1d2-4082-b57a-8bd92eb14463">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.5"/>
 	<property name="ireport.x" value="144"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
 		<pen lineWidth="0.0" lineStyle="Solid"/>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/home/david/workspace/trunk/openbravo/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="AMOUNTFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<parameter name="AMOUNTFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat()]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale">
 		<defaultValueExpression><![CDATA[new Locale("es", "ES")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="InitialBalance" class="java.math.BigDecimal" isForPrompting="false">
+	<parameter name="InitialBalance" forPrompting="false" class="java.math.BigDecimal">
 		<defaultValueExpression><![CDATA[new BigDecimal(1111)]]></defaultValueExpression>
 	</parameter>
 	<parameter name="SUBREPORT_DIR" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{BASE_DESIGN}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATE_FROM" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col1" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col2" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col3" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col4" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col5" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BPartners" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Date1" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Date2" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Date3" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Date4" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Date5" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Organization" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="AccSchema" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Currency" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="toCurrency" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="PayStatus" class="java.lang.String" isForPrompting="false"/>
+	<parameter name="DATE_FROM" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col1" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col2" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col3" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col4" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col5" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BPartners" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Date1" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Date2" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Date3" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Date4" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Date5" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Organization" forPrompting="false" class="java.lang.String"/>
+	<parameter name="AccSchema" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Currency" forPrompting="false" class="java.lang.String"/>
+	<parameter name="toCurrency" forPrompting="false" class="java.lang.String"/>
+	<parameter name="PayStatus" forPrompting="false" class="java.lang.String"/>
 	<parameter name="currentDate" class="java.lang.String"/>
 	<parameter name="tabTitle" class="java.lang.String"/>
 	<parameter name="title" class="java.lang.String"/>
@@ -107,665 +106,423 @@
 	<field name="BPartnerID" class="java.lang.String"/>
 	<field name="credit" class="java.math.BigDecimal"/>
 	<field name="net" class="java.math.BigDecimal"/>
-	<variable name="SUM_ZERO_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount0}]]></variableExpression>
+	<variable name="SUM_ZERO_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount0}]]></expression>
 	</variable>
-	<variable name="SUM_ONE_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount1}]]></variableExpression>
+	<variable name="SUM_ONE_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount1}]]></expression>
 	</variable>
-	<variable name="SUM_TWO_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount2}]]></variableExpression>
+	<variable name="SUM_TWO_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount2}]]></expression>
 	</variable>
-	<variable name="SUM_THREE_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount3}]]></variableExpression>
+	<variable name="SUM_THREE_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount3}]]></expression>
 	</variable>
-	<variable name="SUM_FOUR_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount4}]]></variableExpression>
+	<variable name="SUM_FOUR_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount4}]]></expression>
 	</variable>
-	<variable name="SUM_FIVE_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount5}]]></variableExpression>
+	<variable name="SUM_FIVE_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount5}]]></expression>
 	</variable>
-	<variable name="SUM_TOTAL_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{Total}]]></variableExpression>
+	<variable name="SUM_TOTAL_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{Total}]]></expression>
 	</variable>
 	<variable name="NoBPartner" class="java.lang.String">
-		<variableExpression><![CDATA[($F{BPartnerID}==null)?new String("only"):new String("exclude")]]></variableExpression>
+		<expression><![CDATA[($F{BPartnerID}==null)?new String("only"):new String("exclude")]]></expression>
 	</variable>
 	<variable name="NoBPartnerTotal" class="java.lang.String">
-		<variableExpression><![CDATA[($P{BPartners}=="")?new String("include"):new String("exclude")]]></variableExpression>
+		<expression><![CDATA[($P{BPartners}=="")?new String("include"):new String("exclude")]]></expression>
 	</variable>
-	<variable name="SUM_CREDIT" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{credit}]]></variableExpression>
+	<variable name="SUM_CREDIT" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{credit}]]></expression>
 	</variable>
-	<variable name="SUM_NET" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{net}]]></variableExpression>
+	<variable name="SUM_NET" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{net}]]></expression>
 	</variable>
 	<group name="Totals">
 		<groupFooter>
 			<band height="28">
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="562" y="0" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="260" y="0" width="48" height="1"/>
-				</line>
-				<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-					<reportElement key="textField" mode="Opaque" x="405" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
+				<element kind="line" uuid="958fc221-6a9c-4496-91b8-7f8e138a75af" key="line-33" x="562" y="0" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="441a2356-101c-47be-8bde-59343a1ae339" key="line-33" x="260" y="0" width="48" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="e3228f2f-14ed-482c-97f0-104d7875eb97" key="textField" mode="Opaque" x="405" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{SUM_FIVE_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_FIVE_1}):new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[($V{SUM_FIVE_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_FIVE_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="210" y="17" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="260" y="17" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="410" y="0" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="460" y="0" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="360" y="0" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="210" y="19" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="160" y="19" width="48" height="1"/>
-				</line>
-				<textField pattern="##0.00" isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField" mode="Opaque" x="605" y="2" width="4" height="12" forecolor="#060D0A" backcolor="#FFFFFF"/>
+				</element>
+				<element kind="line" uuid="ef266e00-fdfe-4a54-9f65-5c8a543a3c49" key="line-33" positionType="FixRelativeToBottom" x="210" y="17" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="371bf88d-94f2-4ee5-b34b-f752e84c3775" key="line-33" positionType="FixRelativeToBottom" x="260" y="17" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="6c73cd15-39ce-4c88-b8eb-9f38b2628ce6" key="line-33" x="410" y="0" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="b4be3b2b-277d-4c81-a9b3-67696e0a9fb0" key="line-33" x="460" y="0" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="42f60360-f882-4061-8214-b219999722be" key="line-33" x="360" y="0" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="d9ff34c5-fd47-4fe6-b014-a9418cdbaa9c" key="line-33" positionType="FixRelativeToBottom" x="210" y="19" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="aca79b0a-17e7-4384-bec3-1dd5dc6a2bd5" key="line-33" positionType="FixRelativeToBottom" x="160" y="19" width="48" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="30e6fc62-d3fd-41e7-9044-cada890f14a8" key="textField" mode="Opaque" x="605" y="2" width="4" height="12" forecolor="#060D0A" backcolor="#FFFFFF" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8"/>
-					</textElement>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="360" y="17" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="310" y="0" width="48" height="1"/>
-				</line>
-				<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-					<reportElement key="textField" mode="Opaque" x="255" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
+				</element>
+				<element kind="line" uuid="55634e20-b3b1-45ca-a0c4-b6fd4694d85e" key="line-33" positionType="FixRelativeToBottom" x="360" y="17" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="43e6bb56-2ed6-49d1-aad6-fb0170a144b8" key="line-33" x="310" y="0" width="48" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="089aa1c5-6678-4b2b-a3ea-e79c434ca575" key="textField" mode="Opaque" x="255" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{SUM_TWO_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_TWO_1}):new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[($V{SUM_TWO_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_TWO_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="210" y="0" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="410" y="19" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="460" y="17" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="460" y="19" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="260" y="19" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="512" y="19" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="562" y="17" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="512" y="0" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="310" y="19" width="48" height="1"/>
-				</line>
-				<staticText>
-					<reportElement key="staticText-26" style="Detail_Header" x="0" y="2" width="155" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="line" uuid="08b00252-a58d-4ebd-ac23-bb80bb79288a" key="line-33" x="210" y="0" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="f4128c61-9b27-473d-9415-78ad1cf261cf" key="line-33" positionType="FixRelativeToBottom" x="410" y="19" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="646a3427-390c-4824-af16-349570cb9941" key="line-33" positionType="FixRelativeToBottom" x="460" y="17" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="6f68151c-baad-41c2-9386-7e4456b7aa87" key="line-33" positionType="FixRelativeToBottom" x="460" y="19" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="ea282648-1da7-4691-8604-cfc4d6a48e60" key="line-33" positionType="FixRelativeToBottom" x="260" y="19" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="cca99d89-ea89-427f-8f16-cd2f7dfad9f3" key="line-33" positionType="FixRelativeToBottom" x="512" y="19" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="7dc9778b-8127-48e6-adba-5278d30ba8d9" key="line-33" positionType="FixRelativeToBottom" x="562" y="17" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="40a77dd5-a67b-452a-bcea-da80e80c97ac" key="line-33" x="512" y="0" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="2761884c-d385-4b83-b0c5-47b277d7b796" key="line-33" positionType="FixRelativeToBottom" x="310" y="19" width="48" height="1" style="Report_Footer"/>
+				<element kind="staticText" uuid="cf1d757c-e8f8-43de-9f23-d39bf8e57447" key="staticText-26" x="0" y="2" width="155" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" pdfFontName="Helvetica-Bold" vTextAlign="Middle" style="Detail_Header">
+					<text><![CDATA[TOTAL:]]></text>
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[TOTAL:]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="310" y="17" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="410" y="17" width="48" height="1"/>
-				</line>
-				<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-					<reportElement key="textField" mode="Opaque" x="205" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
+				</element>
+				<element kind="line" uuid="dc4250ae-5e9f-475c-89a9-f6bff2229c9c" key="line-33" positionType="FixRelativeToBottom" x="310" y="17" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="613107ec-9d61-4ae1-bebc-98c0f6c03267" key="line-33" positionType="FixRelativeToBottom" x="410" y="17" width="48" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="0dc876a0-6ed6-4a09-a231-30a191ce338a" key="textField" mode="Opaque" x="205" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{SUM_ONE_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_ONE_1}):new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[($V{SUM_ONE_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_ONE_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-					<reportElement key="textField" mode="Opaque" x="305" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
+				</element>
+				<element kind="textField" uuid="7e515fe9-a893-4108-af97-281e0ee2efa4" key="textField" mode="Opaque" x="305" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{SUM_THREE_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_THREE_1}):new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[($V{SUM_THREE_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_THREE_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="1" y="0" width="207" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="360" y="19" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="160" y="17" width="48" height="1"/>
-				</line>
-				<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-					<reportElement key="textField" mode="Opaque" x="355" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
+				</element>
+				<element kind="line" uuid="7a89bd71-0c28-435d-b458-93af7a534727" key="line-33" x="1" y="0" width="207" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="a50ad012-fadc-403a-9359-53ebd139ce50" key="line-33" positionType="FixRelativeToBottom" x="360" y="19" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="79366d6e-f651-4fba-8eae-0f9906b56f60" key="line-33" positionType="FixRelativeToBottom" x="160" y="17" width="48" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="1a4e41b6-3eef-4ac9-871a-663c479f42ae" key="textField" mode="Opaque" x="355" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{SUM_FOUR_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_FOUR_1}):new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[($V{SUM_FOUR_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_FOUR_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="512" y="17" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="562" y="19" width="48" height="1"/>
-				</line>
-				<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-					<reportElement key="textField" mode="Opaque" x="455" y="2" width="50" height="14" forecolor="#060D0A" backcolor="#FFFFFF"/>
+				</element>
+				<element kind="line" uuid="61706271-5a15-4232-8f03-0ee396cc7157" key="line-33" positionType="FixRelativeToBottom" x="512" y="17" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="3aba6420-b969-471d-9927-5fd3896e9c18" key="line-33" positionType="FixRelativeToBottom" x="562" y="19" width="48" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="9a1f9b9f-a7db-418f-bb9c-31de80dadc2d" key="textField" mode="Opaque" x="455" y="2" width="50" height="14" forecolor="#060D0A" backcolor="#FFFFFF" fontSize="6.0" textAdjust="StretchHeight" pattern="##0.00" linkType="Reference" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{SUM_TOTAL_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_TOTAL_1}):new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[($V{SUM_TOTAL_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_TOTAL_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-					<reportElement key="textField-2" mode="Opaque" x="155" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
+				</element>
+				<element kind="textField" uuid="365f2dd6-eccf-4fd0-b53a-636206910947" key="textField-2" mode="Opaque" x="155" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" textAdjust="StretchHeight" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{SUM_ZERO_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_ZERO_1}):new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[($V{SUM_ZERO_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_ZERO_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" pattern="###0.00;-###0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-					<reportElement key="textField" mode="Opaque" x="555" y="2" width="53" height="14" isPrintWhenDetailOverflows="true" forecolor="#060D0A" backcolor="#FFFFFF"/>
+				</element>
+				<element kind="textField" uuid="2b476482-df8d-4225-9af9-ba7c67b02393" key="textField" mode="Opaque" x="555" y="2" width="53" height="14" forecolor="#060D0A" backcolor="#FFFFFF" fontSize="6.0" textAdjust="StretchHeight" pattern="###0.00;-###0.00" linkType="Reference" blankWhenNull="false" printWhenDetailOverflows="true" strikeThrough="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{SUM_NET}!=null)? "   "+$P{AMOUNTFORMAT}.format($V{SUM_NET})+"   ":new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isStrikeThrough="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[($V{SUM_NET}!=null)? "   "+$P{AMOUNTFORMAT}.format($V{SUM_NET})+"   ":new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="###0.00;-###0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-					<reportElement key="textField" positionType="Float" mode="Opaque" x="505" y="2" width="50" height="14" isPrintWhenDetailOverflows="true" forecolor="#000000" backcolor="#FFFFFF"/>
+				</element>
+				<element kind="textField" uuid="60f963f3-d272-4c2f-84aa-11cf47eebb7b" key="textField" positionType="Float" mode="Opaque" x="505" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" pattern="###0.00;-###0.00" linkType="Reference" blankWhenNull="false" printWhenDetailOverflows="true" underline="false" strikeThrough="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{SUM_CREDIT}!=null)? "(" + $P{AMOUNTFORMAT}.format($V{SUM_CREDIT}) + ")" : "(" + $P{AMOUNTFORMAT}.format(BigDecimal.ZERO) + ")"]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isUnderline="false" isStrikeThrough="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[($V{SUM_CREDIT}!=null)? "(" + $P{AMOUNTFORMAT}.format($V{SUM_CREDIT}) + ")" : "(" + $P{AMOUNTFORMAT}.format(BigDecimal.ZERO) + ")"]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="139" splitType="Stretch">
-			<textField>
-				<reportElement x="6" y="22" width="400" height="28"/>
-				<textElement>
-					<font size="18"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{title}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="112" y="105" width="152" height="18"/>
-				<textElement>
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{currentDate}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="112" y="85" width="152" height="18"/>
-				<textElement>
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{OrganizationName}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-27" style="Report_Footer" x="276" y="85" width="136" height="18"/>
-				<textElement textAlignment="Right">
-					<font size="9"/>
-				</textElement>
-				<text><![CDATA[General Ledger:]]></text>
-			</staticText>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="417" y="85" width="179" height="18"/>
-				<textElement>
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{AccSchemaName}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-26" style="Report_Footer" x="0" y="105" width="107" height="18"/>
-				<textElement textAlignment="Right">
-					<font size="9"/>
-				</textElement>
-				<text><![CDATA[As Of Date:]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-24" style="Report_Footer" x="0" y="85" width="107" height="18"/>
-				<textElement textAlignment="Right">
-					<font size="9"/>
-				</textElement>
-				<text><![CDATA[Organization:]]></text>
-			</staticText>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="139" splitType="Stretch">
+		<element kind="textField" uuid="19930098-dceb-429a-b482-fde60f820083" x="6" y="22" width="400" height="28" fontSize="18.0">
+			<expression><![CDATA[$P{title}]]></expression>
+		</element>
+		<element kind="textField" uuid="700cbc61-6336-48a8-b26c-f24ef56e5205" key="textField-25" x="112" y="105" width="152" height="18" fontSize="9.0" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{currentDate}]]></expression>
+		</element>
+		<element kind="textField" uuid="7932afde-688d-49e1-8aad-17fa3b605bbf" key="textField-25" x="112" y="85" width="152" height="18" fontSize="9.0" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{OrganizationName}]]></expression>
+		</element>
+		<element kind="staticText" uuid="769b4a96-a7b7-4247-8fab-2dc03cf7b055" key="staticText-27" x="276" y="85" width="136" height="18" fontSize="9.0" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[General Ledger:]]></text>
+		</element>
+		<element kind="textField" uuid="44390002-b588-404a-8837-a82433490873" key="textField-25" x="417" y="85" width="179" height="18" fontSize="9.0" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{AccSchemaName}]]></expression>
+		</element>
+		<element kind="staticText" uuid="c91e39a3-7e13-41b7-812a-057df7010af1" key="staticText-26" x="0" y="105" width="107" height="18" fontSize="9.0" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[As Of Date:]]></text>
+		</element>
+		<element kind="staticText" uuid="87e0c1c0-cf2f-4156-9185-35634aa821b0" key="staticText-24" x="0" y="85" width="107" height="18" fontSize="9.0" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Organization:]]></text>
+		</element>
 	</title>
-	<pageHeader>
-		<band height="5" splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band height="15" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-18" style="Detail_Header" x="0" y="0" width="151" height="15"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement>
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[BUSINESS PARTNER]]></text>
-			</staticText>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Header" x="205" y="0" width="50" height="15"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{col1}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-3" style="Detail_Header" x="255" y="0" width="50" height="15"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{col2}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-4" style="Detail_Header" x="305" y="0" width="50" height="15"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{col3}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-5" style="Detail_Header" x="355" y="0" width="50" height="15"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{col4}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-6" style="Detail_Header" x="405" y="0" width="50" height="15"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{col5}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="555" y="0" width="55" height="15"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[NET]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="505" y="0" width="50" height="15"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[CREDITS]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="151" y="0" width="54" height="15"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[CURRENT]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="455" y="0" width="50" height="15"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[TOTAL]]></text>
-			</staticText>
-		</band>
+	<pageHeader height="5" splitType="Stretch"/>
+	<columnHeader height="15" splitType="Stretch">
+		<element kind="staticText" uuid="24d738ab-d129-43d5-a5a7-e83581c380f3" key="staticText-18" x="0" y="0" width="151" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" style="Detail_Header">
+			<text><![CDATA[BUSINESS PARTNER]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="712f19b4-e3d8-4ca4-b296-b80b36922004" key="textField" x="205" y="0" width="50" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col1}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="a58330a7-d4ce-4393-802d-0603693c8866" key="textField-3" x="255" y="0" width="50" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col2}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="6d3c043b-5ba0-463c-abad-18abad0692fa" key="textField-4" x="305" y="0" width="50" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col3}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="b598e5fc-9c30-4577-9bb7-be849df3a0b7" key="textField-5" x="355" y="0" width="50" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col4}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="29f8d948-7f65-4e29-b39b-43ef8acf27fc" key="textField-6" x="405" y="0" width="50" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col5}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="f4c9dcac-1256-408b-a1ec-901fc74e4846" key="staticText-25" x="555" y="0" width="55" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[NET]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="026c12b2-71a0-44fb-857d-7e146c0ba22f" key="staticText-25" x="505" y="0" width="50" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[CREDITS]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="60439cf7-1639-4ad8-b95b-aa53c1f27018" key="staticText-25" x="151" y="0" width="54" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[CURRENT]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="3061b4e6-1b0e-4c39-8864-40f5fa9e8228" key="staticText-25" x="455" y="0" width="50" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[TOTAL]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
 	</columnHeader>
 	<detail>
 		<band height="19" splitType="Stretch">
-			<textField pattern="###0.00;-###0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" x="505" y="0" width="50" height="16" isPrintWhenDetailOverflows="true" forecolor="#000000"/>
+			<element kind="textField" uuid="e4d88643-51bc-46d6-9d71-fa69f65455e7" key="textField" stretchType="ElementGroupHeight" x="505" y="0" width="50" height="16" forecolor="#000000" fontSize="6.0" pattern="###0.00;-###0.00" linkType="Reference" blankWhenNull="false" printWhenDetailOverflows="true" underline="false" strikeThrough="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{credit}!=null)? "(" + $P{AMOUNTFORMAT}.format($F{credit}) + ")" : "(" + $P{AMOUNTFORMAT}.format(BigDecimal.ZERO) + ")"]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false" isStrikeThrough="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[($F{credit}!=null)? "(" + $P{AMOUNTFORMAT}.format($F{credit}) + ")" : "(" + $P{AMOUNTFORMAT}.format(BigDecimal.ZERO) + ")"]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="19"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" x="6" y="0" width="149" height="16"/>
+			</element>
+			<element kind="line" uuid="e8f7609e-a160-4fbb-a5bb-81798d297cfc" key="line-17" stretchType="ContainerHeight" x="1" y="0" width="1" height="19">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="b31bde66-56d8-466a-8644-a155b6d15b84" key="textField" x="6" y="0" width="149" height="16" fontSize="8.0" blankWhenNull="false" vTextAlign="Middle">
+				<expression><![CDATA[$F{BPartner}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{BPartner}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement x="2" y="0" width="4" height="16"/>
-				<textElement/>
+			</element>
+			<element kind="staticText" uuid="855bbbe0-78c2-42f0-874c-eb368166f866" x="2" y="0" width="4" height="16">
 				<text><![CDATA[]]></text>
-			</staticText>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" x="205" y="0" width="50" height="16" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="182d3802-cbe0-47cf-9876-235d73249d34" key="textField" stretchType="ElementGroupHeight" x="205" y="0" width="50" height="16" forecolor="#000000" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{amount1}!=null)?$P{AMOUNTFORMAT}.format($F{amount1}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[($F{amount1}!=null)?$P{AMOUNTFORMAT}.format($F{amount1}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" x="255" y="0" width="50" height="16" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="31eab793-3973-498b-974d-d63d2b14aaf7" key="textField" stretchType="ElementGroupHeight" x="255" y="0" width="50" height="16" forecolor="#000000" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{amount2}!=null)?$P{AMOUNTFORMAT}.format($F{amount2}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[($F{amount2}!=null)?$P{AMOUNTFORMAT}.format($F{amount2}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" x="305" y="0" width="50" height="16" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="b5458c7d-2f10-4b14-b387-bf7bd9f9ffd7" key="textField" stretchType="ElementGroupHeight" x="305" y="0" width="50" height="16" forecolor="#000000" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{amount3}!=null)?$P{AMOUNTFORMAT}.format($F{amount3}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[($F{amount3}!=null)?$P{AMOUNTFORMAT}.format($F{amount3}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" x="355" y="0" width="50" height="16" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="74af286a-c1b1-4391-9f49-a0d028efbac6" key="textField" stretchType="ElementGroupHeight" x="355" y="0" width="50" height="16" forecolor="#000000" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{amount4}!=null)?$P{AMOUNTFORMAT}.format($F{amount4}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[($F{amount4}!=null)?$P{AMOUNTFORMAT}.format($F{amount4}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" x="405" y="0" width="50" height="16" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="9bdba355-ba5e-4052-8f3e-9540c79f4386" key="textField" stretchType="ElementGroupHeight" x="405" y="0" width="50" height="16" forecolor="#000000" markup="html" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{amount5}!=null)?$P{AMOUNTFORMAT}.format($F{amount5}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle" markup="html">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[($F{amount5}!=null)?$P{AMOUNTFORMAT}.format($F{amount5}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" x="455" y="0" width="50" height="16"/>
+			</element>
+			<element kind="textField" uuid="110b1533-d426-45d0-827e-14d4c952692b" key="textField" stretchType="ElementGroupHeight" x="455" y="0" width="50" height="16" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{Total}!=null)?$P{AMOUNTFORMAT}.format($F{Total}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[($F{Total}!=null)?$P{AMOUNTFORMAT}.format($F{Total}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" x="155" y="0" width="50" height="16" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="8bbcee2f-218d-431b-9f9f-dfa5a6e47351" key="textField" stretchType="ElementGroupHeight" x="155" y="0" width="50" height="16" forecolor="#000000" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{amount0}!=null)?$P{AMOUNTFORMAT}.format($F{amount0}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[($F{amount0}!=null)?$P{AMOUNTFORMAT}.format($F{amount0}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="609" y="0" width="1" height="19"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<elementGroup>
-				<textField isStretchWithOverflow="true" pattern="#,##0.00;(-#,##0.00)" isBlankWhenNull="false" hyperlinkType="Reference">
-					<reportElement key="textField" x="555" y="0" width="53" height="16" isPrintWhenDetailOverflows="true"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isStrikeThrough="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[($F{net}!=null)? "   "+$P{AMOUNTFORMAT}.format($F{net})+"   ":new String(" ")]]></textFieldExpression>
-				</textField>
-			</elementGroup>
+			</element>
+			<element kind="line" uuid="a7801b2c-ffe6-4270-b9e9-f5dfc498dbc8" key="line-17" stretchType="ContainerHeight" x="609" y="0" width="1" height="19">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="elementGroup">
+				<element kind="textField" uuid="0ff1a3b2-71ab-4609-9ed8-c0a38e54d58b" key="textField" x="555" y="0" width="53" height="16" fontSize="6.0" textAdjust="StretchHeight" pattern="#,##0.00;(-#,##0.00)" linkType="Reference" blankWhenNull="false" printWhenDetailOverflows="true" strikeThrough="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($F{net}!=null)? "   "+$P{AMOUNTFORMAT}.format($F{net})+"   ":new String(" ")]]></expression>
+				</element>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="17" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="298" y="0" width="113" height="14"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="6"/>
-				</textElement>
-				<textFieldExpression class="java.util.Date"><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="574" y="0" width="36" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="6"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" x="216" y="0" width="78" height="14"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="6"/>
-				</textElement>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="475" y="0" width="95" height="14"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="6"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="17" splitType="Stretch">
+		<element kind="textField" uuid="8eb83fc2-f0eb-40b7-883d-85e7dba52c4c" key="textField" x="298" y="0" width="113" height="14" fontName="Times-Roman" fontSize="6.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="914cbc22-389d-45b0-b030-25bc08161a54" key="textField" x="574" y="0" width="36" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" evaluationTime="Report" pattern="" blankWhenNull="false">
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="7ade48ff-a44a-47d5-bdda-8d6d56996458" key="staticText-1" x="216" y="0" width="78" height="14" fontName="Bitstream Vera Sans" fontSize="6.0" hTextAlign="Right" vTextAlign="Middle">
+			<text><![CDATA[Generated on]]></text>
+			<box leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="ecaaa3e7-9d85-416d-a827-27f2f0fef6df" key="textField" x="475" y="0" width="95" height="14" fontSize="6.0" pattern="" blankWhenNull="false" hTextAlign="Right">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/AgingSchedulePDFDoubtfulDebt.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/AgingSchedulePDFDoubtfulDebt.jrxml
@@ -1,96 +1,95 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportAgingBalance" pageWidth="842" pageHeight="670" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportAgingBalance" language="java" pageWidth="842" pageHeight="670" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="12a9e20b-3b6a-4721-8f76-a76dc00606cb">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
 		<pen lineWidth="0.0" lineStyle="Solid"/>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/home/david/workspace/trunk/openbravo/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="AMOUNTFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<parameter name="AMOUNTFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat()]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale">
 		<defaultValueExpression><![CDATA[new Locale("es", "ES")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="InitialBalance" class="java.math.BigDecimal" isForPrompting="false">
+	<parameter name="InitialBalance" forPrompting="false" class="java.math.BigDecimal">
 		<defaultValueExpression><![CDATA[new BigDecimal(1111)]]></defaultValueExpression>
 	</parameter>
 	<parameter name="SUBREPORT_DIR" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{BASE_DESIGN}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATE_FROM" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col1" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col2" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col3" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col4" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col5" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BPartners" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Date1" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Date2" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Date3" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Date4" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Date5" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Organization" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="AccSchema" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Currency" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="toCurrency" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="PayStatus" class="java.lang.String" isForPrompting="false"/>
+	<parameter name="DATE_FROM" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col1" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col2" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col3" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col4" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col5" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BPartners" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Date1" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Date2" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Date3" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Date4" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Date5" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Organization" forPrompting="false" class="java.lang.String"/>
+	<parameter name="AccSchema" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Currency" forPrompting="false" class="java.lang.String"/>
+	<parameter name="toCurrency" forPrompting="false" class="java.lang.String"/>
+	<parameter name="PayStatus" forPrompting="false" class="java.lang.String"/>
 	<parameter name="currentDate" class="java.lang.String"/>
 	<parameter name="tabTitle" class="java.lang.String"/>
 	<parameter name="title" class="java.lang.String"/>
@@ -109,755 +108,477 @@
 	<field name="net" class="java.math.BigDecimal"/>
 	<field name="doubtfulDebt" class="java.math.BigDecimal"/>
 	<field name="percentage" class="java.math.BigDecimal"/>
-	<variable name="SUM_ZERO_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount0}]]></variableExpression>
+	<variable name="SUM_ZERO_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount0}]]></expression>
 	</variable>
-	<variable name="SUM_ONE_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount1}]]></variableExpression>
+	<variable name="SUM_ONE_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount1}]]></expression>
 	</variable>
-	<variable name="SUM_TWO_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount2}]]></variableExpression>
+	<variable name="SUM_TWO_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount2}]]></expression>
 	</variable>
-	<variable name="SUM_THREE_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount3}]]></variableExpression>
+	<variable name="SUM_THREE_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount3}]]></expression>
 	</variable>
-	<variable name="SUM_FOUR_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount4}]]></variableExpression>
+	<variable name="SUM_FOUR_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount4}]]></expression>
 	</variable>
-	<variable name="SUM_FIVE_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount5}]]></variableExpression>
+	<variable name="SUM_FIVE_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount5}]]></expression>
 	</variable>
-	<variable name="SUM_TOTAL_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{Total}]]></variableExpression>
+	<variable name="SUM_TOTAL_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{Total}]]></expression>
 	</variable>
 	<variable name="NoBPartner" class="java.lang.String">
-		<variableExpression><![CDATA[($F{BPartnerID}==null)?new String("only"):new String("exclude")]]></variableExpression>
+		<expression><![CDATA[($F{BPartnerID}==null)?new String("only"):new String("exclude")]]></expression>
 	</variable>
 	<variable name="NoBPartnerTotal" class="java.lang.String">
-		<variableExpression><![CDATA[($P{BPartners}=="")?new String("include"):new String("exclude")]]></variableExpression>
+		<expression><![CDATA[($P{BPartners}=="")?new String("include"):new String("exclude")]]></expression>
 	</variable>
-	<variable name="SUM_CREDIT" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{credit}]]></variableExpression>
+	<variable name="SUM_CREDIT" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{credit}]]></expression>
 	</variable>
-	<variable name="SUM_NET" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{net}]]></variableExpression>
+	<variable name="SUM_NET" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{net}]]></expression>
 	</variable>
-	<variable name="SUM_DOUBTFUL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{doubtfulDebt}]]></variableExpression>
+	<variable name="SUM_DOUBTFUL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{doubtfulDebt}]]></expression>
 	</variable>
 	<variable name="VAR_PERCENT" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{SUM_DOUBTFUL}.divide( $V{SUM_NET}.doubleValue() == 0 ? new BigDecimal("1"):$V{SUM_NET}, 5, RoundingMode.HALF_UP ).multiply(new BigDecimal("100"))]]></variableExpression>
+		<expression><![CDATA[$V{SUM_DOUBTFUL}.divide( $V{SUM_NET}.doubleValue() == 0 ? new BigDecimal("1"):$V{SUM_NET}, 5, RoundingMode.HALF_UP ).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
 	<group name="Totals">
 		<groupFooter>
 			<band height="28">
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="712" y="0" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="260" y="0" width="48" height="1"/>
-				</line>
-				<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-					<reportElement key="textField" mode="Opaque" x="405" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
+				<element kind="line" uuid="c7883b20-d71c-4fe3-942f-ac1e33f4b34d" key="line-33" x="712" y="0" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="02a60b3c-14dc-4c99-b03f-aa6b2a9f423f" key="line-33" x="260" y="0" width="48" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="29ac8803-2ce3-48f5-9159-64bf712d8d1b" key="textField" mode="Opaque" x="405" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{SUM_FIVE_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_FIVE_1}):new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[($V{SUM_FIVE_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_FIVE_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="210" y="17" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="260" y="17" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="410" y="0" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="460" y="0" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="360" y="0" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="210" y="19" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="160" y="19" width="48" height="1"/>
-				</line>
-				<textField pattern="##0.00" isBlankWhenNull="true" hyperlinkType="Reference">
-					<reportElement key="textField" mode="Opaque" x="755" y="2" width="4" height="12" forecolor="#060D0A" backcolor="#FFFFFF"/>
+				</element>
+				<element kind="line" uuid="9a3b2101-ed76-4465-99f8-f37879f543a1" key="line-33" positionType="FixRelativeToBottom" x="210" y="17" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="5c395f47-d2c8-43ab-b225-006304cecc76" key="line-33" positionType="FixRelativeToBottom" x="260" y="17" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="7ea21885-b390-4211-8e05-c8fa488e789a" key="line-33" x="410" y="0" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="5f50a007-0d04-4b3f-9316-52b58ea38f36" key="line-33" x="460" y="0" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="c57a9d5c-8731-4eb5-bbde-ace05e2f134a" key="line-33" x="360" y="0" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="f92f568c-25f4-46d4-ab3e-19ba37b75150" key="line-33" positionType="FixRelativeToBottom" x="210" y="19" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="60be2958-6064-4d78-9bc7-b7cc3a103a84" key="line-33" positionType="FixRelativeToBottom" x="160" y="19" width="48" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="0f52d81f-5d64-4fa1-8e4c-32a123426c04" key="textField" mode="Opaque" x="755" y="2" width="4" height="12" forecolor="#060D0A" backcolor="#FFFFFF" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8"/>
-					</textElement>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="360" y="17" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="310" y="0" width="48" height="1"/>
-				</line>
-				<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-					<reportElement key="textField" mode="Opaque" x="255" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
+				</element>
+				<element kind="line" uuid="4d1786b9-3ae7-4648-9ee5-5dc58b49714e" key="line-33" positionType="FixRelativeToBottom" x="360" y="17" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="e5df0fd0-c1ba-4d03-9af0-643d0a303563" key="line-33" x="310" y="0" width="48" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="7a4bd9b0-032b-4bd0-a1bd-f537a7858180" key="textField" mode="Opaque" x="255" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{SUM_TWO_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_TWO_1}):new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[($V{SUM_TWO_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_TWO_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="210" y="0" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="410" y="19" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="460" y="17" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="460" y="19" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="260" y="19" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="512" y="19" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="712" y="17" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="512" y="0" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="310" y="19" width="48" height="1"/>
-				</line>
-				<staticText>
-					<reportElement key="staticText-26" style="Detail_Header" x="0" y="2" width="155" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="line" uuid="4298147f-e978-4e67-985d-39e0eea57a68" key="line-33" x="210" y="0" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="6a94c36b-3b32-4b0f-acff-e1e79813240a" key="line-33" positionType="FixRelativeToBottom" x="410" y="19" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="af1f03ae-73b9-4328-a9a9-ef392073581e" key="line-33" positionType="FixRelativeToBottom" x="460" y="17" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="1646baef-21a2-42ca-bd1e-a20bbe4ef40b" key="line-33" positionType="FixRelativeToBottom" x="460" y="19" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="1e9c0c5f-06da-4d75-8c0b-c994ce87c222" key="line-33" positionType="FixRelativeToBottom" x="260" y="19" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="c2cc0e86-d742-4bf6-888e-5f3a93cc6619" key="line-33" positionType="FixRelativeToBottom" x="512" y="19" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="66da5731-124b-49f6-9c79-a9190675d5e2" key="line-33" positionType="FixRelativeToBottom" x="712" y="17" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="66a59d64-d79f-4fe6-8914-efd50004fc01" key="line-33" x="512" y="0" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="85b0ea75-2127-4898-8003-7e534a397a80" key="line-33" positionType="FixRelativeToBottom" x="310" y="19" width="48" height="1" style="Report_Footer"/>
+				<element kind="staticText" uuid="619d880e-1754-48b7-a47a-1df6d95272fa" key="staticText-26" x="0" y="2" width="155" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" pdfFontName="Helvetica-Bold" vTextAlign="Middle" style="Detail_Header">
+					<text><![CDATA[TOTAL:]]></text>
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[TOTAL:]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="310" y="17" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="410" y="17" width="48" height="1"/>
-				</line>
-				<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-					<reportElement key="textField" mode="Opaque" x="205" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
+				</element>
+				<element kind="line" uuid="d1904bd0-5be5-412a-8970-aa5680c71231" key="line-33" positionType="FixRelativeToBottom" x="310" y="17" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="2f4881dc-72aa-4305-855f-5e8559364a35" key="line-33" positionType="FixRelativeToBottom" x="410" y="17" width="48" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="83826606-a7b5-4022-b48c-da8224082894" key="textField" mode="Opaque" x="205" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{SUM_ONE_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_ONE_1}):new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[($V{SUM_ONE_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_ONE_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-					<reportElement key="textField" mode="Opaque" x="305" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
+				</element>
+				<element kind="textField" uuid="e92fc0df-a590-45e6-9e69-3244ed2913aa" key="textField" mode="Opaque" x="305" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{SUM_THREE_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_THREE_1}):new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[($V{SUM_THREE_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_THREE_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="1" y="0" width="207" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="360" y="19" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="160" y="17" width="48" height="1"/>
-				</line>
-				<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-					<reportElement key="textField" mode="Opaque" x="355" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
+				</element>
+				<element kind="line" uuid="3b39f23c-80e1-42d7-837e-737d42be83da" key="line-33" x="1" y="0" width="207" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="8e32876a-8d1f-4d74-92b3-bc1379540a53" key="line-33" positionType="FixRelativeToBottom" x="360" y="19" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="9b216a42-9570-4e17-bcca-50dcf0d242d5" key="line-33" positionType="FixRelativeToBottom" x="160" y="17" width="48" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="ee65dc75-b588-4dd2-9b99-5f35d936c312" key="textField" mode="Opaque" x="355" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{SUM_FOUR_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_FOUR_1}):new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[($V{SUM_FOUR_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_FOUR_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="512" y="17" width="48" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="712" y="19" width="48" height="1"/>
-				</line>
-				<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-					<reportElement key="textField" mode="Opaque" x="455" y="2" width="50" height="14" forecolor="#060D0A" backcolor="#FFFFFF"/>
+				</element>
+				<element kind="line" uuid="7156332c-b689-4bb6-a5e4-c9ccd3430b43" key="line-33" positionType="FixRelativeToBottom" x="512" y="17" width="48" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="ab1fbdf9-ec5c-413a-8e30-d9e39528fe99" key="line-33" positionType="FixRelativeToBottom" x="712" y="19" width="48" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="ad1d4184-1335-4ea8-8cae-cda9e85773cf" key="textField" mode="Opaque" x="455" y="2" width="50" height="14" forecolor="#060D0A" backcolor="#FFFFFF" fontSize="6.0" textAdjust="StretchHeight" pattern="##0.00" linkType="Reference" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{SUM_TOTAL_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_TOTAL_1}):new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[($V{SUM_TOTAL_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_TOTAL_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-					<reportElement key="textField-2" mode="Opaque" x="155" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
+				</element>
+				<element kind="textField" uuid="5882e705-472c-42de-a656-b1eb83578ff8" key="textField-2" mode="Opaque" x="155" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" textAdjust="StretchHeight" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{SUM_ZERO_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_ZERO_1}):new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[($V{SUM_ZERO_1}!=null)?$P{AMOUNTFORMAT}.format($V{SUM_ZERO_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" pattern="###0.00;-###0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-					<reportElement key="textField" mode="Opaque" x="705" y="2" width="53" height="14" isPrintWhenDetailOverflows="true" forecolor="#060D0A" backcolor="#FFFFFF"/>
+				</element>
+				<element kind="textField" uuid="2e958753-bd09-4d96-94c1-7a08642c58a1" key="textField" mode="Opaque" x="705" y="2" width="53" height="14" forecolor="#060D0A" backcolor="#FFFFFF" fontSize="6.0" textAdjust="StretchHeight" pattern="###0.00;-###0.00" linkType="Reference" blankWhenNull="false" printWhenDetailOverflows="true" strikeThrough="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{SUM_NET}!=null)? "   "+$P{AMOUNTFORMAT}.format($V{SUM_NET})+"   ":new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isStrikeThrough="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[($V{SUM_NET}!=null)? "   "+$P{AMOUNTFORMAT}.format($V{SUM_NET})+"   ":new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="###0.00;-###0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-					<reportElement key="textField" positionType="Float" mode="Opaque" x="505" y="2" width="50" height="14" isPrintWhenDetailOverflows="true" forecolor="#000000" backcolor="#FFFFFF"/>
+				</element>
+				<element kind="textField" uuid="73e021e9-b40f-4ed8-9d0f-023100dc5c5f" key="textField" positionType="Float" mode="Opaque" x="505" y="2" width="50" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" pattern="###0.00;-###0.00" linkType="Reference" blankWhenNull="false" printWhenDetailOverflows="true" underline="false" strikeThrough="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{SUM_CREDIT}!=null)? "(" + $P{AMOUNTFORMAT}.format($V{SUM_CREDIT}) + ")" : "(" + $P{AMOUNTFORMAT}.format(BigDecimal.ZERO) + ")"]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isUnderline="false" isStrikeThrough="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[($V{SUM_CREDIT}!=null)? "(" + $P{AMOUNTFORMAT}.format($V{SUM_CREDIT}) + ")" : "(" + $P{AMOUNTFORMAT}.format(BigDecimal.ZERO) + ")"]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="564" y="0" width="78" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" x="646" y="0" width="63" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="564" y="19" width="78" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="564" y="17" width="78" height="1"/>
-				</line>
-				<textField pattern="###0.00;-###0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-					<reportElement key="textField" positionType="Float" mode="Opaque" x="555" y="3" width="82" height="14" isPrintWhenDetailOverflows="true" forecolor="#000000" backcolor="#FFFFFF"/>
+				</element>
+				<element kind="line" uuid="c10028be-378d-4866-abfc-8a1045c49999" key="line-33" x="564" y="0" width="78" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="f57e120c-3c98-472e-9e69-16af010438ba" key="line-33" x="646" y="0" width="63" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="1c920909-fd75-4060-ad1e-99f282c93f13" key="line-33" positionType="FixRelativeToBottom" x="564" y="19" width="78" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="f98e17b3-9c2e-4856-96e7-08f903b17375" key="line-33" positionType="FixRelativeToBottom" x="564" y="17" width="78" height="1" style="Report_Footer"/>
+				<element kind="textField" uuid="6700aecf-cc20-45f1-84e9-0660e0ad7218" key="textField" positionType="Float" mode="Opaque" x="555" y="3" width="82" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" pattern="###0.00;-###0.00" linkType="Reference" blankWhenNull="false" printWhenDetailOverflows="true" underline="false" strikeThrough="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{SUM_DOUBTFUL}!=null)? $P{AMOUNTFORMAT}.format($V{SUM_DOUBTFUL}) : $P{AMOUNTFORMAT}.format(BigDecimal.ZERO)]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isUnderline="false" isStrikeThrough="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[($V{SUM_DOUBTFUL}!=null)? $P{AMOUNTFORMAT}.format($V{SUM_DOUBTFUL}) : $P{AMOUNTFORMAT}.format(BigDecimal.ZERO)]]></textFieldExpression>
-				</textField>
-				<textField pattern="###0.00;-###0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-					<reportElement key="textField" positionType="Float" mode="Opaque" x="637" y="2" width="68" height="14" isPrintWhenDetailOverflows="true" forecolor="#000000" backcolor="#FFFFFF"/>
+				</element>
+				<element kind="textField" uuid="1ca9e54e-4540-415a-99c2-5232b92a409d" key="textField" positionType="Float" mode="Opaque" x="637" y="2" width="68" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" pattern="###0.00;-###0.00" linkType="Reference" blankWhenNull="false" printWhenDetailOverflows="true" underline="false" strikeThrough="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[(($V{VAR_PERCENT}!=null)? $P{AMOUNTFORMAT}.format($V{VAR_PERCENT}) : $P{AMOUNTFORMAT}.format(BigDecimal.ZERO)) + " %"]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isUnderline="false" isStrikeThrough="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[(($V{VAR_PERCENT}!=null)? $P{AMOUNTFORMAT}.format($V{VAR_PERCENT}) : $P{AMOUNTFORMAT}.format(BigDecimal.ZERO)) + " %"]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="646" y="17" width="63" height="1"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="Report_Footer" positionType="FixRelativeToBottom" x="646" y="19" width="63" height="1"/>
-				</line>
+				</element>
+				<element kind="line" uuid="6394c560-6c0e-4602-8cc9-5b5bd0277ae0" key="line-33" positionType="FixRelativeToBottom" x="646" y="17" width="63" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="5aa558cc-c36d-4a7c-9be3-f4a25e2a4d36" key="line-33" positionType="FixRelativeToBottom" x="646" y="19" width="63" height="1" style="Report_Footer"/>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="139" splitType="Stretch">
-			<textField>
-				<reportElement x="6" y="22" width="400" height="28"/>
-				<textElement>
-					<font size="18"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{title}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="112" y="105" width="152" height="18"/>
-				<textElement>
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{currentDate}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="112" y="85" width="152" height="18"/>
-				<textElement>
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{OrganizationName}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-27" style="Report_Footer" x="276" y="85" width="136" height="18"/>
-				<textElement textAlignment="Right">
-					<font size="9"/>
-				</textElement>
-				<text><![CDATA[General Ledger:]]></text>
-			</staticText>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="417" y="85" width="179" height="18"/>
-				<textElement>
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{AccSchemaName}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-26" style="Report_Footer" x="0" y="105" width="107" height="18"/>
-				<textElement textAlignment="Right">
-					<font size="9"/>
-				</textElement>
-				<text><![CDATA[As Of Date:]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-24" style="Report_Footer" x="0" y="85" width="107" height="18"/>
-				<textElement textAlignment="Right">
-					<font size="9"/>
-				</textElement>
-				<text><![CDATA[Organization:]]></text>
-			</staticText>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="139" splitType="Stretch">
+		<element kind="textField" uuid="2b124d00-eedb-4c10-9cf9-e669b13514ac" x="6" y="22" width="400" height="28" fontSize="18.0">
+			<expression><![CDATA[$P{title}]]></expression>
+		</element>
+		<element kind="textField" uuid="20492d25-7801-4ce3-a24e-9b2711b52a1e" key="textField-25" x="112" y="105" width="152" height="18" fontSize="9.0" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{currentDate}]]></expression>
+		</element>
+		<element kind="textField" uuid="24931c98-4bdf-4a89-97de-82d6c6efda41" key="textField-25" x="112" y="85" width="152" height="18" fontSize="9.0" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{OrganizationName}]]></expression>
+		</element>
+		<element kind="staticText" uuid="acb1d8f2-f330-4066-aa81-e6d2ce15cdd0" key="staticText-27" x="276" y="85" width="136" height="18" fontSize="9.0" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[General Ledger:]]></text>
+		</element>
+		<element kind="textField" uuid="a6cd09d6-0151-42c7-89db-36807f1d615f" key="textField-25" x="417" y="85" width="179" height="18" fontSize="9.0" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{AccSchemaName}]]></expression>
+		</element>
+		<element kind="staticText" uuid="e969525a-5c54-4062-9122-82c91d549435" key="staticText-26" x="0" y="105" width="107" height="18" fontSize="9.0" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[As Of Date:]]></text>
+		</element>
+		<element kind="staticText" uuid="8cab8a47-6772-4cbe-bcef-eb451c5a48d6" key="staticText-24" x="0" y="85" width="107" height="18" fontSize="9.0" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Organization:]]></text>
+		</element>
 	</title>
-	<pageHeader>
-		<band height="5" splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band height="15" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-18" style="Detail_Header" x="0" y="0" width="151" height="15"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement>
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[BUSINESS PARTNER]]></text>
-			</staticText>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Header" x="205" y="0" width="50" height="15"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{col1}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-3" style="Detail_Header" x="255" y="0" width="50" height="15"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{col2}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-4" style="Detail_Header" x="305" y="0" width="50" height="15"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{col3}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-5" style="Detail_Header" x="355" y="0" width="50" height="15"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{col4}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-6" style="Detail_Header" x="405" y="0" width="50" height="15"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{col5}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="705" y="0" width="55" height="15"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[NET]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="505" y="0" width="50" height="15"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[CREDITS]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="151" y="0" width="54" height="15"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[CURRENT]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="455" y="0" width="50" height="15"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[TOTAL]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="555" y="0" width="82" height="15"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[DOUBTFUL DEBT]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="637" y="0" width="68" height="15"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[PERCENTAGE]]></text>
-			</staticText>
-		</band>
+	<pageHeader height="5" splitType="Stretch"/>
+	<columnHeader height="15" splitType="Stretch">
+		<element kind="staticText" uuid="fc25374d-1d24-4d51-8703-9df8f600de5e" key="staticText-18" x="0" y="0" width="151" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" style="Detail_Header">
+			<text><![CDATA[BUSINESS PARTNER]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="3f73e850-0a67-473d-ba42-4e53ea1bcf71" key="textField" x="205" y="0" width="50" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col1}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="fd9333c2-27a0-4451-8ab2-eb5ad7e02b77" key="textField-3" x="255" y="0" width="50" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col2}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="3c82affc-9508-4b21-92d9-37104051cf26" key="textField-4" x="305" y="0" width="50" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col3}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="7f711035-c68a-4c8b-a34c-bd30c61477dd" key="textField-5" x="355" y="0" width="50" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col4}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="d247f34f-7ef2-4ffc-8814-3ed8476f31cf" key="textField-6" x="405" y="0" width="50" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col5}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="13b0b887-70ec-4d16-9b00-6f394a0fad58" key="staticText-25" x="705" y="0" width="55" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[NET]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="f77a08bf-eb45-48ec-bbf3-0431c90d39c8" key="staticText-25" x="505" y="0" width="50" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[CREDITS]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="147a2ae9-bd53-46a0-8cf6-9a606e790a5c" key="staticText-25" x="151" y="0" width="54" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[CURRENT]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="c39d0c80-18dc-4649-8c66-3e8e252560f2" key="staticText-25" x="455" y="0" width="50" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[TOTAL]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="f5aec8c0-f62f-41ba-baac-ed31a639301b" key="staticText-25" x="555" y="0" width="82" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[DOUBTFUL DEBT]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="ffba1adf-b528-4cab-a7b4-7fcbfe1d7667" key="staticText-25" x="637" y="0" width="68" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[PERCENTAGE]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
 	</columnHeader>
 	<detail>
 		<band height="19" splitType="Stretch">
-			<textField pattern="###0.00;-###0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" x="505" y="0" width="50" height="16" isPrintWhenDetailOverflows="true" forecolor="#000000"/>
+			<element kind="textField" uuid="e1fa2893-86d3-4758-8d02-7307a3350a67" key="textField" stretchType="ElementGroupHeight" x="505" y="0" width="50" height="16" forecolor="#000000" fontSize="6.0" pattern="###0.00;-###0.00" linkType="Reference" blankWhenNull="false" printWhenDetailOverflows="true" underline="false" strikeThrough="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{credit}!=null)? "(" + $P{AMOUNTFORMAT}.format($F{credit}) + ")" : "(" + $P{AMOUNTFORMAT}.format(BigDecimal.ZERO) + ")"]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false" isStrikeThrough="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[($F{credit}!=null)? "(" + $P{AMOUNTFORMAT}.format($F{credit}) + ")" : "(" + $P{AMOUNTFORMAT}.format(BigDecimal.ZERO) + ")"]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="19"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" x="6" y="0" width="149" height="16"/>
+			</element>
+			<element kind="line" uuid="f0f0ab8d-a605-498a-aa87-d91b655112c4" key="line-17" stretchType="ContainerHeight" x="1" y="0" width="1" height="19">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="7628fbdc-7fae-4b2c-ae06-fb4520a01a06" key="textField" x="6" y="0" width="149" height="16" fontSize="8.0" blankWhenNull="false" vTextAlign="Middle">
+				<expression><![CDATA[$F{BPartner}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{BPartner}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement x="2" y="0" width="4" height="16"/>
-				<textElement/>
+			</element>
+			<element kind="staticText" uuid="ff82432a-f9b0-40f4-a859-5b480eed78b1" x="2" y="0" width="4" height="16">
 				<text><![CDATA[]]></text>
-			</staticText>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" x="205" y="0" width="50" height="16" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="528c4b12-8994-4895-b54a-4d61e175efcc" key="textField" stretchType="ElementGroupHeight" x="205" y="0" width="50" height="16" forecolor="#000000" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{amount1}!=null)?$P{AMOUNTFORMAT}.format($F{amount1}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[($F{amount1}!=null)?$P{AMOUNTFORMAT}.format($F{amount1}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" x="255" y="0" width="50" height="16" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="56aeb7d7-6310-4ecd-8460-cdc2960e04f7" key="textField" stretchType="ElementGroupHeight" x="255" y="0" width="50" height="16" forecolor="#000000" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{amount2}!=null)?$P{AMOUNTFORMAT}.format($F{amount2}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[($F{amount2}!=null)?$P{AMOUNTFORMAT}.format($F{amount2}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" x="305" y="0" width="50" height="16" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="dd455483-1f35-4e44-97d5-5480ecbecca9" key="textField" stretchType="ElementGroupHeight" x="305" y="0" width="50" height="16" forecolor="#000000" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{amount3}!=null)?$P{AMOUNTFORMAT}.format($F{amount3}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[($F{amount3}!=null)?$P{AMOUNTFORMAT}.format($F{amount3}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" x="355" y="0" width="50" height="16" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="af1f6d16-b2e6-46c2-b373-a02e5ccd35d9" key="textField" stretchType="ElementGroupHeight" x="355" y="0" width="50" height="16" forecolor="#000000" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{amount4}!=null)?$P{AMOUNTFORMAT}.format($F{amount4}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[($F{amount4}!=null)?$P{AMOUNTFORMAT}.format($F{amount4}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" x="405" y="0" width="50" height="16" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="e0dc3c64-a6ea-43b9-9165-1ebd5a2b4d18" key="textField" stretchType="ElementGroupHeight" x="405" y="0" width="50" height="16" forecolor="#000000" markup="html" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{amount5}!=null)?$P{AMOUNTFORMAT}.format($F{amount5}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle" markup="html">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[($F{amount5}!=null)?$P{AMOUNTFORMAT}.format($F{amount5}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" x="455" y="0" width="50" height="16"/>
+			</element>
+			<element kind="textField" uuid="648f5ee0-b3f3-48d0-bd00-05ee7de0159c" key="textField" stretchType="ElementGroupHeight" x="455" y="0" width="50" height="16" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{Total}!=null)?$P{AMOUNTFORMAT}.format($F{Total}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[($F{Total}!=null)?$P{AMOUNTFORMAT}.format($F{Total}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" x="155" y="0" width="50" height="16" forecolor="#000000"/>
+			</element>
+			<element kind="textField" uuid="989d836c-b7c3-4a60-a075-cfaee7a45e30" key="textField" stretchType="ElementGroupHeight" x="155" y="0" width="50" height="16" forecolor="#000000" fontSize="6.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{amount0}!=null)?$P{AMOUNTFORMAT}.format($F{amount0}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[($F{amount0}!=null)?$P{AMOUNTFORMAT}.format($F{amount0}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="759" y="0" width="1" height="19"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<elementGroup>
-				<textField isStretchWithOverflow="true" pattern="#,##0.00;(-#,##0.00)" isBlankWhenNull="false" hyperlinkType="Reference">
-					<reportElement key="textField" x="705" y="0" width="53" height="16" isPrintWhenDetailOverflows="true"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6" isStrikeThrough="false"/>
-					</textElement>
-					<textFieldExpression class="java.lang.String"><![CDATA[($F{net}!=null)? "   "+$P{AMOUNTFORMAT}.format($F{net})+"   ":new String(" ")]]></textFieldExpression>
-				</textField>
-			</elementGroup>
-			<textField isStretchWithOverflow="true" pattern="#,##0.00;(-#,##0.00)" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" x="555" y="0" width="82" height="16" isPrintWhenDetailOverflows="true"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isStrikeThrough="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[($F{doubtfulDebt}!=null)? "   "+$P{AMOUNTFORMAT}.format($F{doubtfulDebt})+"   ":new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="#,##0.00;(-#,##0.00)" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" x="637" y="0" width="68" height="16" isPrintWhenDetailOverflows="true"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6" isStrikeThrough="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[($F{percentage}!=null)? "   "+$P{AMOUNTFORMAT}.format($F{percentage})+" % ":  "   "+ $P{AMOUNTFORMAT}.format(BigDecimal.ZERO)+" % "]]></textFieldExpression>
-			</textField>
+			</element>
+			<element kind="line" uuid="360361a5-6ca0-4ae8-9ff4-c3442a411ace" key="line-17" stretchType="ContainerHeight" x="759" y="0" width="1" height="19">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="elementGroup">
+				<element kind="textField" uuid="ecae3195-93ec-4474-ab08-72764e6242d2" key="textField" x="705" y="0" width="53" height="16" fontSize="6.0" textAdjust="StretchHeight" pattern="#,##0.00;(-#,##0.00)" linkType="Reference" blankWhenNull="false" printWhenDetailOverflows="true" strikeThrough="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($F{net}!=null)? "   "+$P{AMOUNTFORMAT}.format($F{net})+"   ":new String(" ")]]></expression>
+				</element>
+			</element>
+			<element kind="textField" uuid="e730843c-10bd-4de1-acf9-9617294eff1f" key="textField" x="555" y="0" width="82" height="16" fontSize="6.0" textAdjust="StretchHeight" pattern="#,##0.00;(-#,##0.00)" linkType="Reference" blankWhenNull="false" printWhenDetailOverflows="true" strikeThrough="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{doubtfulDebt}!=null)? "   "+$P{AMOUNTFORMAT}.format($F{doubtfulDebt})+"   ":new String(" ")]]></expression>
+			</element>
+			<element kind="textField" uuid="dccb1e5a-5efc-4224-a029-8378e6981410" key="textField" x="637" y="0" width="68" height="16" fontSize="6.0" textAdjust="StretchHeight" pattern="#,##0.00;(-#,##0.00)" linkType="Reference" blankWhenNull="false" printWhenDetailOverflows="true" strikeThrough="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{percentage}!=null)? "   "+$P{AMOUNTFORMAT}.format($F{percentage})+" % ":  "   "+ $P{AMOUNTFORMAT}.format(BigDecimal.ZERO)+" % "]]></expression>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="17" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="377" y="0" width="113" height="14"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="6"/>
-				</textElement>
-				<textFieldExpression class="java.util.Date"><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="724" y="3" width="36" height="14" forecolor="#000000" backcolor="#FFFFFF"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="6"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" x="295" y="0" width="78" height="14"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="6"/>
-				</textElement>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="625" y="3" width="95" height="14"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="6"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="17" splitType="Stretch">
+		<element kind="textField" uuid="bfed5eb8-6925-4d19-9bb3-93651ed37927" key="textField" x="377" y="0" width="113" height="14" fontName="Times-Roman" fontSize="6.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="e091393a-0438-4bdb-9f73-a63751f38c7c" key="textField" x="724" y="3" width="36" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="6.0" evaluationTime="Report" pattern="" blankWhenNull="false">
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="303518dd-0ca0-4268-ad39-fe00ac7f17d9" key="staticText-1" x="295" y="0" width="78" height="14" fontName="Bitstream Vera Sans" fontSize="6.0" hTextAlign="Right" vTextAlign="Middle">
+			<text><![CDATA[Generated on]]></text>
+			<box leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="bb7e1140-1e4c-4f6c-9f38-14c5a631e9e9" key="textField" x="625" y="3" width="95" height="14" fontSize="6.0" pattern="" blankWhenNull="false" hTextAlign="Right">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/AgingScheduleXLS.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/AgingScheduleXLS.jrxml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportAgingBalance" pageWidth="920" pageHeight="842" columnWidth="920" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="9b66e7ac-3901-4982-bf21-604fb3cb61a3">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportAgingBalance" language="java" pageWidth="920" pageHeight="842" columnWidth="920" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="9b66e7ac-3901-4982-bf21-604fb3cb61a3">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
@@ -7,91 +7,90 @@
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
 	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
 		<pen lineWidth="0.0" lineStyle="Solid"/>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/home/david/workspace/trunk/openbravo/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="AMOUNTFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<parameter name="AMOUNTFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat()]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale">
 		<defaultValueExpression><![CDATA[new Locale("es", "ES")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="InitialBalance" class="java.math.BigDecimal" isForPrompting="false">
+	<parameter name="InitialBalance" forPrompting="false" class="java.math.BigDecimal">
 		<defaultValueExpression><![CDATA[new BigDecimal(1111)]]></defaultValueExpression>
 	</parameter>
 	<parameter name="SUBREPORT_DIR" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{BASE_DESIGN}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATE_FROM" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col1" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col2" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col3" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col4" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col5" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BPartners" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Date1" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Date2" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Date3" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Date4" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Date5" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Organization" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="AccSchema" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Currency" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="toCurrency" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="PayStatus" class="java.lang.String" isForPrompting="false"/>
+	<parameter name="DATE_FROM" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col1" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col2" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col3" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col4" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col5" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BPartners" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Date1" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Date2" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Date3" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Date4" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Date5" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Organization" forPrompting="false" class="java.lang.String"/>
+	<parameter name="AccSchema" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Currency" forPrompting="false" class="java.lang.String"/>
+	<parameter name="toCurrency" forPrompting="false" class="java.lang.String"/>
+	<parameter name="PayStatus" forPrompting="false" class="java.lang.String"/>
 	<parameter name="currentDate" class="java.lang.String"/>
 	<parameter name="tabTitle" class="java.lang.String"/>
 	<parameter name="title" class="java.lang.String"/>
@@ -111,647 +110,458 @@
 	<field name="net" class="java.math.BigDecimal"/>
 	<field name="doubtfulDebt" class="java.math.BigDecimal"/>
 	<field name="percentage" class="java.math.BigDecimal"/>
-	<variable name="SUM_ZERO_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount0}]]></variableExpression>
+	<variable name="SUM_ZERO_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount0}]]></expression>
 	</variable>
-	<variable name="SUM_ONE_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount1}]]></variableExpression>
+	<variable name="SUM_ONE_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount1}]]></expression>
 	</variable>
-	<variable name="SUM_TWO_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount2}]]></variableExpression>
+	<variable name="SUM_TWO_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount2}]]></expression>
 	</variable>
-	<variable name="SUM_THREE_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount3}]]></variableExpression>
+	<variable name="SUM_THREE_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount3}]]></expression>
 	</variable>
-	<variable name="SUM_FOUR_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount4}]]></variableExpression>
+	<variable name="SUM_FOUR_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount4}]]></expression>
 	</variable>
-	<variable name="SUM_FIVE_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount5}]]></variableExpression>
+	<variable name="SUM_FIVE_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount5}]]></expression>
 	</variable>
-	<variable name="SUM_TOTAL_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{Total}]]></variableExpression>
+	<variable name="SUM_TOTAL_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{Total}]]></expression>
 	</variable>
 	<variable name="NoBPartner" class="java.lang.String">
-		<variableExpression><![CDATA[($F{BPartnerID}==null)?new String("only"):new String("exclude")]]></variableExpression>
+		<expression><![CDATA[($F{BPartnerID}==null)?new String("only"):new String("exclude")]]></expression>
 	</variable>
 	<variable name="NoBPartnerTotal" class="java.lang.String">
-		<variableExpression><![CDATA[($P{BPartners}=="")?new String("include"):new String("exclude")]]></variableExpression>
+		<expression><![CDATA[($P{BPartners}=="")?new String("include"):new String("exclude")]]></expression>
 	</variable>
-	<variable name="SUM_CREDIT" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{credit}.negate()]]></variableExpression>
+	<variable name="SUM_CREDIT" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{credit}.negate()]]></expression>
 	</variable>
-	<variable name="SUM_NET" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{net}]]></variableExpression>
+	<variable name="SUM_NET" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{net}]]></expression>
 	</variable>
-	<variable name="SUM_DOUBTFUL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{doubtfulDebt}]]></variableExpression>
+	<variable name="SUM_DOUBTFUL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{doubtfulDebt}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
 	<variable name="VAR_PERCENT" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{SUM_DOUBTFUL}.divide( $V{SUM_NET}.doubleValue() == 0 ? new BigDecimal("1"):$V{SUM_NET}, 5, RoundingMode.HALF_UP ).multiply(new BigDecimal("100"))]]></variableExpression>
+		<expression><![CDATA[$V{SUM_DOUBTFUL}.divide( $V{SUM_NET}.doubleValue() == 0 ? new BigDecimal("1"):$V{SUM_NET}, 5, RoundingMode.HALF_UP ).multiply(new BigDecimal("100"))]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="64" splitType="Stretch">
-			<textField>
-				<reportElement x="0" y="0" width="920" height="28" uuid="331518f4-4af1-4739-8ac8-80ce7c893fac"/>
-				<textElement>
-					<font size="18"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{title}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-27" style="Report_Footer" x="359" y="28" width="195" height="18" uuid="4b70bb7a-cbc4-4dbd-bfae-76d93733fbc8"/>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[General Ledger:]]></text>
-			</staticText>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="554" y="28" width="366" height="18" uuid="d8eaf337-082a-4fc6-9fc8-604901eb0099"/>
-				<textFieldExpression><![CDATA[$P{AccSchemaName}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-24" style="Report_Footer" x="0" y="28" width="165" height="18" uuid="e705d86b-c96b-4edc-a6a7-bad78446de18"/>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Organization:]]></text>
-			</staticText>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="165" y="28" width="194" height="18" uuid="37959c1f-af73-43f5-bdce-138069d9348f"/>
-				<textFieldExpression><![CDATA[$P{OrganizationName}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-26" style="Report_Footer" x="0" y="46" width="165" height="18" uuid="4bfce0d0-acbf-4d1c-96f9-7e6732003be7"/>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[As Of Date:]]></text>
-			</staticText>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-25" style="Report_Footer" x="165" y="46" width="194" height="18" uuid="cb5889cb-b071-4037-86b5-b5cfd69e515f"/>
-				<textFieldExpression><![CDATA[$P{currentDate}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="64" splitType="Stretch">
+		<element kind="textField" uuid="331518f4-4af1-4739-8ac8-80ce7c893fac" x="0" y="0" width="920" height="28" fontSize="18.0">
+			<expression><![CDATA[$P{title}]]></expression>
+		</element>
+		<element kind="staticText" uuid="4b70bb7a-cbc4-4dbd-bfae-76d93733fbc8" key="staticText-27" x="359" y="28" width="195" height="18" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[General Ledger:]]></text>
+		</element>
+		<element kind="textField" uuid="d8eaf337-082a-4fc6-9fc8-604901eb0099" key="textField-25" x="554" y="28" width="366" height="18" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{AccSchemaName}]]></expression>
+		</element>
+		<element kind="staticText" uuid="e705d86b-c96b-4edc-a6a7-bad78446de18" key="staticText-24" x="0" y="28" width="165" height="18" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Organization:]]></text>
+		</element>
+		<element kind="textField" uuid="37959c1f-af73-43f5-bdce-138069d9348f" key="textField-25" x="165" y="28" width="194" height="18" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{OrganizationName}]]></expression>
+		</element>
+		<element kind="staticText" uuid="4bfce0d0-acbf-4d1c-96f9-7e6732003be7" key="staticText-26" x="0" y="46" width="165" height="18" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[As Of Date:]]></text>
+		</element>
+		<element kind="textField" uuid="cb5889cb-b071-4037-86b5-b5cfd69e515f" key="textField-25" x="165" y="46" width="194" height="18" blankWhenNull="true" style="Report_Footer">
+			<expression><![CDATA[$P{currentDate}]]></expression>
+		</element>
 	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band height="15" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-18" style="Detail_Header" x="0" y="0" width="165" height="15" uuid="b4c55815-5888-4833-9d13-51c7c5fa10c2"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement>
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[BUSINESS PARTNER]]></text>
-			</staticText>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Header" x="229" y="0" width="65" height="15" uuid="a6dce294-5769-4adc-9d7a-51e06543d777"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{col1}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-3" style="Detail_Header" x="294" y="0" width="65" height="15" uuid="552243a5-75c6-409a-8531-ab24688f4c1d"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{col2}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-4" style="Detail_Header" x="359" y="0" width="65" height="15" uuid="c63676f5-2190-4c1f-93d0-38dfd5b9ab84"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{col3}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-5" style="Detail_Header" x="424" y="0" width="65" height="15" uuid="dc8e6bc0-a540-4479-87c1-7d81c8d801ae"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{col4}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-6" style="Detail_Header" x="489" y="0" width="65" height="15" uuid="05ae52c6-b46e-4adb-913d-819061d25d7b"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{col5}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="854" y="0" width="66" height="15" uuid="1cc48a7b-1df9-4305-b021-c79a1e7f55d0">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[NET]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="619" y="0" width="65" height="15" uuid="8049090f-8df6-4024-8b1a-348d7950dec8"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[CREDITS]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="165" y="0" width="64" height="15" uuid="27c1f9bc-2be9-4c9a-a762-e21a68be6f24"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[CURRENT]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="554" y="0" width="65" height="15" uuid="96ce6147-5aca-41da-9faa-a6742ffd6ef3"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[TOTAL]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="684" y="0" width="95" height="15" uuid="dafdd30f-814b-4789-a81a-4cb0f7b333e2">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[DOUBTFUL DEBT]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="779" y="0" width="75" height="15" uuid="d2407206-8a1f-474a-bd03-2dd4878d590a">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[PERCENTAGE]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="684" y="0" width="95" height="15" uuid="75d98d6b-2bac-48f7-8ac7-6602e32f486c">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[NET]]></text>
-			</staticText>
-		</band>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader height="15" splitType="Stretch">
+		<element kind="staticText" uuid="b4c55815-5888-4833-9d13-51c7c5fa10c2" key="staticText-18" x="0" y="0" width="165" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" style="Detail_Header">
+			<text><![CDATA[BUSINESS PARTNER]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="a6dce294-5769-4adc-9d7a-51e06543d777" key="textField" x="229" y="0" width="65" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col1}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="552243a5-75c6-409a-8531-ab24688f4c1d" key="textField-3" x="294" y="0" width="65" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col2}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="c63676f5-2190-4c1f-93d0-38dfd5b9ab84" key="textField-4" x="359" y="0" width="65" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col3}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="dc8e6bc0-a540-4479-87c1-7d81c8d801ae" key="textField-5" x="424" y="0" width="65" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col4}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="05ae52c6-b46e-4adb-913d-819061d25d7b" key="textField-6" x="489" y="0" width="65" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col5}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="1cc48a7b-1df9-4305-b021-c79a1e7f55d0" key="staticText-25" x="854" y="0" width="66" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+			<text><![CDATA[NET]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="8049090f-8df6-4024-8b1a-348d7950dec8" key="staticText-25" x="619" y="0" width="65" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[CREDITS]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="27c1f9bc-2be9-4c9a-a762-e21a68be6f24" key="staticText-25" x="165" y="0" width="64" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[CURRENT]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="96ce6147-5aca-41da-9faa-a6742ffd6ef3" key="staticText-25" x="554" y="0" width="65" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[TOTAL]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="dafdd30f-814b-4789-a81a-4cb0f7b333e2" key="staticText-25" x="684" y="0" width="95" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+			<text><![CDATA[DOUBTFUL DEBT]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="d2407206-8a1f-474a-bd03-2dd4878d590a" key="staticText-25" x="779" y="0" width="75" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+			<text><![CDATA[PERCENTAGE]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="75d98d6b-2bac-48f7-8ac7-6602e32f486c" key="staticText-25" x="684" y="0" width="95" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
+			<text><![CDATA[NET]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
 	</columnHeader>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="0" y="0" width="165" height="16" uuid="5ace785a-e708-41a3-8fe1-899beb767d54"/>
-				<box>
+			<element kind="textField" uuid="5ace785a-e708-41a3-8fe1-899beb767d54" key="textField" x="0" y="0" width="165" height="16" fontSize="8.0" blankWhenNull="false" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{BPartner}]]></expression>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{BPartner}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" style="Detail_Line" x="854" y="0" width="66" height="16" uuid="b168012d-efdb-4032-a14a-a427bd00bfbc">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{net}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="b168012d-efdb-4032-a14a-a427bd00bfbc" key="textField" x="854" y="0" width="66" height="16" fontSize="8.0" textAdjust="StretchHeight" pattern="##0.00" linkType="Reference" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+				<expression><![CDATA[$F{net}]]></expression>
 				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" style="Detail_Line" x="619" y="0" width="65" height="16" forecolor="#000000" uuid="6f37941a-56cc-48cd-8994-5ca2d5d08fcf"/>
-				<box>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{credit}.negate()]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="6f37941a-56cc-48cd-8994-5ca2d5d08fcf" key="textField" x="619" y="0" width="65" height="16" forecolor="#000000" fontSize="8.0" textAdjust="StretchHeight" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{credit}.negate()]]></expression>
 				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" style="Detail_Line" x="165" y="0" width="64" height="16" forecolor="#000000" uuid="408f70dd-dc6d-46d5-9cec-ccc19f256add"/>
-				<box>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{amount0}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="408f70dd-dc6d-46d5-9cec-ccc19f256add" key="textField" x="165" y="0" width="64" height="16" forecolor="#000000" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{amount0}]]></expression>
 				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" style="Detail_Line" x="229" y="0" width="65" height="16" forecolor="#000000" uuid="e36798a9-d665-4bd6-b15b-683d4495641d"/>
-				<box>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{amount1}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="e36798a9-d665-4bd6-b15b-683d4495641d" key="textField" x="229" y="0" width="65" height="16" forecolor="#000000" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{amount1}]]></expression>
 				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" style="Detail_Line" x="294" y="0" width="65" height="16" forecolor="#000000" uuid="990ba03e-2aab-47dc-9124-d200cff02552"/>
-				<box>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{amount2}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="990ba03e-2aab-47dc-9124-d200cff02552" key="textField" x="294" y="0" width="65" height="16" forecolor="#000000" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{amount2}]]></expression>
 				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" style="Detail_Line" x="359" y="0" width="65" height="16" forecolor="#000000" uuid="cf9aab1b-fdd5-4377-9e81-ee9e6f9ab165"/>
-				<box>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{amount3}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="cf9aab1b-fdd5-4377-9e81-ee9e6f9ab165" key="textField" x="359" y="0" width="65" height="16" forecolor="#000000" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{amount3}]]></expression>
 				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" style="Detail_Line" x="424" y="0" width="65" height="16" forecolor="#000000" uuid="dff357f9-d793-4197-b22d-5ae8119fd66d"/>
-				<box>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{amount4}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="dff357f9-d793-4197-b22d-5ae8119fd66d" key="textField" x="424" y="0" width="65" height="16" forecolor="#000000" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{amount4}]]></expression>
 				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" style="Detail_Line" x="489" y="0" width="65" height="16" forecolor="#000000" uuid="72ea090e-3c48-44a1-a9db-f97f9bd8500d"/>
-				<box>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle" markup="html">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{amount5}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="72ea090e-3c48-44a1-a9db-f97f9bd8500d" key="textField" x="489" y="0" width="65" height="16" forecolor="#000000" markup="html" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{amount5}]]></expression>
 				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" style="Detail_Line" x="554" y="0" width="65" height="16" uuid="265f6ac5-a460-4f48-84e9-42a8a39ab065"/>
-				<box>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{Total}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="265f6ac5-a460-4f48-84e9-42a8a39ab065" key="textField" x="554" y="0" width="65" height="16" fontSize="8.0" textAdjust="StretchHeight" pattern="##0.00" linkType="Reference" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{Total}]]></expression>
 				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" style="Detail_Line" x="684" y="0" width="95" height="16" forecolor="#000000" uuid="f9573d90-5882-484b-a7fc-8b2d9ef7343d"/>
-				<box>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" ) ?
+			</element>
+			<element kind="textField" uuid="f9573d90-5882-484b-a7fc-8b2d9ef7343d" key="textField" x="684" y="0" width="95" height="16" forecolor="#000000" fontSize="8.0" textAdjust="StretchHeight" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$P{showDoubtfulDebt}.equals( "true" ) ?
 ($F{doubtfulDebt}!=null)? $F{doubtfulDebt} : BigDecimal.ZERO
-: ($F{net}!=null)? $F{net} : BigDecimal.ZERO]]></textFieldExpression>
+: ($F{net}!=null)? $F{net} : BigDecimal.ZERO]]></expression>
 				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="##0.00%" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" style="Detail_Line" x="779" y="0" width="75" height="16" forecolor="#000000" uuid="2a551a9c-952e-4a45-9c54-a1fca7a7b587">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[(($F{percentage}!=null)? $F{percentage} : BigDecimal.ZERO)]]></textFieldExpression>
-			</textField>
+			</element>
+			<element kind="textField" uuid="2a551a9c-952e-4a45-9c54-a1fca7a7b587" key="textField" x="779" y="0" width="75" height="16" forecolor="#000000" fontSize="8.0" textAdjust="StretchHeight" pattern="##0.00%" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+				<expression><![CDATA[(($F{percentage}!=null)? $F{percentage} : BigDecimal.ZERO)]]></expression>
+				<box style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
 		</band>
 	</detail>
-	<summary>
-		<band height="21" splitType="Stretch">
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" mode="Opaque" x="489" y="2" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="4b414efe-e235-44bd-a34c-3e28ad09a78d"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUM_FIVE_1}]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" mode="Opaque" x="359" y="2" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="e4eff542-e420-47ac-b6fd-0858f24d57f0"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUM_THREE_1}]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="0" y="19" width="920" height="1" uuid="d1abe102-88de-490e-b2c5-0e501bbbcc63">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-			</line>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" mode="Opaque" x="229" y="2" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="d7efe7a0-c278-4ac8-a784-abd4a75253fb"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUM_ONE_1}]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField-2" mode="Opaque" x="165" y="2" width="64" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="4da989b1-b158-4855-966c-57f63f1e1206"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUM_ZERO_1}]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="0" y="17" width="920" height="1" uuid="5045510a-87b6-4c77-b41e-480356f1409f">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-			</line>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" mode="Opaque" x="294" y="2" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="266fb5ce-8c2b-4199-b955-8ef553be52df"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUM_TWO_1}]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="0" y="0" width="920" height="1" uuid="fe336845-f062-432f-8851-f15d9d75bfd8">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-			</line>
-			<staticText>
-				<reportElement key="staticText-26" style="Detail_Header" x="1" y="2" width="164" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="ff94bfcf-29bb-42d7-a7be-0521a0458088"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[TOTAL:]]></text>
-			</staticText>
-			<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" mode="Opaque" x="619" y="2" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="1bce00cc-0199-41d7-882b-6f8ac5fddf2a"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUM_CREDIT}]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" mode="Opaque" x="554" y="2" width="65" height="14" forecolor="#060D0A" backcolor="#FFFFFF" uuid="cd10ee0c-512d-47ab-bd01-f296a16d1403"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUM_TOTAL_1}]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" mode="Opaque" x="854" y="2" width="66" height="14" forecolor="#060D0A" backcolor="#FFFFFF" uuid="11916a30-6a65-4521-adb8-29633f47b35c">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUM_NET}]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" mode="Opaque" x="424" y="2" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="843041eb-26f2-49a7-b2d6-980842ad03ba"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUM_FOUR_1}]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="##0.00" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" mode="Opaque" x="684" y="1" width="95" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="d3c73922-bd47-4c22-923e-7ee2d32a9701"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" ) ?
+	<summary height="21" splitType="Stretch">
+		<element kind="textField" uuid="4b414efe-e235-44bd-a34c-3e28ad09a78d" key="textField" mode="Opaque" x="489" y="2" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[$V{SUM_FIVE_1}]]></expression>
+			<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="e4eff542-e420-47ac-b6fd-0858f24d57f0" key="textField" mode="Opaque" x="359" y="2" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[$V{SUM_THREE_1}]]></expression>
+			<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="d1abe102-88de-490e-b2c5-0e501bbbcc63" key="line-33" x="0" y="19" width="920" height="1" style="Report_Footer">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+		</element>
+		<element kind="textField" uuid="d7efe7a0-c278-4ac8-a784-abd4a75253fb" key="textField" mode="Opaque" x="229" y="2" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[$V{SUM_ONE_1}]]></expression>
+			<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="4da989b1-b158-4855-966c-57f63f1e1206" key="textField-2" mode="Opaque" x="165" y="2" width="64" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[$V{SUM_ZERO_1}]]></expression>
+			<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="5045510a-87b6-4c77-b41e-480356f1409f" key="line-33" x="0" y="17" width="920" height="1" style="Report_Footer">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+		</element>
+		<element kind="textField" uuid="266fb5ce-8c2b-4199-b955-8ef553be52df" key="textField" mode="Opaque" x="294" y="2" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[$V{SUM_TWO_1}]]></expression>
+			<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="fe336845-f062-432f-8851-f15d9d75bfd8" key="line-33" x="0" y="0" width="920" height="1" style="Report_Footer">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+		</element>
+		<element kind="staticText" uuid="ff94bfcf-29bb-42d7-a7be-0521a0458088" key="staticText-26" x="1" y="2" width="164" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" pdfFontName="Helvetica-Bold" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[TOTAL:]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="1bce00cc-0199-41d7-882b-6f8ac5fddf2a" key="textField" mode="Opaque" x="619" y="2" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" textAdjust="StretchHeight" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[$V{SUM_CREDIT}]]></expression>
+			<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="cd10ee0c-512d-47ab-bd01-f296a16d1403" key="textField" mode="Opaque" x="554" y="2" width="65" height="14" forecolor="#060D0A" backcolor="#FFFFFF" fontSize="8.0" textAdjust="StretchHeight" pattern="##0.00" linkType="Reference" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[$V{SUM_TOTAL_1}]]></expression>
+			<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="11916a30-6a65-4521-adb8-29633f47b35c" key="textField" mode="Opaque" x="854" y="2" width="66" height="14" forecolor="#060D0A" backcolor="#FFFFFF" fontSize="8.0" textAdjust="StretchHeight" pattern="##0.00" linkType="Reference" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+			<expression><![CDATA[$V{SUM_NET}]]></expression>
+			<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="843041eb-26f2-49a7-b2d6-980842ad03ba" key="textField" mode="Opaque" x="424" y="2" width="65" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[$V{SUM_FOUR_1}]]></expression>
+			<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="d3c73922-bd47-4c22-923e-7ee2d32a9701" key="textField" mode="Opaque" x="684" y="1" width="95" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" textAdjust="StretchHeight" pattern="##0.00" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[$P{showDoubtfulDebt}.equals( "true" ) ?
 ($V{SUM_DOUBTFUL}!=null)? $V{SUM_DOUBTFUL} : BigDecimal.ZERO
-: ($V{SUM_NET}!=null)?$V{SUM_NET} : BigDecimal.ZERO]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="##0.00%" isBlankWhenNull="false" hyperlinkType="Reference">
-				<reportElement key="textField" mode="Opaque" x="779" y="1" width="75" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="a0a01cd6-8f69-4315-b271-191a24b5e259">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
-				</reportElement>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isUnderline="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[(($V{VAR_PERCENT}!=null)? $V{VAR_PERCENT} : BigDecimal.ZERO)]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="0" y="17" width="779" height="1" uuid="6cff0ad7-0a98-4d31-8a0c-13344540e2bc">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
-				</reportElement>
-			</line>
-			<line>
-				<reportElement key="line-33" style="Report_Footer" x="0" y="19" width="779" height="1" uuid="5c25821a-4458-4d55-abf9-fc7536c47915">
-					<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
-				</reportElement>
-			</line>
-		</band>
+: ($V{SUM_NET}!=null)?$V{SUM_NET} : BigDecimal.ZERO]]></expression>
+			<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="a0a01cd6-8f69-4315-b271-191a24b5e259" key="textField" mode="Opaque" x="779" y="1" width="75" height="14" forecolor="#000000" backcolor="#FFFFFF" fontSize="8.0" textAdjust="StretchHeight" pattern="##0.00%" linkType="Reference" blankWhenNull="false" underline="false" hTextAlign="Right" vTextAlign="Middle">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "true" )]]></printWhenExpression>
+			<expression><![CDATA[(($V{VAR_PERCENT}!=null)? $V{VAR_PERCENT} : BigDecimal.ZERO)]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="6cff0ad7-0a98-4d31-8a0c-13344540e2bc" key="line-33" x="0" y="17" width="779" height="1" style="Report_Footer">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
+		</element>
+		<element kind="line" uuid="5c25821a-4458-4d55-abf9-fc7536c47915" key="line-33" x="0" y="19" width="779" height="1" style="Report_Footer">
+			<printWhenExpression><![CDATA[$P{showDoubtfulDebt}.equals( "false" )]]></printWhenExpression>
+		</element>
 	</summary>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/CashflowForecast.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/CashflowForecast.jrxml
@@ -1,53 +1,53 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="CashflowForecast" pageWidth="595" pageHeight="842" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="3e8177ed-1f04-47c0-8c79-41687401c9d8">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="CashflowForecast" language="java" pageWidth="595" pageHeight="842" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="3e8177ed-1f04-47c0-8c79-41687401c9d8">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.zoom" value="1.1000000000000052"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="6">
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="6.0">
 		<box leftPadding="5" rightPadding="5"/>
 	</style>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="6" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="6.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="AMOUNTFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<parameter name="AMOUNTFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat()]]></defaultValueExpression>
 	</parameter>
-	<parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
+	<parameter name="SUBREPORT_DIR" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["./modules/org.openbravo.financial.cashflowforecast/src/org/openbravo/financial/cashflowforecast/"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="BreakByDate" class="java.lang.Boolean">
@@ -55,9 +55,9 @@
 	</parameter>
 	<parameter name="DatePlanned" class="java.util.Date"/>
 	<parameter name="FinancialAccountId" class="java.lang.String"/>
-	<parameter name="fieldProviderSummary" class="org.openbravo.erpCommon.utility.JRFieldProviderDataSource" isForPrompting="false"/>
-	<parameter name="fieldProviderSubReport" class="org.openbravo.erpCommon.utility.JRFieldProviderDataSource" isForPrompting="false"/>
-	<parameter name="SUBREP_CashflowForecastLinesByDate" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false">
+	<parameter name="fieldProviderSummary" forPrompting="false" class="org.openbravo.erpCommon.utility.JRFieldProviderDataSource"/>
+	<parameter name="fieldProviderSubReport" forPrompting="false" class="org.openbravo.erpCommon.utility.JRFieldProviderDataSource"/>
+	<parameter name="SUBREP_CashflowForecastLinesByDate" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport">
 		<defaultValueExpression><![CDATA[]]></defaultValueExpression>
 	</parameter>
 	<parameter name="SUBREP_CashflowForecastLines" class="net.sf.jasperreports.engine.JasperReport">
@@ -67,126 +67,89 @@
 		<defaultValueExpression><![CDATA[]]></defaultValueExpression>
 	</parameter>
 	<parameter name="OUTPUT_FORMAT" class="java.lang.String"/>
-	<queryString>
-		<![CDATA[select 1 from dual]]>
-	</queryString>
-	<variable name="SUBREPORT_COUNT" class="java.lang.Integer" calculation="System">
+	<query language="sql"><![CDATA[select 1 from dual]]></query>
+	<variable name="SUBREPORT_COUNT" calculation="System" class="java.lang.Integer">
 		<initialValueExpression><![CDATA[0]]></initialValueExpression>
 	</variable>
 	<group name="Summary">
 		<groupHeader>
 			<band height="35">
-				<line>
-					<reportElement stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="15" uuid="38c386c7-3d44-44c3-8a3b-d35cebbcbb2e"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-21" style="Detail_Header" x="187" y="0" width="65" height="15" forecolor="#FEFEFE" backcolor="#969696" uuid="3212afd6-3a87-41c6-aef7-b6e21e3f8d89"/>
-					<box leftPadding="0" rightPadding="0">
-						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
-						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="SansSerif" size="6" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				<element kind="line" uuid="38c386c7-3d44-44c3-8a3b-d35cebbcbb2e" stretchType="ContainerHeight" x="0" y="0" width="1" height="15">
+					<pen lineColor="#959595"/>
+				</element>
+				<element kind="staticText" uuid="3212afd6-3a87-41c6-aef7-b6e21e3f8d89" key="staticText-21" x="187" y="0" width="65" height="15" forecolor="#FEFEFE" backcolor="#969696" fontName="SansSerif" fontSize="6.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Current Balance]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-24" style="Detail_Header" x="380" y="0" width="70" height="15" forecolor="#FEFEFE" backcolor="#969696" uuid="005593e4-1127-4b44-9021-d43947d4307b"/>
-					<box leftPadding="5" rightPadding="5">
+					<box leftPadding="0" rightPadding="0" style="Detail_Header">
 						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="SansSerif" size="6" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="005593e4-1127-4b44-9021-d43947d4307b" key="staticText-24" x="380" y="0" width="70" height="15" forecolor="#FEFEFE" backcolor="#969696" fontName="SansSerif" fontSize="6.0" pdfFontName="Helvetica-Bold" bold="true" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Payment]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField-10" style="Detail_Header" x="505" y="0" width="50" height="15" forecolor="#FEFEFE" backcolor="#969696" uuid="438cac5e-1f48-4d03-8cf1-63960e4296f8"/>
-					<box leftPadding="2" rightPadding="5">
+					<box leftPadding="5" rightPadding="5" style="Detail_Header">
+						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
+						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="438cac5e-1f48-4d03-8cf1-63960e4296f8" key="textField-10" x="505" y="0" width="50" height="15" forecolor="#FEFEFE" backcolor="#969696" fontName="SansSerif" fontSize="6.0" pdfFontName="Helvetica-Bold" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="true" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$P{DatePlanned}]]></expression>
+					<box leftPadding="2" rightPadding="5" style="Detail_Header">
 						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#959595"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="SansSerif" size="6" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$P{DatePlanned}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-25" style="Detail_Header" x="450" y="0" width="55" height="15" forecolor="#FEFEFE" backcolor="#969696" uuid="713887af-b1da-415b-8ade-b3abd65e96c3"/>
-					<box leftPadding="0" rightPadding="0">
-						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
-						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
-					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="SansSerif" size="6" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="713887af-b1da-415b-8ade-b3abd65e96c3" key="staticText-25" x="450" y="0" width="55" height="15" forecolor="#FEFEFE" backcolor="#969696" fontName="SansSerif" fontSize="6.0" pdfFontName="Helvetica-Bold" bold="true" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Final Balance]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-23" style="Detail_Header" x="310" y="0" width="70" height="15" forecolor="#FEFEFE" backcolor="#969696" uuid="d3ee29b5-af88-47fa-88a1-7f5e92a8ae9c"/>
-					<box leftPadding="5" rightPadding="5">
+					<box leftPadding="0" rightPadding="0" style="Detail_Header">
 						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="SansSerif" size="6" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="d3ee29b5-af88-47fa-88a1-7f5e92a8ae9c" key="staticText-23" x="310" y="0" width="70" height="15" forecolor="#FEFEFE" backcolor="#969696" fontName="SansSerif" fontSize="6.0" pdfFontName="Helvetica-Bold" bold="true" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Income]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField-11" style="Detail_Header" x="252" y="0" width="59" height="15" forecolor="#FEFEFE" backcolor="#969696" uuid="565c2eb6-ab2c-413a-a1ef-6baf37e0fd97"/>
-					<box leftPadding="2" rightPadding="5">
+					<box leftPadding="5" rightPadding="5" style="Detail_Header">
 						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="SansSerif" size="6" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-18" style="Detail_Header" x="0" y="0" width="187" height="15" forecolor="#FEFEFE" backcolor="#969696" uuid="1f9a8496-8633-4706-9a7c-ce220ecd414e"/>
-					<box leftPadding="5" rightPadding="5">
+				</element>
+				<element kind="textField" uuid="565c2eb6-ab2c-413a-a1ef-6baf37e0fd97" key="textField-11" x="252" y="0" width="59" height="15" forecolor="#FEFEFE" backcolor="#969696" fontName="SansSerif" fontSize="6.0" pdfFontName="Helvetica-Bold" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="true" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[new Date()]]></expression>
+					<box leftPadding="2" rightPadding="5" style="Detail_Header">
+						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
+						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="1f9a8496-8633-4706-9a7c-ce220ecd414e" key="staticText-18" x="0" y="0" width="187" height="15" forecolor="#FEFEFE" backcolor="#969696" fontName="SansSerif" fontSize="6.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<text><![CDATA[Financial Account]]></text>
+					<box leftPadding="5" rightPadding="5" style="Detail_Header">
 						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#959595"/>
 						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="SansSerif" size="6" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Financial Account]]></text>
-				</staticText>
-				<line>
-					<reportElement stretchType="RelativeToBandHeight" x="554" y="0" width="1" height="15" uuid="315f9fe3-fbaf-4d6e-bdcf-9ae914578555"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
-				<subreport>
-					<reportElement x="0" y="15" width="555" height="20" uuid="ea4147d9-c196-4b12-967b-30fd63b6334f"/>
-					<subreportParameter name="AMOUNTFORMAT">
-						<subreportParameterExpression><![CDATA[$P{AMOUNTFORMAT}]]></subreportParameterExpression>
-					</subreportParameter>
+				</element>
+				<element kind="line" uuid="315f9fe3-fbaf-4d6e-bdcf-9ae914578555" stretchType="ContainerHeight" x="554" y="0" width="1" height="15">
+					<pen lineColor="#959595"/>
+				</element>
+				<element kind="subreport" uuid="ea4147d9-c196-4b12-967b-30fd63b6334f" x="0" y="15" width="555" height="20">
 					<dataSourceExpression><![CDATA[$P{fieldProviderSummary}]]></dataSourceExpression>
-					<subreportExpression><![CDATA[$P{SUBREP_CashflowForecastSummary}]]></subreportExpression>
-				</subreport>
+					<expression><![CDATA[$P{SUBREP_CashflowForecastSummary}]]></expression>
+					<parameter name="AMOUNTFORMAT">
+						<expression><![CDATA[$P{AMOUNTFORMAT}]]></expression>
+					</parameter>
+				</element>
 			</band>
 		</groupHeader>
 	</group>
@@ -194,36 +157,29 @@
 		<groupHeader>
 			<band height="13"/>
 			<band height="50">
-				<subreport>
-					<reportElement x="0" y="0" width="555" height="50" uuid="250b685d-7fae-4cd3-b70d-a02e90426e8e"/>
-					<subreportParameter name="OUTPUT_FORMAT">
-						<subreportParameterExpression><![CDATA[$P{OUTPUT_FORMAT}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="AMOUNTFORMAT">
-						<subreportParameterExpression><![CDATA[$P{AMOUNTFORMAT}]]></subreportParameterExpression>
-					</subreportParameter>
+				<element kind="subreport" uuid="250b685d-7fae-4cd3-b70d-a02e90426e8e" x="0" y="0" width="555" height="50">
 					<dataSourceExpression><![CDATA[$P{fieldProviderSubReport}]]></dataSourceExpression>
-					<subreportExpression><![CDATA[($P{BreakByDate}==true)?$P{SUBREP_CashflowForecastLinesByDate}:$P{SUBREP_CashflowForecastLines}]]></subreportExpression>
-				</subreport>
+					<expression><![CDATA[($P{BreakByDate}==true)?$P{SUBREP_CashflowForecastLinesByDate}:$P{SUBREP_CashflowForecastLines}]]></expression>
+					<parameter name="OUTPUT_FORMAT">
+						<expression><![CDATA[$P{OUTPUT_FORMAT}]]></expression>
+					</parameter>
+					<parameter name="AMOUNTFORMAT">
+						<expression><![CDATA[$P{AMOUNTFORMAT}]]></expression>
+					</parameter>
+				</element>
 			</band>
 		</groupHeader>
 	</group>
-	<title>
-		<band height="46" splitType="Stretch">
-			<staticText>
-				<reportElement style="Report_Subtitle" x="343" y="26" width="113" height="20" uuid="5731d121-54bb-4037-b9bb-6d93f35db8e7"/>
-				<box rightPadding="5"/>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Planned Date:]]></text>
-			</staticText>
-			<textField>
-				<reportElement style="Report_Subtitle" x="455" y="26" width="100" height="20" uuid="2537c53c-98b3-4543-a1de-8eae0395e562"/>
-				<textFieldExpression><![CDATA[$P{DatePlanned}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement style="Report_Title" x="1" y="0" width="342" height="25" uuid="f5c32ccf-f000-4aae-bb8b-11d0832c0466"/>
-				<text><![CDATA[Cashflow Forecast Report]]></text>
-			</staticText>
-		</band>
+	<title height="46" splitType="Stretch">
+		<element kind="staticText" uuid="5731d121-54bb-4037-b9bb-6d93f35db8e7" x="343" y="26" width="113" height="20" hTextAlign="Right" style="Report_Subtitle">
+			<text><![CDATA[Planned Date:]]></text>
+			<box rightPadding="5" style="Report_Subtitle"/>
+		</element>
+		<element kind="textField" uuid="2537c53c-98b3-4543-a1de-8eae0395e562" x="455" y="26" width="100" height="20" style="Report_Subtitle">
+			<expression><![CDATA[$P{DatePlanned}]]></expression>
+		</element>
+		<element kind="staticText" uuid="f5c32ccf-f000-4aae-bb8b-11d0832c0466" x="1" y="0" width="342" height="25" style="Report_Title">
+			<text><![CDATA[Cashflow Forecast Report]]></text>
+		</element>
 	</title>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/CashflowForecastExcel.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/CashflowForecastExcel.jrxml
@@ -1,66 +1,66 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="CashflowForecast" pageWidth="1200" pageHeight="802" columnWidth="1200" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="8cf57cc3-56dc-49f4-9907-573fa59e1111">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="CashflowForecast" language="java" pageWidth="1200" pageHeight="802" columnWidth="1200" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="8cf57cc3-56dc-49f4-9907-573fa59e1111">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.zoom" value="2.593742460100007"/>
 	<property name="ireport.x" value="2300"/>
 	<property name="ireport.y" value="0"/>
 	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="6">
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="6.0">
 		<box leftPadding="5" rightPadding="5"/>
 	</style>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="6" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="6.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="AMOUNTFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<parameter name="AMOUNTFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat()]]></defaultValueExpression>
 	</parameter>
-	<parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
+	<parameter name="SUBREPORT_DIR" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["./src/org/openbravo/erpCommon/ad_reports/"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="BreakByDate" class="java.lang.Boolean">
 		<defaultValueExpression><![CDATA[false]]></defaultValueExpression>
 	</parameter>
 	<parameter name="DatePlanned" class="java.util.Date"/>
-	<parameter name="DetailMainJR" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="DetailByDateJR" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
+	<parameter name="DetailMainJR" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="DetailByDateJR" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
 	<parameter name="FinancialAccountId" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="Aux_FinancialAccountId" class="java.lang.String" isForPrompting="false">
+	<parameter name="Aux_FinancialAccountId" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["".equals($P{FinancialAccountId}) ? "" : " AND fa.fin_financial_account_id = '" + $P{FinancialAccountId} +"' "]]></defaultValueExpression>
 	</parameter>
 	<parameter name="orderbyclause" class="java.lang.String">
@@ -68,9 +68,7 @@
 "COALESCE(p.paymentdate, psinv.duedate), COALESCE(p.isreceipt, i.issotrx)":
 "COALESCE(p.isreceipt, i.issotrx), COALESCE(p.paymentdate, psinv.duedate)"]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[]]>
-	</queryString>
+	<query language="sql"><![CDATA[]]></query>
 	<field name="FIN_FINANCIAL_ACCOUNT_ID" class="java.lang.String"/>
 	<field name="FINANCIALACCOUNT" class="java.lang.String"/>
 	<field name="CURRENTBALANCE" class="java.math.BigDecimal"/>
@@ -90,275 +88,161 @@
 	<field name="FACUR" class="java.lang.String"/>
 	<field name="TRANS_DESCRIP" class="java.lang.String"/>
 	<field name="ORIGINALAMOUNT" class="java.math.BigDecimal"/>
-	<variable name="acum" class="java.math.BigDecimal" resetType="Group" resetGroup="FinancialAccount" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVERTEDAMOUNT}]]></variableExpression>
+	<variable name="acum" resetType="Group" calculation="Sum" resetGroup="FinancialAccount" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVERTEDAMOUNT}]]></expression>
 		<initialValueExpression><![CDATA[$F{CURRENTBALANCE}]]></initialValueExpression>
 	</variable>
 	<group name="FinancialAccount">
-		<groupExpression><![CDATA[$F{FIN_FINANCIAL_ACCOUNT_ID}]]></groupExpression>
+		<expression><![CDATA[$F{FIN_FINANCIAL_ACCOUNT_ID}]]></expression>
 		<groupHeader>
 			<band height="12">
-				<textField isStretchWithOverflow="true">
-					<reportElement style="default" stretchType="RelativeToBandHeight" x="0" y="0" width="350" height="12" uuid="86d8523d-7dcd-48f9-83e3-6c24e08a13ea"/>
-					<textElement>
-						<font size="7" isBold="true"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{FINANCIALACCOUNT} + " - " + $F{FACUR}]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true">
-					<reportElement style="default" stretchType="RelativeToBandHeight" x="1123" y="0" width="70" height="12" uuid="d6804f6c-fedb-48bc-b4d1-16b1e92faf70"/>
-					<textElement textAlignment="Right">
-						<font size="7" isBold="true"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CURRENTBALANCE}]]></textFieldExpression>
+				<element kind="textField" uuid="86d8523d-7dcd-48f9-83e3-6c24e08a13ea" stretchType="ContainerHeight" x="0" y="0" width="350" height="12" fontSize="7.0" textAdjust="StretchHeight" bold="true" style="default">
+					<expression><![CDATA[$F{FINANCIALACCOUNT} + " - " + $F{FACUR}]]></expression>
+				</element>
+				<element kind="textField" uuid="d6804f6c-fedb-48bc-b4d1-16b1e92faf70" stretchType="ContainerHeight" x="1123" y="0" width="70" height="12" fontSize="7.0" textAdjust="StretchHeight" bold="true" hTextAlign="Right" style="default">
+					<expression><![CDATA[$F{CURRENTBALANCE}]]></expression>
 					<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<staticText>
-					<reportElement style="default" stretchType="RelativeToBandHeight" x="840" y="0" width="283" height="12" uuid="bccd514c-82d2-490a-b6a1-c01d0faa2e60"/>
-					<textElement markup="none">
-						<font size="7" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="bccd514c-82d2-490a-b6a1-c01d0faa2e60" stretchType="ContainerHeight" x="840" y="0" width="283" height="12" markup="none" fontSize="7.0" bold="true" style="default">
 					<text><![CDATA[Current Balance]]></text>
-				</staticText>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="24">
-				<textField isStretchWithOverflow="true">
-					<reportElement style="default" stretchType="RelativeToBandHeight" x="0" y="0" width="350" height="12" uuid="a3327cc9-a93f-4890-801b-a5f122c522a4"/>
-					<textElement>
-						<font size="7" isBold="true"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{FINANCIALACCOUNT} + " - " + $F{FACUR}]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true">
-					<reportElement style="default" stretchType="RelativeToBandHeight" x="1123" y="0" width="70" height="12" uuid="02988dad-6cb7-4165-8b67-2856e5a39699"/>
-					<textElement textAlignment="Right">
-						<font size="7" isBold="true"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{acum}.add($F{CURRENTBALANCE})]]></textFieldExpression>
+				<element kind="textField" uuid="a3327cc9-a93f-4890-801b-a5f122c522a4" stretchType="ContainerHeight" x="0" y="0" width="350" height="12" fontSize="7.0" textAdjust="StretchHeight" bold="true" style="default">
+					<expression><![CDATA[$F{FINANCIALACCOUNT} + " - " + $F{FACUR}]]></expression>
+				</element>
+				<element kind="textField" uuid="02988dad-6cb7-4165-8b67-2856e5a39699" stretchType="ContainerHeight" x="1123" y="0" width="70" height="12" fontSize="7.0" textAdjust="StretchHeight" bold="true" hTextAlign="Right" style="default">
+					<expression><![CDATA[$V{acum}.add($F{CURRENTBALANCE})]]></expression>
 					<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<staticText>
-					<reportElement style="default" stretchType="RelativeToBandHeight" x="840" y="0" width="283" height="12" uuid="09214c70-434f-4b16-81f1-94233e4bbe40"/>
-					<textElement markup="none">
-						<font size="7" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="09214c70-434f-4b16-81f1-94233e4bbe40" stretchType="ContainerHeight" x="840" y="0" width="283" height="12" markup="none" fontSize="7.0" bold="true" style="default">
 					<text><![CDATA[Final Balance]]></text>
-				</staticText>
-				<line>
-					<reportElement x="0" y="22" width="1193" height="1" uuid="f385961e-cd2d-4a1a-b253-c9be34751e34"/>
-				</line>
+				</element>
+				<element kind="line" uuid="f385961e-cd2d-4a1a-b253-c9be34751e34" x="0" y="22" width="1193" height="1"/>
 			</band>
 		</groupFooter>
 	</group>
-	<title>
-		<band height="87" splitType="Stretch">
-			<staticText>
-				<reportElement style="Report_Subtitle" x="0" y="40" width="200" height="20" uuid="af6f403d-ed5d-4b40-b969-c8d3f86e8135"/>
-				<box rightPadding="5"/>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Date Planned:]]></text>
-			</staticText>
-			<textField>
-				<reportElement style="Report_Subtitle" x="200" y="40" width="150" height="20" uuid="82fb6491-748d-4089-b59f-5a1ef3d84d79"/>
-				<textFieldExpression><![CDATA[$P{DatePlanned}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-18" style="Detail_Header" x="0" y="72" width="200" height="15" uuid="61e1acd7-72c2-4d07-93ab-d9491e87d216"/>
-				<box leftPadding="5">
-					<leftPen lineWidth="0.0"/>
-					<rightPen lineWidth="0.0"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="7" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Financial Account]]></text>
-			</staticText>
-			<staticText>
-				<reportElement style="Detail_Header" x="350" y="72" width="90" height="15" uuid="a695cf92-6ced-4004-b884-31d2b18ac09d"/>
-				<box leftPadding="5">
-					<leftPen lineWidth="0.0"/>
-					<rightPen lineWidth="0.0"/>
-				</box>
-				<textElement>
-					<font size="7"/>
-				</textElement>
-				<text><![CDATA[Invoice No.]]></text>
-			</staticText>
-			<staticText>
-				<reportElement style="Detail_Header" x="200" y="72" width="77" height="15" uuid="4ec6d7f6-006a-4312-b0ac-b99fd8d0e0e6"/>
-				<box leftPadding="5">
-					<leftPen lineWidth="0.0"/>
-					<rightPen lineWidth="0.0"/>
-				</box>
-				<textElement>
-					<font size="7"/>
-				</textElement>
-				<text><![CDATA[Date Planned]]></text>
-			</staticText>
-			<staticText>
-				<reportElement style="Detail_Header" x="277" y="72" width="73" height="15" uuid="a4e3cdff-ba0b-41d1-a003-f2daedc9c07d"/>
-				<box leftPadding="5">
-					<leftPen lineWidth="0.0"/>
-					<rightPen lineWidth="0.0"/>
-				</box>
-				<textElement>
-					<font size="7"/>
-				</textElement>
-				<text><![CDATA[Date Invoiced]]></text>
-			</staticText>
-			<staticText>
-				<reportElement style="Detail_Header" x="440" y="72" width="200" height="15" uuid="bd6929f6-980c-4573-b440-e5f3494e67c4"/>
-				<box leftPadding="5">
-					<leftPen lineWidth="0.0"/>
-					<rightPen lineWidth="0.0"/>
-				</box>
-				<textElement>
-					<font size="7"/>
-				</textElement>
-				<text><![CDATA[Business Partner]]></text>
-			</staticText>
-			<staticText>
-				<reportElement style="Detail_Header" x="1023" y="72" width="70" height="15" uuid="59b1eb23-8df3-4337-b1e5-fd2fc2fbfac8"/>
-				<box leftPadding="5">
-					<leftPen lineWidth="0.0"/>
-					<rightPen lineWidth="0.0"/>
-				</box>
-				<textElement>
-					<font size="7"/>
-				</textElement>
-				<text><![CDATA[Orig. Amount]]></text>
-			</staticText>
-			<staticText>
-				<reportElement style="Detail_Header" x="640" y="72" width="200" height="15" uuid="e16655a7-b67c-4119-8c06-8af35551a1f2"/>
-				<box leftPadding="5">
-					<leftPen lineWidth="0.0"/>
-					<rightPen lineWidth="0.0"/>
-				</box>
-				<textElement>
-					<font size="7"/>
-				</textElement>
-				<text><![CDATA[Payment]]></text>
-			</staticText>
-			<staticText>
-				<reportElement style="Detail_Header" x="1123" y="72" width="70" height="15" uuid="e5351b55-3f00-47e5-a8f1-dccee05fb278"/>
-				<box leftPadding="5">
-					<leftPen lineWidth="0.0"/>
-					<rightPen lineWidth="0.0"/>
-				</box>
-				<textElement>
-					<font size="7"/>
-				</textElement>
-				<text><![CDATA[Amount]]></text>
-			</staticText>
-			<staticText>
-				<reportElement style="Detail_Header" x="1093" y="72" width="30" height="15" uuid="4c702fe2-44c3-4976-85cb-6d0d0f64eaea"/>
-				<box leftPadding="5">
-					<leftPen lineWidth="0.0"/>
-					<rightPen lineWidth="0.0"/>
-				</box>
-				<textElement>
-					<font size="7"/>
-				</textElement>
-				<text><![CDATA[Cur.]]></text>
-			</staticText>
-			<staticText>
-				<reportElement style="Detail_Header" x="840" y="72" width="183" height="15" uuid="1e466eac-6ca8-4e2e-a024-c292fd13d8cd"/>
-				<box leftPadding="5">
-					<leftPen lineWidth="0.0"/>
-					<rightPen lineWidth="0.0"/>
-				</box>
-				<textElement>
-					<font size="7"/>
-				</textElement>
-				<text><![CDATA[Transaction]]></text>
-			</staticText>
-			<staticText>
-				<reportElement style="Report_Title" x="0" y="0" width="1010" height="25" uuid="3342b854-a100-4950-903a-c3af2e85a957"/>
-				<text><![CDATA[Cashflow Forecast Report]]></text>
-			</staticText>
-		</band>
+	<title height="87" splitType="Stretch">
+		<element kind="staticText" uuid="af6f403d-ed5d-4b40-b969-c8d3f86e8135" x="0" y="40" width="200" height="20" hTextAlign="Right" style="Report_Subtitle">
+			<text><![CDATA[Date Planned:]]></text>
+			<box rightPadding="5" style="Report_Subtitle"/>
+		</element>
+		<element kind="textField" uuid="82fb6491-748d-4089-b59f-5a1ef3d84d79" x="200" y="40" width="150" height="20" style="Report_Subtitle">
+			<expression><![CDATA[$P{DatePlanned}]]></expression>
+		</element>
+		<element kind="staticText" uuid="61e1acd7-72c2-4d07-93ab-d9491e87d216" key="staticText-18" x="0" y="72" width="200" height="15" fontSize="7.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Financial Account]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<leftPen lineWidth="0.0"/>
+				<rightPen lineWidth="0.0"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="a695cf92-6ced-4004-b884-31d2b18ac09d" x="350" y="72" width="90" height="15" fontSize="7.0" style="Detail_Header">
+			<text><![CDATA[Invoice No.]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<leftPen lineWidth="0.0"/>
+				<rightPen lineWidth="0.0"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="4ec6d7f6-006a-4312-b0ac-b99fd8d0e0e6" x="200" y="72" width="77" height="15" fontSize="7.0" style="Detail_Header">
+			<text><![CDATA[Date Planned]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<leftPen lineWidth="0.0"/>
+				<rightPen lineWidth="0.0"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="a4e3cdff-ba0b-41d1-a003-f2daedc9c07d" x="277" y="72" width="73" height="15" fontSize="7.0" style="Detail_Header">
+			<text><![CDATA[Date Invoiced]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<leftPen lineWidth="0.0"/>
+				<rightPen lineWidth="0.0"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="bd6929f6-980c-4573-b440-e5f3494e67c4" x="440" y="72" width="200" height="15" fontSize="7.0" style="Detail_Header">
+			<text><![CDATA[Business Partner]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<leftPen lineWidth="0.0"/>
+				<rightPen lineWidth="0.0"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="59b1eb23-8df3-4337-b1e5-fd2fc2fbfac8" x="1023" y="72" width="70" height="15" fontSize="7.0" style="Detail_Header">
+			<text><![CDATA[Orig. Amount]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<leftPen lineWidth="0.0"/>
+				<rightPen lineWidth="0.0"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="e16655a7-b67c-4119-8c06-8af35551a1f2" x="640" y="72" width="200" height="15" fontSize="7.0" style="Detail_Header">
+			<text><![CDATA[Payment]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<leftPen lineWidth="0.0"/>
+				<rightPen lineWidth="0.0"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="e5351b55-3f00-47e5-a8f1-dccee05fb278" x="1123" y="72" width="70" height="15" fontSize="7.0" style="Detail_Header">
+			<text><![CDATA[Amount]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<leftPen lineWidth="0.0"/>
+				<rightPen lineWidth="0.0"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="4c702fe2-44c3-4976-85cb-6d0d0f64eaea" x="1093" y="72" width="30" height="15" fontSize="7.0" style="Detail_Header">
+			<text><![CDATA[Cur.]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<leftPen lineWidth="0.0"/>
+				<rightPen lineWidth="0.0"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="1e466eac-6ca8-4e2e-a024-c292fd13d8cd" x="840" y="72" width="183" height="15" fontSize="7.0" style="Detail_Header">
+			<text><![CDATA[Transaction]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<leftPen lineWidth="0.0"/>
+				<rightPen lineWidth="0.0"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="3342b854-a100-4950-903a-c3af2e85a957" x="0" y="0" width="1010" height="25" style="Report_Title">
+			<text><![CDATA[Cashflow Forecast Report]]></text>
+		</element>
 	</title>
 	<detail>
 		<band height="12" splitType="Stretch">
-			<textField isStretchWithOverflow="true">
-				<reportElement style="default" stretchType="RelativeToBandHeight" x="0" y="0" width="200" height="12" uuid="6d0c8836-0bf7-4708-8bce-7317990a886f"/>
-				<textElement>
-					<font size="7"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{FINANCIALACCOUNT} + " - " + $F{FACUR}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true">
-				<reportElement style="default" stretchType="RelativeToBandHeight" x="200" y="0" width="77" height="12" uuid="4e771277-5cc2-47ab-8e6a-68891c9d92f4"/>
-				<textElement>
-					<font size="7"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DUEDATE}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement style="default" stretchType="RelativeToBandHeight" x="277" y="0" width="73" height="12" uuid="53a867db-240d-461d-9260-44134d8f2d39"/>
-				<textElement>
-					<font size="7"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DATEINVOICED}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement style="default" stretchType="RelativeToBandHeight" x="350" y="0" width="90" height="12" uuid="9580d1eb-b2a1-48c2-adfd-3a2d38508e2c"/>
-				<textElement>
-					<font size="7"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{INVOICENO}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement style="default" stretchType="RelativeToBandHeight" x="440" y="0" width="200" height="12" uuid="9e27c66a-4e88-46b2-bdef-95aaa989e5fd"/>
-				<textElement>
-					<font size="7"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{BPNAME}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement style="default" stretchType="RelativeToBandHeight" x="640" y="0" width="200" height="12" uuid="9ad4339b-f3fe-47bd-a098-2110179091eb"/>
-				<textElement>
-					<font size="7"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PAYMENT_DESC}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true">
-				<reportElement style="default" stretchType="RelativeToBandHeight" x="1023" y="0" width="70" height="12" uuid="9d04660d-e497-401c-a03c-39cc60f7eb52">
-					<printWhenExpression><![CDATA[$F{ORIGINALAMOUNT}!=null]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right">
-					<font size="7"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{ORIGINALAMOUNT}]]></textFieldExpression>
+			<element kind="textField" uuid="6d0c8836-0bf7-4708-8bce-7317990a886f" stretchType="ContainerHeight" x="0" y="0" width="200" height="12" fontSize="7.0" textAdjust="StretchHeight" style="default">
+				<expression><![CDATA[$F{FINANCIALACCOUNT} + " - " + $F{FACUR}]]></expression>
+			</element>
+			<element kind="textField" uuid="4e771277-5cc2-47ab-8e6a-68891c9d92f4" stretchType="ContainerHeight" x="200" y="0" width="77" height="12" fontSize="7.0" textAdjust="StretchHeight" style="default">
+				<expression><![CDATA[$F{DUEDATE}]]></expression>
+			</element>
+			<element kind="textField" uuid="53a867db-240d-461d-9260-44134d8f2d39" stretchType="ContainerHeight" x="277" y="0" width="73" height="12" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="default">
+				<expression><![CDATA[$F{DATEINVOICED}]]></expression>
+			</element>
+			<element kind="textField" uuid="9580d1eb-b2a1-48c2-adfd-3a2d38508e2c" stretchType="ContainerHeight" x="350" y="0" width="90" height="12" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="default">
+				<expression><![CDATA[$F{INVOICENO}]]></expression>
+			</element>
+			<element kind="textField" uuid="9e27c66a-4e88-46b2-bdef-95aaa989e5fd" stretchType="ContainerHeight" x="440" y="0" width="200" height="12" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="default">
+				<expression><![CDATA[$F{BPNAME}]]></expression>
+			</element>
+			<element kind="textField" uuid="9ad4339b-f3fe-47bd-a098-2110179091eb" stretchType="ContainerHeight" x="640" y="0" width="200" height="12" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="default">
+				<expression><![CDATA[$F{PAYMENT_DESC}]]></expression>
+			</element>
+			<element kind="textField" uuid="9d04660d-e497-401c-a03c-39cc60f7eb52" stretchType="ContainerHeight" x="1023" y="0" width="70" height="12" fontSize="7.0" textAdjust="StretchHeight" hTextAlign="Right" style="default">
+				<printWhenExpression><![CDATA[$F{ORIGINALAMOUNT}!=null]]></printWhenExpression>
+				<expression><![CDATA[$F{ORIGINALAMOUNT}]]></expression>
 				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isStretchWithOverflow="true">
-				<reportElement style="default" stretchType="RelativeToBandHeight" x="1123" y="0" width="70" height="12" uuid="bee74432-6238-4256-a128-37ffdc106211"/>
-				<textElement textAlignment="Right">
-					<font size="7"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVERTEDAMOUNT}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="bee74432-6238-4256-a128-37ffdc106211" stretchType="ContainerHeight" x="1123" y="0" width="70" height="12" fontSize="7.0" textAdjust="StretchHeight" hTextAlign="Right" style="default">
+				<expression><![CDATA[$F{CONVERTEDAMOUNT}]]></expression>
 				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isStretchWithOverflow="true">
-				<reportElement style="default" stretchType="RelativeToBandHeight" x="1093" y="0" width="30" height="12" uuid="4a4b8349-c4d9-4811-af3e-89fcfa425923">
-					<printWhenExpression><![CDATA[$F{TRXCUR}!=null]]></printWhenExpression>
-				</reportElement>
-				<textElement>
-					<font size="7"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{TRXCUR}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="4a4b8349-c4d9-4811-af3e-89fcfa425923" stretchType="ContainerHeight" x="1093" y="0" width="30" height="12" fontSize="7.0" textAdjust="StretchHeight" style="default">
+				<printWhenExpression><![CDATA[$F{TRXCUR}!=null]]></printWhenExpression>
+				<expression><![CDATA[$F{TRXCUR}]]></expression>
 				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement style="default" stretchType="RelativeToBandHeight" x="840" y="0" width="182" height="12" uuid="9a3e44c6-a6dd-4db8-b532-752510cd0538"/>
-				<textElement>
-					<font size="7"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{TRANS_DESCRIP}]]></textFieldExpression>
-			</textField>
+			</element>
+			<element kind="textField" uuid="9a3e44c6-a6dd-4db8-b532-752510cd0538" stretchType="ContainerHeight" x="840" y="0" width="182" height="12" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="default">
+				<expression><![CDATA[$F{TRANS_DESCRIP}]]></expression>
+			</element>
 		</band>
 	</detail>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/CashflowForecastLines.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/CashflowForecastLines.jrxml
@@ -1,59 +1,57 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="CashFlowForecastLines" pageWidth="555" pageHeight="802" columnWidth="555" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="fcd348c6-0a67-4165-8614-88c9ae90e2f3">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="CashFlowForecastLines" language="java" pageWidth="555" pageHeight="802" columnWidth="555" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="fcd348c6-0a67-4165-8614-88c9ae90e2f3">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.zoom" value="1.4483218986834392"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="6">
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="6.0">
 		<box leftPadding="5" rightPadding="5"/>
 	</style>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="6" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="6.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
 	<parameter name="FIN_FINANCIAL_ACCOUNT_ID" class="java.lang.String">
 		<defaultValueExpression><![CDATA[]]></defaultValueExpression>
 	</parameter>
-	<parameter name="AMOUNTFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<parameter name="AMOUNTFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat()]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="CURRENT_BALANCE" class="java.math.BigDecimal"/>
 	<parameter name="DatePlanned" class="java.util.Date"/>
 	<parameter name="fieldProviderSubReport" class="net.sf.jasperreports.engine.JRDataSource"/>
 	<parameter name="OUTPUT_FORMAT" class="java.lang.String"/>
-	<queryString>
-		<![CDATA[]]>
-	</queryString>
+	<query language="sql"><![CDATA[]]></query>
 	<field name="FIN_FINANCIAL_ACCOUNT_ID" class="java.lang.String"/>
 	<field name="FINANCIALACCOUNT" class="java.lang.String"/>
 	<field name="CURRENTBALANCE" class="java.math.BigDecimal"/>
@@ -76,390 +74,260 @@
 	<field name="RECORDID" class="java.lang.String"/>
 	<field name="TABTOOPEN" class="java.lang.String"/>
 	<field name="FIN_FINACC_TRANSACTION_ID" class="java.lang.String"/>
-	<variable name="Accum" class="java.math.BigDecimal" resetType="Group" resetGroup="isReceipt" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVERTEDAMOUNT}]]></variableExpression>
+	<variable name="Accum" resetType="Group" calculation="Sum" resetGroup="isReceipt" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVERTEDAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVERTEDAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVERTEDAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_TOTAL_IN" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{ISRECEIPT}.equals("Y")?$F{CONVERTEDAMOUNT}:BigDecimal.ZERO]]></variableExpression>
+	<variable name="AMOUNT_TOTAL_IN" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{ISRECEIPT}.equals("Y")?$F{CONVERTEDAMOUNT}:BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="AMOUNT_TOTAL_OUT" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{ISRECEIPT}.equals("N")?$F{CONVERTEDAMOUNT}:BigDecimal.ZERO]]></variableExpression>
+	<variable name="AMOUNT_TOTAL_OUT" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{ISRECEIPT}.equals("N")?$F{CONVERTEDAMOUNT}:BigDecimal.ZERO]]></expression>
 	</variable>
 	<variable name="OPEN_INVOICE_TAB" class="java.lang.String">
-		<variableExpression><![CDATA[$F{ISRECEIPT}.equals("Y")?"263":"290"]]></variableExpression>
+		<expression><![CDATA[$F{ISRECEIPT}.equals("Y")?"263":"290"]]></expression>
 	</variable>
 	<variable name="OPEN_PAYMENT_TAB" class="java.lang.String">
-		<variableExpression><![CDATA[$F{ISRECEIPT}.equals("Y")?"C4B6506838E14A349D6717D6856F1B56":"F7A52FDAAA0346EFA07D53C125B40404"]]></variableExpression>
+		<expression><![CDATA[$F{ISRECEIPT}.equals("Y")?"C4B6506838E14A349D6717D6856F1B56":"F7A52FDAAA0346EFA07D53C125B40404"]]></expression>
 	</variable>
 	<variable name="OPEN_SUITABLE_TAB" class="java.lang.String">
-		<variableExpression><![CDATA[$F{ISRECEIPT}.equals("Y")?($F{TABTOOPEN}.equals("InvoicePlan")?"60825C9E68644DBC9C530DDCABE05A6E":($F{TABTOOPEN}.equals("PaymentLine")?"34DA12C2E9E3424E9A853563BEFDE81F":"23691259D1BD4496BCC5F32645BCA4B9")):($F{TABTOOPEN}.equals("InvoicePlan")?"7A8D43541F8C49F1BD8A431A0041BF89":($F{TABTOOPEN}.equals("PaymentLine")?"809C66481863428C8D714F2018644CC6":"23691259D1BD4496BCC5F32645BCA4B9"))]]></variableExpression>
+		<expression><![CDATA[$F{ISRECEIPT}.equals("Y")?($F{TABTOOPEN}.equals("InvoicePlan")?"60825C9E68644DBC9C530DDCABE05A6E":($F{TABTOOPEN}.equals("PaymentLine")?"34DA12C2E9E3424E9A853563BEFDE81F":"23691259D1BD4496BCC5F32645BCA4B9")):($F{TABTOOPEN}.equals("InvoicePlan")?"7A8D43541F8C49F1BD8A431A0041BF89":($F{TABTOOPEN}.equals("PaymentLine")?"809C66481863428C8D714F2018644CC6":"23691259D1BD4496BCC5F32645BCA4B9"))]]></expression>
 	</variable>
 	<variable name="TRANS_DESCRIP_V" class="java.lang.String">
-		<variableExpression><![CDATA[($F{TRANS_DESCRIP}!=null)?"23691259D1BD4496BCC5F32645BCA4B9":$V{OPEN_PAYMENT_TAB}]]></variableExpression>
+		<expression><![CDATA[($F{TRANS_DESCRIP}!=null)?"23691259D1BD4496BCC5F32645BCA4B9":$V{OPEN_PAYMENT_TAB}]]></expression>
 	</variable>
-	<variable name="Accum_Fin_Acc" class="java.math.BigDecimal" resetType="Group" resetGroup="FinancialAccount" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVERTEDAMOUNT}]]></variableExpression>
+	<variable name="Accum_Fin_Acc" resetType="Group" calculation="Sum" resetGroup="FinancialAccount" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVERTEDAMOUNT}]]></expression>
 	</variable>
 	<group name="FinancialAccount">
-		<groupExpression><![CDATA[$F{FINANCIALACCOUNT}]]></groupExpression>
+		<expression><![CDATA[$F{FINANCIALACCOUNT}]]></expression>
 		<groupHeader>
 			<band height="42">
-				<staticText>
-					<reportElement style="Detail_Header" stretchType="RelativeToBandHeight" x="120" y="27" width="60" height="15" forecolor="#010101" backcolor="#CBCBCB" uuid="4d84a485-1949-4ad1-9713-41ddfec3114c"/>
-					<box leftPadding="5" rightPadding="5">
-						<topPen lineWidth="1.0" lineColor="#959595"/>
-						<leftPen lineColor="#959595"/>
-						<rightPen lineColor="#959595"/>
-					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
+				<element kind="staticText" uuid="4d84a485-1949-4ad1-9713-41ddfec3114c" stretchType="ContainerHeight" x="120" y="27" width="60" height="15" forecolor="#010101" backcolor="#CBCBCB" fontSize="7.0" style="Detail_Header">
 					<text><![CDATA[Invoice No.]]></text>
-				</staticText>
-				<staticText>
-					<reportElement style="Detail_Header" stretchType="RelativeToBandHeight" x="305" y="27" width="125" height="15" forecolor="#010101" backcolor="#CBCBCB" uuid="a43000e9-6cbe-48fe-8402-e94ddc81f10b"/>
-					<box leftPadding="5" rightPadding="5">
+					<box leftPadding="5" rightPadding="5" style="Detail_Header">
 						<topPen lineWidth="1.0" lineColor="#959595"/>
 						<leftPen lineColor="#959595"/>
 						<rightPen lineColor="#959595"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="a43000e9-6cbe-48fe-8402-e94ddc81f10b" stretchType="ContainerHeight" x="305" y="27" width="125" height="15" forecolor="#010101" backcolor="#CBCBCB" fontSize="7.0" style="Detail_Header">
 					<text><![CDATA[Description]]></text>
-				</staticText>
-				<staticText>
-					<reportElement style="Detail_Header" stretchType="RelativeToBandHeight" x="65" y="27" width="55" height="15" forecolor="#010101" backcolor="#CBCBCB" uuid="dcff7583-de1c-4c4f-b630-c80a4cfc2223"/>
-					<box leftPadding="5" rightPadding="5">
+					<box leftPadding="5" rightPadding="5" style="Detail_Header">
 						<topPen lineWidth="1.0" lineColor="#959595"/>
 						<leftPen lineColor="#959595"/>
 						<rightPen lineColor="#959595"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="dcff7583-de1c-4c4f-b630-c80a4cfc2223" stretchType="ContainerHeight" x="65" y="27" width="55" height="15" forecolor="#010101" backcolor="#CBCBCB" fontSize="7.0" style="Detail_Header">
 					<text><![CDATA[Invoiced]]></text>
-				</staticText>
-				<staticText>
-					<reportElement style="Detail_Header" stretchType="RelativeToBandHeight" x="10" y="27" width="55" height="15" forecolor="#010101" backcolor="#CBCBCB" uuid="af1621f1-12a8-49ec-9949-aab97b283a07"/>
-					<box leftPadding="5" rightPadding="5">
+					<box leftPadding="5" rightPadding="5" style="Detail_Header">
 						<topPen lineWidth="1.0" lineColor="#959595"/>
 						<leftPen lineColor="#959595"/>
 						<rightPen lineColor="#959595"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="af1621f1-12a8-49ec-9949-aab97b283a07" stretchType="ContainerHeight" x="10" y="27" width="55" height="15" forecolor="#010101" backcolor="#CBCBCB" fontSize="7.0" style="Detail_Header">
 					<text><![CDATA[Planned]]></text>
-				</staticText>
-				<staticText>
-					<reportElement style="Detail_Header" stretchType="RelativeToBandHeight" x="180" y="27" width="125" height="15" forecolor="#010101" backcolor="#CBCBCB" uuid="1af92abe-8da5-4372-85e1-ee59633b9317"/>
-					<box leftPadding="5" rightPadding="5">
+					<box leftPadding="5" rightPadding="5" style="Detail_Header">
 						<topPen lineWidth="1.0" lineColor="#959595"/>
 						<leftPen lineColor="#959595"/>
 						<rightPen lineColor="#959595"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="1af92abe-8da5-4372-85e1-ee59633b9317" stretchType="ContainerHeight" x="180" y="27" width="125" height="15" forecolor="#010101" backcolor="#CBCBCB" fontSize="7.0" style="Detail_Header">
 					<text><![CDATA[Business Partner]]></text>
-				</staticText>
-				<staticText>
-					<reportElement style="Detail_Header" stretchType="RelativeToBandHeight" x="430" y="27" width="65" height="15" forecolor="#010101" backcolor="#CBCBCB" uuid="b08915db-1af6-4833-a44b-a3e6946e755d"/>
-					<box leftPadding="5" rightPadding="5">
+					<box leftPadding="5" rightPadding="5" style="Detail_Header">
 						<topPen lineWidth="1.0" lineColor="#959595"/>
 						<leftPen lineColor="#959595"/>
 						<rightPen lineColor="#959595"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="b08915db-1af6-4833-a44b-a3e6946e755d" stretchType="ContainerHeight" x="430" y="27" width="65" height="15" forecolor="#010101" backcolor="#CBCBCB" fontSize="7.0" style="Detail_Header">
 					<text><![CDATA[Orig. Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement style="Detail_Header" stretchType="RelativeToBandHeight" x="495" y="27" width="59" height="15" forecolor="#010101" backcolor="#CBCBCB" uuid="15f0f0ea-a14e-4160-a73b-5ea88498a096"/>
-					<box leftPadding="5" rightPadding="5">
+					<box leftPadding="5" rightPadding="5" style="Detail_Header">
 						<topPen lineWidth="1.0" lineColor="#959595"/>
 						<leftPen lineColor="#959595"/>
 						<rightPen lineColor="#959595"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="15f0f0ea-a14e-4160-a73b-5ea88498a096" stretchType="ContainerHeight" x="495" y="27" width="59" height="15" forecolor="#010101" backcolor="#CBCBCB" fontSize="7.0" style="Detail_Header">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<line>
-					<reportElement stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="42" uuid="474d78b2-0db4-41de-a2f3-47005eb8ec9f"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement stretchType="RelativeToBandHeight" x="554" y="0" width="1" height="42" uuid="53776807-9b3d-4311-af0f-068890c02a3a"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
-				<textField>
-					<reportElement x="10" y="3" width="544" height="15" uuid="aabbc73a-5b00-430e-a7da-aa20107c216c"/>
-					<textFieldExpression><![CDATA[$F{FINANCIALACCOUNT}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement x="0" y="0" width="554" height="1" uuid="bd9130c4-4954-43fd-8cc7-554e88d292c6"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
+					<box leftPadding="5" rightPadding="5" style="Detail_Header">
+						<topPen lineWidth="1.0" lineColor="#959595"/>
+						<leftPen lineColor="#959595"/>
+						<rightPen lineColor="#959595"/>
+					</box>
+				</element>
+				<element kind="line" uuid="474d78b2-0db4-41de-a2f3-47005eb8ec9f" stretchType="ContainerHeight" x="0" y="0" width="1" height="42">
+					<pen lineColor="#959595"/>
+				</element>
+				<element kind="line" uuid="53776807-9b3d-4311-af0f-068890c02a3a" stretchType="ContainerHeight" x="554" y="0" width="1" height="42">
+					<pen lineColor="#959595"/>
+				</element>
+				<element kind="textField" uuid="aabbc73a-5b00-430e-a7da-aa20107c216c" x="10" y="3" width="544" height="15">
+					<expression><![CDATA[$F{FINANCIALACCOUNT}]]></expression>
+				</element>
+				<element kind="line" uuid="bd9130c4-4954-43fd-8cc7-554e88d292c6" x="0" y="0" width="554" height="1">
+					<pen lineColor="#959595"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="15">
-				<line>
-					<reportElement x="0" y="5" width="555" height="1" uuid="9aa66e29-dbf1-496a-8920-5a88b648e4d0"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="5" uuid="774d16c7-bcd3-4c5f-a1bd-1055bef290c2"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement stretchType="RelativeToBandHeight" x="554" y="0" width="1" height="6" uuid="4ffa714b-538f-42e3-8fbe-75644775e38c"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="9aa66e29-dbf1-496a-8920-5a88b648e4d0" x="0" y="5" width="555" height="1">
+					<pen lineColor="#959595"/>
+				</element>
+				<element kind="line" uuid="774d16c7-bcd3-4c5f-a1bd-1055bef290c2" stretchType="ContainerHeight" x="0" y="0" width="1" height="5">
+					<pen lineColor="#959595"/>
+				</element>
+				<element kind="line" uuid="4ffa714b-538f-42e3-8fbe-75644775e38c" stretchType="ContainerHeight" x="554" y="0" width="1" height="6">
+					<pen lineColor="#959595"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="isReceipt">
-		<groupExpression><![CDATA[$F{ISRECEIPT}]]></groupExpression>
+		<expression><![CDATA[$F{ISRECEIPT}]]></expression>
 		<groupHeader>
 			<band height="13">
-				<line>
-					<reportElement stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="13" uuid="5ce0dc50-69e1-4cc4-b9ac-255be901788e"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement stretchType="RelativeToBandHeight" x="554" y="0" width="1" height="13" uuid="68debaf8-f3d6-475f-9b91-572648c632b0"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement style="GroupHeader_Gray" x="10" y="0" width="544" height="13" backcolor="#FFFFFF" uuid="96c881af-25b4-43fd-9c56-15f3a879b57d">
-						<printWhenExpression><![CDATA[$F{ISRECEIPT}.equals("Y")]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5" rightPadding="5">
-						<pen lineWidth="1.0" lineColor="#959595"/>
-						<topPen lineWidth="1.0" lineColor="#959595"/>
-						<leftPen lineWidth="1.0" lineColor="#959595"/>
-						<bottomPen lineWidth="1.0" lineColor="#959595"/>
-						<rightPen lineWidth="1.0" lineColor="#959595"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="7" isBold="true"/>
-					</textElement>
+				<element kind="line" uuid="5ce0dc50-69e1-4cc4-b9ac-255be901788e" stretchType="ContainerHeight" x="0" y="0" width="1" height="13">
+					<pen lineColor="#959595"/>
+				</element>
+				<element kind="line" uuid="68debaf8-f3d6-475f-9b91-572648c632b0" stretchType="ContainerHeight" x="554" y="0" width="1" height="13">
+					<pen lineColor="#959595"/>
+				</element>
+				<element kind="staticText" uuid="96c881af-25b4-43fd-9c56-15f3a879b57d" x="10" y="0" width="544" height="13" backcolor="#FFFFFF" fontName="Bitstream Vera Sans" fontSize="7.0" bold="true" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_Gray">
+					<printWhenExpression><![CDATA[$F{ISRECEIPT}.equals("Y")]]></printWhenExpression>
 					<text><![CDATA[INCOME]]></text>
-				</staticText>
-				<staticText>
-					<reportElement style="GroupHeader_Gray" x="10" y="0" width="544" height="13" backcolor="#FFFFFF" uuid="e7957935-dcdb-4722-97c8-02183ab0755d">
-						<printWhenExpression><![CDATA[!$F{ISRECEIPT}.equals("Y")]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5" rightPadding="5">
+					<box leftPadding="5" rightPadding="5" style="GroupHeader_Gray">
 						<pen lineWidth="1.0" lineColor="#959595"/>
 						<topPen lineWidth="1.0" lineColor="#959595"/>
 						<leftPen lineWidth="1.0" lineColor="#959595"/>
 						<bottomPen lineWidth="1.0" lineColor="#959595"/>
 						<rightPen lineWidth="1.0" lineColor="#959595"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="7" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="e7957935-dcdb-4722-97c8-02183ab0755d" x="10" y="0" width="544" height="13" backcolor="#FFFFFF" fontName="Bitstream Vera Sans" fontSize="7.0" bold="true" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_Gray">
+					<printWhenExpression><![CDATA[!$F{ISRECEIPT}.equals("Y")]]></printWhenExpression>
 					<text><![CDATA[PAYMENT]]></text>
-				</staticText>
+					<box leftPadding="5" rightPadding="5" style="GroupHeader_Gray">
+						<pen lineWidth="1.0" lineColor="#959595"/>
+						<topPen lineWidth="1.0" lineColor="#959595"/>
+						<leftPen lineWidth="1.0" lineColor="#959595"/>
+						<bottomPen lineWidth="1.0" lineColor="#959595"/>
+						<rightPen lineWidth="1.0" lineColor="#959595"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="15">
-				<textField evaluationTime="Group" evaluationGroup="isReceipt" pattern="##0.00" isBlankWhenNull="true">
-					<reportElement key="textField-14" mode="Opaque" x="10" y="0" width="490" height="15" backcolor="#CBCBCB" uuid="7623e485-d50e-4b35-9382-1155ed011a88"/>
+				<element kind="textField" uuid="7623e485-d50e-4b35-9382-1155ed011a88" key="textField-14" mode="Opaque" x="10" y="0" width="490" height="15" backcolor="#CBCBCB" fontSize="7.0" evaluationTime="Group" pattern="##0.00" evaluationGroup="isReceipt" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($F{ISRECEIPT}.equals("Y")?"Total Amount Incoming":"Total Amount Payments")+" ("+$F{FACUR}+")"]]></expression>
 					<box leftPadding="5" rightPadding="10">
 						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{ISRECEIPT}.equals("Y")?"Total Amount Incoming":"Total Amount Payments")+" ("+$F{FACUR}+")"]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="isReceipt" pattern="##0.00" isBlankWhenNull="true">
-					<reportElement key="textField" mode="Opaque" x="500" y="0" width="54" height="15" backcolor="#CBCBCB" uuid="bff50e70-2c37-4a8f-9912-a7f8cec40480"/>
+				</element>
+				<element kind="textField" uuid="bff50e70-2c37-4a8f-9912-a7f8cec40480" key="textField" mode="Opaque" x="500" y="0" width="54" height="15" backcolor="#CBCBCB" fontSize="7.0" evaluationTime="Group" pattern="##0.00" evaluationGroup="isReceipt" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{Accum}!=null)?$P{AMOUNTFORMAT}.format($V{Accum}):new String(" ")]]></expression>
 					<box leftPadding="5" rightPadding="5">
 						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#959595"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{Accum}!=null)?$P{AMOUNTFORMAT}.format($V{Accum}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="15" uuid="d64dba45-427f-4101-8b95-d2244c97c965"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement stretchType="RelativeToBandHeight" x="554" y="0" width="1" height="15" uuid="d7a15e4d-9f72-4e6b-a07e-19e72be437d0"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
+				</element>
+				<element kind="line" uuid="d64dba45-427f-4101-8b95-d2244c97c965" stretchType="ContainerHeight" x="0" y="0" width="1" height="15">
+					<pen lineColor="#959595"/>
+				</element>
+				<element kind="line" uuid="d7a15e4d-9f72-4e6b-a07e-19e72be437d0" stretchType="ContainerHeight" x="554" y="0" width="1" height="15">
+					<pen lineColor="#959595"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
 	<detail>
 		<band height="14">
-			<textField pattern="">
-				<reportElement style="default" stretchType="RelativeToBandHeight" x="10" y="0" width="55" height="13" uuid="0ef4c85c-0d91-4cab-ad9d-f7aaaffffb69"/>
-				<box leftPadding="5" rightPadding="5">
+			<element kind="textField" uuid="0ef4c85c-0d91-4cab-ad9d-f7aaaffffb69" stretchType="ContainerHeight" x="10" y="0" width="55" height="13" fontSize="7.0" pattern="" style="default">
+				<expression><![CDATA[$F{DUEDATE}]]></expression>
+				<box leftPadding="5" rightPadding="5" style="default">
 					<topPen lineWidth="0.0" lineColor="#959595"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 				</box>
-				<textElement>
-					<font size="7"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DUEDATE}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement style="default" stretchType="RelativeToBandHeight" x="180" y="0" width="125" height="13" uuid="1cb6035b-7e45-4889-a9b0-63cb89b2a3a1"/>
-				<box leftPadding="5" rightPadding="5">
+			</element>
+			<element kind="textField" uuid="1cb6035b-7e45-4889-a9b0-63cb89b2a3a1" stretchType="ContainerHeight" x="180" y="0" width="125" height="13" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="default">
+				<expression><![CDATA[$F{BPNAME}]]></expression>
+				<box leftPadding="5" rightPadding="5" style="default">
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 				</box>
-				<textElement>
-					<font size="7"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{BPNAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement style="default" stretchType="RelativeToBandHeight" x="65" y="0" width="55" height="13" uuid="3b7c0b83-04e8-4186-9597-54fff76e2bb4"/>
-				<box leftPadding="5" rightPadding="5">
+			</element>
+			<element kind="textField" uuid="3b7c0b83-04e8-4186-9597-54fff76e2bb4" stretchType="ContainerHeight" x="65" y="0" width="55" height="13" fontSize="7.0" pattern="" blankWhenNull="true" style="default">
+				<expression><![CDATA[$F{DATEINVOICED}]]></expression>
+				<box leftPadding="5" rightPadding="5" style="default">
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 				</box>
-				<textElement>
-					<font size="7"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DATEINVOICED}]]></textFieldExpression>
-			</textField>
-			<textField pattern="#,##0.0##" hyperlinkType="Reference">
-				<reportElement style="default" stretchType="RelativeToBandHeight" x="495" y="0" width="59" height="13" forecolor="#0000FF" uuid="52c7ee2e-9ae6-4e3e-90e8-c7ab3128ed0a">
-					<propertyExpression name="net.sf.jasperreports.style.forecolor"><![CDATA[$P{OUTPUT_FORMAT}.equals("HTML") && !$F{TABTOOPEN}.equals("PaymentLine")?"#0000FF":"#000000"]]></propertyExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="5">
+			</element>
+			<element kind="textField" uuid="52c7ee2e-9ae6-4e3e-90e8-c7ab3128ed0a" stretchType="ContainerHeight" x="495" y="0" width="59" height="13" forecolor="#0000FF" fontSize="7.0" pattern="#,##0.0##" linkType="Reference" hTextAlign="Right" style="default">
+				<expression><![CDATA[$P{AMOUNTFORMAT}.format($F{CONVERTEDAMOUNT})]]></expression>
+				<hyperlinkReferenceExpression><![CDATA["javascript:top.OB.Utilities.openDirectTab('" + $V{OPEN_SUITABLE_TAB} + "', '" + $F{RECORDID} + "');"]]></hyperlinkReferenceExpression>
+				<hyperlinkWhenExpression><![CDATA[$P{OUTPUT_FORMAT}.equalsIgnoreCase("HTML") && !$F{TABTOOPEN}.equals("PaymentLine")? Boolean.TRUE: Boolean.FALSE]]></hyperlinkWhenExpression>
+				<propertyExpression name="net.sf.jasperreports.style.forecolor"><![CDATA[$P{OUTPUT_FORMAT}.equals("HTML") && !$F{TABTOOPEN}.equals("PaymentLine")?"#0000FF":"#000000"]]></propertyExpression>
+				<box leftPadding="5" rightPadding="5" style="default">
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#959595"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="7"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{AMOUNTFORMAT}.format($F{CONVERTEDAMOUNT})]]></textFieldExpression>
-				<hyperlinkReferenceExpression><![CDATA["javascript:top.OB.Utilities.openDirectTab('" + $V{OPEN_SUITABLE_TAB} + "', '" + $F{RECORDID} + "');"]]></hyperlinkReferenceExpression>
-				<hyperlinkWhenExpression><![CDATA[$P{OUTPUT_FORMAT}.equalsIgnoreCase("HTML") && !$F{TABTOOPEN}.equals("PaymentLine")? Boolean.TRUE: Boolean.FALSE]]></hyperlinkWhenExpression>
-			</textField>
-			<line>
-				<reportElement stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="14" uuid="1f997374-5cf6-40d7-809f-92c4340202e9"/>
-				<graphicElement>
-					<pen lineColor="#959595"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement stretchType="RelativeToBandHeight" x="554" y="0" width="1" height="14" uuid="c92f437c-08be-442b-85cb-425aef33d90b"/>
-				<graphicElement>
-					<pen lineColor="#959595"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement positionType="Float" x="10" y="13" width="544" height="1" uuid="dffb6f62-bfc8-4250-a6ed-709fba37cf7b"/>
-				<graphicElement>
-					<pen lineColor="#959595"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true">
-				<reportElement style="default" stretchType="RelativeToBandHeight" x="430" y="0" width="65" height="13" uuid="d38dff1d-644c-4aa4-88ce-ac5fead7ed99">
-					<printWhenExpression><![CDATA[!$F{TRXCUR}.equals($F{FACUR})]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="5">
+			</element>
+			<element kind="line" uuid="1f997374-5cf6-40d7-809f-92c4340202e9" stretchType="ContainerHeight" x="0" y="0" width="1" height="14">
+				<pen lineColor="#959595"/>
+			</element>
+			<element kind="line" uuid="c92f437c-08be-442b-85cb-425aef33d90b" stretchType="ContainerHeight" x="554" y="0" width="1" height="14">
+				<pen lineColor="#959595"/>
+			</element>
+			<element kind="line" uuid="dffb6f62-bfc8-4250-a6ed-709fba37cf7b" positionType="Float" x="10" y="13" width="544" height="1">
+				<pen lineColor="#959595"/>
+			</element>
+			<element kind="textField" uuid="d38dff1d-644c-4aa4-88ce-ac5fead7ed99" stretchType="ContainerHeight" x="430" y="0" width="65" height="13" fontSize="7.0" textAdjust="StretchHeight" hTextAlign="Right" style="default">
+				<printWhenExpression><![CDATA[!$F{TRXCUR}.equals($F{FACUR})]]></printWhenExpression>
+				<expression><![CDATA[$P{AMOUNTFORMAT}.format($F{ORIGINALAMOUNT}) + " ("+$F{TRXCUR}+")"]]></expression>
+				<box leftPadding="5" rightPadding="5" style="default">
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="7"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{AMOUNTFORMAT}.format($F{ORIGINALAMOUNT}) + " ("+$F{TRXCUR}+")"]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement style="default" stretchType="RelativeToBandHeight" x="120" y="0" width="60" height="13" forecolor="#0000FF" uuid="c33fffb5-ddd3-4dcc-8f5b-a80722d5e59d">
-					<propertyExpression name="net.sf.jasperreports.style.forecolor"><![CDATA[$P{OUTPUT_FORMAT}.equals("HTML")?"#0000FF":"#000000"]]></propertyExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="5">
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
-				</box>
-				<textElement>
-					<font size="7"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{INVOICENO}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="c33fffb5-ddd3-4dcc-8f5b-a80722d5e59d" stretchType="ContainerHeight" x="120" y="0" width="60" height="13" forecolor="#0000FF" fontSize="7.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" style="default">
+				<expression><![CDATA[$F{INVOICENO}]]></expression>
 				<hyperlinkReferenceExpression><![CDATA["javascript:top.OB.Utilities.openDirectTab('" + $V{OPEN_INVOICE_TAB} + "', '" + $F{C_INVOICE_ID} + "');"]]></hyperlinkReferenceExpression>
 				<hyperlinkWhenExpression><![CDATA[$P{OUTPUT_FORMAT}.equalsIgnoreCase("HTML")? Boolean.TRUE: Boolean.FALSE]]></hyperlinkWhenExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement style="default" stretchType="RelativeToBandHeight" x="305" y="0" width="125" height="13" forecolor="#0000FF" uuid="1d306d94-1352-4992-beab-49032842f2c5">
-					<propertyExpression name="net.sf.jasperreports.style.forecolor"><![CDATA[$P{OUTPUT_FORMAT}.equals("HTML")?"#0000FF":"#000000"]]></propertyExpression>
-				</reportElement>
-				<box topPadding="1" leftPadding="5" rightPadding="5">
+				<propertyExpression name="net.sf.jasperreports.style.forecolor"><![CDATA[$P{OUTPUT_FORMAT}.equals("HTML")?"#0000FF":"#000000"]]></propertyExpression>
+				<box leftPadding="5" rightPadding="5" style="default">
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 				</box>
-				<textElement>
-					<font size="7"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{TRANS_DESCRIP}!=null)?$F{TRANS_DESCRIP}:$F{PAYMENT_DESC}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="1d306d94-1352-4992-beab-49032842f2c5" stretchType="ContainerHeight" x="305" y="0" width="125" height="13" forecolor="#0000FF" fontSize="7.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" style="default">
+				<expression><![CDATA[($F{TRANS_DESCRIP}!=null)?$F{TRANS_DESCRIP}:$F{PAYMENT_DESC}]]></expression>
 				<hyperlinkReferenceExpression><![CDATA["javascript:top.OB.Utilities.openDirectTab('" + $V{TRANS_DESCRIP_V} + "', '" + $F{FIN_PAYMENT_ID} + "');"]]></hyperlinkReferenceExpression>
 				<hyperlinkWhenExpression><![CDATA[$P{OUTPUT_FORMAT}.equalsIgnoreCase("HTML")? Boolean.TRUE: Boolean.FALSE]]></hyperlinkWhenExpression>
-			</textField>
+				<propertyExpression name="net.sf.jasperreports.style.forecolor"><![CDATA[$P{OUTPUT_FORMAT}.equals("HTML")?"#0000FF":"#000000"]]></propertyExpression>
+				<box topPadding="1" leftPadding="5" rightPadding="5" style="default">
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
+				</box>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/CashflowForecastLinesByDate.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/CashflowForecastLinesByDate.jrxml
@@ -1,59 +1,57 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="CashFlowForecastLines" pageWidth="555" pageHeight="802" columnWidth="555" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="1300d746-b52d-41b8-b049-6e6f683f2fec">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="CashFlowForecastLines" language="java" pageWidth="555" pageHeight="802" columnWidth="555" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="1300d746-b52d-41b8-b049-6e6f683f2fec">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.zoom" value="1.3310000000000106"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="6">
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="6.0">
 		<box leftPadding="5" rightPadding="5"/>
 	</style>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="6" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="6.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
 	<parameter name="FIN_FINANCIAL_ACCOUNT_ID" class="java.lang.String">
 		<defaultValueExpression><![CDATA[]]></defaultValueExpression>
 	</parameter>
-	<parameter name="AMOUNTFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<parameter name="AMOUNTFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat()]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="CURRENT_BALANCE" class="java.math.BigDecimal"/>
 	<parameter name="DatePlanned" class="java.util.Date"/>
 	<parameter name="fieldProviderSubReport" class="net.sf.jasperreports.engine.JRDataSource"/>
 	<parameter name="OUTPUT_FORMAT" class="java.lang.String"/>
-	<queryString>
-		<![CDATA[]]>
-	</queryString>
+	<query language="sql"><![CDATA[]]></query>
 	<field name="FIN_FINANCIAL_ACCOUNT_ID" class="java.lang.String"/>
 	<field name="FINANCIALACCOUNT" class="java.lang.String"/>
 	<field name="CURRENTBALANCE" class="java.math.BigDecimal"/>
@@ -76,416 +74,274 @@
 	<field name="RECORDID" class="java.lang.String"/>
 	<field name="TABTOOPEN" class="java.lang.String"/>
 	<field name="FIN_FINACC_TRANSACTION_ID" class="java.lang.String"/>
-	<variable name="Accum" class="java.math.BigDecimal" resetType="Group" resetGroup="DueDate" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVERTEDAMOUNT}]]></variableExpression>
+	<variable name="Accum" resetType="Group" calculation="Sum" resetGroup="DueDate" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVERTEDAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVERTEDAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVERTEDAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_TOTAL_IN" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{ISRECEIPT}.equals("Y")?$F{CONVERTEDAMOUNT}:BigDecimal.ZERO]]></variableExpression>
+	<variable name="AMOUNT_TOTAL_IN" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{ISRECEIPT}.equals("Y")?$F{CONVERTEDAMOUNT}:BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="AMOUNT_TOTAL_OUT" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{ISRECEIPT}.equals("N")?$F{CONVERTEDAMOUNT}:BigDecimal.ZERO]]></variableExpression>
+	<variable name="AMOUNT_TOTAL_OUT" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{ISRECEIPT}.equals("N")?$F{CONVERTEDAMOUNT}:BigDecimal.ZERO]]></expression>
 	</variable>
 	<variable name="OPEN_INVOICE_TAB" class="java.lang.String">
-		<variableExpression><![CDATA[$F{ISRECEIPT}.equals("Y")?"263":"290"]]></variableExpression>
+		<expression><![CDATA[$F{ISRECEIPT}.equals("Y")?"263":"290"]]></expression>
 	</variable>
 	<variable name="OPEN_PAYMENT_TAB" class="java.lang.String">
-		<variableExpression><![CDATA[$F{ISRECEIPT}.equals("Y")?"C4B6506838E14A349D6717D6856F1B56":"F7A52FDAAA0346EFA07D53C125B40404"]]></variableExpression>
+		<expression><![CDATA[$F{ISRECEIPT}.equals("Y")?"C4B6506838E14A349D6717D6856F1B56":"F7A52FDAAA0346EFA07D53C125B40404"]]></expression>
 	</variable>
 	<variable name="OPEN_SUITABLE_TAB" class="java.lang.String">
-		<variableExpression><![CDATA[$F{ISRECEIPT}.equals("Y")?($F{TABTOOPEN}.equals("InvoicePlan")?"60825C9E68644DBC9C530DDCABE05A6E":($F{TABTOOPEN}.equals("PaymentLine")?"34DA12C2E9E3424E9A853563BEFDE81F":"23691259D1BD4496BCC5F32645BCA4B9")):($F{TABTOOPEN}.equals("InvoicePlan")?"7A8D43541F8C49F1BD8A431A0041BF89":($F{TABTOOPEN}.equals("PaymentLine")?"809C66481863428C8D714F2018644CC6":"23691259D1BD4496BCC5F32645BCA4B9"))]]></variableExpression>
+		<expression><![CDATA[$F{ISRECEIPT}.equals("Y")?($F{TABTOOPEN}.equals("InvoicePlan")?"60825C9E68644DBC9C530DDCABE05A6E":($F{TABTOOPEN}.equals("PaymentLine")?"34DA12C2E9E3424E9A853563BEFDE81F":"23691259D1BD4496BCC5F32645BCA4B9")):($F{TABTOOPEN}.equals("InvoicePlan")?"7A8D43541F8C49F1BD8A431A0041BF89":($F{TABTOOPEN}.equals("PaymentLine")?"809C66481863428C8D714F2018644CC6":"23691259D1BD4496BCC5F32645BCA4B9"))]]></expression>
 	</variable>
 	<variable name="TRANS_DESCRIP_V" class="java.lang.String">
-		<variableExpression><![CDATA[($F{TRANS_DESCRIP}!=null)?"23691259D1BD4496BCC5F32645BCA4B9":$V{OPEN_PAYMENT_TAB}]]></variableExpression>
+		<expression><![CDATA[($F{TRANS_DESCRIP}!=null)?"23691259D1BD4496BCC5F32645BCA4B9":$V{OPEN_PAYMENT_TAB}]]></expression>
 	</variable>
 	<group name="FinancialAccount">
-		<groupExpression><![CDATA[$F{FINANCIALACCOUNT}]]></groupExpression>
+		<expression><![CDATA[$F{FINANCIALACCOUNT}]]></expression>
 		<groupHeader>
 			<band height="42">
-				<staticText>
-					<reportElement style="Detail_Header" stretchType="RelativeToBandHeight" x="65" y="27" width="75" height="15" forecolor="#010101" backcolor="#CBCBCB" uuid="8a000c52-25f3-491c-9c76-9469029deecd"/>
-					<box leftPadding="5" rightPadding="5">
-						<topPen lineWidth="1.0" lineColor="#959595"/>
-						<leftPen lineColor="#959595"/>
-						<rightPen lineColor="#959595"/>
-					</box>
-					<textElement>
-						<font size="6"/>
-					</textElement>
+				<element kind="staticText" uuid="8a000c52-25f3-491c-9c76-9469029deecd" stretchType="ContainerHeight" x="65" y="27" width="75" height="15" forecolor="#010101" backcolor="#CBCBCB" fontSize="6.0" style="Detail_Header">
 					<text><![CDATA[Invoice No.]]></text>
-				</staticText>
-				<staticText>
-					<reportElement style="Detail_Header" stretchType="RelativeToBandHeight" x="295" y="27" width="125" height="15" forecolor="#010101" backcolor="#CBCBCB" uuid="fcecd6a5-cf2f-4de3-8242-bc48de2a1f13"/>
-					<box leftPadding="5" rightPadding="5">
+					<box leftPadding="5" rightPadding="5" style="Detail_Header">
 						<topPen lineWidth="1.0" lineColor="#959595"/>
 						<leftPen lineColor="#959595"/>
 						<rightPen lineColor="#959595"/>
 					</box>
-					<textElement>
-						<font size="6"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="fcecd6a5-cf2f-4de3-8242-bc48de2a1f13" stretchType="ContainerHeight" x="295" y="27" width="125" height="15" forecolor="#010101" backcolor="#CBCBCB" fontSize="6.0" style="Detail_Header">
 					<text><![CDATA[Description]]></text>
-				</staticText>
-				<staticText>
-					<reportElement style="Detail_Header" stretchType="RelativeToBandHeight" x="10" y="27" width="55" height="15" forecolor="#010101" backcolor="#CBCBCB" uuid="079a1cb0-27c4-4e12-b0ea-d4793da0e01e"/>
-					<box leftPadding="5" rightPadding="5">
+					<box leftPadding="5" rightPadding="5" style="Detail_Header">
 						<topPen lineWidth="1.0" lineColor="#959595"/>
 						<leftPen lineColor="#959595"/>
 						<rightPen lineColor="#959595"/>
 					</box>
-					<textElement>
-						<font size="6"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="079a1cb0-27c4-4e12-b0ea-d4793da0e01e" stretchType="ContainerHeight" x="10" y="27" width="55" height="15" forecolor="#010101" backcolor="#CBCBCB" fontSize="6.0" style="Detail_Header">
 					<text><![CDATA[Invoiced]]></text>
-				</staticText>
-				<staticText>
-					<reportElement style="Detail_Header" stretchType="RelativeToBandHeight" x="140" y="27" width="155" height="15" forecolor="#010101" backcolor="#CBCBCB" uuid="9224c2a2-894f-4643-abfd-2e82ed606aff"/>
-					<box leftPadding="5" rightPadding="5">
+					<box leftPadding="5" rightPadding="5" style="Detail_Header">
 						<topPen lineWidth="1.0" lineColor="#959595"/>
 						<leftPen lineColor="#959595"/>
 						<rightPen lineColor="#959595"/>
 					</box>
-					<textElement>
-						<font size="6"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="9224c2a2-894f-4643-abfd-2e82ed606aff" stretchType="ContainerHeight" x="140" y="27" width="155" height="15" forecolor="#010101" backcolor="#CBCBCB" fontSize="6.0" style="Detail_Header">
 					<text><![CDATA[Business Partner]]></text>
-				</staticText>
-				<staticText>
-					<reportElement style="Detail_Header" stretchType="RelativeToBandHeight" x="420" y="27" width="75" height="15" forecolor="#010101" backcolor="#CBCBCB" uuid="21e5fe74-135b-42f1-aa1f-357b517ac1f5"/>
-					<box leftPadding="5" rightPadding="5">
+					<box leftPadding="5" rightPadding="5" style="Detail_Header">
 						<topPen lineWidth="1.0" lineColor="#959595"/>
 						<leftPen lineColor="#959595"/>
 						<rightPen lineColor="#959595"/>
 					</box>
-					<textElement>
-						<font size="6"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="21e5fe74-135b-42f1-aa1f-357b517ac1f5" stretchType="ContainerHeight" x="420" y="27" width="75" height="15" forecolor="#010101" backcolor="#CBCBCB" fontSize="6.0" style="Detail_Header">
 					<text><![CDATA[Orig. Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement style="Detail_Header" stretchType="RelativeToBandHeight" x="495" y="27" width="59" height="15" forecolor="#010101" backcolor="#CBCBCB" uuid="3217f2fe-f7f5-414a-a246-78af5b466dcf"/>
-					<box leftPadding="5" rightPadding="5">
+					<box leftPadding="5" rightPadding="5" style="Detail_Header">
 						<topPen lineWidth="1.0" lineColor="#959595"/>
 						<leftPen lineColor="#959595"/>
 						<rightPen lineColor="#959595"/>
 					</box>
-					<textElement>
-						<font size="6"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="3217f2fe-f7f5-414a-a246-78af5b466dcf" stretchType="ContainerHeight" x="495" y="27" width="59" height="15" forecolor="#010101" backcolor="#CBCBCB" fontSize="6.0" style="Detail_Header">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<line>
-					<reportElement stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="42" uuid="d8999859-a650-47aa-9ee1-ad751141d410"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement stretchType="RelativeToBandHeight" x="554" y="0" width="1" height="42" uuid="2bf87764-489b-4b25-afe1-31ff78ae82d4"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
-				<textField>
-					<reportElement x="10" y="3" width="545" height="15" uuid="a08ba2cd-b8fa-4680-b085-2815d80cab94"/>
-					<textFieldExpression><![CDATA[$F{FINANCIALACCOUNT}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement x="0" y="0" width="555" height="1" uuid="c6a35c7f-18d5-492b-b1c3-bb19070ac05f"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
+					<box leftPadding="5" rightPadding="5" style="Detail_Header">
+						<topPen lineWidth="1.0" lineColor="#959595"/>
+						<leftPen lineColor="#959595"/>
+						<rightPen lineColor="#959595"/>
+					</box>
+				</element>
+				<element kind="line" uuid="d8999859-a650-47aa-9ee1-ad751141d410" stretchType="ContainerHeight" x="0" y="0" width="1" height="42">
+					<pen lineColor="#959595"/>
+				</element>
+				<element kind="line" uuid="2bf87764-489b-4b25-afe1-31ff78ae82d4" stretchType="ContainerHeight" x="554" y="0" width="1" height="42">
+					<pen lineColor="#959595"/>
+				</element>
+				<element kind="textField" uuid="a08ba2cd-b8fa-4680-b085-2815d80cab94" x="10" y="3" width="545" height="15">
+					<expression><![CDATA[$F{FINANCIALACCOUNT}]]></expression>
+				</element>
+				<element kind="line" uuid="c6a35c7f-18d5-492b-b1c3-bb19070ac05f" x="0" y="0" width="555" height="1">
+					<pen lineColor="#959595"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="13">
-				<line>
-					<reportElement x="0" y="5" width="555" height="1" uuid="368906bc-aef7-4de4-a006-2542e322830f"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="5" uuid="bcd9a70c-4ced-4e25-9b3c-29aad0d086f5"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement stretchType="RelativeToBandHeight" x="554" y="0" width="1" height="5" uuid="11f61ee7-42c0-4914-8f5f-65f18573de60"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="368906bc-aef7-4de4-a006-2542e322830f" x="0" y="5" width="555" height="1">
+					<pen lineColor="#959595"/>
+				</element>
+				<element kind="line" uuid="bcd9a70c-4ced-4e25-9b3c-29aad0d086f5" stretchType="ContainerHeight" x="0" y="0" width="1" height="5">
+					<pen lineColor="#959595"/>
+				</element>
+				<element kind="line" uuid="11f61ee7-42c0-4914-8f5f-65f18573de60" stretchType="ContainerHeight" x="554" y="0" width="1" height="5">
+					<pen lineColor="#959595"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="DueDate">
-		<groupExpression><![CDATA[$F{DUEDATE}]]></groupExpression>
+		<expression><![CDATA[$F{DUEDATE}]]></expression>
 		<groupHeader>
 			<band height="15">
-				<textField pattern="">
-					<reportElement style="default" stretchType="RelativeToBandHeight" x="100" y="0" width="454" height="15" uuid="e6f47c97-e44a-44d6-924c-4180265e495a"/>
-					<box leftPadding="5" rightPadding="5">
+				<element kind="textField" uuid="e6f47c97-e44a-44d6-924c-4180265e495a" stretchType="ContainerHeight" x="100" y="0" width="454" height="15" fontSize="6.0" pattern="" vTextAlign="Bottom" style="default">
+					<expression><![CDATA[$F{DUEDATE}]]></expression>
+					<box leftPadding="5" rightPadding="5" style="default">
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					</box>
-					<textElement verticalAlignment="Bottom">
-						<font size="6"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{DUEDATE}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement style="Detail_Header" stretchType="RelativeToBandHeight" x="10" y="0" width="90" height="15" forecolor="#010101" backcolor="#CBCBCB" uuid="36a7dae6-590d-4327-b81c-0afa6f300d43"/>
-					<box leftPadding="5" rightPadding="5">
+				</element>
+				<element kind="staticText" uuid="36a7dae6-590d-4327-b81c-0afa6f300d43" stretchType="ContainerHeight" x="10" y="0" width="90" height="15" forecolor="#010101" backcolor="#CBCBCB" fontSize="6.0" vTextAlign="Bottom" style="Detail_Header">
+					<text><![CDATA[Date Planned]]></text>
+					<box leftPadding="5" rightPadding="5" style="Detail_Header">
 						<topPen lineWidth="1.0" lineColor="#959595"/>
 						<leftPen lineColor="#959595"/>
 						<rightPen lineColor="#959595"/>
 					</box>
-					<textElement verticalAlignment="Bottom">
-						<font size="6"/>
-					</textElement>
-					<text><![CDATA[Date Planned]]></text>
-				</staticText>
-				<line>
-					<reportElement stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="15" uuid="2143b7d1-e5c4-4596-851c-3314c9b3da9d"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement stretchType="RelativeToBandHeight" x="554" y="0" width="1" height="15" uuid="1229b1c2-7725-4c87-846f-11845f2b4e22"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement x="10" y="0" width="544" height="1" uuid="229907ae-cc01-4c26-96ad-8f6d55c77b86"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="15" uuid="47ae914e-18b1-45f6-a768-545ff0b59d05"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
+				</element>
+				<element kind="line" uuid="2143b7d1-e5c4-4596-851c-3314c9b3da9d" stretchType="ContainerHeight" x="0" y="0" width="1" height="15">
+					<pen lineColor="#959595"/>
+				</element>
+				<element kind="line" uuid="1229b1c2-7725-4c87-846f-11845f2b4e22" stretchType="ContainerHeight" x="554" y="0" width="1" height="15">
+					<pen lineColor="#959595"/>
+				</element>
+				<element kind="line" uuid="229907ae-cc01-4c26-96ad-8f6d55c77b86" x="10" y="0" width="544" height="1">
+					<pen lineColor="#959595"/>
+				</element>
+				<element kind="line" uuid="47ae914e-18b1-45f6-a768-545ff0b59d05" stretchType="ContainerHeight" x="10" y="0" width="1" height="15">
+					<pen lineColor="#959595"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="15">
-				<textField evaluationTime="Group" evaluationGroup="isReceipt" pattern="##0.00" isBlankWhenNull="true">
-					<reportElement key="textField-14" mode="Opaque" x="10" y="0" width="490" height="15" backcolor="#CBCBCB" uuid="c1a536f1-f34f-49df-a469-bf7e89f80717"/>
+				<element kind="textField" uuid="c1a536f1-f34f-49df-a469-bf7e89f80717" key="textField-14" mode="Opaque" x="10" y="0" width="490" height="15" backcolor="#CBCBCB" fontSize="6.0" evaluationTime="Group" pattern="##0.00" evaluationGroup="isReceipt" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA["Total Amount Incoming - Payments ("+$F{FACUR}+")"]]></expression>
 					<box leftPadding="5" rightPadding="10">
 						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6"/>
-					</textElement>
-					<textFieldExpression><![CDATA["Total Amount Incoming - Payments ("+$F{FACUR}+")"]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="isReceipt" pattern="##0.00" isBlankWhenNull="true">
-					<reportElement key="textField" mode="Opaque" x="500" y="0" width="54" height="15" backcolor="#CBCBCB" uuid="e6f5dab0-b6fb-4564-b1a9-fb4676af342d"/>
+				</element>
+				<element kind="textField" uuid="e6f5dab0-b6fb-4564-b1a9-fb4676af342d" key="textField" mode="Opaque" x="500" y="0" width="54" height="15" backcolor="#CBCBCB" fontSize="6.0" evaluationTime="Group" pattern="##0.00" evaluationGroup="isReceipt" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{Accum}!=null)?$P{AMOUNTFORMAT}.format($V{Accum}):new String(" ")]]></expression>
 					<box leftPadding="5" rightPadding="5">
 						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 						<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#959595"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{Accum}!=null)?$P{AMOUNTFORMAT}.format($V{Accum}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="15" uuid="92b550ad-a0de-4e54-a101-927e0397b2ae"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement stretchType="RelativeToBandHeight" x="554" y="0" width="1" height="15" uuid="fe5af48d-ce09-4e9f-8354-895aa061a7f7"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
+				</element>
+				<element kind="line" uuid="92b550ad-a0de-4e54-a101-927e0397b2ae" stretchType="ContainerHeight" x="0" y="0" width="1" height="15">
+					<pen lineColor="#959595"/>
+				</element>
+				<element kind="line" uuid="fe5af48d-ce09-4e9f-8354-895aa061a7f7" stretchType="ContainerHeight" x="554" y="0" width="1" height="15">
+					<pen lineColor="#959595"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="isReceipt">
-		<groupExpression><![CDATA[$F{ISRECEIPT}]]></groupExpression>
+		<expression><![CDATA[$F{ISRECEIPT}]]></expression>
 		<groupHeader>
 			<band height="13">
-				<line>
-					<reportElement stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="13" uuid="68ad6411-e1f6-4b86-86a5-b0f3204f9097"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement stretchType="RelativeToBandHeight" x="554" y="0" width="1" height="13" uuid="1ee47cc9-7d0f-4930-84dc-53fc9d261834"/>
-					<graphicElement>
-						<pen lineColor="#959595"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement style="GroupHeader_Gray" x="10" y="0" width="544" height="13" backcolor="#FFFFFF" uuid="e436a934-349d-4465-aebf-371b0f0d1cf4">
-						<printWhenExpression><![CDATA[!$F{ISRECEIPT}.equals("Y")]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5" rightPadding="5">
-						<pen lineWidth="1.0" lineColor="#959595"/>
-						<topPen lineWidth="1.0" lineColor="#959595"/>
-						<leftPen lineWidth="1.0" lineColor="#959595"/>
-						<bottomPen lineWidth="1.0" lineColor="#959595"/>
-						<rightPen lineWidth="1.0" lineColor="#959595"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="7" isBold="true"/>
-					</textElement>
+				<element kind="line" uuid="68ad6411-e1f6-4b86-86a5-b0f3204f9097" stretchType="ContainerHeight" x="0" y="0" width="1" height="13">
+					<pen lineColor="#959595"/>
+				</element>
+				<element kind="line" uuid="1ee47cc9-7d0f-4930-84dc-53fc9d261834" stretchType="ContainerHeight" x="554" y="0" width="1" height="13">
+					<pen lineColor="#959595"/>
+				</element>
+				<element kind="staticText" uuid="e436a934-349d-4465-aebf-371b0f0d1cf4" x="10" y="0" width="544" height="13" backcolor="#FFFFFF" fontName="Bitstream Vera Sans" fontSize="7.0" bold="true" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_Gray">
+					<printWhenExpression><![CDATA[!$F{ISRECEIPT}.equals("Y")]]></printWhenExpression>
 					<text><![CDATA[PAYMENT]]></text>
-				</staticText>
-				<staticText>
-					<reportElement style="GroupHeader_Gray" x="11" y="0" width="544" height="13" backcolor="#FFFFFF" uuid="fb16b0ab-961c-4938-935f-8d90e99e9300">
-						<printWhenExpression><![CDATA[$F{ISRECEIPT}.equals("Y")]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5" rightPadding="5">
+					<box leftPadding="5" rightPadding="5" style="GroupHeader_Gray">
 						<pen lineWidth="1.0" lineColor="#959595"/>
 						<topPen lineWidth="1.0" lineColor="#959595"/>
 						<leftPen lineWidth="1.0" lineColor="#959595"/>
 						<bottomPen lineWidth="1.0" lineColor="#959595"/>
 						<rightPen lineWidth="1.0" lineColor="#959595"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="7" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="fb16b0ab-961c-4938-935f-8d90e99e9300" x="11" y="0" width="544" height="13" backcolor="#FFFFFF" fontName="Bitstream Vera Sans" fontSize="7.0" bold="true" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_Gray">
+					<printWhenExpression><![CDATA[$F{ISRECEIPT}.equals("Y")]]></printWhenExpression>
 					<text><![CDATA[INCOME]]></text>
-				</staticText>
+					<box leftPadding="5" rightPadding="5" style="GroupHeader_Gray">
+						<pen lineWidth="1.0" lineColor="#959595"/>
+						<topPen lineWidth="1.0" lineColor="#959595"/>
+						<leftPen lineWidth="1.0" lineColor="#959595"/>
+						<bottomPen lineWidth="1.0" lineColor="#959595"/>
+						<rightPen lineWidth="1.0" lineColor="#959595"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
 	<detail>
 		<band height="13">
-			<textField isStretchWithOverflow="true">
-				<reportElement style="default" positionType="Float" stretchType="RelativeToTallestObject" x="420" y="0" width="75" height="13" uuid="6bb0262b-5842-4aea-844f-06f342cd1b49">
-					<printWhenExpression><![CDATA[!$F{TRXCUR}.equals($F{FACUR})]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="5">
+			<element kind="textField" uuid="6bb0262b-5842-4aea-844f-06f342cd1b49" positionType="Float" stretchType="ElementGroupHeight" x="420" y="0" width="75" height="13" fontSize="6.0" textAdjust="StretchHeight" hTextAlign="Right" style="default">
+				<printWhenExpression><![CDATA[!$F{TRXCUR}.equals($F{FACUR})]]></printWhenExpression>
+				<expression><![CDATA[$P{AMOUNTFORMAT}.format($F{ORIGINALAMOUNT}) + " ("+$F{TRXCUR}+")"]]></expression>
+				<box leftPadding="5" rightPadding="5" style="default">
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="6"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{AMOUNTFORMAT}.format($F{ORIGINALAMOUNT}) + " ("+$F{TRXCUR}+")"]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement style="default" positionType="Float" stretchType="RelativeToTallestObject" x="65" y="0" width="75" height="13" forecolor="#0000FF" uuid="39798b79-0b1e-44da-9e44-71e069e0c6ad">
-					<propertyExpression name="net.sf.jasperreports.style.forecolor"><![CDATA[$P{OUTPUT_FORMAT}.equals("HTML")?"#0000FF":"#000000"]]></propertyExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="5">
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
-				</box>
-				<textElement>
-					<font size="6"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{INVOICENO}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="39798b79-0b1e-44da-9e44-71e069e0c6ad" positionType="Float" stretchType="ElementGroupHeight" x="65" y="0" width="75" height="13" forecolor="#0000FF" fontSize="6.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" style="default">
+				<expression><![CDATA[$F{INVOICENO}]]></expression>
 				<hyperlinkReferenceExpression><![CDATA["javascript:top.OB.Utilities.openDirectTab('" + $V{OPEN_INVOICE_TAB} + "', '" + $F{C_INVOICE_ID} + "');"]]></hyperlinkReferenceExpression>
 				<hyperlinkWhenExpression><![CDATA[$P{OUTPUT_FORMAT}.equalsIgnoreCase("HTML")? Boolean.TRUE: Boolean.FALSE]]></hyperlinkWhenExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference">
-				<reportElement style="default" positionType="Float" stretchType="RelativeToTallestObject" x="295" y="0" width="125" height="13" forecolor="#0000FF" uuid="7599d262-3cf4-4dd5-a079-7dee46897720">
-					<propertyExpression name="net.sf.jasperreports.style.forecolor"><![CDATA[$P{OUTPUT_FORMAT}.equals("HTML")?"#0000FF":"#000000"]]></propertyExpression>
-				</reportElement>
-				<box topPadding="1" leftPadding="5" rightPadding="5">
+				<propertyExpression name="net.sf.jasperreports.style.forecolor"><![CDATA[$P{OUTPUT_FORMAT}.equals("HTML")?"#0000FF":"#000000"]]></propertyExpression>
+				<box leftPadding="5" rightPadding="5" style="default">
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 				</box>
-				<textElement>
-					<font size="6"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{TRANS_DESCRIP}!=null)?$F{TRANS_DESCRIP}:$F{PAYMENT_DESC}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="7599d262-3cf4-4dd5-a079-7dee46897720" positionType="Float" stretchType="ElementGroupHeight" x="295" y="0" width="125" height="13" forecolor="#0000FF" fontSize="6.0" textAdjust="StretchHeight" linkType="Reference" blankWhenNull="true" style="default">
+				<expression><![CDATA[($F{TRANS_DESCRIP}!=null)?$F{TRANS_DESCRIP}:$F{PAYMENT_DESC}]]></expression>
 				<hyperlinkReferenceExpression><![CDATA["javascript:top.OB.Utilities.openDirectTab('" + $V{TRANS_DESCRIP_V} + "', '" + $F{FIN_PAYMENT_ID} + "');"]]></hyperlinkReferenceExpression>
 				<hyperlinkWhenExpression><![CDATA[$P{OUTPUT_FORMAT}.equalsIgnoreCase("HTML")? Boolean.TRUE: Boolean.FALSE]]></hyperlinkWhenExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement style="default" positionType="Float" stretchType="RelativeToTallestObject" x="140" y="0" width="155" height="13" uuid="8d490ac9-7dd7-4e36-8308-b0d0ed352897"/>
-				<box leftPadding="5" rightPadding="5">
+				<propertyExpression name="net.sf.jasperreports.style.forecolor"><![CDATA[$P{OUTPUT_FORMAT}.equals("HTML")?"#0000FF":"#000000"]]></propertyExpression>
+				<box topPadding="1" leftPadding="5" rightPadding="5" style="default">
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 				</box>
-				<textElement>
-					<font size="6"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{BPNAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement style="default" positionType="Float" stretchType="RelativeToTallestObject" x="10" y="0" width="55" height="13" uuid="865288c9-f49f-4360-b510-0ac472532a02"/>
-				<box leftPadding="5" rightPadding="5">
+			</element>
+			<element kind="textField" uuid="8d490ac9-7dd7-4e36-8308-b0d0ed352897" positionType="Float" stretchType="ElementGroupHeight" x="140" y="0" width="155" height="13" fontSize="6.0" textAdjust="StretchHeight" blankWhenNull="true" style="default">
+				<expression><![CDATA[$F{BPNAME}]]></expression>
+				<box leftPadding="5" rightPadding="5" style="default">
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 				</box>
-				<textElement>
-					<font size="6"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DATEINVOICED}]]></textFieldExpression>
-			</textField>
-			<textField hyperlinkType="Reference">
-				<reportElement style="default" positionType="Float" stretchType="RelativeToTallestObject" x="495" y="0" width="59" height="13" forecolor="#0000FF" uuid="99334768-711c-4e4f-8aff-7ed8447d7dd3">
-					<propertyExpression name="net.sf.jasperreports.style.forecolor"><![CDATA[$P{OUTPUT_FORMAT}.equals("HTML") && !$F{TABTOOPEN}.equals("PaymentLine")?"#0000FF":"#000000"]]></propertyExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="5">
+			</element>
+			<element kind="textField" uuid="865288c9-f49f-4360-b510-0ac472532a02" positionType="Float" stretchType="ElementGroupHeight" x="10" y="0" width="55" height="13" fontSize="6.0" pattern="" blankWhenNull="true" style="default">
+				<expression><![CDATA[$F{DATEINVOICED}]]></expression>
+				<box leftPadding="5" rightPadding="5" style="default">
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="99334768-711c-4e4f-8aff-7ed8447d7dd3" positionType="Float" stretchType="ElementGroupHeight" x="495" y="0" width="59" height="13" forecolor="#0000FF" fontSize="6.0" linkType="Reference" hTextAlign="Right" style="default">
+				<expression><![CDATA[$P{AMOUNTFORMAT}.format($F{CONVERTEDAMOUNT})]]></expression>
+				<hyperlinkReferenceExpression><![CDATA["javascript:top.OB.Utilities.openDirectTab('" + $V{OPEN_SUITABLE_TAB} + "', '" + $F{RECORDID} + "');"]]></hyperlinkReferenceExpression>
+				<hyperlinkWhenExpression><![CDATA[$P{OUTPUT_FORMAT}.equalsIgnoreCase("HTML") && !$F{TABTOOPEN}.equals("PaymentLine")? Boolean.TRUE: Boolean.FALSE]]></hyperlinkWhenExpression>
+				<propertyExpression name="net.sf.jasperreports.style.forecolor"><![CDATA[$P{OUTPUT_FORMAT}.equals("HTML") && !$F{TABTOOPEN}.equals("PaymentLine")?"#0000FF":"#000000"]]></propertyExpression>
+				<box leftPadding="5" rightPadding="5" style="default">
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#959595"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="6"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{AMOUNTFORMAT}.format($F{CONVERTEDAMOUNT})]]></textFieldExpression>
-				<hyperlinkReferenceExpression><![CDATA["javascript:top.OB.Utilities.openDirectTab('" + $V{OPEN_SUITABLE_TAB} + "', '" + $F{RECORDID} + "');"]]></hyperlinkReferenceExpression>
-				<hyperlinkWhenExpression><![CDATA[$P{OUTPUT_FORMAT}.equalsIgnoreCase("HTML") && !$F{TABTOOPEN}.equals("PaymentLine")? Boolean.TRUE: Boolean.FALSE]]></hyperlinkWhenExpression>
-			</textField>
-			<line>
-				<reportElement stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="13" uuid="33b8d819-be22-4944-9d0b-b5b51977711b"/>
-				<graphicElement>
-					<pen lineColor="#959595"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement stretchType="RelativeToBandHeight" x="554" y="0" width="1" height="13" uuid="68a20ece-f444-448f-9f31-5c5df0c63056"/>
-				<graphicElement>
-					<pen lineColor="#959595"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement positionType="FixRelativeToBottom" x="10" y="12" width="544" height="1" uuid="4d98c9b6-2a0d-4972-b581-3de6e2435179"/>
-				<graphicElement>
-					<pen lineColor="#959595"/>
-				</graphicElement>
-			</line>
+			</element>
+			<element kind="line" uuid="33b8d819-be22-4944-9d0b-b5b51977711b" stretchType="ContainerHeight" x="0" y="0" width="1" height="13">
+				<pen lineColor="#959595"/>
+			</element>
+			<element kind="line" uuid="68a20ece-f444-448f-9f31-5c5df0c63056" stretchType="ContainerHeight" x="554" y="0" width="1" height="13">
+				<pen lineColor="#959595"/>
+			</element>
+			<element kind="line" uuid="4d98c9b6-2a0d-4972-b581-3de6e2435179" positionType="FixRelativeToBottom" x="10" y="12" width="544" height="1">
+				<pen lineColor="#959595"/>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/CashflowForecastSummary.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/CashflowForecastSummary.jrxml
@@ -1,54 +1,53 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="FinaccDetailMain" pageWidth="555" pageHeight="802" columnWidth="555" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="FinaccDetailMain" language="java" pageWidth="555" pageHeight="802" columnWidth="555" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="2479bbb7-32ac-4020-91d5-33667ad02480">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.zoom" value="1.2100000000000044"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="6">
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="6.0">
 		<box leftPadding="5" rightPadding="5"/>
 	</style>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="6" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="6.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="AMOUNTFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="AMOUNTFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat()]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="CURRENT_BALANCE" class="java.math.BigDecimal"/>
 	<parameter name="DatePlanned" class="java.util.Date"/>
 	<parameter name="fieldProviderSubReport" class="net.sf.jasperreports.engine.JRDataSource"/>
-	<queryString>
-		<![CDATA[select fa.fin_financial_account_id, fa.name as FINANCIALACCOUNT, fa.currentbalance as initialbalance, fa.accountno, null as income, null as payment, null as finalsummary
+	<query language="sql"><![CDATA[select fa.fin_financial_account_id, fa.name as FINANCIALACCOUNT, fa.currentbalance as initialbalance, fa.accountno, null as income, null as payment, null as finalsummary
     (select 1 from dual
     where exists (
         select 1
@@ -64,8 +63,7 @@
           and COALESCE(psinv.duedate, p.paymentdate)-1 < $P{DatePlanned})) as has_lines
 from fin_financial_account fa
 where fa.isactive = 'Y'
-order by fa.name, fa.fin_financial_account_id]]>
-	</queryString>
+order by fa.name, fa.fin_financial_account_id]]></query>
 	<field name="FINANCIALACCOUNT" class="java.lang.String"/>
 	<field name="INITIALBALANCE" class="java.math.BigDecimal"/>
 	<field name="PAYMENT" class="java.math.BigDecimal"/>
@@ -73,83 +71,57 @@ order by fa.name, fa.fin_financial_account_id]]>
 	<field name="FINALSUMMARY" class="java.math.BigDecimal"/>
 	<detail>
 		<band height="15">
-			<textField>
-				<reportElement style="Total_Gray" x="310" y="0" width="70" height="15" backcolor="#FEFEFE"/>
-				<box leftPadding="5" rightPadding="5">
+			<element kind="textField" uuid="762bc995-2c4c-4a25-be28-e03dc18b2b9f" x="310" y="0" width="70" height="15" backcolor="#FEFEFE" fontName="Bitstream Vera Sans" fontSize="6.0" hTextAlign="Right" vTextAlign="Middle" style="Total_Gray">
+				<expression><![CDATA[$P{AMOUNTFORMAT}.format($F{INCOME}==null?BigDecimal.ZERO:$F{INCOME})]]></expression>
+				<box leftPadding="5" rightPadding="5" style="Total_Gray">
 					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="6"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{AMOUNTFORMAT}.format($F{INCOME}==null?BigDecimal.ZERO:$F{INCOME})]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement style="Total_Gray" x="187" y="0" width="123" height="15" backcolor="#FEFEFE"/>
-				<box leftPadding="5" rightPadding="5">
+			</element>
+			<element kind="textField" uuid="2393a627-ce2c-4437-98e6-fd9b283a35fb" x="187" y="0" width="123" height="15" backcolor="#FEFEFE" fontName="Bitstream Vera Sans" fontSize="6.0" hTextAlign="Right" vTextAlign="Middle" style="Total_Gray">
+				<expression><![CDATA[$P{AMOUNTFORMAT}.format($F{INITIALBALANCE})]]></expression>
+				<box leftPadding="5" rightPadding="5" style="Total_Gray">
 					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="6"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{AMOUNTFORMAT}.format($F{INITIALBALANCE})]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement style="Total_Gray" x="450" y="0" width="104" height="15" backcolor="#FEFEFE"/>
-				<box leftPadding="5" rightPadding="5">
+			</element>
+			<element kind="textField" uuid="68ae105a-8a35-46a3-a3dc-6e4c88e6f9ff" x="450" y="0" width="104" height="15" backcolor="#FEFEFE" fontName="Bitstream Vera Sans" fontSize="6.0" hTextAlign="Right" vTextAlign="Middle" style="Total_Gray">
+				<expression><![CDATA[$P{AMOUNTFORMAT}.format($F{FINALSUMMARY})]]></expression>
+				<box leftPadding="5" rightPadding="5" style="Total_Gray">
 					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#959595"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="6"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{AMOUNTFORMAT}.format($F{FINALSUMMARY})]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement style="Total_Gray" x="380" y="0" width="70" height="15" backcolor="#FEFEFE"/>
-				<box leftPadding="5" rightPadding="5">
+			</element>
+			<element kind="textField" uuid="abb5233c-c0ae-42bf-a2dd-843615d1dcf1" x="380" y="0" width="70" height="15" backcolor="#FEFEFE" fontName="Bitstream Vera Sans" fontSize="6.0" hTextAlign="Right" vTextAlign="Middle" style="Total_Gray">
+				<expression><![CDATA[$P{AMOUNTFORMAT}.format($F{PAYMENT}==null?BigDecimal.ZERO:$F{PAYMENT})]]></expression>
+				<box leftPadding="5" rightPadding="5" style="Total_Gray">
 					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="6"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{AMOUNTFORMAT}.format($F{PAYMENT}==null?BigDecimal.ZERO:$F{PAYMENT})]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement style="Total_Gray" x="0" y="0" width="187" height="15" backcolor="#FEFEFE"/>
-				<box leftPadding="5" rightPadding="5">
+			</element>
+			<element kind="textField" uuid="192f6de5-5014-4644-9a60-14dc6cf92741" x="0" y="0" width="187" height="15" backcolor="#FEFEFE" fontName="Bitstream Vera Sans" fontSize="6.0" vTextAlign="Middle" style="Total_Gray">
+				<expression><![CDATA[$F{FINANCIALACCOUNT}]]></expression>
+				<box leftPadding="5" rightPadding="5" style="Total_Gray">
 					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#959595"/>
 					<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#959595"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="6"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{FINANCIALACCOUNT}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="15"/>
-				<graphicElement>
-					<pen lineColor="#959595"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement stretchType="RelativeToBandHeight" x="554" y="0" width="1" height="15"/>
-				<graphicElement>
-					<pen lineColor="#959595"/>
-				</graphicElement>
-			</line>
+			</element>
+			<element kind="line" uuid="f4cb59e5-6231-4459-ba47-acb6c31e011c" stretchType="ContainerHeight" x="0" y="0" width="1" height="15">
+				<pen lineColor="#959595"/>
+			</element>
+			<element kind="line" uuid="2f2cef99-81d5-4336-b2b5-0fed5a19c303" stretchType="ContainerHeight" x="554" y="0" width="1" height="15">
+				<pen lineColor="#959595"/>
+			</element>
 		</band>
 	</detail>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/CustomerStatement.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/CustomerStatement.jrxml
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
-<!-- 2025-05-08T11:05:44 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Customer Statement" pageWidth="595" pageHeight="842" whenNoDataType="AllSectionsNoDetail" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="497a0ae3-5aac-448b-a8a4-4b6619407498">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="Customer Statement" language="java" pageWidth="595" pageHeight="842" whenNoDataType="AllSectionsNoDetail" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="497a0ae3-5aac-448b-a8a4-4b6619407498">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
@@ -9,60 +7,59 @@
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
 	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="org.openbravo.erpCommon.ReportsUtility"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>org.openbravo.erpCommon.ReportsUtility</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["http://localhost:8080/openbravo/web"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/home/openbravo/servers/tomcat6/webapps/openbravo/src-loc/design"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["('1000000')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["('0')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
 	<parameter name="C_BPartner_ID" class="java.lang.String"/>
 	<parameter name="C_AcctSchema_ID" class="java.lang.String"/>
 	<parameter name="DateFrom" class="java.lang.String"/>
@@ -74,8 +71,7 @@
 	<parameter name="reportType" class="java.lang.String"/>
 	<parameter name="sumInitialBalance" class="java.lang.String"/>
 	<parameter name="Multicurrency" class="java.lang.String"/>
-	<queryString language="SQL">
-		<![CDATA[SELECT trunc(f.dateacct) as dateacct,
+	<query language="SQL"><![CDATA[SELECT trunc(f.dateacct) as dateacct,
         CASE WHEN f.c_doctype_id IS NOT NULL THEN (SELECT MIN(name)
                                        FROM c_doctype
                                        WHERE c_doctype_id = f.c_doctype_id)
@@ -149,8 +145,7 @@ WHERE o.ad_org_id=$P{AD_Org_ID}
     AND trunc(f.dateacct) <= (CASE WHEN ($P{DateTo} IS NULL OR $P{DateTo}='') THEN TO_DATE('09-09-9999')
         ELSE TO_DATE($P{DateTo}) END)
     AND f.ad_table_id not IN ('145')
-ORDER BY currency_id, issotrx, f.dateacct, f.created]]>
-	</queryString>
+ORDER BY currency_id, issotrx, f.dateacct, f.created]]></query>
 	<field name="org_address" class="java.lang.String"/>
 	<field name="org_postal" class="java.lang.String"/>
 	<field name="dateacct" class="java.util.Date"/>
@@ -164,458 +159,259 @@ ORDER BY currency_id, issotrx, f.dateacct, f.created]]>
 	<field name="credit" class="java.math.BigDecimal"/>
 	<field name="net" class="java.math.BigDecimal"/>
 	<field name="currency_id" class="java.lang.String">
-		<fieldDescription><![CDATA[]]></fieldDescription>
+		<description><![CDATA[]]></description>
 	</field>
 	<field name="currency_code" class="java.lang.String">
-		<fieldDescription><![CDATA[]]></fieldDescription>
+		<description><![CDATA[]]></description>
 	</field>
 	<field name="currency_name" class="java.lang.String">
-		<fieldDescription><![CDATA[]]></fieldDescription>
+		<description><![CDATA[]]></description>
 	</field>
 	<field name="issotrx" class="java.lang.String"/>
-	<variable name="SUM" class="java.math.BigDecimal" resetType="Group" resetGroup="Sales / Purchase" calculation="Sum">
-		<variableExpression><![CDATA[$F{net}]]></variableExpression>
+	<variable name="SUM" resetType="Group" calculation="Sum" resetGroup="Sales / Purchase" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{net}]]></expression>
 	</variable>
-	<variable name="DateFrom" class="java.util.Date" calculation="Lowest">
-		<variableExpression><![CDATA[$F{dateacct}]]></variableExpression>
+	<variable name="DateFrom" calculation="Lowest" class="java.util.Date">
+		<expression><![CDATA[$F{dateacct}]]></expression>
 	</variable>
-	<variable name="DateTo" class="java.util.Date" calculation="Highest">
-		<variableExpression><![CDATA[$F{dateacct}]]></variableExpression>
+	<variable name="DateTo" calculation="Highest" class="java.util.Date">
+		<expression><![CDATA[$F{dateacct}]]></expression>
 	</variable>
-	<variable name="customerInitialBalance" class="java.math.BigDecimal" resetType="Group" resetGroup="Currency">
-		<variableExpression><![CDATA[ReportsUtility.getBeginningBalance($P{AD_Org_ID}, $P{C_AcctSchema_ID}, $P{C_BPartner_ID}, $P{DateFrom}, true, $F{currency_id})]]></variableExpression>
+	<variable name="customerInitialBalance" resetType="Group" resetGroup="Currency" class="java.math.BigDecimal">
+		<expression><![CDATA[ReportsUtility.getBeginningBalance($P{AD_Org_ID}, $P{C_AcctSchema_ID}, $P{C_BPartner_ID}, $P{DateFrom}, true, $F{currency_id})]]></expression>
 	</variable>
-	<variable name="customerBalance" class="java.math.BigDecimal" resetType="Group" resetGroup="Sales / Purchase">
-		<variableExpression><![CDATA[$V{customerInitialBalance}.add($V{SUM})]]></variableExpression>
+	<variable name="customerBalance" resetType="Group" resetGroup="Sales / Purchase" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{customerInitialBalance}.add($V{SUM})]]></expression>
 	</variable>
-	<variable name="vendorInitialBalance" class="java.math.BigDecimal" resetType="Group" resetGroup="Currency">
-		<variableExpression><![CDATA[ReportsUtility.getBeginningBalance($P{AD_Org_ID}, $P{C_AcctSchema_ID}, $P{C_BPartner_ID}, $P{DateFrom}, false, $F{currency_id})]]></variableExpression>
+	<variable name="vendorInitialBalance" resetType="Group" resetGroup="Currency" class="java.math.BigDecimal">
+		<expression><![CDATA[ReportsUtility.getBeginningBalance($P{AD_Org_ID}, $P{C_AcctSchema_ID}, $P{C_BPartner_ID}, $P{DateFrom}, false, $F{currency_id})]]></expression>
 	</variable>
-	<variable name="vendorBalance" class="java.math.BigDecimal" resetType="Group" resetGroup="Sales / Purchase">
-		<variableExpression><![CDATA[$V{vendorInitialBalance}.add($V{SUM})]]></variableExpression>
+	<variable name="vendorBalance" resetType="Group" resetGroup="Sales / Purchase" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{vendorInitialBalance}.add($V{SUM})]]></expression>
 	</variable>
-	<variable name="TOTALSUM" class="java.math.BigDecimal" resetType="Group" resetGroup="Currency" calculation="Sum">
-		<variableExpression><![CDATA[$F{net}]]></variableExpression>
+	<variable name="TOTALSUM" resetType="Group" calculation="Sum" resetGroup="Currency" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{net}]]></expression>
 	</variable>
-	<variable name="totalBalance" class="java.math.BigDecimal" resetType="Group" resetGroup="Currency">
-		<variableExpression><![CDATA[$V{TOTALSUM}.add($V{customerInitialBalance}).add($V{vendorInitialBalance})]]></variableExpression>
+	<variable name="totalBalance" resetType="Group" resetGroup="Currency" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{TOTALSUM}.add($V{customerInitialBalance}).add($V{vendorInitialBalance})]]></expression>
 	</variable>
-	<variable name="totalInitialBalance" class="java.math.BigDecimal" resetType="Group" resetGroup="Currency">
-		<variableExpression><![CDATA[$V{vendorInitialBalance}.add($V{customerInitialBalance})]]></variableExpression>
+	<variable name="totalInitialBalance" resetType="Group" resetGroup="Currency" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{vendorInitialBalance}.add($V{customerInitialBalance})]]></expression>
 	</variable>
-	<group name="PrintLarge" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintLarge" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 	</group>
-	<group name="PrintMedium" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintMedium" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 	</group>
-	<group name="Currency" isStartNewPage="true">
-		<groupExpression><![CDATA[$F{currency_id}]]></groupExpression>
+	<group name="Currency" startNewPage="true">
+		<expression><![CDATA[$F{currency_id}]]></expression>
 		<groupHeader>
 			<band height="65">
-				<property name="com.jaspersoft.studio.layout" value="com.jaspersoft.studio.editor.layout.FreeLayout"/>
 				<printWhenExpression><![CDATA["Y".equals($P{Multicurrency})]]></printWhenExpression>
-				<textField>
-					<reportElement x="80" y="34" width="47" height="29" uuid="688616ea-456f-4d6f-bc04-0c3e5066ae6b">
-						<property name="local_mesure_unitheight" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.height" value="px"/>
-					</reportElement>
-					<textElement verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="16"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{currency_code}]]></textFieldExpression>
-				</textField>
-				<textField>
-					<reportElement x="127" y="34" width="243" height="29" uuid="f8b29d19-412a-4998-8f35-03550e7d78eb">
-						<property name="local_mesure_unitheight" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.height" value="px"/>
-					</reportElement>
-					<textElement verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="16"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{currency_name}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement x="0" y="34" width="80" height="29" uuid="003bd68e-0af5-4a3d-a985-7aefb853337f"/>
-					<textElement verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="16" isBold="false"/>
-					</textElement>
+				<element kind="textField" uuid="688616ea-456f-4d6f-bc04-0c3e5066ae6b" x="80" y="34" width="47" height="29" fontName="DejaVu Sans" fontSize="16.0" vTextAlign="Middle">
+					<expression><![CDATA[$F{currency_code}]]></expression>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</element>
+				<element kind="textField" uuid="f8b29d19-412a-4998-8f35-03550e7d78eb" x="127" y="34" width="243" height="29" fontName="DejaVu Sans" fontSize="16.0" vTextAlign="Middle">
+					<expression><![CDATA[$F{currency_name}]]></expression>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</element>
+				<element kind="staticText" uuid="003bd68e-0af5-4a3d-a985-7aefb853337f" x="0" y="34" width="80" height="29" fontName="DejaVu Sans" fontSize="16.0" bold="false" vTextAlign="Middle">
 					<text><![CDATA[Currency]]></text>
-				</staticText>
-				<line>
-					<reportElement x="0" y="30" width="555" height="1" uuid="3928cbc2-8a16-499c-8baa-fb72b379b792"/>
-				</line>
+				</element>
+				<element kind="line" uuid="3928cbc2-8a16-499c-8baa-fb72b379b792" x="0" y="30" width="555" height="1"/>
+				<property name="com.jaspersoft.studio.layout" value="com.jaspersoft.studio.editor.layout.FreeLayout"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="67">
 				<printWhenExpression><![CDATA[$P{reportType}.equals("both")]]></printWhenExpression>
-				<line>
-					<reportElement x="236" y="47" width="320" height="3" uuid="382bf123-c27c-426b-a320-1a2df3a239e9"/>
-				</line>
-				<line>
-					<reportElement x="236" y="45" width="320" height="3" uuid="5d70d63d-44fd-446f-ba3f-04bfa9101df7"/>
-				</line>
-				<staticText>
-					<reportElement positionType="Float" mode="Opaque" x="236" y="32" width="210" height="15" isPrintWhenDetailOverflows="true" forecolor="#000000" backcolor="#FFFFFF" uuid="4b7939f4-7137-4121-a9e9-687b1e20cc84"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle" rotation="None" markup="none">
-						<font fontName="DejaVu Sans" size="10" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-						<paragraph lineSpacing="Single"/>
-					</textElement>
+				<element kind="line" uuid="382bf123-c27c-426b-a320-1a2df3a239e9" x="236" y="47" width="320" height="3"/>
+				<element kind="line" uuid="5d70d63d-44fd-446f-ba3f-04bfa9101df7" x="236" y="45" width="320" height="3"/>
+				<element kind="staticText" uuid="4b7939f4-7137-4121-a9e9-687b1e20cc84" positionType="Float" mode="Opaque" x="236" y="32" width="210" height="15" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" printWhenDetailOverflows="true" pdfEmbedded="false" underline="false" strikeThrough="false" bold="true" italic="false" hTextAlign="Right" vTextAlign="Middle">
+					<paragraph lineSpacing="Single"/>
 					<text><![CDATA[Business Partner Balance :]]></text>
-				</staticText>
-				<line>
-					<reportElement x="236" y="17" width="320" height="1" uuid="cd37578f-91ec-4417-ad1c-e1f2889f6d6a"/>
-				</line>
-				<textField evaluationTime="Group" evaluationGroup="Sales / Purchase" pattern="" isBlankWhenNull="true">
-					<reportElement positionType="Float" mode="Transparent" x="446" y="32" width="110" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="3d009a3e-d394-4eba-a4f7-7b29d5b99f74"/>
-					<box rightPadding="5"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle" rotation="None" markup="none">
-						<font fontName="DejaVu Sans" size="10" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-						<paragraph lineSpacing="Single"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{totalBalance}.compareTo(BigDecimal.ZERO) < 0 ? $V{totalBalance}.abs() : $V{totalBalance}]]></textFieldExpression>
+				</element>
+				<element kind="line" uuid="cd37578f-91ec-4417-ad1c-e1f2889f6d6a" x="236" y="17" width="320" height="1"/>
+				<element kind="textField" uuid="3d009a3e-d394-4eba-a4f7-7b29d5b99f74" positionType="Float" mode="Transparent" x="446" y="32" width="110" height="15" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" evaluationTime="Group" pattern="" evaluationGroup="Sales / Purchase" blankWhenNull="true" pdfEmbedded="false" underline="false" strikeThrough="false" bold="true" italic="false" hTextAlign="Right" vTextAlign="Middle">
+					<paragraph lineSpacing="Single"/>
+					<expression><![CDATA[$V{totalBalance}.compareTo(BigDecimal.ZERO) < 0 ? $V{totalBalance}.abs() : $V{totalBalance}]]></expression>
 					<patternExpression><![CDATA[$V{totalBalance}.compareTo(BigDecimal.ZERO) < 0 ? ("("+$P{NUMBERFORMAT}.toPattern()+")") : $P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<staticText>
-					<reportElement x="236" y="3" width="210" height="14" isPrintWhenDetailOverflows="true" forecolor="#000000" backcolor="#FFFFFF" uuid="62499066-a0e4-46b3-bd28-3e611823c5dd"/>
-					<textElement textAlignment="Right" verticalAlignment="Top">
-						<font fontName="DejaVu Sans" size="10" isBold="true"/>
-					</textElement>
+					<box rightPadding="5"/>
+				</element>
+				<element kind="staticText" uuid="62499066-a0e4-46b3-bd28-3e611823c5dd" x="236" y="3" width="210" height="14" forecolor="#000000" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="10.0" printWhenDetailOverflows="true" bold="true" hTextAlign="Right" vTextAlign="Top">
 					<text><![CDATA[Business Partner Initial Balance :]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" evaluationTime="Group" evaluationGroup="Sales / Purchase" pattern="" isBlankWhenNull="true">
-					<reportElement style="Detail_Line" stretchType="RelativeToTallestObject" mode="Transparent" x="446" y="3" width="110" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="db8ea373-d4a6-4a80-9543-edb9914382c4"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle" rotation="None" markup="none">
-						<font fontName="DejaVu Sans" size="10" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-						<paragraph lineSpacing="Single"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{totalInitialBalance}.compareTo(BigDecimal.ZERO) < 0 ? $V{totalInitialBalance}.abs() : $V{totalInitialBalance}]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="db8ea373-d4a6-4a80-9543-edb9914382c4" stretchType="ElementGroupHeight" mode="Transparent" x="446" y="3" width="110" height="14" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" textAdjust="StretchHeight" evaluationTime="Group" pattern="" evaluationGroup="Sales / Purchase" blankWhenNull="true" pdfEmbedded="false" underline="false" strikeThrough="false" bold="true" italic="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+					<paragraph lineSpacing="Single" style="Detail_Line"/>
+					<expression><![CDATA[$V{totalInitialBalance}.compareTo(BigDecimal.ZERO) < 0 ? $V{totalInitialBalance}.abs() : $V{totalInitialBalance}]]></expression>
 					<patternExpression><![CDATA[$V{totalInitialBalance}.compareTo(BigDecimal.ZERO) < 0 ? ("("+$P{NUMBERFORMAT}.toPattern()+")") : $P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<group name="Sales / Purchase" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[$F{issotrx}]]></groupExpression>
+	<group name="Sales / Purchase" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[$F{issotrx}]]></expression>
 		<groupHeader>
 			<band height="78">
-				<textField isStretchWithOverflow="true" evaluationTime="Group" evaluationGroup="Sales / Purchase" pattern="" isBlankWhenNull="true">
-					<reportElement style="Detail_Line" stretchType="RelativeToTallestObject" mode="Transparent" x="446" y="56" width="110" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="bab14b42-0911-481b-84b2-200ab637a727">
-						<printWhenExpression><![CDATA[($P{reportType}.equals("cus")) || ($P{reportType}.equals("both") && $F{issotrx}.equals("Y"))]]></printWhenExpression>
-					</reportElement>
-					<textElement textAlignment="Right" verticalAlignment="Middle" rotation="None" markup="none">
-						<font fontName="DejaVu Sans" size="10" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-						<paragraph lineSpacing="Single"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{customerInitialBalance}.compareTo(BigDecimal.ZERO) < 0 ?  $V{customerInitialBalance}.abs() : $V{customerInitialBalance}]]></textFieldExpression>
+				<element kind="textField" uuid="bab14b42-0911-481b-84b2-200ab637a727" stretchType="ElementGroupHeight" mode="Transparent" x="446" y="56" width="110" height="14" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" textAdjust="StretchHeight" evaluationTime="Group" pattern="" evaluationGroup="Sales / Purchase" blankWhenNull="true" pdfEmbedded="false" underline="false" strikeThrough="false" bold="true" italic="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+					<printWhenExpression><![CDATA[($P{reportType}.equals("cus")) || ($P{reportType}.equals("both") && $F{issotrx}.equals("Y"))]]></printWhenExpression>
+					<paragraph lineSpacing="Single" style="Detail_Line"/>
+					<expression><![CDATA[$V{customerInitialBalance}.compareTo(BigDecimal.ZERO) < 0 ?  $V{customerInitialBalance}.abs() : $V{customerInitialBalance}]]></expression>
 					<patternExpression><![CDATA[$V{customerInitialBalance}.compareTo(BigDecimal.ZERO) < 0 ? ("("+$P{NUMBERFORMAT}.toPattern()+")") : $P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<staticText>
-					<reportElement x="331" y="56" width="115" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="b7fa0a14-eaf8-4ba3-8f63-b539a95d5c7f"/>
-					<textElement textAlignment="Right" verticalAlignment="Top">
-						<font fontName="DejaVu Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="b7fa0a14-eaf8-4ba3-8f63-b539a95d5c7f" x="331" y="56" width="115" height="14" forecolor="#000000" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="10.0" bold="true" hTextAlign="Right" vTextAlign="Top">
 					<text><![CDATA[Initial Balance :]]></text>
-				</staticText>
-				<line>
-					<reportElement x="331" y="70" width="225" height="1" uuid="0324ab00-5242-4117-bc12-2413a8568017"/>
-				</line>
-				<staticText>
-					<reportElement x="0" y="7" width="330" height="20" forecolor="#595959" uuid="bfae711e-d1a9-41a6-ab3e-ee8818f58e76">
-						<printWhenExpression><![CDATA[$P{reportType}.equals("both") && $F{issotrx}.equals("Y")]]></printWhenExpression>
-					</reportElement>
-					<textElement>
-						<font fontName="DejaVu Sans" size="16"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="0324ab00-5242-4117-bc12-2413a8568017" x="331" y="70" width="225" height="1"/>
+				<element kind="staticText" uuid="bfae711e-d1a9-41a6-ab3e-ee8818f58e76" x="0" y="7" width="330" height="20" forecolor="#595959" fontName="DejaVu Sans" fontSize="16.0">
+					<printWhenExpression><![CDATA[$P{reportType}.equals("both") && $F{issotrx}.equals("Y")]]></printWhenExpression>
 					<text><![CDATA[Customer Statement]]></text>
-				</staticText>
-				<staticText>
-					<reportElement x="128" y="36" width="202" height="13" isPrintWhenDetailOverflows="true" forecolor="#000000" backcolor="#FFFFFF" uuid="6c954583-0980-4275-b5c6-94726deb66fb"/>
-					<textElement textAlignment="Left" verticalAlignment="Top">
-						<font fontName="DejaVu Sans" size="8" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="6c954583-0980-4275-b5c6-94726deb66fb" x="128" y="36" width="202" height="13" forecolor="#000000" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="8.0" printWhenDetailOverflows="true" bold="true" hTextAlign="Left" vTextAlign="Top">
 					<text><![CDATA[Description]]></text>
-				</staticText>
-				<staticText>
-					<reportElement x="0" y="36" width="47" height="13" isPrintWhenDetailOverflows="true" forecolor="#000000" backcolor="#FFFFFF" uuid="41e42641-3f87-4355-9e24-f48fe98633d1"/>
-					<textElement verticalAlignment="Top">
-						<font fontName="DejaVu Sans" size="8" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="41e42641-3f87-4355-9e24-f48fe98633d1" x="0" y="36" width="47" height="13" forecolor="#000000" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="8.0" printWhenDetailOverflows="true" bold="true" vTextAlign="Top">
 					<text><![CDATA[Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement x="47" y="36" width="81" height="13" isPrintWhenDetailOverflows="true" forecolor="#000000" backcolor="#FFFFFF" uuid="2684e5bb-9e7f-4006-9a50-334a26bc8144"/>
-					<textElement textAlignment="Left" verticalAlignment="Top">
-						<font fontName="DejaVu Sans" size="8" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="2684e5bb-9e7f-4006-9a50-334a26bc8144" x="47" y="36" width="81" height="13" forecolor="#000000" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="8.0" printWhenDetailOverflows="true" bold="true" hTextAlign="Left" vTextAlign="Top">
 					<text><![CDATA[Document Type]]></text>
-				</staticText>
-				<staticText>
-					<reportElement x="330" y="36" width="75" height="13" isPrintWhenDetailOverflows="true" forecolor="#000000" backcolor="#FFFFFF" uuid="1a9426e0-9cd4-444a-84e4-2ef7f31d0115"/>
-					<textElement textAlignment="Right" verticalAlignment="Top">
-						<font fontName="DejaVu Sans" size="8" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="1a9426e0-9cd4-444a-84e4-2ef7f31d0115" x="330" y="36" width="75" height="13" forecolor="#000000" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="8.0" printWhenDetailOverflows="true" bold="true" hTextAlign="Right" vTextAlign="Top">
 					<text><![CDATA[Debit]]></text>
-				</staticText>
-				<staticText>
-					<reportElement x="405" y="36" width="75" height="13" isPrintWhenDetailOverflows="true" forecolor="#000000" backcolor="#FFFFFF" uuid="a6803da0-801c-473c-9122-0fdae0ad6b4c"/>
-					<textElement textAlignment="Right" verticalAlignment="Top">
-						<font fontName="DejaVu Sans" size="8" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="a6803da0-801c-473c-9122-0fdae0ad6b4c" x="405" y="36" width="75" height="13" forecolor="#000000" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="8.0" printWhenDetailOverflows="true" bold="true" hTextAlign="Right" vTextAlign="Top">
 					<text><![CDATA[Credit]]></text>
-				</staticText>
-				<staticText>
-					<reportElement x="480" y="36" width="75" height="13" isPrintWhenDetailOverflows="true" forecolor="#000000" backcolor="#FFFFFF" uuid="550e60d2-54e1-410d-8059-90e8bc32ac01"/>
-					<textElement textAlignment="Right" verticalAlignment="Top">
-						<font fontName="DejaVu Sans" size="8" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="550e60d2-54e1-410d-8059-90e8bc32ac01" x="480" y="36" width="75" height="13" forecolor="#000000" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="8.0" printWhenDetailOverflows="true" bold="true" hTextAlign="Right" vTextAlign="Top">
 					<text><![CDATA[Net]]></text>
-				</staticText>
-				<line>
-					<reportElement x="0" y="49" width="555" height="1" uuid="750cccdd-cdc1-4e35-8fef-cd0bc3440eff"/>
-				</line>
-				<staticText>
-					<reportElement stretchType="RelativeToBandHeight" x="1" y="7" width="330" height="20" forecolor="#595959" uuid="fcaab7ce-176e-4b44-81c4-a9df9f2bb719">
-						<printWhenExpression><![CDATA[$P{reportType}.equals("both") && $F{issotrx}.equals("N")]]></printWhenExpression>
-					</reportElement>
-					<textElement markup="html">
-						<font fontName="DejaVu Sans" size="16"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="750cccdd-cdc1-4e35-8fef-cd0bc3440eff" x="0" y="49" width="555" height="1"/>
+				<element kind="staticText" uuid="fcaab7ce-176e-4b44-81c4-a9df9f2bb719" stretchType="ContainerHeight" x="1" y="7" width="330" height="20" forecolor="#595959" markup="html" fontName="DejaVu Sans" fontSize="16.0">
+					<printWhenExpression><![CDATA[$P{reportType}.equals("both") && $F{issotrx}.equals("N")]]></printWhenExpression>
 					<text><![CDATA[Vendor Statement]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" evaluationTime="Group" evaluationGroup="Sales / Purchase" pattern="" isBlankWhenNull="true">
-					<reportElement style="Detail_Line" stretchType="RelativeToTallestObject" mode="Transparent" x="446" y="56" width="110" height="14" forecolor="#000000" backcolor="#FFFFFF" uuid="0af3ed56-3508-44dd-aeb6-4e3ff0c30acd">
-						<printWhenExpression><![CDATA[($P{reportType}.equals("ven")) || ($P{reportType}.equals("both") && $F{issotrx}.equals("N"))]]></printWhenExpression>
-					</reportElement>
-					<textElement textAlignment="Right" verticalAlignment="Middle" rotation="None" markup="none">
-						<font fontName="DejaVu Sans" size="10" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-						<paragraph lineSpacing="Single"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{vendorInitialBalance}.compareTo(BigDecimal.ZERO) < 0 ? $V{vendorInitialBalance}.abs() : $V{vendorInitialBalance}]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="0af3ed56-3508-44dd-aeb6-4e3ff0c30acd" stretchType="ElementGroupHeight" mode="Transparent" x="446" y="56" width="110" height="14" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" textAdjust="StretchHeight" evaluationTime="Group" pattern="" evaluationGroup="Sales / Purchase" blankWhenNull="true" pdfEmbedded="false" underline="false" strikeThrough="false" bold="true" italic="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+					<printWhenExpression><![CDATA[($P{reportType}.equals("ven")) || ($P{reportType}.equals("both") && $F{issotrx}.equals("N"))]]></printWhenExpression>
+					<paragraph lineSpacing="Single" style="Detail_Line"/>
+					<expression><![CDATA[$V{vendorInitialBalance}.compareTo(BigDecimal.ZERO) < 0 ? $V{vendorInitialBalance}.abs() : $V{vendorInitialBalance}]]></expression>
 					<patternExpression><![CDATA[$V{vendorInitialBalance}.compareTo(BigDecimal.ZERO) < 0 ? ("("+$P{NUMBERFORMAT}.toPattern()+")") : $P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="44">
-				<textField evaluationTime="Group" evaluationGroup="Sales / Purchase" pattern="" isBlankWhenNull="true">
-					<reportElement positionType="Float" mode="Transparent" x="445" y="12" width="110" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="a75fd489-5f32-4dba-adc8-d961d69350fe">
-						<printWhenExpression><![CDATA[($P{reportType}.equals("cus")) || ($P{reportType}.equals("both") && $F{issotrx}.equals("Y"))]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="5"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle" rotation="None" markup="none">
-						<font fontName="DejaVu Sans" size="10" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-						<paragraph lineSpacing="Single"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{customerBalance}.compareTo(BigDecimal.ZERO) < 0 ? $V{customerBalance}.abs() : $V{customerBalance}]]></textFieldExpression>
+				<element kind="textField" uuid="a75fd489-5f32-4dba-adc8-d961d69350fe" positionType="Float" mode="Transparent" x="445" y="12" width="110" height="15" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" evaluationTime="Group" pattern="" evaluationGroup="Sales / Purchase" blankWhenNull="true" pdfEmbedded="false" underline="false" strikeThrough="false" bold="true" italic="false" hTextAlign="Right" vTextAlign="Middle">
+					<printWhenExpression><![CDATA[($P{reportType}.equals("cus")) || ($P{reportType}.equals("both") && $F{issotrx}.equals("Y"))]]></printWhenExpression>
+					<paragraph lineSpacing="Single"/>
+					<expression><![CDATA[$V{customerBalance}.compareTo(BigDecimal.ZERO) < 0 ? $V{customerBalance}.abs() : $V{customerBalance}]]></expression>
 					<patternExpression><![CDATA[$V{customerBalance}.compareTo(BigDecimal.ZERO) < 0 ? ("("+$P{NUMBERFORMAT}.toPattern()+")") : $P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<staticText>
-					<reportElement positionType="Float" mode="Opaque" x="330" y="12" width="115" height="15" isPrintWhenDetailOverflows="true" forecolor="#000000" backcolor="#FFFFFF" uuid="8d228eb8-2fde-4f0a-9bfb-b6ee85f1eb54"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle" rotation="None" markup="none">
-						<font fontName="DejaVu Sans" size="10" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-						<paragraph lineSpacing="Single"/>
-					</textElement>
-					<text><![CDATA[Balance :]]></text>
-				</staticText>
-				<line>
-					<reportElement x="330" y="27" width="225" height="1" uuid="ba5bc91e-a835-4136-8823-f5bffa8b544b"/>
-				</line>
-				<line>
-					<reportElement x="330" y="29" width="225" height="1" uuid="d705d5a1-56f8-4f10-80fb-171f41cf12a9"/>
-				</line>
-				<textField evaluationTime="Group" evaluationGroup="Sales / Purchase" pattern="" isBlankWhenNull="true">
-					<reportElement positionType="Float" mode="Transparent" x="445" y="12" width="110" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="5ebb7055-46fa-4b7a-bf93-a40c5a017d07">
-						<printWhenExpression><![CDATA[($P{reportType}.equals("ven")) || ($P{reportType}.equals("both") && $F{issotrx}.equals("N"))]]></printWhenExpression>
-					</reportElement>
 					<box rightPadding="5"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle" rotation="None" markup="none">
-						<font fontName="DejaVu Sans" size="10" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-						<paragraph lineSpacing="Single"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{vendorBalance}.compareTo(BigDecimal.ZERO) < 0 ? $V{vendorBalance}.abs() : $V{vendorBalance}]]></textFieldExpression>
+				</element>
+				<element kind="staticText" uuid="8d228eb8-2fde-4f0a-9bfb-b6ee85f1eb54" positionType="Float" mode="Opaque" x="330" y="12" width="115" height="15" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" printWhenDetailOverflows="true" pdfEmbedded="false" underline="false" strikeThrough="false" bold="true" italic="false" hTextAlign="Right" vTextAlign="Middle">
+					<paragraph lineSpacing="Single"/>
+					<text><![CDATA[Balance :]]></text>
+				</element>
+				<element kind="line" uuid="ba5bc91e-a835-4136-8823-f5bffa8b544b" x="330" y="27" width="225" height="1"/>
+				<element kind="line" uuid="d705d5a1-56f8-4f10-80fb-171f41cf12a9" x="330" y="29" width="225" height="1"/>
+				<element kind="textField" uuid="5ebb7055-46fa-4b7a-bf93-a40c5a017d07" positionType="Float" mode="Transparent" x="445" y="12" width="110" height="15" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" evaluationTime="Group" pattern="" evaluationGroup="Sales / Purchase" blankWhenNull="true" pdfEmbedded="false" underline="false" strikeThrough="false" bold="true" italic="false" hTextAlign="Right" vTextAlign="Middle">
+					<printWhenExpression><![CDATA[($P{reportType}.equals("ven")) || ($P{reportType}.equals("both") && $F{issotrx}.equals("N"))]]></printWhenExpression>
+					<paragraph lineSpacing="Single"/>
+					<expression><![CDATA[$V{vendorBalance}.compareTo(BigDecimal.ZERO) < 0 ? $V{vendorBalance}.abs() : $V{vendorBalance}]]></expression>
 					<patternExpression><![CDATA[$V{vendorBalance}.compareTo(BigDecimal.ZERO) < 0 ? ("("+$P{NUMBERFORMAT}.toPattern()+")") : $P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
+					<box rightPadding="5"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="141" splitType="Stretch">
-			<rectangle>
-				<reportElement key="" x="0" y="0" width="559" height="77" isPrintInFirstWholeBand="true" forecolor="#FFFFFF" backcolor="#FFFFFF" uuid="a61f942d-14ea-46fc-865a-0fd446b65e6f"/>
-			</rectangle>
-			<image scaleImage="RetainShape" hAlign="Center" vAlign="Middle" isUsingCache="true">
-				<reportElement key="image-1" x="10" y="4" width="205" height="55" uuid="73a5995d-9060-4607-b691-814fd83574d6"/>
-				<imageExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylegal", $F{organizationid})]]></imageExpression>
-			</image>
-			<textField>
-				<reportElement x="490" y="48" width="59" height="11" uuid="715f1869-f95e-466f-9cb4-bf0ae163334c"/>
-				<textElement textAlignment="Right" verticalAlignment="Bottom">
-					<font fontName="DejaVu Sans" size="9" isBold="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[DateFormat.getDateInstance(DateFormat.SHORT,
-        $P{LOCALE}).format(new Date())]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="0" y="101" width="371" height="12" uuid="9c171589-afee-4689-82e1-1bf6ef256481"/>
-				<textElement textAlignment="Left" verticalAlignment="Bottom">
-					<font fontName="DejaVu Sans" size="10" isBold="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{bpname}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement x="10" y="59" width="301" height="12" isPrintInFirstWholeBand="true" isPrintWhenDetailOverflows="true" forecolor="#595959" uuid="714e47f3-816e-4fc3-ae02-57bb0a15be40"/>
-				<textElement>
-					<font fontName="DejaVu Sans" size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{org_address}.equals(null)?" ":$F{org_address}) + " " + ($F{org_postal}.equals(null)?" ":$F{org_postal})]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement x="236" y="4" width="313" height="20" forecolor="#595959" uuid="d4dc815c-b252-4559-ad05-71cf8cb0029a">
-					<printWhenExpression><![CDATA[$P{reportType}.equals("cus") && $F{issotrx}.equals("Y")]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right">
-					<font fontName="DejaVu Sans" size="16"/>
-				</textElement>
-				<text><![CDATA[Customer Statement]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="371" y="48" width="119" height="11" isPrintWhenDetailOverflows="true" forecolor="#595959" uuid="27172c38-5715-434d-9031-b5e0bde7fb17"/>
-				<textElement textAlignment="Right">
-					<font fontName="DejaVu Sans" size="9"/>
-				</textElement>
-				<text><![CDATA[Issued]]></text>
-			</staticText>
-			<textField>
-				<reportElement x="515" y="101" width="12" height="12" uuid="a47d2f0f-04c2-44f0-b11d-d0a2a91b159d"/>
-				<textElement textAlignment="Center" verticalAlignment="Bottom">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement x="483" y="101" width="32" height="12" isPrintWhenDetailOverflows="true" uuid="9a3bae21-c7d1-4187-a004-43f58364b284"/>
-				<textElement textAlignment="Center" verticalAlignment="Bottom">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<text><![CDATA[Page]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="527" y="101" width="11" height="12" uuid="7f781088-a5a6-4588-a67e-87ab7281fb70"/>
-				<textElement textAlignment="Justified" verticalAlignment="Bottom">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<text><![CDATA[of]]></text>
-			</staticText>
-			<textField evaluationTime="Report">
-				<reportElement positionType="Float" x="538" y="101" width="12" height="12" uuid="e5239722-8262-456f-901e-2e2f2b4d6c72"/>
-				<textElement textAlignment="Justified" verticalAlignment="Bottom">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement x="0" y="124" width="32" height="12" uuid="bfddfcad-55b3-4e95-9f35-d3fd940bb3b8"/>
-				<textElement verticalAlignment="Bottom">
-					<font fontName="DejaVu Sans" size="10" isBold="false"/>
-				</textElement>
-				<text><![CDATA[From]]></text>
-			</staticText>
-			<textField evaluationTime="Report">
-				<reportElement x="80" y="124" width="45" height="12" uuid="0d10c075-8588-4aba-b65a-7216a84b11ad"/>
-				<textElement textAlignment="Right" verticalAlignment="Bottom">
-					<font fontName="DejaVu Sans" size="10" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{DateFrom} != null ? DateFormat.getDateInstance(DateFormat.SHORT,$P{LOCALE}).format($P{DATEFORMAT}.parse($P{DateFrom}))  : DateFormat.getDateInstance(DateFormat.SHORT,$P{LOCALE}).format($V{DateFrom})]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" isBlankWhenNull="true">
-				<reportElement x="143" y="124" width="45" height="12" uuid="92cbe9ad-289f-4912-b262-215fae340e01"/>
-				<textElement verticalAlignment="Bottom">
-					<font fontName="DejaVu Sans" size="10" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{DateTo}  != null ? DateFormat.getDateInstance(DateFormat.SHORT,$P{LOCALE}).format($P{DATEFORMAT}.parse($P{DateTo})) : DateFormat.getDateInstance(DateFormat.SHORT,$P{LOCALE}).format($V{DateTo})]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement x="125" y="124" width="18" height="12" uuid="5cf7ca7b-3437-4ecb-8a88-06fdc9224186"/>
-				<textElement textAlignment="Center" verticalAlignment="Bottom">
-					<font fontName="DejaVu Sans" size="10" isBold="false"/>
-				</textElement>
-				<text><![CDATA[to]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="235" y="4" width="314" height="20" isPrintWhenDetailOverflows="true" forecolor="#595959" uuid="994be6a7-05b5-4ef9-9577-2ed953b20190">
-					<printWhenExpression><![CDATA[$P{reportType}.equals("ven") && $F{issotrx}.equals("N")]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right">
-					<font fontName="DejaVu Sans" size="16"/>
-				</textElement>
-				<text><![CDATA[Vendor Statement]]></text>
-			</staticText>
-		</band>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader height="141" splitType="Stretch">
+		<element kind="rectangle" uuid="a61f942d-14ea-46fc-865a-0fd446b65e6f" key="" x="0" y="0" width="559" height="77" forecolor="#FFFFFF" backcolor="#FFFFFF" printInFirstWholeBand="true"/>
+		<element kind="image" uuid="73a5995d-9060-4607-b691-814fd83574d6" key="image-1" x="10" y="4" width="205" height="55" scaleImage="RetainShape" usingCache="true" hImageAlign="Center" vImageAlign="Middle">
+			<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylegal", $F{organizationid})]]></expression>
+		</element>
+		<element kind="textField" uuid="715f1869-f95e-466f-9cb4-bf0ae163334c" x="490" y="48" width="59" height="11" fontName="DejaVu Sans" fontSize="9.0" bold="true" hTextAlign="Right" vTextAlign="Bottom">
+			<expression><![CDATA[DateFormat.getDateInstance(DateFormat.SHORT,
+        $P{LOCALE}).format(new Date())]]></expression>
+		</element>
+		<element kind="textField" uuid="9c171589-afee-4689-82e1-1bf6ef256481" x="0" y="101" width="371" height="12" fontName="DejaVu Sans" fontSize="10.0" blankWhenNull="true" bold="true" hTextAlign="Left" vTextAlign="Bottom">
+			<expression><![CDATA[$F{bpname}]]></expression>
+		</element>
+		<element kind="textField" uuid="714e47f3-816e-4fc3-ae02-57bb0a15be40" x="10" y="59" width="301" height="12" forecolor="#595959" fontName="DejaVu Sans" fontSize="9.0" textAdjust="StretchHeight" blankWhenNull="true" printInFirstWholeBand="true" printWhenDetailOverflows="true">
+			<expression><![CDATA[($F{org_address}.equals(null)?" ":$F{org_address}) + " " + ($F{org_postal}.equals(null)?" ":$F{org_postal})]]></expression>
+		</element>
+		<element kind="staticText" uuid="d4dc815c-b252-4559-ad05-71cf8cb0029a" x="236" y="4" width="313" height="20" forecolor="#595959" fontName="DejaVu Sans" fontSize="16.0" hTextAlign="Right">
+			<printWhenExpression><![CDATA[$P{reportType}.equals("cus") && $F{issotrx}.equals("Y")]]></printWhenExpression>
+			<text><![CDATA[Customer Statement]]></text>
+		</element>
+		<element kind="staticText" uuid="27172c38-5715-434d-9031-b5e0bde7fb17" x="371" y="48" width="119" height="11" forecolor="#595959" fontName="DejaVu Sans" fontSize="9.0" printWhenDetailOverflows="true" hTextAlign="Right">
+			<text><![CDATA[Issued]]></text>
+		</element>
+		<element kind="textField" uuid="a47d2f0f-04c2-44f0-b11d-d0a2a91b159d" x="515" y="101" width="12" height="12" fontName="DejaVu Sans" fontSize="8.0" hTextAlign="Center" vTextAlign="Bottom">
+			<expression><![CDATA[$V{PAGE_NUMBER}]]></expression>
+		</element>
+		<element kind="staticText" uuid="9a3bae21-c7d1-4187-a004-43f58364b284" x="483" y="101" width="32" height="12" fontName="DejaVu Sans" fontSize="8.0" printWhenDetailOverflows="true" hTextAlign="Center" vTextAlign="Bottom">
+			<text><![CDATA[Page]]></text>
+		</element>
+		<element kind="staticText" uuid="7f781088-a5a6-4588-a67e-87ab7281fb70" x="527" y="101" width="11" height="12" fontName="DejaVu Sans" fontSize="8.0" hTextAlign="Justified" vTextAlign="Bottom">
+			<text><![CDATA[of]]></text>
+		</element>
+		<element kind="textField" uuid="e5239722-8262-456f-901e-2e2f2b4d6c72" positionType="Float" x="538" y="101" width="12" height="12" fontName="DejaVu Sans" fontSize="8.0" evaluationTime="Report" hTextAlign="Justified" vTextAlign="Bottom">
+			<expression><![CDATA[$V{PAGE_NUMBER}]]></expression>
+		</element>
+		<element kind="staticText" uuid="bfddfcad-55b3-4e95-9f35-d3fd940bb3b8" x="0" y="124" width="32" height="12" fontName="DejaVu Sans" fontSize="10.0" bold="false" vTextAlign="Bottom">
+			<text><![CDATA[From]]></text>
+		</element>
+		<element kind="textField" uuid="0d10c075-8588-4aba-b65a-7216a84b11ad" x="80" y="124" width="45" height="12" fontName="DejaVu Sans" fontSize="10.0" evaluationTime="Report" bold="false" hTextAlign="Right" vTextAlign="Bottom">
+			<expression><![CDATA[$P{DateFrom} != null ? DateFormat.getDateInstance(DateFormat.SHORT,$P{LOCALE}).format($P{DATEFORMAT}.parse($P{DateFrom}))  : DateFormat.getDateInstance(DateFormat.SHORT,$P{LOCALE}).format($V{DateFrom})]]></expression>
+		</element>
+		<element kind="textField" uuid="92cbe9ad-289f-4912-b262-215fae340e01" x="143" y="124" width="45" height="12" fontName="DejaVu Sans" fontSize="10.0" evaluationTime="Report" blankWhenNull="true" bold="false" vTextAlign="Bottom">
+			<expression><![CDATA[$P{DateTo}  != null ? DateFormat.getDateInstance(DateFormat.SHORT,$P{LOCALE}).format($P{DATEFORMAT}.parse($P{DateTo})) : DateFormat.getDateInstance(DateFormat.SHORT,$P{LOCALE}).format($V{DateTo})]]></expression>
+		</element>
+		<element kind="staticText" uuid="5cf7ca7b-3437-4ecb-8a88-06fdc9224186" x="125" y="124" width="18" height="12" fontName="DejaVu Sans" fontSize="10.0" bold="false" hTextAlign="Center" vTextAlign="Bottom">
+			<text><![CDATA[to]]></text>
+		</element>
+		<element kind="staticText" uuid="994be6a7-05b5-4ef9-9577-2ed953b20190" x="235" y="4" width="314" height="20" forecolor="#595959" fontName="DejaVu Sans" fontSize="16.0" printWhenDetailOverflows="true" hTextAlign="Right">
+			<printWhenExpression><![CDATA[$P{reportType}.equals("ven") && $F{issotrx}.equals("N")]]></printWhenExpression>
+			<text><![CDATA[Vendor Statement]]></text>
+		</element>
 	</pageHeader>
 	<detail>
 		<band height="17">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement stretchType="RelativeToTallestObject" x="0" y="0" width="47" height="14" uuid="9c631d3f-0a97-4b1a-91da-50e30e36d6f5"/>
+			<element kind="textField" uuid="9c631d3f-0a97-4b1a-91da-50e30e36d6f5" stretchType="ElementGroupHeight" x="0" y="0" width="47" height="14" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" vTextAlign="Middle">
+				<paragraph lineSpacing="1_1_2"/>
+				<expression><![CDATA[DateFormat.getDateInstance(DateFormat.SHORT,
+        $P{LOCALE}).format($F{dateacct})]]></expression>
 				<box leftPadding="3"/>
-				<textElement verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8"/>
-					<paragraph lineSpacing="1_1_2"/>
-				</textElement>
-				<textFieldExpression><![CDATA[DateFormat.getDateInstance(DateFormat.SHORT,
-        $P{LOCALE}).format($F{dateacct})]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement stretchType="RelativeToTallestObject" x="47" y="0" width="81" height="14" uuid="e2f6368f-f0af-4bf7-83a2-79d74f1f5b6a"/>
-				<textElement verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8"/>
-					<paragraph lineSpacing="1_1_2"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{documenttype}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement stretchType="RelativeToTallestObject" x="128" y="0" width="202" height="14" uuid="67088f29-11e9-4552-8f4f-bf88390a29d8"/>
-				<textElement verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8"/>
-					<paragraph lineSpacing="1_1_2"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{description}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement stretchType="RelativeToTallestObject" x="405" y="0" width="75" height="14" uuid="37b11b94-f0ef-4332-a602-0addfc0a8980"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8"/>
-					<paragraph lineSpacing="1_1_2"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{credit}.compareTo(BigDecimal.ZERO) < 0 ? $F{credit}.abs() : $F{credit}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="e2f6368f-f0af-4bf7-83a2-79d74f1f5b6a" stretchType="ElementGroupHeight" x="47" y="0" width="81" height="14" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" vTextAlign="Middle">
+				<paragraph lineSpacing="1_1_2"/>
+				<expression><![CDATA[$F{documenttype}]]></expression>
+			</element>
+			<element kind="textField" uuid="67088f29-11e9-4552-8f4f-bf88390a29d8" stretchType="ElementGroupHeight" x="128" y="0" width="202" height="14" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" vTextAlign="Middle">
+				<paragraph lineSpacing="1_1_2"/>
+				<expression><![CDATA[$F{description}]]></expression>
+			</element>
+			<element kind="textField" uuid="37b11b94-f0ef-4332-a602-0addfc0a8980" stretchType="ElementGroupHeight" x="405" y="0" width="75" height="14" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<paragraph lineSpacing="1_1_2"/>
+				<expression><![CDATA[$F{credit}.compareTo(BigDecimal.ZERO) < 0 ? $F{credit}.abs() : $F{credit}]]></expression>
 				<patternExpression><![CDATA[$F{credit}.compareTo(BigDecimal.ZERO) < 0 ? ("("+$P{NUMBERFORMAT}.toPattern()+")") : $P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement stretchType="RelativeToTallestObject" x="330" y="0" width="75" height="14" uuid="b9cb19fe-6b55-4c0c-9089-a3c3c8e88223"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8"/>
-					<paragraph lineSpacing="1_1_2"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{debit}.compareTo(BigDecimal.ZERO) < 0 ? $F{debit}.abs() : $F{debit}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="b9cb19fe-6b55-4c0c-9089-a3c3c8e88223" stretchType="ElementGroupHeight" x="330" y="0" width="75" height="14" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<paragraph lineSpacing="1_1_2"/>
+				<expression><![CDATA[$F{debit}.compareTo(BigDecimal.ZERO) < 0 ? $F{debit}.abs() : $F{debit}]]></expression>
 				<patternExpression><![CDATA[$F{debit}.compareTo(BigDecimal.ZERO) < 0 ? ("("+$P{NUMBERFORMAT}.toPattern()+")") : $P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement stretchType="RelativeToTallestObject" x="480" y="0" width="75" height="14" uuid="50a77f9b-8c48-4f56-837c-590c02bf0166"/>
-				<box rightPadding="3"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8"/>
-					<paragraph lineSpacing="1_1_2"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Y".equals($P{sumInitialBalance}) ? new BigDecimal("Y".equals($F{issotrx}) ? $V{customerInitialBalance}.toString() : $V{vendorInitialBalance}.toString()).add($V{SUM}).abs() : $V{SUM}.abs()]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="50a77f9b-8c48-4f56-837c-590c02bf0166" stretchType="ElementGroupHeight" x="480" y="0" width="75" height="14" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<paragraph lineSpacing="1_1_2"/>
+				<expression><![CDATA["Y".equals($P{sumInitialBalance}) ? new BigDecimal("Y".equals($F{issotrx}) ? $V{customerInitialBalance}.toString() : $V{vendorInitialBalance}.toString()).add($V{SUM}).abs() : $V{SUM}.abs()]]></expression>
 				<patternExpression><![CDATA[new BigDecimal("Y".equals($P{sumInitialBalance}) ? new BigDecimal("Y".equals($F{issotrx}) ? $V{customerInitialBalance}.toString() : $V{vendorInitialBalance}.toString()).add($V{SUM}).toString() : $V{SUM}.toString()).compareTo(BigDecimal.ZERO) < 0 ? ("("+$P{NUMBERFORMAT}.toPattern()+")") : $P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-			</textField>
+				<box rightPadding="3"/>
+			</element>
 		</band>
 	</detail>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/GeneralAccountingReportsLandscapeActive.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/GeneralAccountingReportsLandscapeActive.jrxml
@@ -1,36 +1,31 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.5.1.final using JasperReports Library version 6.5.1  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="GeneralAccountingReportsLandscapeActive" pageWidth="595" pageHeight="842" whenNoDataType="NoPages" columnWidth="595" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="206db32e-71ab-4edc-9aa1-2cb48e611ad9">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="GeneralAccountingReportsLandscapeActive" language="java" pageWidth="595" pageHeight="842" whenNoDataType="NoPages" columnWidth="595" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="206db32e-71ab-4edc-9aa1-2cb48e611ad9">
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.6500000000000001"/>
 	<property name="ireport.x" value="277"/>
 	<property name="ireport.y" value="0"/>
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="CustSatIndexMarkup" forecolor="#000000" pattern="###0.00;-###0.00" isBlankWhenNull="false" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="CustSatIndexMarkup" forecolor="#000000" pattern="###0.00;-###0.00" blankWhenNull="false" bold="true" italic="false" underline="false" strikeThrough="false">
+		<conditionalStyle fontSize="12.0" bold="true">
 			<conditionExpression><![CDATA[new Boolean(new BigDecimal($F{elementLevel}).intValue() == 1)]]></conditionExpression>
-			<style fontSize="12" isBold="true"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle fontSize="11.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(new BigDecimal($F{elementLevel}).intValue() == 2)]]></conditionExpression>
-			<style fontSize="11" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle fontSize="10.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(new BigDecimal($F{elementLevel}).intValue() == 3)]]></conditionExpression>
-			<style fontSize="10" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle fontSize="9.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(new BigDecimal($F{elementLevel}).intValue() >= 4)]]></conditionExpression>
-			<style fontSize="9" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="TOTAL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="TOTAL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
 	<parameter name="pageNo" class="java.lang.String"/>
 	<parameter name="qty" class="java.lang.String"/>
 	<parameter name="qtyRef" class="java.lang.String"/>
@@ -40,9 +35,7 @@
 	<parameter name="compareTo" class="java.lang.String">
 		<defaultValueExpression><![CDATA[]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[]]>
-	</queryString>
+	<query language="sql"><![CDATA[]]></query>
 	<field name="name" class="java.lang.String"/>
 	<field name="qty" class="java.lang.String"/>
 	<field name="qtyRef" class="java.lang.String"/>
@@ -50,46 +43,27 @@
 	<field name="groupname" class="java.lang.String"/>
 	<field name="pagebreak" class="java.lang.String"/>
 	<field name="compareTo" class="java.lang.String"/>
-	<group name="group" isStartNewPage="true">
-		<groupExpression><![CDATA[$F{groupname}]]></groupExpression>
+	<group name="group" startNewPage="true">
+		<expression><![CDATA[$F{groupname}]]></expression>
 	</group>
 	<detail>
 		<band height="19" splitType="Prevent">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="staticText-7" style="CustSatIndexMarkup" positionType="Float" stretchType="RelativeToTallestObject" x="1" y="0" width="220" height="14" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" uuid="735ad739-a933-455a-9e7d-99cd9b395232"/>
-				<textElement textAlignment="Left" markup="none">
-					<font fontName="DejaVu Sans"/>
-					<paragraph leftIndent="0"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new BigDecimal($F{elementLevel}).intValue()>=4 ? "      " + $F{name}: new BigDecimal($F{elementLevel}).intValue()==3 ? "     " + $F{name}: new BigDecimal($F{elementLevel}).intValue()==2 ? "  " + $F{name}:$F{name}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="staticText-7" stretchType="RelativeToTallestObject" x="223" y="0" width="67" height="14" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" uuid="01aee813-34cc-45a7-bcbb-2f5182893b71">
-					<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right" markup="none">
-					<font fontName="DejaVu Sans" size="8" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{qty}!=null) ? $P{NUMBERFORMAT}.format(new BigDecimal($F{qty})).toString() : new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="staticText-7" stretchType="RelativeToTallestObject" x="302" y="0" width="67" height="14" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" uuid="d3ffdf0b-5d5d-4263-9ba5-c4bd76ae726d">
-					<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right" markup="none">
-					<font fontName="DejaVu Sans" size="8" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{qtyRef}!=null) ? $P{NUMBERFORMAT}.format(new BigDecimal($F{qtyRef})).toString() : new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="staticText-7" stretchType="RelativeToTallestObject" x="221" y="0" width="146" height="14" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" uuid="fc5162ed-04a0-42bd-94bc-6ae5539e587f">
-					<printWhenExpression><![CDATA[$P{compareTo}.equals("N")]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right" markup="none">
-					<font fontName="DejaVu Sans" size="8" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{qty}!=null) ? $P{NUMBERFORMAT}.format(new BigDecimal($F{qty})).toString() : new String(" ")]]></textFieldExpression>
-			</textField>
+			<element kind="textField" uuid="735ad739-a933-455a-9e7d-99cd9b395232" key="staticText-7" positionType="Float" stretchType="ElementGroupHeight" x="1" y="0" width="220" height="14" markup="none" fontName="DejaVu Sans" textAdjust="StretchHeight" blankWhenNull="true" removeLineWhenBlank="true" printWhenDetailOverflows="true" hTextAlign="Left" style="CustSatIndexMarkup">
+				<paragraph leftIndent="0" style="CustSatIndexMarkup"/>
+				<expression><![CDATA[new BigDecimal($F{elementLevel}).intValue()>=4 ? "      " + $F{name}: new BigDecimal($F{elementLevel}).intValue()==3 ? "     " + $F{name}: new BigDecimal($F{elementLevel}).intValue()==2 ? "  " + $F{name}:$F{name}]]></expression>
+			</element>
+			<element kind="textField" uuid="01aee813-34cc-45a7-bcbb-2f5182893b71" key="staticText-7" stretchType="ElementGroupHeight" x="223" y="0" width="67" height="14" markup="none" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" removeLineWhenBlank="true" printWhenDetailOverflows="true" bold="false" hTextAlign="Right">
+				<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
+				<expression><![CDATA[($F{qty}!=null) ? $P{NUMBERFORMAT}.format(new BigDecimal($F{qty})).toString() : new String(" ")]]></expression>
+			</element>
+			<element kind="textField" uuid="d3ffdf0b-5d5d-4263-9ba5-c4bd76ae726d" key="staticText-7" stretchType="ElementGroupHeight" x="302" y="0" width="67" height="14" markup="none" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" removeLineWhenBlank="true" printWhenDetailOverflows="true" bold="false" hTextAlign="Right">
+				<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
+				<expression><![CDATA[($F{qtyRef}!=null) ? $P{NUMBERFORMAT}.format(new BigDecimal($F{qtyRef})).toString() : new String(" ")]]></expression>
+			</element>
+			<element kind="textField" uuid="fc5162ed-04a0-42bd-94bc-6ae5539e587f" key="staticText-7" stretchType="ElementGroupHeight" x="221" y="0" width="146" height="14" markup="none" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" removeLineWhenBlank="true" printWhenDetailOverflows="true" bold="false" hTextAlign="Right">
+				<printWhenExpression><![CDATA[$P{compareTo}.equals("N")]]></printWhenExpression>
+				<expression><![CDATA[($F{qty}!=null) ? $P{NUMBERFORMAT}.format(new BigDecimal($F{qty})).toString() : new String(" ")]]></expression>
+			</element>
 		</band>
 	</detail>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/GeneralAccountingReportsLandscapePDF.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/GeneralAccountingReportsLandscapePDF.jrxml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.5.1.final using JasperReports Library version 6.5.1  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="GeneralAccountingReportsPDF" pageWidth="842" pageHeight="595" orientation="Landscape" whenNoDataType="AllSectionsNoDetail" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="206db32e-71ab-4edc-9aa1-2cb48e611ad9">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="GeneralAccountingReportsPDF" language="java" pageWidth="842" pageHeight="595" orientation="Landscape" whenNoDataType="AllSectionsNoDetail" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="206db32e-71ab-4edc-9aa1-2cb48e611ad9">
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.6500000000000001"/>
@@ -17,30 +16,26 @@
 	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
 	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w1" value="292"/>
 	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w2" value="702"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="CustSatIndexMarkup" forecolor="#000000" pattern="###0.00;-###0.00" isBlankWhenNull="false" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="CustSatIndexMarkup" forecolor="#000000" pattern="###0.00;-###0.00" blankWhenNull="false" bold="true" italic="false" underline="false" strikeThrough="false">
+		<conditionalStyle fontSize="12.0" bold="true">
 			<conditionExpression><![CDATA[new Boolean($F{elementLevel} == 1)]]></conditionExpression>
-			<style fontSize="12" isBold="true"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle fontSize="11.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean($F{elementLevel} == 2)]]></conditionExpression>
-			<style fontSize="11" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle fontSize="10.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean($F{elementLevel} == 3)]]></conditionExpression>
-			<style fontSize="10" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle fontSize="9.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean($F{elementLevel} >= 4)]]></conditionExpression>
-			<style fontSize="9" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="TOTAL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="TOTAL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
 	<parameter name="companyName" class="java.lang.String"/>
 	<parameter name="agno" class="java.lang.String"/>
 	<parameter name="agno2" class="java.lang.String"/>
@@ -68,9 +63,7 @@
 	<parameter name="reportType" class="java.lang.String"/>
 	<parameter name="balanced" class="java.lang.Boolean"/>
 	<parameter name="SUBREPORT_DATA_ACTIVE" class="net.sf.jasperreports.engine.JRDataSource"/>
-	<queryString>
-		<![CDATA[]]>
-	</queryString>
+	<query language="sql"><![CDATA[]]></query>
 	<field name="name" class="java.lang.String"/>
 	<field name="qty" class="java.math.BigDecimal"/>
 	<field name="qtyRef" class="java.math.BigDecimal"/>
@@ -78,243 +71,141 @@
 	<field name="groupname" class="java.lang.String"/>
 	<field name="pagebreak" class="java.lang.String"/>
 	<variable name="PNAndP" class="java.lang.Boolean">
-		<variableExpression><![CDATA[!$F{groupname}.equalsIgnoreCase("Activo")]]></variableExpression>
+		<expression><![CDATA[!$F{groupname}.equalsIgnoreCase("Activo")]]></expression>
 	</variable>
 	<group name="group">
 		<groupHeader>
 			<band height="19">
-				<subreport>
-					<reportElement x="410" y="0" width="372" height="14" isRemoveLineWhenBlank="true" uuid="e4d5eeda-acbf-400c-828d-616198694163">
-						<printWhenExpression><![CDATA[!$P{reportType}.equals("N") && $P{balanced}]]></printWhenExpression>
-					</reportElement>
-					<subreportParameter name="NUMBERFORMAT">
-						<subreportParameterExpression><![CDATA[$P{NUMBERFORMAT}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="compareTo">
-						<subreportParameterExpression><![CDATA[$P{compareTo}]]></subreportParameterExpression>
-					</subreportParameter>
+				<element kind="subreport" uuid="e4d5eeda-acbf-400c-828d-616198694163" x="410" y="0" width="372" height="14" removeLineWhenBlank="true">
+					<printWhenExpression><![CDATA[!$P{reportType}.equals("N") && $P{balanced}]]></printWhenExpression>
 					<dataSourceExpression><![CDATA[$P{SUBREPORT_DATA}]]></dataSourceExpression>
-					<subreportExpression><![CDATA[$P{SUBREP_GeneralAccountingReportsLandscapePyPN}]]></subreportExpression>
-				</subreport>
-				<subreport>
-					<reportElement x="0" y="0" width="372" height="14" isRemoveLineWhenBlank="true" uuid="6d2a3a27-eba6-40c1-9f36-9a4a032cfe13">
-						<printWhenExpression><![CDATA[!$P{reportType}.equals("N") && $P{balanced}]]></printWhenExpression>
-					</reportElement>
-					<subreportParameter name="NUMBERFORMAT">
-						<subreportParameterExpression><![CDATA[$P{NUMBERFORMAT}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="compareTo">
-						<subreportParameterExpression><![CDATA[$P{compareTo}]]></subreportParameterExpression>
-					</subreportParameter>
+					<expression><![CDATA[$P{SUBREP_GeneralAccountingReportsLandscapePyPN}]]></expression>
+					<parameter name="NUMBERFORMAT">
+						<expression><![CDATA[$P{NUMBERFORMAT}]]></expression>
+					</parameter>
+					<parameter name="compareTo">
+						<expression><![CDATA[$P{compareTo}]]></expression>
+					</parameter>
+				</element>
+				<element kind="subreport" uuid="6d2a3a27-eba6-40c1-9f36-9a4a032cfe13" x="0" y="0" width="372" height="14" removeLineWhenBlank="true">
+					<printWhenExpression><![CDATA[!$P{reportType}.equals("N") && $P{balanced}]]></printWhenExpression>
 					<dataSourceExpression><![CDATA[$P{SUBREPORT_DATA_ACTIVE}]]></dataSourceExpression>
-					<subreportExpression><![CDATA[$P{SUBREP_GeneralAccountingReportsLandscapeActive}]]></subreportExpression>
-				</subreport>
-				<line>
-					<reportElement key="line-1" stretchType="RelativeToTallestObject" x="389" y="0" width="1" height="19" isPrintWhenDetailOverflows="true" forecolor="#000000" backcolor="#000000" uuid="0eb1c566-b20e-40e1-b6b5-362c07720c95">
-						<printWhenExpression><![CDATA[!$P{reportType}.equals("N") && $P{balanced}]]></printWhenExpression>
-					</reportElement>
-				</line>
-				<subreport>
-					<reportElement x="0" y="0" width="782" height="14" isRemoveLineWhenBlank="true" uuid="71387492-9804-45c3-b245-11a43eb10082">
-						<printWhenExpression><![CDATA[$P{reportType}.equals("N") && !$P{balanced}]]></printWhenExpression>
-					</reportElement>
-					<subreportParameter name="NUMBERFORMAT">
-						<subreportParameterExpression><![CDATA[$P{NUMBERFORMAT}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="compareTo">
-						<subreportParameterExpression><![CDATA[$P{compareTo}]]></subreportParameterExpression>
-					</subreportParameter>
+					<expression><![CDATA[$P{SUBREP_GeneralAccountingReportsLandscapeActive}]]></expression>
+					<parameter name="NUMBERFORMAT">
+						<expression><![CDATA[$P{NUMBERFORMAT}]]></expression>
+					</parameter>
+					<parameter name="compareTo">
+						<expression><![CDATA[$P{compareTo}]]></expression>
+					</parameter>
+				</element>
+				<element kind="line" uuid="0eb1c566-b20e-40e1-b6b5-362c07720c95" key="line-1" stretchType="ElementGroupHeight" x="389" y="0" width="1" height="19" forecolor="#000000" backcolor="#000000" printWhenDetailOverflows="true">
+					<printWhenExpression><![CDATA[!$P{reportType}.equals("N") && $P{balanced}]]></printWhenExpression>
+				</element>
+				<element kind="subreport" uuid="71387492-9804-45c3-b245-11a43eb10082" x="0" y="0" width="782" height="14" removeLineWhenBlank="true">
+					<printWhenExpression><![CDATA[$P{reportType}.equals("N") && !$P{balanced}]]></printWhenExpression>
 					<dataSourceExpression><![CDATA[$P{SUBREPORT_DATA}]]></dataSourceExpression>
-					<subreportExpression><![CDATA[$P{SUBREP_GeneralAccountingReportsLandscapePyPNUnique}]]></subreportExpression>
-				</subreport>
+					<expression><![CDATA[$P{SUBREP_GeneralAccountingReportsLandscapePyPNUnique}]]></expression>
+					<parameter name="NUMBERFORMAT">
+						<expression><![CDATA[$P{NUMBERFORMAT}]]></expression>
+					</parameter>
+					<parameter name="compareTo">
+						<expression><![CDATA[$P{compareTo}]]></expression>
+					</parameter>
+				</element>
 			</band>
 		</groupHeader>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="121" splitType="Stretch">
-			<textField>
-				<reportElement key="staticText-15" x="0" y="0" width="782" height="18" uuid="cdf8a947-5626-4841-b08d-d51949358663"/>
-				<textElement textAlignment="Center" markup="none">
-					<font fontName="DejaVu Sans" size="12" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{principalTitle}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="71" width="782" height="1" forecolor="#555555" uuid="acf2b053-5f63-4623-a2d0-5408186381ed"/>
-			</line>
-			<staticText>
-				<reportElement key="staticText-7" x="0" y="23" width="37" height="14" uuid="a99a8e3c-cd02-42a8-84a1-6ebc9f4d5c2c"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="DejaVu Sans" size="9" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Client:]]></text>
-			</staticText>
-			<textField>
-				<reportElement key="staticText-7" x="37" y="23" width="192" height="14" uuid="9bbc2171-9acd-4a8b-acc1-860043cb560a"/>
-				<textElement markup="none">
-					<font fontName="DejaVu Sans" size="9" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{companyName}+ " "+ $P{agnoInitial}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-7" x="464" y="23" width="71" height="14" uuid="cd5ea301-2cd0-421b-b6b4-b78e0c946ce5"/>
-				<textElement markup="none">
-					<font fontName="DejaVu Sans" size="9" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{date}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-7" x="436" y="23" width="28" height="14" uuid="3831ef89-db88-42c1-87a3-0c2341ba0582"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="DejaVu Sans" size="9" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Date:]]></text>
-			</staticText>
-			<textField>
-				<reportElement key="staticText-7" x="298" y="23" width="138" height="14" uuid="05e5d5f9-03c9-4d72-9803-960b07249fd9"/>
-				<textElement markup="none">
-					<font fontName="DejaVu Sans" size="9" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{org}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-7" x="229" y="23" width="69" height="14" uuid="ff9a70b1-5919-4c69-8c0c-b5fb09ee30c7"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="DejaVu Sans" size="9" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Organization:]]></text>
-			</staticText>
-			<textField>
-				<reportElement key="staticText-7" x="62" y="39" width="720" height="14" uuid="5a54428a-0e5b-4a3a-8d99-d1be99e6f678"/>
-				<textElement markup="none">
-					<font fontName="DejaVu Sans" size="9" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Period:" + $P{period} + (($P{compareTo}.equals("Y")) ? "   Period N-1: "+ $P{periodRef}:"")]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-7" x="0" y="39" width="62" height="14" uuid="24f1c0ae-ccef-4773-b62b-eff3f5aae24a"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="DejaVu Sans" size="9" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Conditions:]]></text>
-			</staticText>
-			<line>
-				<reportElement key="line-1" x="0" y="19" width="782" height="1" uuid="69fda2cf-3dae-43b0-b435-17e11b4669cb"/>
-			</line>
-			<textField>
-				<reportElement key="staticText-7" x="63" y="55" width="719" height="14" uuid="96b7881b-198c-42e9-90bf-c987db4e38cc"/>
-				<textElement markup="none">
-					<font fontName="DejaVu Sans" size="9" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Client N-1: "+ $P{companyName}+ " " +$P{agnoRef}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-7" x="0" y="78" width="112" height="11" uuid="2329ac59-191c-4b42-9260-0ac68dad6cde"/>
-				<textElement markup="none">
-					<font fontName="DejaVu Sans" size="9" isBold="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{agno}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-7" mode="Transparent" x="0" y="94" width="112" height="10" forecolor="#000000" backcolor="#FFFFFF" uuid="485915aa-6b3d-4f79-aad1-6b72524bae85"/>
-				<textElement textAlignment="Left" rotation="None" markup="none">
-					<font fontName="DejaVu Sans" size="8" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-				</textElement>
-				<text><![CDATA[Element]]></text>
-			</staticText>
-			<textField>
-				<reportElement key="staticText-7" x="211" y="94" width="80" height="10" uuid="3af2f8e6-8930-4457-9723-be80fd987500">
-					<printWhenExpression><![CDATA[$P{compareTo}.equals("Y") && (!$P{reportType}.equals("N") && $P{balanced})]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right" markup="none">
-					<font fontName="DejaVu Sans" size="8" isBold="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{column}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-7" x="290" y="94" width="80" height="10" uuid="552729e6-b02b-49f3-8dab-a5959e851d63">
-					<printWhenExpression><![CDATA[$P{compareTo}.equals("Y") && (!$P{reportType}.equals("N") && $P{balanced})]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right" markup="none">
-					<font fontName="DejaVu Sans" size="8" isBold="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{columnRef}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-7" x="211" y="95" width="157" height="10" uuid="747fc3f8-999c-4abd-b1eb-ccbc69954e8e">
-					<printWhenExpression><![CDATA[$P{compareTo}.equals("N") && (!$P{reportType}.equals("N") && $P{balanced})]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right" markup="none">
-					<font fontName="DejaVu Sans" size="8" isBold="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{column}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-7" x="621" y="94" width="80" height="10" uuid="6bc9c5f9-8ad8-4bbf-9d3f-b943d1f306ac">
-					<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right" markup="none">
-					<font fontName="DejaVu Sans" size="8" isBold="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{column}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-7" x="700" y="94" width="80" height="10" uuid="819f6ab1-a7f9-4ab2-b2ad-1990c5ea4389">
-					<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right" markup="none">
-					<font fontName="DejaVu Sans" size="8" isBold="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{columnRef}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-7" x="621" y="95" width="157" height="10" uuid="c8624477-2d8e-4ebe-a94d-53b2e5f3cd2b">
-					<printWhenExpression><![CDATA[$P{compareTo}.equals("N")]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right" markup="none">
-					<font fontName="DejaVu Sans" size="8" isBold="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{column}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader height="121" splitType="Stretch">
+		<element kind="textField" uuid="cdf8a947-5626-4841-b08d-d51949358663" key="staticText-15" x="0" y="0" width="782" height="18" markup="none" fontName="DejaVu Sans" fontSize="12.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Center">
+			<expression><![CDATA[$P{principalTitle}]]></expression>
+		</element>
+		<element kind="line" uuid="acf2b053-5f63-4623-a2d0-5408186381ed" key="line-1" x="0" y="71" width="782" height="1" forecolor="#555555"/>
+		<element kind="staticText" uuid="a99a8e3c-cd02-42a8-84a1-6ebc9f4d5c2c" key="staticText-7" x="0" y="23" width="37" height="14" fontName="DejaVu Sans" fontSize="9.0" bold="true">
+			<text><![CDATA[Client:]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="9bbc2171-9acd-4a8b-acc1-860043cb560a" key="staticText-7" x="37" y="23" width="192" height="14" markup="none" fontName="DejaVu Sans" fontSize="9.0" bold="false">
+			<expression><![CDATA[$P{companyName}+ " "+ $P{agnoInitial}]]></expression>
+		</element>
+		<element kind="textField" uuid="cd5ea301-2cd0-421b-b6b4-b78e0c946ce5" key="staticText-7" x="464" y="23" width="71" height="14" markup="none" fontName="DejaVu Sans" fontSize="9.0" bold="false">
+			<expression><![CDATA[$P{date}]]></expression>
+		</element>
+		<element kind="staticText" uuid="3831ef89-db88-42c1-87a3-0c2341ba0582" key="staticText-7" x="436" y="23" width="28" height="14" fontName="DejaVu Sans" fontSize="9.0" bold="true">
+			<text><![CDATA[Date:]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="05e5d5f9-03c9-4d72-9803-960b07249fd9" key="staticText-7" x="298" y="23" width="138" height="14" markup="none" fontName="DejaVu Sans" fontSize="9.0" bold="false">
+			<expression><![CDATA[$P{org}]]></expression>
+		</element>
+		<element kind="staticText" uuid="ff9a70b1-5919-4c69-8c0c-b5fb09ee30c7" key="staticText-7" x="229" y="23" width="69" height="14" fontName="DejaVu Sans" fontSize="9.0" bold="true">
+			<text><![CDATA[Organization:]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="5a54428a-0e5b-4a3a-8d99-d1be99e6f678" key="staticText-7" x="62" y="39" width="720" height="14" markup="none" fontName="DejaVu Sans" fontSize="9.0" bold="false">
+			<expression><![CDATA["Period:" + $P{period} + (($P{compareTo}.equals("Y")) ? "   Period N-1: "+ $P{periodRef}:"")]]></expression>
+		</element>
+		<element kind="staticText" uuid="24f1c0ae-ccef-4773-b62b-eff3f5aae24a" key="staticText-7" x="0" y="39" width="62" height="14" fontName="DejaVu Sans" fontSize="9.0" bold="true">
+			<text><![CDATA[Conditions:]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="69fda2cf-3dae-43b0-b435-17e11b4669cb" key="line-1" x="0" y="19" width="782" height="1"/>
+		<element kind="textField" uuid="96b7881b-198c-42e9-90bf-c987db4e38cc" key="staticText-7" x="63" y="55" width="719" height="14" markup="none" fontName="DejaVu Sans" fontSize="9.0" bold="false">
+			<expression><![CDATA["Client N-1: "+ $P{companyName}+ " " +$P{agnoRef}]]></expression>
+		</element>
+		<element kind="textField" uuid="2329ac59-191c-4b42-9260-0ac68dad6cde" key="staticText-7" x="0" y="78" width="112" height="11" markup="none" fontName="DejaVu Sans" fontSize="9.0" bold="true">
+			<expression><![CDATA[$P{agno}]]></expression>
+		</element>
+		<element kind="staticText" uuid="485915aa-6b3d-4f79-aad1-6b72524bae85" key="staticText-7" mode="Transparent" x="0" y="94" width="112" height="10" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="8.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" pdfEmbedded="false" underline="false" strikeThrough="false" bold="true" italic="false" hTextAlign="Left">
+			<text><![CDATA[Element]]></text>
+		</element>
+		<element kind="textField" uuid="3af2f8e6-8930-4457-9723-be80fd987500" key="staticText-7" x="211" y="94" width="80" height="10" markup="none" fontName="DejaVu Sans" fontSize="8.0" bold="true" hTextAlign="Right">
+			<printWhenExpression><![CDATA[$P{compareTo}.equals("Y") && (!$P{reportType}.equals("N") && $P{balanced})]]></printWhenExpression>
+			<expression><![CDATA[$P{column}]]></expression>
+		</element>
+		<element kind="textField" uuid="552729e6-b02b-49f3-8dab-a5959e851d63" key="staticText-7" x="290" y="94" width="80" height="10" markup="none" fontName="DejaVu Sans" fontSize="8.0" bold="true" hTextAlign="Right">
+			<printWhenExpression><![CDATA[$P{compareTo}.equals("Y") && (!$P{reportType}.equals("N") && $P{balanced})]]></printWhenExpression>
+			<expression><![CDATA[$P{columnRef}]]></expression>
+		</element>
+		<element kind="textField" uuid="747fc3f8-999c-4abd-b1eb-ccbc69954e8e" key="staticText-7" x="211" y="95" width="157" height="10" markup="none" fontName="DejaVu Sans" fontSize="8.0" bold="true" hTextAlign="Right">
+			<printWhenExpression><![CDATA[$P{compareTo}.equals("N") && (!$P{reportType}.equals("N") && $P{balanced})]]></printWhenExpression>
+			<expression><![CDATA[$P{column}]]></expression>
+		</element>
+		<element kind="textField" uuid="6bc9c5f9-8ad8-4bbf-9d3f-b943d1f306ac" key="staticText-7" x="621" y="94" width="80" height="10" markup="none" fontName="DejaVu Sans" fontSize="8.0" bold="true" hTextAlign="Right">
+			<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
+			<expression><![CDATA[$P{column}]]></expression>
+		</element>
+		<element kind="textField" uuid="819f6ab1-a7f9-4ab2-b2ad-1990c5ea4389" key="staticText-7" x="700" y="94" width="80" height="10" markup="none" fontName="DejaVu Sans" fontSize="8.0" bold="true" hTextAlign="Right">
+			<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
+			<expression><![CDATA[$P{columnRef}]]></expression>
+		</element>
+		<element kind="textField" uuid="c8624477-2d8e-4ebe-a94d-53b2e5f3cd2b" key="staticText-7" x="621" y="95" width="157" height="10" markup="none" fontName="DejaVu Sans" fontSize="8.0" bold="true" hTextAlign="Right">
+			<printWhenExpression><![CDATA[$P{compareTo}.equals("N")]]></printWhenExpression>
+			<expression><![CDATA[$P{column}]]></expression>
+		</element>
 	</pageHeader>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="40" splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="40" splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/GeneralAccountingReportsLandscapePyPN.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/GeneralAccountingReportsLandscapePyPN.jrxml
@@ -1,36 +1,31 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.5.1.final using JasperReports Library version 6.5.1  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="GeneralAccountingReportsLandscapePyPN" pageWidth="595" pageHeight="842" whenNoDataType="NoPages" columnWidth="595" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="206db32e-71ab-4edc-9aa1-2cb48e611ad9">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="GeneralAccountingReportsLandscapePyPN" language="java" pageWidth="595" pageHeight="842" whenNoDataType="NoPages" columnWidth="595" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="206db32e-71ab-4edc-9aa1-2cb48e611ad9">
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.6500000000000001"/>
 	<property name="ireport.x" value="277"/>
 	<property name="ireport.y" value="0"/>
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="CustSatIndexMarkup" forecolor="#000000" pattern="###0.00;-###0.00" isBlankWhenNull="false" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="CustSatIndexMarkup" forecolor="#000000" pattern="###0.00;-###0.00" blankWhenNull="false" bold="true" italic="false" underline="false" strikeThrough="false">
+		<conditionalStyle fontSize="12.0" bold="true">
 			<conditionExpression><![CDATA[new Boolean(new BigDecimal($F{elementLevel}).intValue() == 1)]]></conditionExpression>
-			<style fontSize="12" isBold="true"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle fontSize="11.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(new BigDecimal($F{elementLevel}).intValue() == 2)]]></conditionExpression>
-			<style fontSize="11" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle fontSize="10.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(new BigDecimal($F{elementLevel}).intValue() == 3)]]></conditionExpression>
-			<style fontSize="10" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle fontSize="9.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(new BigDecimal($F{elementLevel}).intValue() >= 4)]]></conditionExpression>
-			<style fontSize="9" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="TOTAL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="TOTAL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
 	<parameter name="pageNo" class="java.lang.String"/>
 	<parameter name="qty" class="java.lang.String"/>
 	<parameter name="qtyRef" class="java.lang.String"/>
@@ -41,9 +36,7 @@
 		<defaultValueExpression><![CDATA[]]></defaultValueExpression>
 	</parameter>
 	<parameter name="SUBREPORT_DATA" class="net.sf.jasperreports.engine.JRDataSource"/>
-	<queryString>
-		<![CDATA[]]>
-	</queryString>
+	<query language="sql"><![CDATA[]]></query>
 	<field name="name" class="java.lang.String"/>
 	<field name="qty" class="java.lang.String"/>
 	<field name="qtyRef" class="java.lang.String"/>
@@ -51,45 +44,26 @@
 	<field name="groupname" class="java.lang.String"/>
 	<field name="pagebreak" class="java.lang.String"/>
 	<field name="compareTo" class="java.lang.String"/>
-	<group name="group" isStartNewPage="true">
-		<groupExpression><![CDATA[$F{groupname}]]></groupExpression>
+	<group name="group" startNewPage="true">
+		<expression><![CDATA[$F{groupname}]]></expression>
 	</group>
 	<detail>
 		<band height="19" splitType="Prevent">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="staticText-7" style="CustSatIndexMarkup" stretchType="RelativeToTallestObject" x="1" y="0" width="220" height="14" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" uuid="735ad739-a933-455a-9e7d-99cd9b395232"/>
-				<textElement markup="none">
-					<font fontName="DejaVu Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new BigDecimal($F{elementLevel}).intValue()>=4 ? "      " + $F{name}:new BigDecimal ($F{elementLevel}).intValue()==3 ? "     " + $F{name}: new BigDecimal($F{elementLevel}).intValue()==2 ? "  " + $F{name}:$F{name}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="staticText-7" stretchType="RelativeToTallestObject" x="223" y="0" width="67" height="14" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" uuid="01aee813-34cc-45a7-bcbb-2f5182893b71">
-					<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right" markup="none">
-					<font fontName="DejaVu Sans" size="8" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{qty}!=null) ? $P{NUMBERFORMAT}.format(new BigDecimal($F{qty})).toString() : new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="staticText-7" stretchType="RelativeToTallestObject" x="302" y="0" width="67" height="14" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" uuid="d3ffdf0b-5d5d-4263-9ba5-c4bd76ae726d">
-					<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right" markup="none">
-					<font fontName="DejaVu Sans" size="8" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{qtyRef}!=null) ? $P{NUMBERFORMAT}.format(new BigDecimal($F{qtyRef})).toString() : new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="staticText-7" stretchType="RelativeToTallestObject" x="221" y="0" width="146" height="14" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" uuid="fc5162ed-04a0-42bd-94bc-6ae5539e587f">
-					<printWhenExpression><![CDATA[$P{compareTo}.equals("N")]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right" markup="none">
-					<font fontName="DejaVu Sans" size="8" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{qty}!=null) ? $P{NUMBERFORMAT}.format(new BigDecimal($F{qty})).toString() : new String(" ")]]></textFieldExpression>
-			</textField>
+			<element kind="textField" uuid="735ad739-a933-455a-9e7d-99cd9b395232" key="staticText-7" stretchType="ElementGroupHeight" x="1" y="0" width="220" height="14" markup="none" fontName="DejaVu Sans" textAdjust="StretchHeight" blankWhenNull="true" removeLineWhenBlank="true" printWhenDetailOverflows="true" style="CustSatIndexMarkup">
+				<expression><![CDATA[new BigDecimal($F{elementLevel}).intValue()>=4 ? "      " + $F{name}:new BigDecimal ($F{elementLevel}).intValue()==3 ? "     " + $F{name}: new BigDecimal($F{elementLevel}).intValue()==2 ? "  " + $F{name}:$F{name}]]></expression>
+			</element>
+			<element kind="textField" uuid="01aee813-34cc-45a7-bcbb-2f5182893b71" key="staticText-7" stretchType="ElementGroupHeight" x="223" y="0" width="67" height="14" markup="none" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" removeLineWhenBlank="true" printWhenDetailOverflows="true" bold="false" hTextAlign="Right">
+				<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
+				<expression><![CDATA[($F{qty}!=null) ? $P{NUMBERFORMAT}.format(new BigDecimal($F{qty})).toString() : new String(" ")]]></expression>
+			</element>
+			<element kind="textField" uuid="d3ffdf0b-5d5d-4263-9ba5-c4bd76ae726d" key="staticText-7" stretchType="ElementGroupHeight" x="302" y="0" width="67" height="14" markup="none" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" removeLineWhenBlank="true" printWhenDetailOverflows="true" bold="false" hTextAlign="Right">
+				<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
+				<expression><![CDATA[($F{qtyRef}!=null) ? $P{NUMBERFORMAT}.format(new BigDecimal($F{qtyRef})).toString() : new String(" ")]]></expression>
+			</element>
+			<element kind="textField" uuid="fc5162ed-04a0-42bd-94bc-6ae5539e587f" key="staticText-7" stretchType="ElementGroupHeight" x="221" y="0" width="146" height="14" markup="none" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" removeLineWhenBlank="true" printWhenDetailOverflows="true" bold="false" hTextAlign="Right">
+				<printWhenExpression><![CDATA[$P{compareTo}.equals("N")]]></printWhenExpression>
+				<expression><![CDATA[($F{qty}!=null) ? $P{NUMBERFORMAT}.format(new BigDecimal($F{qty})).toString() : new String(" ")]]></expression>
+			</element>
 		</band>
 	</detail>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/GeneralAccountingReportsLandscapePyPNUnique.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/GeneralAccountingReportsLandscapePyPNUnique.jrxml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.5.1.final using JasperReports Library version 6.5.1  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="GeneralAccountingReportsLandscapePyPNUnique" pageWidth="842" pageHeight="595" orientation="Landscape" whenNoDataType="NoPages" columnWidth="842" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="206db32e-71ab-4edc-9aa1-2cb48e611ad9">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="GeneralAccountingReportsLandscapePyPNUnique" language="java" pageWidth="842" pageHeight="595" orientation="Landscape" whenNoDataType="NoPages" columnWidth="842" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="206db32e-71ab-4edc-9aa1-2cb48e611ad9">
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.6500000000000001"/>
@@ -15,30 +14,26 @@
 	<property name="com.jaspersoft.studio.unit.rightMargin" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnWidth" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="CustSatIndexMarkup" forecolor="#000000" pattern="###0.00;-###0.00" isBlankWhenNull="false" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="CustSatIndexMarkup" forecolor="#000000" pattern="###0.00;-###0.00" blankWhenNull="false" bold="true" italic="false" underline="false" strikeThrough="false">
+		<conditionalStyle fontSize="12.0" bold="true">
 			<conditionExpression><![CDATA[new Boolean(new BigDecimal($F{elementLevel}).intValue() == 1)]]></conditionExpression>
-			<style fontSize="12" isBold="true"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle fontSize="11.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(new BigDecimal($F{elementLevel}).intValue() == 2)]]></conditionExpression>
-			<style fontSize="11" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle fontSize="10.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(new BigDecimal($F{elementLevel}).intValue() == 3)]]></conditionExpression>
-			<style fontSize="10" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle fontSize="9.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(new BigDecimal($F{elementLevel}).intValue() >= 4)]]></conditionExpression>
-			<style fontSize="9" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="TOTAL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="TOTAL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
 	<parameter name="pageNo" class="java.lang.String"/>
 	<parameter name="qty" class="java.lang.String"/>
 	<parameter name="qtyRef" class="java.lang.String"/>
@@ -49,9 +44,7 @@
 		<defaultValueExpression><![CDATA[]]></defaultValueExpression>
 	</parameter>
 	<parameter name="SUBREPORT_DATA" class="net.sf.jasperreports.engine.JRDataSource"/>
-	<queryString>
-		<![CDATA[]]>
-	</queryString>
+	<query language="sql"><![CDATA[]]></query>
 	<field name="name" class="java.lang.String"/>
 	<field name="qty" class="java.lang.String"/>
 	<field name="qtyRef" class="java.lang.String"/>
@@ -59,45 +52,26 @@
 	<field name="groupname" class="java.lang.String"/>
 	<field name="pagebreak" class="java.lang.String"/>
 	<field name="compareTo" class="java.lang.String"/>
-	<group name="group" isStartNewPage="true">
-		<groupExpression><![CDATA[$F{groupname}]]></groupExpression>
+	<group name="group" startNewPage="true">
+		<expression><![CDATA[$F{groupname}]]></expression>
 	</group>
 	<detail>
 		<band height="19" splitType="Prevent">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="staticText-7" style="CustSatIndexMarkup" stretchType="RelativeToTallestObject" x="1" y="0" width="629" height="14" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" uuid="735ad739-a933-455a-9e7d-99cd9b395232"/>
-				<textElement markup="none">
-					<font fontName="DejaVu Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new BigDecimal($F{elementLevel}).intValue()>=4 ? "      " + $F{name}:new BigDecimal ($F{elementLevel}).intValue()==3 ? "     " + $F{name}: new BigDecimal($F{elementLevel}).intValue()==2 ? "  " + $F{name}:$F{name}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="staticText-7" stretchType="RelativeToTallestObject" x="633" y="0" width="67" height="14" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" uuid="01aee813-34cc-45a7-bcbb-2f5182893b71">
-					<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right" markup="none">
-					<font fontName="DejaVu Sans" size="8" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{qty}!=null) ? $P{NUMBERFORMAT}.format(new BigDecimal($F{qty})).toString() : new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="staticText-7" stretchType="RelativeToTallestObject" x="712" y="0" width="67" height="14" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" uuid="d3ffdf0b-5d5d-4263-9ba5-c4bd76ae726d">
-					<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right" markup="none">
-					<font fontName="DejaVu Sans" size="8" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{qtyRef}!=null) ? $P{NUMBERFORMAT}.format(new BigDecimal($F{qtyRef})).toString() : new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="staticText-7" stretchType="RelativeToTallestObject" x="631" y="0" width="146" height="14" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" uuid="fc5162ed-04a0-42bd-94bc-6ae5539e587f">
-					<printWhenExpression><![CDATA[$P{compareTo}.equals("N")]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right" markup="none">
-					<font fontName="DejaVu Sans" size="8" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{qty}!=null) ? $P{NUMBERFORMAT}.format(new BigDecimal($F{qty})).toString() : new String(" ")]]></textFieldExpression>
-			</textField>
+			<element kind="textField" uuid="735ad739-a933-455a-9e7d-99cd9b395232" key="staticText-7" stretchType="ElementGroupHeight" x="1" y="0" width="629" height="14" markup="none" fontName="DejaVu Sans" textAdjust="StretchHeight" blankWhenNull="true" removeLineWhenBlank="true" printWhenDetailOverflows="true" style="CustSatIndexMarkup">
+				<expression><![CDATA[new BigDecimal($F{elementLevel}).intValue()>=4 ? "      " + $F{name}:new BigDecimal ($F{elementLevel}).intValue()==3 ? "     " + $F{name}: new BigDecimal($F{elementLevel}).intValue()==2 ? "  " + $F{name}:$F{name}]]></expression>
+			</element>
+			<element kind="textField" uuid="01aee813-34cc-45a7-bcbb-2f5182893b71" key="staticText-7" stretchType="ElementGroupHeight" x="633" y="0" width="67" height="14" markup="none" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" removeLineWhenBlank="true" printWhenDetailOverflows="true" bold="false" hTextAlign="Right">
+				<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
+				<expression><![CDATA[($F{qty}!=null) ? $P{NUMBERFORMAT}.format(new BigDecimal($F{qty})).toString() : new String(" ")]]></expression>
+			</element>
+			<element kind="textField" uuid="d3ffdf0b-5d5d-4263-9ba5-c4bd76ae726d" key="staticText-7" stretchType="ElementGroupHeight" x="712" y="0" width="67" height="14" markup="none" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" removeLineWhenBlank="true" printWhenDetailOverflows="true" bold="false" hTextAlign="Right">
+				<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
+				<expression><![CDATA[($F{qtyRef}!=null) ? $P{NUMBERFORMAT}.format(new BigDecimal($F{qtyRef})).toString() : new String(" ")]]></expression>
+			</element>
+			<element kind="textField" uuid="fc5162ed-04a0-42bd-94bc-6ae5539e587f" key="staticText-7" stretchType="ElementGroupHeight" x="631" y="0" width="146" height="14" markup="none" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" removeLineWhenBlank="true" printWhenDetailOverflows="true" bold="false" hTextAlign="Right">
+				<printWhenExpression><![CDATA[$P{compareTo}.equals("N")]]></printWhenExpression>
+				<expression><![CDATA[($F{qty}!=null) ? $P{NUMBERFORMAT}.format(new BigDecimal($F{qty})).toString() : new String(" ")]]></expression>
+			</element>
 		</band>
 	</detail>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/GeneralAccountingReportsPDF.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/GeneralAccountingReportsPDF.jrxml
@@ -1,34 +1,30 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="GeneralAccountingReportsPDF" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="GeneralAccountingReportsPDF" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="bce7c747-f846-4f4c-9946-97d7611d2008">
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.6500000000000001"/>
 	<property name="ireport.x" value="277"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="CustSatIndexMarkup" forecolor="#000000" pattern="###0.00;-###0.00" isBlankWhenNull="false" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="CustSatIndexMarkup" forecolor="#000000" pattern="###0.00;-###0.00" blankWhenNull="false" bold="true" italic="false" underline="false" strikeThrough="false">
+		<conditionalStyle fontSize="12.0" bold="true">
 			<conditionExpression><![CDATA[new Boolean($F{elementLevel} == 1)]]></conditionExpression>
-			<style fontSize="12" isBold="true"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle fontSize="11.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean($F{elementLevel} == 2)]]></conditionExpression>
-			<style fontSize="11" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle fontSize="10.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean($F{elementLevel} == 3)]]></conditionExpression>
-			<style fontSize="10" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle fontSize="9.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean($F{elementLevel} >= 4)]]></conditionExpression>
-			<style fontSize="9" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="TOTAL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="TOTAL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
 	<parameter name="companyName" class="java.lang.String"/>
 	<parameter name="agno" class="java.lang.String"/>
 	<parameter name="agno2" class="java.lang.String"/>
@@ -49,17 +45,15 @@
 	<parameter name="compareTo" class="java.lang.String">
 		<defaultValueExpression><![CDATA[]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[]]>
-	</queryString>
+	<query language="sql"><![CDATA[]]></query>
 	<field name="name" class="java.lang.String"/>
 	<field name="qty" class="java.math.BigDecimal"/>
 	<field name="qtyRef" class="java.math.BigDecimal"/>
 	<field name="elementLevel" class="java.lang.Integer"/>
 	<field name="groupname" class="java.lang.String"/>
 	<field name="pagebreak" class="java.lang.String"/>
-	<group name="group" isStartNewPage="true">
-		<groupExpression><![CDATA[$F{groupname}]]></groupExpression>
+	<group name="group" startNewPage="true">
+		<expression><![CDATA[$F{groupname}]]></expression>
 		<groupHeader>
 			<band/>
 		</groupHeader>
@@ -67,212 +61,108 @@
 			<band/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="121" splitType="Stretch">
-			<textField>
-				<reportElement key="staticText-15" x="0" y="0" width="535" height="18"/>
-				<textElement textAlignment="Center" markup="none">
-					<font fontName="DejaVu Sans" size="12" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{principalTitle}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="71" width="535" height="1" forecolor="#555555"/>
-			</line>
-			<staticText>
-				<reportElement key="staticText-7" x="0" y="23" width="37" height="14"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="DejaVu Sans" size="9" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Client:]]></text>
-			</staticText>
-			<textField>
-				<reportElement key="staticText-7" x="37" y="23" width="192" height="14"/>
-				<textElement markup="none">
-					<font fontName="DejaVu Sans" size="9" isBold="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{companyName}+ " "+ $P{agnoInitial}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-7" x="464" y="23" width="71" height="14"/>
-				<textElement markup="none">
-					<font fontName="DejaVu Sans" size="9" isBold="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{date}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-7" x="436" y="23" width="28" height="14"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="DejaVu Sans" size="9" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Date:]]></text>
-			</staticText>
-			<textField>
-				<reportElement key="staticText-7" x="298" y="23" width="138" height="14"/>
-				<textElement markup="none">
-					<font fontName="DejaVu Sans" size="9" isBold="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{org}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-7" x="229" y="23" width="69" height="14"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="DejaVu Sans" size="9" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Organization:]]></text>
-			</staticText>
-			<textField>
-				<reportElement key="staticText-7" x="62" y="39" width="473" height="14"/>
-				<textElement markup="none">
-					<font fontName="DejaVu Sans" size="9" isBold="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["Period:" + $P{period} + (($P{compareTo}.equals("Y")) ? "   Period N-1: "+ $P{periodRef}:"")]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-7" x="0" y="39" width="62" height="14"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="DejaVu Sans" size="9" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Conditions:]]></text>
-			</staticText>
-			<line>
-				<reportElement key="line-1" x="0" y="19" width="535" height="1"/>
-			</line>
-			<textField>
-				<reportElement key="staticText-7" x="63" y="55" width="472" height="14"/>
-				<textElement markup="none">
-					<font fontName="DejaVu Sans" size="9" isBold="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA["Client N-1: "+ $P{companyName}+ " " +$P{agnoRef}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-7" x="211" y="84" width="112" height="11"/>
-				<textElement markup="none">
-					<font fontName="DejaVu Sans" size="9" isBold="true"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{agno}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-7" mode="Transparent" x="0" y="94" width="112" height="10" forecolor="#000000" backcolor="#FFFFFF"/>
-				<textElement textAlignment="Left" rotation="None" markup="none">
-					<font fontName="DejaVu Sans" size="8" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-				</textElement>
-				<text><![CDATA[Element]]></text>
-			</staticText>
-			<textField>
-				<reportElement key="staticText-7" x="376" y="94" width="80" height="10">
-					<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right" markup="none">
-					<font fontName="DejaVu Sans" size="8" isBold="true"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{column}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-7" x="455" y="94" width="80" height="10">
-					<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right" markup="none">
-					<font fontName="DejaVu Sans" size="8" isBold="true"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{columnRef}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-7" x="0" y="74" width="229" height="12"/>
-				<textElement markup="none">
-					<font fontName="DejaVu Sans" size="9" isBold="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{groupname}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="staticText-7" x="376" y="95" width="157" height="10">
-					<printWhenExpression><![CDATA[$P{compareTo}.equals("N")]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right" markup="none">
-					<font fontName="DejaVu Sans" size="8" isBold="true"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$P{column}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader height="121" splitType="Stretch">
+		<element kind="textField" uuid="4be8c590-4f02-484b-b728-8b8f4503bbba" key="staticText-15" x="0" y="0" width="535" height="18" markup="none" fontName="DejaVu Sans" fontSize="12.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Center">
+			<expression><![CDATA[$P{principalTitle}]]></expression>
+		</element>
+		<element kind="line" uuid="2e5eb7cb-67f5-4c0b-add1-f64ca32df9fd" key="line-1" x="0" y="71" width="535" height="1" forecolor="#555555"/>
+		<element kind="staticText" uuid="a7ef5cb3-91a8-4c07-8b12-61073ee37174" key="staticText-7" x="0" y="23" width="37" height="14" fontName="DejaVu Sans" fontSize="9.0" bold="true">
+			<text><![CDATA[Client:]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="e38d5d86-d70a-4dbb-ac1d-55e0164d6988" key="staticText-7" x="37" y="23" width="192" height="14" markup="none" fontName="DejaVu Sans" fontSize="9.0" bold="false">
+			<expression><![CDATA[$P{companyName}+ " "+ $P{agnoInitial}]]></expression>
+		</element>
+		<element kind="textField" uuid="7e5990c6-11a7-4109-90f9-5ff33ee5d02f" key="staticText-7" x="464" y="23" width="71" height="14" markup="none" fontName="DejaVu Sans" fontSize="9.0" bold="false">
+			<expression><![CDATA[$P{date}]]></expression>
+		</element>
+		<element kind="staticText" uuid="b74ae8d6-676f-4b13-a762-55e19db7d444" key="staticText-7" x="436" y="23" width="28" height="14" fontName="DejaVu Sans" fontSize="9.0" bold="true">
+			<text><![CDATA[Date:]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="f51f8fbc-acdc-4663-b929-f53a7711d045" key="staticText-7" x="298" y="23" width="138" height="14" markup="none" fontName="DejaVu Sans" fontSize="9.0" bold="false">
+			<expression><![CDATA[$P{org}]]></expression>
+		</element>
+		<element kind="staticText" uuid="09aacacb-5e31-4e05-87d8-851ac4b9f6d7" key="staticText-7" x="229" y="23" width="69" height="14" fontName="DejaVu Sans" fontSize="9.0" bold="true">
+			<text><![CDATA[Organization:]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="90f922db-38bc-4b7f-ad98-1d55d1798561" key="staticText-7" x="62" y="39" width="473" height="14" markup="none" fontName="DejaVu Sans" fontSize="9.0" bold="false">
+			<expression><![CDATA["Period:" + $P{period} + (($P{compareTo}.equals("Y")) ? "   Period N-1: "+ $P{periodRef}:"")]]></expression>
+		</element>
+		<element kind="staticText" uuid="ba95c86c-c15e-4864-88b3-9c8ce3830095" key="staticText-7" x="0" y="39" width="62" height="14" fontName="DejaVu Sans" fontSize="9.0" bold="true">
+			<text><![CDATA[Conditions:]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="3b412ae2-05b6-4268-bc82-6148417f99c0" key="line-1" x="0" y="19" width="535" height="1"/>
+		<element kind="textField" uuid="83135213-cf29-4bb5-b9ce-fb185491fca9" key="staticText-7" x="63" y="55" width="472" height="14" markup="none" fontName="DejaVu Sans" fontSize="9.0" bold="false">
+			<expression><![CDATA["Client N-1: "+ $P{companyName}+ " " +$P{agnoRef}]]></expression>
+		</element>
+		<element kind="textField" uuid="61e61550-86e2-461c-aa11-4dbbef785a0f" key="staticText-7" x="211" y="84" width="112" height="11" markup="none" fontName="DejaVu Sans" fontSize="9.0" bold="true">
+			<expression><![CDATA[$P{agno}]]></expression>
+		</element>
+		<element kind="staticText" uuid="6e43dee0-48af-419c-989c-b3e47e40dff5" key="staticText-7" mode="Transparent" x="0" y="94" width="112" height="10" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="8.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" pdfEmbedded="false" underline="false" strikeThrough="false" bold="true" italic="false" hTextAlign="Left">
+			<text><![CDATA[Element]]></text>
+		</element>
+		<element kind="textField" uuid="888a0a8c-606c-4b67-85f6-866acc2de554" key="staticText-7" x="376" y="94" width="80" height="10" markup="none" fontName="DejaVu Sans" fontSize="8.0" bold="true" hTextAlign="Right">
+			<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
+			<expression><![CDATA[$P{column}]]></expression>
+		</element>
+		<element kind="textField" uuid="4026f9c3-c946-4423-89af-d6ff0c4aa61b" key="staticText-7" x="455" y="94" width="80" height="10" markup="none" fontName="DejaVu Sans" fontSize="8.0" bold="true" hTextAlign="Right">
+			<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
+			<expression><![CDATA[$P{columnRef}]]></expression>
+		</element>
+		<element kind="textField" uuid="2d41f522-e572-42dc-8c8f-033f71f1b091" key="staticText-7" x="0" y="74" width="229" height="12" markup="none" fontName="DejaVu Sans" fontSize="9.0" bold="false">
+			<expression><![CDATA[$F{groupname}]]></expression>
+		</element>
+		<element kind="textField" uuid="75053b41-c06a-485d-8cbf-e0988185bbd6" key="staticText-7" x="376" y="95" width="157" height="10" markup="none" fontName="DejaVu Sans" fontSize="8.0" bold="true" hTextAlign="Right">
+			<printWhenExpression><![CDATA[$P{compareTo}.equals("N")]]></printWhenExpression>
+			<expression><![CDATA[$P{column}]]></expression>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="15" splitType="Stretch">
-			<textField>
-				<reportElement key="staticText-7" style="CustSatIndexMarkup" x="0" y="0" width="376" height="14"/>
-				<textElement markup="none">
-					<font fontName="DejaVu Sans"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{elementLevel}>=4 ? "      " + $F{name}: $F{elementLevel}==3 ? "     " + $F{name}: $F{elementLevel}==2 ? "  " + $F{name}:$F{name}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="staticText-7" x="376" y="0" width="80" height="14">
-					<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right" markup="none">
-					<font fontName="DejaVu Sans" size="9" isBold="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[($F{qty}!=null) ? $P{NUMBERFORMAT}.format($F{qty}).toString() : new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="staticText-7" x="455" y="0" width="80" height="14">
-					<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right" markup="none">
-					<font fontName="DejaVu Sans" size="9" isBold="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[($F{qtyRef}!=null) ? $P{NUMBERFORMAT}.format($F{qtyRef}).toString() : new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="staticText-7" x="374" y="0" width="159" height="14">
-					<printWhenExpression><![CDATA[$P{compareTo}.equals("N")]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right" markup="none">
-					<font fontName="DejaVu Sans" size="9" isBold="false"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[($F{qty}!=null) ? $P{NUMBERFORMAT}.format($F{qty}).toString() : new String(" ")]]></textFieldExpression>
-			</textField>
+			<element kind="textField" uuid="3adcf54d-16b7-4d1a-a800-d89167ef9f30" key="staticText-7" x="0" y="0" width="376" height="14" markup="none" fontName="DejaVu Sans" style="CustSatIndexMarkup">
+				<expression><![CDATA[$F{elementLevel}>=4 ? "      " + $F{name}: $F{elementLevel}==3 ? "     " + $F{name}: $F{elementLevel}==2 ? "  " + $F{name}:$F{name}]]></expression>
+			</element>
+			<element kind="textField" uuid="7ff6404d-4926-44d1-ac2b-e8067943ce4e" key="staticText-7" x="376" y="0" width="80" height="14" markup="none" fontName="DejaVu Sans" fontSize="9.0" blankWhenNull="true" bold="false" hTextAlign="Right">
+				<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
+				<expression><![CDATA[($F{qty}!=null) ? $P{NUMBERFORMAT}.format($F{qty}).toString() : new String(" ")]]></expression>
+			</element>
+			<element kind="textField" uuid="6f93ffcc-ba6f-4b1e-bfcb-e1151411b7fa" key="staticText-7" x="455" y="0" width="80" height="14" markup="none" fontName="DejaVu Sans" fontSize="9.0" blankWhenNull="true" bold="false" hTextAlign="Right">
+				<printWhenExpression><![CDATA[$P{compareTo}.equals("Y")]]></printWhenExpression>
+				<expression><![CDATA[($F{qtyRef}!=null) ? $P{NUMBERFORMAT}.format($F{qtyRef}).toString() : new String(" ")]]></expression>
+			</element>
+			<element kind="textField" uuid="361f795c-8f66-465d-b932-e584e090b820" key="staticText-7" x="374" y="0" width="159" height="14" markup="none" fontName="DejaVu Sans" fontSize="9.0" blankWhenNull="true" bold="false" hTextAlign="Right">
+				<printWhenExpression><![CDATA[$P{compareTo}.equals("N")]]></printWhenExpression>
+				<expression><![CDATA[($F{qty}!=null) ? $P{NUMBERFORMAT}.format($F{qty}).toString() : new String(" ")]]></expression>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="40" splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="40" splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportAgingBalance.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportAgingBalance.jrxml
@@ -1,75 +1,75 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportAgingBalance" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="3547a519-9e65-4956-98c7-f0145bad4e3b">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportAgingBalance" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="3547a519-9e65-4956-98c7-f0145bad4e3b">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/home/david/workspace/trunk/openbravo/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat()]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale">
 		<defaultValueExpression><![CDATA[new Locale("es", "ES")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="InitialBalance" class="java.math.BigDecimal" isForPrompting="false">
+	<parameter name="InitialBalance" forPrompting="false" class="java.math.BigDecimal">
 		<defaultValueExpression><![CDATA[new BigDecimal(1111)]]></defaultValueExpression>
 	</parameter>
 	<parameter name="SUBREPORT_DIR" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{BASE_DESIGN}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATE_FROM" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col1" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col2" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col3" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col4" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="col5" class="java.lang.String" isForPrompting="false"/>
+	<parameter name="DATE_FROM" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col1" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col2" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col3" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col4" forPrompting="false" class="java.lang.String"/>
+	<parameter name="col5" forPrompting="false" class="java.lang.String"/>
 	<field name="BPARTNER" class="java.lang.String"/>
 	<field name="ISRECEIPT" class="java.lang.String"/>
 	<field name="ZERO" class="java.math.BigDecimal"/>
@@ -79,426 +79,297 @@
 	<field name="FOUR" class="java.math.BigDecimal"/>
 	<field name="FIVE" class="java.math.BigDecimal"/>
 	<field name="TOTAL" class="java.math.BigDecimal"/>
-	<variable name="SUM_ZERO_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{ZERO}]]></variableExpression>
+	<variable name="SUM_ZERO_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{ZERO}]]></expression>
 	</variable>
-	<variable name="SUM_ONE_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{ONE}]]></variableExpression>
+	<variable name="SUM_ONE_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{ONE}]]></expression>
 	</variable>
-	<variable name="SUM_TWO_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{TWO}]]></variableExpression>
+	<variable name="SUM_TWO_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{TWO}]]></expression>
 	</variable>
-	<variable name="SUM_THREE_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{THREE}]]></variableExpression>
+	<variable name="SUM_THREE_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{THREE}]]></expression>
 	</variable>
-	<variable name="SUM_FOUR_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{FOUR}]]></variableExpression>
+	<variable name="SUM_FOUR_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{FOUR}]]></expression>
 	</variable>
-	<variable name="SUM_FIVE_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{FIVE}]]></variableExpression>
+	<variable name="SUM_FIVE_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{FIVE}]]></expression>
 	</variable>
-	<variable name="SUM_TOTAL_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{TOTAL}]]></variableExpression>
+	<variable name="SUM_TOTAL_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{TOTAL}]]></expression>
 	</variable>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="73" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-17" style="Report_Footer" x="1" y="37" width="294" height="28" uuid="a2e1b5da-5cba-445f-8771-6c5b81288950"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="18"/>
-				</textElement>
-				<text><![CDATA[Payment Aging Balance]]></text>
-			</staticText>
-			<image isLazy="true">
-				<reportElement key="image-1" x="321" y="10" width="197" height="55" uuid="3bf9ba50-fdda-4559-ac4a-e0d7df739b9c"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<imageExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylogin")]]></imageExpression>
-			</image>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="73" splitType="Stretch">
+		<element kind="staticText" uuid="a2e1b5da-5cba-445f-8771-6c5b81288950" key="staticText-17" x="1" y="37" width="294" height="28" fontSize="18.0" style="Report_Footer">
+			<text><![CDATA[Payment Aging Balance]]></text>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="image" uuid="3bf9ba50-fdda-4559-ac4a-e0d7df739b9c" key="image-1" x="321" y="10" width="197" height="55" lazy="true">
+			<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylogin")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</title>
-	<pageHeader>
-		<band height="5" splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band height="15" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-18" style="Detail_Header" x="0" y="0" width="164" height="15" uuid="9e02a09e-c0c6-4ae2-add2-34fd09b8a573"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement>
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[BUSINESS PARTNER]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-19" style="Detail_Header" x="164" y="0" width="56" height="15" uuid="d904e338-9ae2-407f-8beb-1db9b465fe0f"/>
-				<box leftPadding="5" rightPadding="4">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[PREVIOUS]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="463" y="0" width="50" height="15" uuid="321f6916-21fe-4976-b34b-78cbe0cd416d"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[TOTAL]]></text>
-			</staticText>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Header" x="220" y="0" width="47" height="15" uuid="9cb21d47-4593-4eca-88a6-c8d16fac0149"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{col1}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-3" style="Detail_Header" x="267" y="0" width="48" height="15" uuid="68aadfa3-a8c5-4a5f-a461-044f9b67b4c2"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{col2}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-4" style="Detail_Header" x="315" y="0" width="50" height="15" uuid="b1912d19-e438-42b9-80b1-3673e0d3afe8"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{col3}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-5" style="Detail_Header" x="365" y="0" width="48" height="15" uuid="4a9dbeb6-4e95-43d3-8756-67669f6106f8"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{col4}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-6" style="Detail_Header" x="414" y="0" width="49" height="15" uuid="4f63b05f-e3c4-456d-997a-20512d151a2f"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{col5}]]></textFieldExpression>
-			</textField>
-		</band>
+	<pageHeader height="5" splitType="Stretch"/>
+	<columnHeader height="15" splitType="Stretch">
+		<element kind="staticText" uuid="9e02a09e-c0c6-4ae2-add2-34fd09b8a573" key="staticText-18" x="0" y="0" width="164" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" style="Detail_Header">
+			<text><![CDATA[BUSINESS PARTNER]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="d904e338-9ae2-407f-8beb-1db9b465fe0f" key="staticText-19" x="164" y="0" width="56" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Left" style="Detail_Header">
+			<text><![CDATA[PREVIOUS]]></text>
+			<box leftPadding="5" rightPadding="4" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="321f6916-21fe-4976-b34b-78cbe0cd416d" key="staticText-25" x="463" y="0" width="50" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[TOTAL]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="9cb21d47-4593-4eca-88a6-c8d16fac0149" key="textField" x="220" y="0" width="47" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col1}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="68aadfa3-a8c5-4a5f-a461-044f9b67b4c2" key="textField-3" x="267" y="0" width="48" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col2}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="b1912d19-e438-42b9-80b1-3673e0d3afe8" key="textField-4" x="315" y="0" width="50" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col3}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="4a9dbeb6-4e95-43d3-8756-67669f6106f8" key="textField-5" x="365" y="0" width="48" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col4}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="4f63b05f-e3c4-456d-997a-20512d151a2f" key="textField-6" x="414" y="0" width="49" height="15" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{col5}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
 	</columnHeader>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="512" y="0" width="1" height="16" uuid="307b619b-e2a4-4505-88a7-10af4f8a9b0e"/>
-				<graphicElement>
-					<pen lineWidth="0.25" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="16" uuid="827d5490-13e5-45a8-b5f6-ce3381354b36"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" x="6" y="0" width="159" height="16" uuid="a86c810e-5383-472f-ba75-8b94b841dbbd"/>
+			<element kind="line" uuid="307b619b-e2a4-4505-88a7-10af4f8a9b0e" key="line-16" stretchType="ContainerHeight" x="512" y="0" width="1" height="16">
+				<pen lineWidth="0.25" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="827d5490-13e5-45a8-b5f6-ce3381354b36" key="line-17" stretchType="ContainerHeight" x="1" y="0" width="1" height="16">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="a86c810e-5383-472f-ba75-8b94b841dbbd" key="textField" x="6" y="0" width="159" height="16" fontSize="8.0" blankWhenNull="false">
+				<expression><![CDATA[$F{BPARTNER}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{BPARTNER}]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="220" y="0" width="47" height="16" uuid="19601cc2-2c45-4d5e-a9e1-70608ab7fc2a"/>
+			</element>
+			<element kind="textField" uuid="19601cc2-2c45-4d5e-a9e1-70608ab7fc2a" key="textField" x="220" y="0" width="47" height="16" fontSize="8.0" pattern="##0.00" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[($F{ONE}!=null)?$P{NUMBERFORMAT}.format($F{ONE}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{ONE}!=null)?$P{NUMBERFORMAT}.format($F{ONE}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="267" y="0" width="48" height="16" uuid="58da08e0-cd67-45f8-87f2-6ac4c4472c16"/>
+			</element>
+			<element kind="textField" uuid="58da08e0-cd67-45f8-87f2-6ac4c4472c16" key="textField" x="267" y="0" width="48" height="16" fontSize="8.0" pattern="##0.00" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[($F{TWO}!=null)?$P{NUMBERFORMAT}.format($F{TWO}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{TWO}!=null)?$P{NUMBERFORMAT}.format($F{TWO}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="315" y="0" width="50" height="16" uuid="0baeb604-3efe-4652-8bf5-33fa1bfdbb6d"/>
+			</element>
+			<element kind="textField" uuid="0baeb604-3efe-4652-8bf5-33fa1bfdbb6d" key="textField" x="315" y="0" width="50" height="16" fontSize="8.0" pattern="##0.00" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[($F{THREE}!=null)?$P{NUMBERFORMAT}.format($F{THREE}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{THREE}!=null)?$P{NUMBERFORMAT}.format($F{THREE}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="365" y="0" width="49" height="16" uuid="63340e6c-ff8f-441e-92ba-fc876ec0bf49"/>
+			</element>
+			<element kind="textField" uuid="63340e6c-ff8f-441e-92ba-fc876ec0bf49" key="textField" x="365" y="0" width="49" height="16" fontSize="8.0" pattern="##0.00" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[($F{FOUR}!=null)?$P{NUMBERFORMAT}.format($F{FOUR}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{FOUR}!=null)?$P{NUMBERFORMAT}.format($F{FOUR}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="414" y="0" width="50" height="16" uuid="d75820ab-a460-4905-83a5-77dce6eed154"/>
+			</element>
+			<element kind="textField" uuid="d75820ab-a460-4905-83a5-77dce6eed154" key="textField" x="414" y="0" width="50" height="16" fontSize="8.0" pattern="##0.00" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[($F{FIVE}!=null)?$P{NUMBERFORMAT}.format($F{FIVE}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{FIVE}!=null)?$P{NUMBERFORMAT}.format($F{FIVE}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="464" y="0" width="47" height="16" uuid="0c29bc28-115a-422a-92ec-b590a64e85d7"/>
+			</element>
+			<element kind="textField" uuid="0c29bc28-115a-422a-92ec-b590a64e85d7" key="textField" x="464" y="0" width="47" height="16" fontSize="8.0" pattern="##0.00" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[($F{TOTAL}!=null)?$P{NUMBERFORMAT}.format($F{TOTAL}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{TOTAL}!=null)?$P{NUMBERFORMAT}.format($F{TOTAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="165" y="0" width="55" height="16" uuid="561c1fc3-3a8d-4d87-a72c-4b90ab1cf767"/>
+			</element>
+			<element kind="textField" uuid="561c1fc3-3a8d-4d87-a72c-4b90ab1cf767" key="textField" x="165" y="0" width="55" height="16" fontSize="8.0" pattern="##0.00" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[($F{ZERO}!=null)?$P{NUMBERFORMAT}.format($F{ZERO}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{ZERO}!=null)?$P{NUMBERFORMAT}.format($F{ZERO}):new String(" ")]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="1" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="3" splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band height="30" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="279" y="20" width="69" height="8" uuid="d28d977f-b365-4378-9364-337abc01c1c0"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" style="Report_Footer" x="200" y="20" width="76" height="8" uuid="89886912-58d2-4a4d-a6d4-9ddff2596b2f"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="5"/>
-				</textElement>
-				<text><![CDATA[Printed on]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-26" style="Detail_Header" x="1" y="0" width="164" height="14" uuid="7d3331ac-5e47-475b-9c6a-4da5573e5d69"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[TOTAL:]]></text>
-			</staticText>
-			<textField pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField-2" mode="Opaque" x="165" y="0" width="51" height="14" forecolor="#060D0A" backcolor="#CAB7B7" uuid="e24b10ee-2ecf-40f0-979c-9952833e02ba"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_ZERO_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_ZERO_1}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" mode="Opaque" x="216" y="0" width="51" height="14" forecolor="#060D0A" backcolor="#CAB7B7" uuid="d52d73e7-df66-4a11-b781-51d89d03611b"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_ONE_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_ONE_1}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" mode="Opaque" x="267" y="0" width="48" height="14" forecolor="#060D0A" backcolor="#CAB7B7" uuid="072715e7-4a84-4726-b4ca-b256223f379c"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_TWO_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_TWO_1}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" mode="Opaque" x="315" y="0" width="50" height="14" forecolor="#060D0A" backcolor="#CAB7B7" uuid="115a7f76-121f-451c-8a25-b851acd0d7d6"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_THREE_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_THREE_1}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" mode="Opaque" x="365" y="0" width="49" height="14" forecolor="#060D0A" backcolor="#CAB7B7" uuid="89fb1f6c-d197-4077-9b14-083694c3057e"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_FOUR_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_FOUR_1}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" mode="Opaque" x="414" y="0" width="50" height="14" forecolor="#060D0A" backcolor="#CAB7B7" uuid="8a6b64dd-c17c-4c68-95df-0d2480e34dfc"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_FIVE_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_FIVE_1}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" mode="Opaque" x="464" y="0" width="47" height="14" forecolor="#060D0A" backcolor="#CAB7B7" uuid="ac2428a2-ab7e-4a4b-9e23-af25e618bda5"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_TOTAL_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_TOTAL_1}):new String(" ")]]></textFieldExpression>
-			</textField>
-		</band>
+	<columnFooter height="1" splitType="Stretch"/>
+	<pageFooter height="3" splitType="Stretch"/>
+	<summary height="30" splitType="Stretch">
+		<element kind="textField" uuid="d28d977f-b365-4378-9364-337abc01c1c0" key="textField" x="279" y="20" width="69" height="8" fontName="Times-Roman" fontSize="5.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="89886912-58d2-4a4d-a6d4-9ddff2596b2f" key="staticText-1" x="200" y="20" width="76" height="8" fontSize="5.0" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Printed on]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="7d3331ac-5e47-475b-9c6a-4da5573e5d69" key="staticText-26" x="1" y="0" width="164" height="14" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[TOTAL:]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="e24b10ee-2ecf-40f0-979c-9952833e02ba" key="textField-2" mode="Opaque" x="165" y="0" width="51" height="14" forecolor="#060D0A" backcolor="#CAB7B7" fontSize="8.0" pattern="##0.00" blankWhenNull="false" hTextAlign="Right">
+			<expression><![CDATA[($V{SUM_ZERO_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_ZERO_1}):new String(" ")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="d52d73e7-df66-4a11-b781-51d89d03611b" key="textField" mode="Opaque" x="216" y="0" width="51" height="14" forecolor="#060D0A" backcolor="#CAB7B7" fontSize="8.0" pattern="##0.00" blankWhenNull="false" hTextAlign="Right">
+			<expression><![CDATA[($V{SUM_ONE_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_ONE_1}):new String(" ")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="072715e7-4a84-4726-b4ca-b256223f379c" key="textField" mode="Opaque" x="267" y="0" width="48" height="14" forecolor="#060D0A" backcolor="#CAB7B7" fontSize="8.0" pattern="##0.00" blankWhenNull="false" hTextAlign="Right">
+			<expression><![CDATA[($V{SUM_TWO_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_TWO_1}):new String(" ")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="115a7f76-121f-451c-8a25-b851acd0d7d6" key="textField" mode="Opaque" x="315" y="0" width="50" height="14" forecolor="#060D0A" backcolor="#CAB7B7" fontSize="8.0" pattern="##0.00" blankWhenNull="false" hTextAlign="Right">
+			<expression><![CDATA[($V{SUM_THREE_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_THREE_1}):new String(" ")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="89fb1f6c-d197-4077-9b14-083694c3057e" key="textField" mode="Opaque" x="365" y="0" width="49" height="14" forecolor="#060D0A" backcolor="#CAB7B7" fontSize="8.0" pattern="##0.00" blankWhenNull="false" hTextAlign="Right">
+			<expression><![CDATA[($V{SUM_FOUR_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_FOUR_1}):new String(" ")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="8a6b64dd-c17c-4c68-95df-0d2480e34dfc" key="textField" mode="Opaque" x="414" y="0" width="50" height="14" forecolor="#060D0A" backcolor="#CAB7B7" fontSize="8.0" pattern="##0.00" blankWhenNull="false" hTextAlign="Right">
+			<expression><![CDATA[($V{SUM_FIVE_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_FIVE_1}):new String(" ")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="ac2428a2-ab7e-4a4b-9e23-af25e618bda5" key="textField" mode="Opaque" x="464" y="0" width="47" height="14" forecolor="#060D0A" backcolor="#CAB7B7" fontSize="8.0" pattern="##0.00" blankWhenNull="false" hTextAlign="Right">
+			<expression><![CDATA[($V{SUM_TOTAL_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_TOTAL_1}):new String(" ")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</summary>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportAnnualCertification.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportAnnualCertification.jrxml
@@ -1,24 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportAnnualCertification" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="02325b36-2c8d-4de0-9ff2-59bb35427704">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportAnnualCertification" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="02325b36-2c8d-4de0-9ff2-59bb35427704">
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<parameter name="DateFrom" class="java.lang.String" isForPrompting="false">
-		<parameterDescription><![CDATA[Date From]]></parameterDescription>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<parameter name="DateFrom" forPrompting="false" class="java.lang.String">
+		<description><![CDATA[Date From]]></description>
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DateTo" class="java.lang.String" isForPrompting="false">
-		<parameterDescription><![CDATA[Date To]]></parameterDescription>
+	<parameter name="DateTo" forPrompting="false" class="java.lang.String">
+		<description><![CDATA[Date To]]></description>
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATEFORMATTER" class="java.text.DateFormat" isForPrompting="false">
+	<parameter name="DATEFORMATTER" forPrompting="false" class="java.text.DateFormat">
 		<defaultValueExpression><![CDATA[$P{REPORT_FORMAT_FACTORY}.createDateFormat("", $P{REPORT_LOCALE}, $P{REPORT_TIME_ZONE})]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT '' as Mittente, '' as Erogante,'' as AddressOrganization, buspar.name as BusinessPartner,buspar.taxid,buspar.fiscalcode,Loc.ADDRESS1,Loc.POSTAL,City.NAME as City,City.LOCODE,
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT '' as Mittente, '' as Erogante,'' as AddressOrganization, buspar.name as BusinessPartner,buspar.taxid,buspar.fiscalcode,Loc.ADDRESS1,Loc.POSTAL,City.NAME as City,City.LOCODE,
  debpaycancel.DATEPLANNED,bank.Name,bank.Codebank,bank.Codebranch,bank.Digitcontrol as DigitcontrolBank,bankaccount.Digitcontrol as DigitcontrolBankAccount,bankaccount.Codeaccount,
  coalesce ( sum(invoic.TOTALLINES),0) as SummedLineAmount,
  coalesce ( sum(invoic.GRANDTOTAL),0) as GrandTotalAmount,
@@ -46,8 +45,7 @@
  left join (select C_BankAccount_ID, C_Bank_ID, Digitcontrol, Codeaccount from C_BankAccount) bankaccount on (debpaygenerate.C_BankAccount_ID = bankaccount.C_BankAccount_ID) 
  left join (select C_Bank_ID, Name, Codebank, Codebranch, Digitcontrol from C_Bank) bank on (bank.C_Bank_ID = bankaccount.C_Bank_ID) 
  group by buspar.name,buspar.taxid,buspar.fiscalcode,Loc.ADDRESS1,Loc.POSTAL,City.NAME,City.LOCODE ,debpaycancel.DATEPLANNED,bank.Name,bank.Codebank,bank.Codebranch,bank.Digitcontrol,bankaccount.Digitcontrol,bankaccount.Codeaccount
- order by buspar.name asc]]>
-	</queryString>
+ order by buspar.name asc]]></query>
 	<field name="MITTENTE" class="java.lang.String"/>
 	<field name="EROGANTE" class="java.lang.String"/>
 	<field name="ADDRESSORGANIZATION" class="java.lang.String"/>
@@ -68,354 +66,239 @@
 	<field name="SUMMEDLINEAMOUNT" class="java.math.BigDecimal"/>
 	<field name="GRANDTOTALAMOUNT" class="java.math.BigDecimal"/>
 	<field name="WITHHOLDINGAMOUNT" class="java.math.BigDecimal"/>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch">
-			<line>
-				<reportElement key="line" x="0" y="-2" width="534" height="1" uuid="fa2fbf64-d75d-4177-924e-b95eab716537"/>
-			</line>
-			<line>
-				<reportElement key="line" x="0" y="-47" width="534" height="1" uuid="48634cb7-a4d7-41f9-9dc1-0973bf7e60f7"/>
-			</line>
-		</band>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch">
+		<element kind="line" uuid="fa2fbf64-d75d-4177-924e-b95eab716537" key="line" x="0" y="-2" width="534" height="1"/>
+		<element kind="line" uuid="48634cb7-a4d7-41f9-9dc1-0973bf7e60f7" key="line" x="0" y="-47" width="534" height="1"/>
 	</title>
-	<pageHeader>
-		<band height="10" splitType="Stretch">
-			<line direction="BottomUp">
-				<reportElement key="line" x="0" y="9" width="535" height="1" uuid="397a7976-964f-4a1d-b6e4-7b8e26a8eaf4"/>
-			</line>
-		</band>
+	<pageHeader height="10" splitType="Stretch">
+		<element kind="line" uuid="397a7976-964f-4a1d-b6e4-7b8e26a8eaf4" key="line" x="0" y="9" width="535" height="1" direction="BottomUp"/>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="600" splitType="Stretch">
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" x="0" y="545" width="404" height="30" forecolor="#000000" backcolor="#FFFFFF" uuid="0c6c461a-5ae5-461a-a7c1-d6ac3a3d46b9"/>
+			<element kind="textField" uuid="0c6c461a-5ae5-461a-a7c1-d6ac3a3d46b9" key="textField" x="0" y="545" width="404" height="30" forecolor="#000000" backcolor="#FFFFFF" fontName="Courier New" fontSize="10.0" blankWhenNull="false">
+				<expression><![CDATA[($F{ADDRESSORGANIZATION}!=null)?$F{ADDRESSORGANIZATION}:new String(" ")+ " " + $P{DATEFORMATTER}.format(new Date())]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font fontName="Courier New" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{ADDRESSORGANIZATION}!=null)?$F{ADDRESSORGANIZATION}:new String(" ")+ " " + $P{DATEFORMATTER}.format(new Date())]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" x="220" y="32" width="315" height="17" forecolor="#000000" backcolor="#FFFFFF" uuid="d0dd8e4d-c7ed-4f7b-ac23-69cb27d1cab8"/>
+			</element>
+			<element kind="textField" uuid="d0dd8e4d-c7ed-4f7b-ac23-69cb27d1cab8" key="textField" x="220" y="32" width="315" height="17" forecolor="#000000" backcolor="#FFFFFF" fontName="Courier New" fontSize="10.0" pattern="" blankWhenNull="true" vTextAlign="Middle">
+				<expression><![CDATA[$F{BUSINESSPARTNER}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Courier New" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{BUSINESSPARTNER}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" x="76" y="170" width="196" height="17" forecolor="#000000" backcolor="#FFFFFF" uuid="c8b05ace-b7d9-4bd3-a7f4-54e56e9c96e4"/>
+			</element>
+			<element kind="textField" uuid="c8b05ace-b7d9-4bd3-a7f4-54e56e9c96e4" key="textField" x="76" y="170" width="196" height="17" forecolor="#000000" backcolor="#FFFFFF" fontName="Courier New" fontSize="10.0" pattern="" blankWhenNull="true" vTextAlign="Middle">
+				<expression><![CDATA[$F{FISCALCODE}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Courier New" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{FISCALCODE}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" x="76" y="153" width="196" height="17" forecolor="#000000" backcolor="#FFFFFF" uuid="2bfc5c00-3325-421f-a241-437ee0245643"/>
+			</element>
+			<element kind="textField" uuid="2bfc5c00-3325-421f-a241-437ee0245643" key="textField" x="76" y="153" width="196" height="17" forecolor="#000000" backcolor="#FFFFFF" fontName="Courier New" fontSize="10.0" pattern="" blankWhenNull="true" vTextAlign="Middle">
+				<expression><![CDATA[$F{ADDRESS1}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Courier New" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{ADDRESS1}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" x="387" y="153" width="74" height="17" forecolor="#000000" backcolor="#FFFFFF" uuid="0ef95905-cb51-4cbe-a9e0-363f4d38d01e"/>
+			</element>
+			<element kind="textField" uuid="0ef95905-cb51-4cbe-a9e0-363f4d38d01e" key="textField" x="387" y="153" width="74" height="17" forecolor="#000000" backcolor="#FFFFFF" fontName="Courier New" fontSize="10.0" pattern="" blankWhenNull="true" vTextAlign="Middle">
+				<expression><![CDATA[$F{POSTAL}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Courier New" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{POSTAL}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" x="277" y="153" width="107" height="17" forecolor="#000000" backcolor="#FFFFFF" uuid="9c9b019e-cea5-4573-b3e0-a311ad50b9a1"/>
+			</element>
+			<element kind="textField" uuid="9c9b019e-cea5-4573-b3e0-a311ad50b9a1" key="textField" x="277" y="153" width="107" height="17" forecolor="#000000" backcolor="#FFFFFF" fontName="Courier New" fontSize="10.0" pattern="" blankWhenNull="true" vTextAlign="Middle">
+				<expression><![CDATA[$F{CITY}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Courier New" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CITY}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" x="467" y="153" width="67" height="17" forecolor="#000000" backcolor="#FFFFFF" uuid="4fdabc2b-8dbc-4a95-8b4b-7fe2ce5089f8"/>
+			</element>
+			<element kind="textField" uuid="4fdabc2b-8dbc-4a95-8b4b-7fe2ce5089f8" key="textField" x="467" y="153" width="67" height="17" forecolor="#000000" backcolor="#FFFFFF" fontName="Courier New" fontSize="10.0" pattern="" blankWhenNull="true" vTextAlign="Middle">
+				<expression><![CDATA[$F{LOCODE}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Courier New" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{LOCODE}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-6" x="0" y="69" width="535" height="33" uuid="25c36fec-dfaa-4700-9378-76125d5f8760"/>
+			</element>
+			<element kind="textField" uuid="25c36fec-dfaa-4700-9378-76125d5f8760" key="textField-6" x="0" y="69" width="535" height="33" fontName="Courier New" pdfFontName="Helvetica-Bold" blankWhenNull="false" bold="true">
+				<expression><![CDATA["Subject: Certification of compensation subject to withholding"]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font fontName="Courier New" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Subject: Certification of compensation subject to withholding"]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-7" x="1" y="117" width="75" height="18" uuid="f7962023-7ee3-47d3-a96f-653370cfbdd5"/>
+			</element>
+			<element kind="textField" uuid="f7962023-7ee3-47d3-a96f-653370cfbdd5" key="textField-7" x="1" y="117" width="75" height="18" fontName="Courier New" blankWhenNull="false" vTextAlign="Middle">
+				<expression><![CDATA["Tax payer :"]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Courier New"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Tax payer :"]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-8" x="1" y="135" width="75" height="18" uuid="c52366b0-4838-49eb-9fa8-2d1a63571943"/>
+			</element>
+			<element kind="textField" uuid="c52366b0-4838-49eb-9fa8-2d1a63571943" key="textField-8" x="1" y="135" width="75" height="18" fontName="Courier New" blankWhenNull="false" vTextAlign="Middle">
+				<expression><![CDATA["Date of birth :"]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Courier New"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Date of birth :"]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-9" x="1" y="153" width="75" height="18" uuid="b9d70a5e-751a-4389-acc9-651facf7f707"/>
+			</element>
+			<element kind="textField" uuid="b9d70a5e-751a-4389-acc9-651facf7f707" key="textField-9" x="1" y="153" width="75" height="18" fontName="Courier New" blankWhenNull="false" vTextAlign="Middle">
+				<expression><![CDATA["Address :"]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Courier New"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Address :"]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-10" x="1" y="171" width="75" height="18" uuid="f5edd9c4-11b7-4bf9-94f3-82cd3c699861"/>
+			</element>
+			<element kind="textField" uuid="f5edd9c4-11b7-4bf9-94f3-82cd3c699861" key="textField-10" x="1" y="171" width="75" height="18" fontName="Courier New" blankWhenNull="false" vTextAlign="Middle">
+				<expression><![CDATA["Tax ID :"]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Courier New"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Tax ID :"]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-11" x="0" y="199" width="75" height="18" uuid="23a8da65-9149-4e98-8093-11c7c77c08b0"/>
+			</element>
+			<element kind="textField" uuid="23a8da65-9149-4e98-8093-11c7c77c08b0" key="textField-11" x="0" y="199" width="75" height="18" fontName="Courier New" blankWhenNull="false" vTextAlign="Middle">
+				<expression><![CDATA["Employer :"]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Courier New"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Employer :"]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-1" x="0" y="217" width="535" height="62" uuid="3ac6d2e8-92bd-404d-a8c4-9e68b76a95ba"/>
+			</element>
+			<element kind="textField" uuid="3ac6d2e8-92bd-404d-a8c4-9e68b76a95ba" key="textField-1" x="0" y="217" width="535" height="62" fontName="Courier New" blankWhenNull="false">
+				<expression><![CDATA["We certify that for the period from "+$P{DateFrom}.toString()+" to "+$P{DateTo}.toString()+" total payments to the payee were "+$F{GRANDTOTALAMOUNT}.toString()+
+" and that the withholding amount is "+$F{WITHHOLDINGAMOUNT}.toString()]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font fontName="Courier New"/>
-				</textElement>
-				<textFieldExpression><![CDATA["We certify that for the period from "+$P{DateFrom}.toString()+" to "+$P{DateTo}.toString()+" total payments to the payee were "+$F{GRANDTOTALAMOUNT}.toString()+
-" and that the withholding amount is "+$F{WITHHOLDINGAMOUNT}.toString()]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-12" x="0" y="527" width="131" height="18" uuid="c88084e3-e0f6-4a24-b699-1239adab2a33"/>
+			</element>
+			<element kind="textField" uuid="c88084e3-e0f6-4a24-b699-1239adab2a33" key="textField-12" x="0" y="527" width="131" height="18" fontName="Courier New" blankWhenNull="false">
+				<expression><![CDATA["Best regards :"]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font fontName="Courier New"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Best regards :"]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-13" x="404" y="557" width="131" height="18" uuid="827b43a0-9b2a-43eb-8947-1a6bd0ebe85d"/>
+			</element>
+			<element kind="textField" uuid="827b43a0-9b2a-43eb-8947-1a6bd0ebe85d" key="textField-13" x="404" y="557" width="131" height="18" fontName="Courier New" pdfFontName="Helvetica" blankWhenNull="false" bold="false" hTextAlign="Right">
+				<expression><![CDATA["Signature"]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Courier New" isBold="false" pdfFontName="Helvetica"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Signature"]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" x="0" y="9" width="109" height="12" uuid="6bdcb39d-43b9-49f6-8aad-b3ee7ec711ea"/>
+			</element>
+			<element kind="textField" uuid="6bdcb39d-43b9-49f6-8aad-b3ee7ec711ea" key="textField" x="0" y="9" width="109" height="12" fontName="Courier New" blankWhenNull="false">
+				<expression><![CDATA[$F{MITTENTE}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font fontName="Courier New"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{MITTENTE}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" x="76" y="199" width="458" height="18" uuid="58796205-08d4-4e7e-b225-02ee07f3972d"/>
+			</element>
+			<element kind="textField" uuid="58796205-08d4-4e7e-b225-02ee07f3972d" key="textField" x="76" y="199" width="458" height="18" blankWhenNull="false">
+				<expression><![CDATA[$F{EROGANTE}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$F{EROGANTE}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-2" x="76" y="117" width="315" height="17" forecolor="#000000" backcolor="#FFFFFF" uuid="8dc59fad-8ac0-4b06-8266-f0c53e7048ee"/>
+			</element>
+			<element kind="textField" uuid="8dc59fad-8ac0-4b06-8266-f0c53e7048ee" key="textField-2" x="76" y="117" width="315" height="17" forecolor="#000000" backcolor="#FFFFFF" fontName="Courier New" fontSize="10.0" pattern="" blankWhenNull="true" vTextAlign="Middle">
+				<expression><![CDATA[$F{BUSINESSPARTNER}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Courier New" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{BUSINESSPARTNER}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-3" x="0" y="319" width="535" height="20" uuid="563f4587-cfeb-4a8e-ab42-d9b075093928"/>
+			</element>
+			<element kind="textField" uuid="563f4587-cfeb-4a8e-ab42-d9b075093928" key="textField-3" x="0" y="319" width="535" height="20" fontName="Courier New" blankWhenNull="false">
+				<expression><![CDATA["On : "+ $P{DATEFORMATTER}.format($F{DATEPLANNED})]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font fontName="Courier New"/>
-				</textElement>
-				<textFieldExpression><![CDATA["On : "+ $P{DATEFORMATTER}.format($F{DATEPLANNED})]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-4" x="0" y="279" width="535" height="20" uuid="8535180c-5e15-4ad5-9428-d29b9305324b"/>
+			</element>
+			<element kind="textField" uuid="8535180c-5e15-4ad5-9428-d29b9305324b" key="textField-4" x="0" y="279" width="535" height="20" fontName="Courier New" blankWhenNull="false">
+				<expression><![CDATA["The withhold amount has been deposited at: "]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font fontName="Courier New"/>
-				</textElement>
-				<textFieldExpression><![CDATA["The withhold amount has been deposited at: "]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-5" x="0" y="299" width="535" height="20" uuid="e989ff64-f136-4c49-839e-ba73b88e44fb"/>
+			</element>
+			<element kind="textField" uuid="e989ff64-f136-4c49-839e-ba73b88e44fb" key="textField-5" x="0" y="299" width="535" height="20" fontName="Courier New" blankWhenNull="true">
+				<expression><![CDATA[$F{NAME}.trim()+"-"+$F{CODEBANK}.toString()+"-"+$F{CODEBRANCH}.toString()+"-"+$F{DIGITCONTROLBANK}.toString()+"-"+$F{DIGITCONTROLBANKACCOUNT}.toString()+"-"+$F{CODEACCOUNT}.toString()]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font fontName="Courier New"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{NAME}.trim()+"-"+$F{CODEBANK}.toString()+"-"+$F{CODEBRANCH}.toString()+"-"+$F{DIGITCONTROLBANK}.toString()+"-"+$F{DIGITCONTROLBANKACCOUNT}.toString()+"-"+$F{CODEACCOUNT}.toString()]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="27" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="325" y="4" width="170" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="64a208ef-2f7c-4a81-b448-5d544eeafc8b"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="499" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="493f67e2-1fdb-41e9-b296-730e258f54a1"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="3" width="535" height="1" uuid="a556713d-ebe1-4e10-b4bd-80a853425443"/>
-			</line>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="27" splitType="Stretch">
+		<element kind="textField" uuid="64a208ef-2f7c-4a81-b448-5d544eeafc8b" key="textField" x="325" y="4" width="170" height="19" forecolor="#000000" backcolor="#FFFFFF" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="493f67e2-1fdb-41e9-b296-730e258f54a1" key="textField" x="499" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" fontSize="10.0" evaluationTime="Report" pattern="" blankWhenNull="false">
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="a556713d-ebe1-4e10-b4bd-80a853425443" key="line" x="0" y="3" width="535" height="1"/>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportAssetDepreciationSchedule.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportAssetDepreciationSchedule.jrxml
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="AssetsReportDepreciationSchedule" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="b16175b8-cd76-4fbc-b1fe-68ce5fa2a70f">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="AssetsReportDepreciationSchedule" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="b16175b8-cd76-4fbc-b1fe-68ce5fa2a70f">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
 	<field name="fieldFiscalYear" class="java.lang.String"/>
 	<field name="amount" class="java.math.BigDecimal"/>
 	<field name="endDate" class="java.lang.String"/>
@@ -14,183 +14,127 @@
 	<field name="currency" class="java.lang.String"/>
 	<field name="assetName" class="java.lang.String"/>
 	<field name="Assetdescription" class="java.lang.String"/>
-	<variable name="TotalAmount" class="java.math.BigDecimal" resetType="Group" resetGroup="AssetsGroup" calculation="Sum">
-		<variableExpression><![CDATA[$F{amount}]]></variableExpression>
+	<variable name="TotalAmount" resetType="Group" calculation="Sum" resetGroup="AssetsGroup" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{amount}]]></expression>
 	</variable>
 	<group name="AssetsGroup">
-		<groupExpression><![CDATA[$F{assetName}]]></groupExpression>
+		<expression><![CDATA[$F{assetName}]]></expression>
 		<groupHeader>
 			<band height="38" splitType="Stretch">
-				<line>
-					<reportElement key="line-11" x="528" y="13" width="1" height="25" uuid="1284e16c-801f-4aba-9a42-7e54e130fd25"/>
-				</line>
-				<line>
-					<reportElement key="line-8" x="6" y="13" width="1" height="25" uuid="7e1c28fb-12da-433b-860f-b3f339c677d3"/>
-				</line>
-				<staticText>
-					<reportElement key="staticText-1" x="78" y="24" width="132" height="13" uuid="7882916b-ab24-4ad7-9220-cabd2ff1bbca"/>
-					<box topPadding="2" leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8" isBold="true" isItalic="false" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				<element kind="line" uuid="1284e16c-801f-4aba-9a42-7e54e130fd25" key="line-11" x="528" y="13" width="1" height="25"/>
+				<element kind="line" uuid="7e1c28fb-12da-433b-860f-b3f339c677d3" key="line-8" x="6" y="13" width="1" height="25"/>
+				<element kind="staticText" uuid="7882916b-ab24-4ad7-9220-cabd2ff1bbca" key="staticText-1" x="78" y="24" width="132" height="13" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" italic="false" hTextAlign="Left" vTextAlign="Middle">
 					<text><![CDATA[Amortization Start Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-2" x="209" y="24" width="128" height="13" uuid="afd0e0a1-87ef-4d91-8d6d-909f915cc8cd"/>
 					<box topPadding="2" leftPadding="2" rightPadding="2">
 						<topPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8" isBold="true" isItalic="false" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="afd0e0a1-87ef-4d91-8d6d-909f915cc8cd" key="staticText-2" x="209" y="24" width="128" height="13" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" italic="false" hTextAlign="Left" vTextAlign="Middle">
 					<text><![CDATA[Amortization End Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-3" x="337" y="24" width="126" height="13" uuid="7d83bcb2-06a3-415b-8c90-c72e24259c3e"/>
+					<box topPadding="2" leftPadding="2" rightPadding="2">
+						<topPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="7d83bcb2-06a3-415b-8c90-c72e24259c3e" key="staticText-3" x="337" y="24" width="126" height="13" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" italic="false" hTextAlign="Left" vTextAlign="Middle">
+					<text><![CDATA[Depreciation Amount]]></text>
 					<box topPadding="2" leftPadding="2" rightPadding="2">
 						<topPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8" isBold="true" isItalic="false" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Depreciation Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-4" x="463" y="24" width="58" height="13" uuid="4bae6158-801b-4a84-a582-82212a6fb1a7"/>
+				</element>
+				<element kind="staticText" uuid="4bae6158-801b-4a84-a582-82212a6fb1a7" key="staticText-4" x="463" y="24" width="58" height="13" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" italic="false" hTextAlign="Left" vTextAlign="Middle">
+					<text><![CDATA[Currency]]></text>
 					<box topPadding="2" leftPadding="1" bottomPadding="1" rightPadding="1">
 						<topPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8" isBold="true" isItalic="false" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Currency]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-7" x="15" y="24" width="63" height="13" uuid="e4b3cf4b-caaf-4bee-85ef-cb6d3fdb213a"/>
+				</element>
+				<element kind="staticText" uuid="e4b3cf4b-caaf-4bee-85ef-cb6d3fdb213a" key="staticText-7" x="15" y="24" width="63" height="13" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" italic="false" hTextAlign="Left" vTextAlign="Middle">
+					<text><![CDATA[Fiscal Year]]></text>
 					<box topPadding="2" leftPadding="2" rightPadding="2">
 						<topPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8" isBold="true" isItalic="false" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Fiscal Year]]></text>
-				</staticText>
-				<rectangle>
-					<reportElement key="rectangle-1" x="6" y="1" width="523" height="15" backcolor="#666666" uuid="1b3b99cc-da5d-4588-a7d5-707206849777"/>
-				</rectangle>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField" x="38" y="1" width="143" height="15" forecolor="#FFFFFF" uuid="3db90cce-3d65-41ba-a01a-1c70b4350a15"/>
+				</element>
+				<element kind="rectangle" uuid="1b3b99cc-da5d-4588-a7d5-707206849777" key="rectangle-1" x="6" y="1" width="523" height="15" backcolor="#666666"/>
+				<element kind="textField" uuid="3db90cce-3d65-41ba-a01a-1c70b4350a15" key="textField" x="38" y="1" width="143" height="15" forecolor="#FFFFFF" fontSize="9.0" pdfFontName="Helvetica" blankWhenNull="false" bold="false" hTextAlign="Left" vTextAlign="Middle">
+					<expression><![CDATA[$F{assetName}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="9" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{assetName}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-8" x="9" y="1" width="30" height="15" forecolor="#FFFFFF" uuid="0c6e0701-ce62-4443-83db-8331de40b649"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement verticalAlignment="Middle">
-						<font size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="0c6e0701-ce62-4443-83db-8331de40b649" key="staticText-8" x="9" y="1" width="30" height="15" forecolor="#FFFFFF" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" vTextAlign="Middle">
 					<text><![CDATA[Asset :]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-9" x="213" y="1" width="78" height="15" forecolor="#FFFFFF" uuid="837e448c-32ef-4806-b35c-d1ad8f3db3e2"/>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="837e448c-32ef-4806-b35c-d1ad8f3db3e2" key="staticText-9" x="213" y="1" width="78" height="15" forecolor="#FFFFFF" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" vTextAlign="Middle">
 					<text><![CDATA[Asset Description :]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField" x="291" y="1" width="218" height="15" forecolor="#FFFFFF" uuid="a126653a-911b-465e-bc6f-d9d417774d4e"/>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font size="9" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{Assetdescription}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="a126653a-911b-465e-bc6f-d9d417774d4e" key="textField" x="291" y="1" width="218" height="15" forecolor="#FFFFFF" fontSize="9.0" pdfFontName="Helvetica" blankWhenNull="false" bold="false" vTextAlign="Middle">
+					<expression><![CDATA[$F{Assetdescription}]]></expression>
+					<box>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="27" splitType="Stretch">
-				<line>
-					<reportElement key="line-3" x="6" y="0" width="1" height="17" uuid="5ff63a9d-c902-4a32-bb23-69f770a52e40"/>
-				</line>
-				<line>
-					<reportElement key="line-4" x="7" y="16" width="521" height="1" uuid="33623776-ba6b-4369-9241-f74a26671b7c"/>
-				</line>
-				<line>
-					<reportElement key="line-5" x="528" y="0" width="1" height="17" uuid="125fc19c-560e-414e-961e-25f44dccff29"/>
-				</line>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-1" x="373" y="0" width="120" height="12" uuid="a4baeebb-f32a-4341-bd59-175c4621beed"/>
+				<element kind="line" uuid="5ff63a9d-c902-4a32-bb23-69f770a52e40" key="line-3" x="6" y="0" width="1" height="17"/>
+				<element kind="line" uuid="33623776-ba6b-4369-9241-f74a26671b7c" key="line-4" x="7" y="16" width="521" height="1"/>
+				<element kind="line" uuid="125fc19c-560e-414e-961e-25f44dccff29" key="line-5" x="528" y="0" width="1" height="17"/>
+				<element kind="textField" uuid="a4baeebb-f32a-4341-bd59-175c4621beed" key="textField-1" x="373" y="0" width="120" height="12" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" bold="true" vTextAlign="Middle">
+					<expression><![CDATA[$V{TotalAmount}.toString()]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{TotalAmount}.toString()]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-10" x="15" y="0" width="105" height="12" uuid="a7a65ded-4c8c-4129-a8f5-37c053d8dea5"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement verticalAlignment="Middle">
-						<font size="9" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="a7a65ded-4c8c-4129-a8f5-37c053d8dea5" key="staticText-10" x="15" y="0" width="105" height="12" fontSize="9.0" pdfFontName="Helvetica" bold="false" vTextAlign="Middle">
 					<text><![CDATA[Total Amount]]></text>
-				</staticText>
+					<box>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="Year_Group">
-		<groupExpression><![CDATA[$F{fieldFiscalYear}]]></groupExpression>
+		<expression><![CDATA[$F{fieldFiscalYear}]]></expression>
 		<groupHeader>
 			<band splitType="Stretch"/>
 		</groupHeader>
@@ -198,117 +142,73 @@
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band height="19" splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="7" splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="29" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-6" x="6" y="0" width="521" height="25" forecolor="#000000" uuid="312cd162-a222-46a1-86f3-c7383bf2b2e1"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.5" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="16" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[ASSET REPORT - DEPRECIATION SCHEDULE]]></text>
-			</staticText>
-		</band>
+	<background height="19" splitType="Stretch"/>
+	<title height="7" splitType="Stretch"/>
+	<pageHeader height="29" splitType="Stretch">
+		<element kind="staticText" uuid="312cd162-a222-46a1-86f3-c7383bf2b2e1" key="staticText-6" x="6" y="0" width="521" height="25" forecolor="#000000" fontSize="16.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle">
+			<text><![CDATA[ASSET REPORT - DEPRECIATION SCHEDULE]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.5" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band height="8" splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader height="8" splitType="Stretch"/>
 	<detail>
 		<band height="14" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="78" y="0" width="132" height="12" uuid="539d76d9-7792-4b15-a8ff-bb7f4749008d"/>
+			<element kind="textField" uuid="539d76d9-7792-4b15-a8ff-bb7f4749008d" key="textField" x="78" y="0" width="132" height="12" fontSize="8.0" pattern="" blankWhenNull="false">
+				<expression><![CDATA[$F{startDate}]]></expression>
 				<box leftPadding="1" rightPadding="1">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{startDate}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" x="209" y="0" width="128" height="12" uuid="f2e93ac2-d54d-4a06-9e78-9ce5cded9ee4"/>
+			</element>
+			<element kind="textField" uuid="f2e93ac2-d54d-4a06-9e78-9ce5cded9ee4" key="textField" x="209" y="0" width="128" height="12" fontSize="8.0" blankWhenNull="false">
+				<expression><![CDATA[$F{endDate}]]></expression>
 				<box leftPadding="1" rightPadding="1">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{endDate}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" x="15" y="-1" width="63" height="13" uuid="5ff7ea61-fc32-4e4f-a846-d9832cc0027b"/>
+			</element>
+			<element kind="textField" uuid="5ff7ea61-fc32-4e4f-a846-d9832cc0027b" key="textField" x="15" y="-1" width="63" height="13" fontSize="8.0" blankWhenNull="false">
+				<expression><![CDATA[$F{fieldFiscalYear}]]></expression>
 				<box leftPadding="1" rightPadding="1">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{fieldFiscalYear}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-7" x="6" y="0" width="1" height="14" uuid="c61dc13b-a440-41b9-ab5f-88a9c4d64402"/>
-			</line>
-			<line>
-				<reportElement key="line-10" x="528" y="0" width="1" height="14" uuid="3790b90b-1267-4059-b12b-2352988d58be"/>
-			</line>
-			<line>
-				<reportElement key="line-13" x="15" y="11" width="506" height="2" uuid="b2ac2369-cf35-43a6-aa4d-8cd644acdc28"/>
-			</line>
-			<textField pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="337" y="-1" width="126" height="12" uuid="4072121d-498f-4e59-a4d0-0f048b7430c8"/>
+			</element>
+			<element kind="line" uuid="c61dc13b-a440-41b9-ab5f-88a9c4d64402" key="line-7" x="6" y="0" width="1" height="14"/>
+			<element kind="line" uuid="3790b90b-1267-4059-b12b-2352988d58be" key="line-10" x="528" y="0" width="1" height="14"/>
+			<element kind="line" uuid="b2ac2369-cf35-43a6-aa4d-8cd644acdc28" key="line-13" x="15" y="11" width="506" height="2"/>
+			<element kind="textField" uuid="4072121d-498f-4e59-a4d0-0f048b7430c8" key="textField" x="337" y="-1" width="126" height="12" fontSize="8.0" pattern="##0.00" blankWhenNull="false">
+				<expression><![CDATA[$F{amount}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{amount}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" x="463" y="0" width="58" height="12" uuid="3f497499-99ec-4417-8dbf-a88b20be0433"/>
+			</element>
+			<element kind="textField" uuid="3f497499-99ec-4417-8dbf-a88b20be0433" key="textField" x="463" y="0" width="58" height="12" fontSize="8.0" blankWhenNull="false">
+				<expression><![CDATA[$F{currency}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{currency}]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="7" splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="7" splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportBankJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportBankJR.jrxml
@@ -1,63 +1,61 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportBankJR" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="a9061d9b-450e-43bb-9cd4-faa46dcc3ae2">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportBankJR" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="a9061d9b-450e-43bb-9cd4-faa46dcc3ae2">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true"/>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true"/>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="11">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="11.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{NAME2_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat()]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale">
 		<defaultValueExpression><![CDATA[new Locale("es", "ES")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="InitialBalance" class="java.math.BigDecimal" isForPrompting="false">
+	<parameter name="InitialBalance" forPrompting="false" class="java.math.BigDecimal">
 		<defaultValueExpression><![CDATA[new BigDecimal(1111)]]></defaultValueExpression>
 	</parameter>
 	<parameter name="SUBREPORT_DIR" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{BASE_DESIGN}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATE_FROM" class="java.lang.String" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT C_BANK.NAME AS NAME, C_BANKSTATEMENT.NAME AS NAME2, C_BANKSTATEMENT.C_BANKACCOUNT_ID AS C_BANKACCOUNT_ID,    
+	<parameter name="DATE_FROM" forPrompting="false" class="java.lang.String"/>
+	<query language="sql"><![CDATA[SELECT C_BANK.NAME AS NAME, C_BANKSTATEMENT.NAME AS NAME2, C_BANKSTATEMENT.C_BANKACCOUNT_ID AS C_BANKACCOUNT_ID,    
 (C_BANK.CODEBANK || '/' || C_BANK.CODEBRANCH || C_BANK.DIGITCONTROL || C_BANKACCOUNT.CODEACCOUNT || '.' || C_BANKACCOUNT.DIGITCONTROL) AS bankaccount,      
 C_BANKSTATEMENTLINE.STMTAMT AS TRXAMT, C_DEBT_PAYMENT.AMOUNT AS PAYAMT, C_BANKSTATEMENT.C_BANKSTATEMENT_ID AS BANKSTATEMENT_ID, 
 C_BANKSTATEMENTLINE.DATEACCT AS STATEMENTDATE, C_BANKSTATEMENT.BEGINNINGBALANCE AS BEGINING, C_BANKSTATEMENT.ENDINGBALANCE AS ENDING, C_CURRENCY.DESCRIPTION AS CURRENCY, C_BANKSTATEMENTLINE.LINE AS LINE, C_BANKSTATEMENTLINE.DESCRIPTION AS DESCRIPTION,
@@ -87,8 +85,7 @@ AND C_BANK.AD_ORG_ID IN (0,1000000,1000002,1000003,1000004,1000005,1000006,10000
 AND 1=1 AND C_BANKSTATEMENTLINE.DATEACCT >= TO_DATE('11-09-2006')  
 AND C_BANKSTATEMENTLINE.DATEACCT < TO_DATE('01-01-2223')       
 AND C_BANKSTATEMENT.PROCESSED='Y'     
-ORDER BY STATEMENTDATE, NAME2]]>
-	</queryString>
+ORDER BY STATEMENTDATE, NAME2]]></query>
 	<field name="NAME" class="java.lang.String"/>
 	<field name="NAME2" class="java.lang.String"/>
 	<field name="C_BANKACCOUNT_ID" class="java.lang.String"/>
@@ -103,387 +100,258 @@ ORDER BY STATEMENTDATE, NAME2]]>
 	<field name="LINE" class="java.math.BigDecimal"/>
 	<field name="DESCRIPTION" class="java.lang.String"/>
 	<field name="INITIALBALANCE" class="java.math.BigDecimal"/>
-	<variable name="LINE_SUM" class="java.math.BigDecimal" resetType="Group" resetGroup="NAME2" calculation="Sum">
-		<variableExpression><![CDATA[$F{TRXAMT}]]></variableExpression>
+	<variable name="LINE_SUM" resetType="Group" calculation="Sum" resetGroup="NAME2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{TRXAMT}]]></expression>
 	</variable>
-	<variable name="accumulated" class="java.math.BigDecimal" resetType="Group" resetGroup="BANKACCOUNT" calculation="Sum">
-		<variableExpression><![CDATA[$F{TRXAMT}]]></variableExpression>
+	<variable name="accumulated" resetType="Group" calculation="Sum" resetGroup="BANKACCOUNT" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{TRXAMT}]]></expression>
 		<initialValueExpression><![CDATA[$F{INITIALBALANCE}]]></initialValueExpression>
 	</variable>
-	<variable name="initialBalance" class="java.math.BigDecimal" resetType="Group" resetGroup="BANKACCOUNT">
-		<variableExpression><![CDATA[$F{INITIALBALANCE}]]></variableExpression>
+	<variable name="initialBalance" resetType="Group" resetGroup="BANKACCOUNT" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{INITIALBALANCE}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0.00)]]></initialValueExpression>
 	</variable>
 	<group name="BANKACCOUNT">
-		<groupExpression><![CDATA[$F{BANKACCOUNT}]]></groupExpression>
+		<expression><![CDATA[$F{BANKACCOUNT}]]></expression>
 		<groupHeader>
 			<band height="50" splitType="Stretch">
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="default" x="131" y="25" width="210" height="24" uuid="7b0b8c73-3170-48d7-a882-b7619a38033f"/>
-					<box topPadding="2" leftPadding="5">
+				<element kind="textField" uuid="7b0b8c73-3170-48d7-a882-b7619a38033f" key="textField" x="131" y="25" width="210" height="24" fontName="Bitstream Vera Sans" fontSize="10.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="default">
+					<expression><![CDATA[$F{BANKACCOUNT}]]></expression>
+					<box topPadding="2" leftPadding="5" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{BANKACCOUNT}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="26" width="1" height="24" forecolor="#555555" uuid="23fd7c29-b862-4a89-b178-e19114212dc6"/>
-				</line>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="533" y="25" width="1" height="25" forecolor="#555555" uuid="3a654e4a-97ce-471c-b7f1-2010dde2cbef"/>
-				</line>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="0" y="0" width="535" height="25" uuid="5c010751-dc5e-4c82-9544-0b6d37717f98"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="line" uuid="23fd7c29-b862-4a89-b178-e19114212dc6" key="line-2" stretchType="ContainerHeight" x="0" y="26" width="1" height="24" forecolor="#555555"/>
+				<element kind="line" uuid="3a654e4a-97ce-471c-b7f1-2010dde2cbef" key="line-3" stretchType="ContainerHeight" x="533" y="25" width="1" height="25" forecolor="#555555"/>
+				<element kind="textField" uuid="5c010751-dc5e-4c82-9544-0b6d37717f98" key="textField" x="0" y="0" width="535" height="25" fontName="Bitstream Vera Sans" fontSize="12.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{NAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="12"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NAME}]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="default" x="440" y="25" width="91" height="24" uuid="268324c8-c8e2-4426-a5f5-5048257f0415"/>
-					<box topPadding="2" leftPadding="5">
+				</element>
+				<element kind="textField" uuid="268324c8-c8e2-4426-a5f5-5048257f0415" key="textField" x="440" y="25" width="91" height="24" fontName="Bitstream Vera Sans" fontSize="10.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="default">
+					<expression><![CDATA[$F{CURRENCY}]]></expression>
+					<box topPadding="2" leftPadding="5" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CURRENCY}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-2" style="Report_Footer" x="9" y="25" width="122" height="24" uuid="f5fee6c8-f67d-4644-a873-d6634ab01f32"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="f5fee6c8-f67d-4644-a873-d6634ab01f32" key="staticText-2" x="9" y="25" width="122" height="24" fontName="Bitstream Vera Sans" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
 					<text><![CDATA[Account No.:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-3" style="Report_Footer" x="341" y="25" width="99" height="24" uuid="8425f9ba-e315-4138-a3b7-4ee3efd0801e"/>
-					<box>
+					<box style="Report_Footer">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="8425f9ba-e315-4138-a3b7-4ee3efd0801e" key="staticText-3" x="341" y="25" width="99" height="24" fontName="Bitstream Vera Sans" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
 					<text><![CDATA[Currency:]]></text>
-				</staticText>
+					<box style="Report_Footer">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-32" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="14" forecolor="#555555" uuid="1572b211-4fb6-4a27-a08f-4a90f10430ca"/>
-				</line>
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="533" y="0" width="1" height="14" forecolor="#555555" uuid="186ece1b-5e7f-4d05-ae7b-6a04d9f84126"/>
-				</line>
-				<line>
-					<reportElement key="line-34" x="1" y="14" width="533" height="1" forecolor="#555555" uuid="e3c089bc-d45e-4984-b6be-f2f4f16c9040"/>
-				</line>
+				<element kind="line" uuid="1572b211-4fb6-4a27-a08f-4a90f10430ca" key="line-32" stretchType="ContainerHeight" x="0" y="0" width="1" height="14" forecolor="#555555"/>
+				<element kind="line" uuid="186ece1b-5e7f-4d05-ae7b-6a04d9f84126" key="line-33" stretchType="ContainerHeight" x="533" y="0" width="1" height="14" forecolor="#555555"/>
+				<element kind="line" uuid="e3c089bc-d45e-4984-b6be-f2f4f16c9040" key="line-34" x="1" y="14" width="533" height="1" forecolor="#555555"/>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="NAME2">
-		<groupExpression><![CDATA[$F{STATEMENTDATE}]]></groupExpression>
+		<expression><![CDATA[$F{STATEMENTDATE}]]></expression>
 		<groupHeader>
 			<band height="70" splitType="Stretch">
-				<line>
-					<reportElement key="line-4" stretchType="RelativeToBandHeight" x="9" y="24" width="1" height="46" forecolor="#555555" uuid="58f1465e-7073-491c-afec-c467afa8b46c"/>
-				</line>
-				<line>
-					<reportElement key="line-6" stretchType="RelativeToBandHeight" x="533" y="23" width="1" height="47" forecolor="#555555" uuid="c01dc80c-e937-49ed-8b39-46439f00e725"/>
-				</line>
-				<line>
-					<reportElement key="line-8" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="70" forecolor="#555555" uuid="1614634f-9045-4ebc-98c0-42ae9b601656"/>
-				</line>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="341" y="54" width="99" height="16" uuid="fc917962-9553-4dbc-bbbf-ff1fa6574d0c"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Center">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
+				<element kind="line" uuid="58f1465e-7073-491c-afec-c467afa8b46c" key="line-4" stretchType="ContainerHeight" x="9" y="24" width="1" height="46" forecolor="#555555"/>
+				<element kind="line" uuid="c01dc80c-e937-49ed-8b39-46439f00e725" key="line-6" stretchType="ContainerHeight" x="533" y="23" width="1" height="47" forecolor="#555555"/>
+				<element kind="line" uuid="1614634f-9045-4ebc-98c0-42ae9b601656" key="line-8" stretchType="ContainerHeight" x="0" y="0" width="1" height="70" forecolor="#555555"/>
+				<element kind="staticText" uuid="fc917962-9553-4dbc-bbbf-ff1fa6574d0c" key="element-90" x="341" y="54" width="99" height="16" fontName="Bitstream Vera Sans" hTextAlign="Center" style="Detail_Header">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="440" y="54" width="91" height="16" uuid="67c422f7-d489-4d6f-a830-d328e6857262"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="67c422f7-d489-4d6f-a830-d328e6857262" key="element-90" x="440" y="54" width="91" height="16" fontName="Bitstream Vera Sans" style="Detail_Header">
 					<text><![CDATA[Accumulated]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="Detail_Header" x="9" y="0" width="526" height="23" uuid="60bb6276-4c2d-4927-82f9-fa55a09810f0"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="12"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{STATEMENTDATE}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-90" style="default" x="15" y="30" width="116" height="16" uuid="dc045ee8-fb71-488e-bcdc-d677bb8e497f"/>
-					<box leftPadding="5" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="60bb6276-4c2d-4927-82f9-fa55a09810f0" key="textField" x="9" y="0" width="526" height="23" fontName="Bitstream Vera Sans" fontSize="12.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{STATEMENTDATE}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font fontName="Bitstream Vera Sans" size="11" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="dc045ee8-fb71-488e-bcdc-d677bb8e497f" key="element-90" x="15" y="30" width="116" height="16" fontName="Bitstream Vera Sans" fontSize="11.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" style="default">
 					<text><![CDATA[Initial Balance:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="default" x="341" y="30" width="99" height="16" uuid="5aa8a25a-dd39-48ce-a21b-cfb96389a348"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font fontName="Bitstream Vera Sans" size="11" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="5aa8a25a-dd39-48ce-a21b-cfb96389a348" key="element-90" x="341" y="30" width="99" height="16" fontName="Bitstream Vera Sans" fontSize="11.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" style="default">
 					<text><![CDATA[Final Balance:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="15" y="54" width="326" height="16" uuid="fc38a7f9-a39e-49e1-9049-2e766f8f3430"/>
-					<box leftPadding="5">
+					<box leftPadding="5" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="fc38a7f9-a39e-49e1-9049-2e766f8f3430" key="element-90" x="15" y="54" width="326" height="16" fontName="Bitstream Vera Sans" style="Detail_Header">
 					<text><![CDATA[Description]]></text>
-				</staticText>
-				<textField evaluationTime="Group" evaluationGroup="NAME2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="440" y="30" width="91" height="16" uuid="01b86bb9-45bd-42e0-a938-82382e3e9109"/>
+					<box leftPadding="5" style="Detail_Header">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="01b86bb9-45bd-42e0-a938-82382e3e9109" key="textField" x="440" y="30" width="91" height="16" fontName="Bitstream Vera Sans" fontSize="11.0" evaluationTime="Group" pattern="" evaluationGroup="NAME2" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[($V{accumulated}!=null)?$P{NUMBERFORMAT}.format($V{accumulated}.add($F{INITIALBALANCE})):new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="11"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{accumulated}!=null)?$P{NUMBERFORMAT}.format($V{accumulated}.add($F{INITIALBALANCE})):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="131" y="30" width="210" height="16" uuid="d26cfa74-6ffa-4a47-bc7c-1a19b7e5a0eb"/>
+				</element>
+				<element kind="textField" uuid="d26cfa74-6ffa-4a47-bc7c-1a19b7e5a0eb" key="textField" x="131" y="30" width="210" height="16" pattern="" blankWhenNull="false">
+					<expression><![CDATA[($V{accumulated}!=null)?$P{NUMBERFORMAT}.format($V{accumulated}.add($V{initialBalance})):new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[($V{accumulated}!=null)?$P{NUMBERFORMAT}.format($V{accumulated}.add($V{initialBalance})):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-28" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="20" forecolor="#555555" uuid="35fe5930-902e-40e9-88d6-76e57264c501"/>
-				</line>
-				<line>
-					<reportElement key="line-29" stretchType="RelativeToBandHeight" x="9" y="0" width="1" height="10" forecolor="#555555" uuid="f7058f94-534c-4d6d-a1d9-1890c724c692"/>
-				</line>
-				<line>
-					<reportElement key="line-30" stretchType="RelativeToBandHeight" x="533" y="0" width="1" height="20" forecolor="#555555" uuid="6a636eb6-5300-46ad-9407-3179640fee06"/>
-				</line>
-				<line>
-					<reportElement key="line-31" x="10" y="10" width="523" height="1" forecolor="#555555" uuid="1e3bcfed-bd97-4c0c-acb1-b6b5db51cbb0"/>
-				</line>
-				<line>
-					<reportElement key="line-35" style="Report_Footer" x="15" y="0" width="517" height="1" uuid="0d78707a-35d6-4a7d-a6a1-e45a7edd824b"/>
-				</line>
+				<element kind="line" uuid="35fe5930-902e-40e9-88d6-76e57264c501" key="line-28" stretchType="ContainerHeight" x="0" y="0" width="1" height="20" forecolor="#555555"/>
+				<element kind="line" uuid="f7058f94-534c-4d6d-a1d9-1890c724c692" key="line-29" stretchType="ContainerHeight" x="9" y="0" width="1" height="10" forecolor="#555555"/>
+				<element kind="line" uuid="6a636eb6-5300-46ad-9407-3179640fee06" key="line-30" stretchType="ContainerHeight" x="533" y="0" width="1" height="20" forecolor="#555555"/>
+				<element kind="line" uuid="1e3bcfed-bd97-4c0c-acb1-b6b5db51cbb0" key="line-31" x="10" y="10" width="523" height="1" forecolor="#555555"/>
+				<element kind="line" uuid="0d78707a-35d6-4a7d-a6a1-e45a7edd824b" key="line-35" x="15" y="0" width="517" height="1" style="Report_Footer"/>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="20" splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="41" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Title" mode="Transparent" x="0" y="0" width="535" height="20" uuid="b2454459-3866-4cee-aeb2-0b40bd48d835"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="25" width="535" height="1" uuid="e50cdc01-a09d-4539-82a6-b1234a93efd6"/>
-			</line>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="20" splitType="Stretch"/>
+	<pageHeader height="41" splitType="Stretch">
+		<element kind="textField" uuid="b2454459-3866-4cee-aeb2-0b40bd48d835" key="textField" mode="Transparent" x="0" y="0" width="535" height="20" fontName="Bitstream Vera Sans" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="e50cdc01-a09d-4539-82a6-b1234a93efd6" key="line-1" x="0" y="25" width="535" height="1"/>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="533" y="0" width="1" height="16" forecolor="#555555" uuid="669e9010-f7a2-488e-a415-08d7a257d50e"/>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="16" forecolor="#555555" uuid="6cf689dd-5316-406e-bba6-20b34bfbd080"/>
-			</line>
-			<line>
-				<reportElement key="line-18" stretchType="RelativeToBandHeight" x="9" y="0" width="1" height="16" forecolor="#555555" uuid="bcea8c5d-2b07-4134-93dc-791d65b0c53c"/>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-1" style="Detail_Line" x="341" y="0" width="99" height="16" uuid="7b7176ad-1ceb-4d88-8b39-8c8021726e88"/>
-				<box leftPadding="2" rightPadding="2">
+			<element kind="line" uuid="669e9010-f7a2-488e-a415-08d7a257d50e" key="line-16" stretchType="ContainerHeight" x="533" y="0" width="1" height="16" forecolor="#555555"/>
+			<element kind="line" uuid="6cf689dd-5316-406e-bba6-20b34bfbd080" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="16" forecolor="#555555"/>
+			<element kind="line" uuid="bcea8c5d-2b07-4134-93dc-791d65b0c53c" key="line-18" stretchType="ContainerHeight" x="9" y="0" width="1" height="16" forecolor="#555555"/>
+			<element kind="textField" uuid="7b7176ad-1ceb-4d88-8b39-8c8021726e88" key="textField-1" x="341" y="0" width="99" height="16" fontName="Bitstream Vera Sans" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{TRXAMT}!=null)?$P{NUMBERFORMAT}.format($F{TRXAMT}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{TRXAMT}!=null)?$P{NUMBERFORMAT}.format($F{TRXAMT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-3" style="Detail_Line" x="15" y="0" width="326" height="16" uuid="fcaab249-11c1-4681-b2d9-2fec335b713f"/>
-				<box leftPadding="5" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="fcaab249-11c1-4681-b2d9-2fec335b713f" key="textField-3" x="15" y="0" width="326" height="16" fontName="Bitstream Vera Sans" fontSize="10.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{DESCRIPTION}==null)?new String("  "):$F{DESCRIPTION}]]></expression>
+				<box leftPadding="5" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{DESCRIPTION}==null)?new String("  "):$F{DESCRIPTION}]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Band" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="440" y="0" width="91" height="16" uuid="55452b24-8ac3-4c49-b254-503c2873fdce"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="55452b24-8ac3-4c49-b254-503c2873fdce" key="textField" stretchType="ContainerHeight" x="440" y="0" width="91" height="16" fontName="Bitstream Vera Sans" evaluationTime="Band" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($V{accumulated}!=null)?$P{NUMBERFORMAT}.format($V{accumulated}.add($F{INITIALBALANCE})):new String(" ")]]></expression>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{accumulated}!=null)?$P{NUMBERFORMAT}.format($V{accumulated}.add($F{INITIALBALANCE})):new String(" ")]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="6" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="20" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="402" y="4" width="95" height="16" uuid="206e39f2-9a90-4ed9-b5a6-05e7c3daeb33"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="499" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="f9f4182c-7f20-421d-909c-5e4e79ee025a"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="1" width="535" height="1" forecolor="#000000" uuid="1c3ed1f4-f580-42ff-8c1a-e4f3bf9b906b"/>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="277" y="4" width="69" height="16" uuid="915f1b80-4548-4362-b7b9-a11675e53577"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" style="Report_Footer" x="195" y="4" width="78" height="16" uuid="b294d78c-53c5-493a-90a1-d9927e721988"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="6" splitType="Stretch"/>
+	<pageFooter height="20" splitType="Stretch">
+		<element kind="textField" uuid="206e39f2-9a90-4ed9-b5a6-05e7c3daeb33" key="textField" x="402" y="4" width="95" height="16" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="f9f4182c-7f20-421d-909c-5e4e79ee025a" key="textField" x="499" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle" style="Report_Footer">
+			<paragraph lineSpacing="Single" style="Report_Footer"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="1c3ed1f4-f580-42ff-8c1a-e4f3bf9b906b" key="line" x="0" y="1" width="535" height="1" forecolor="#000000"/>
+		<element kind="textField" uuid="915f1b80-4548-4362-b7b9-a11675e53577" key="textField" x="277" y="4" width="69" height="16" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="b294d78c-53c5-493a-90a1-d9927e721988" key="staticText-1" x="195" y="4" width="78" height="16" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportCashJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportCashJR.jrxml
@@ -1,45 +1,43 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportCashJR" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="588a2887-2b38-4f00-ba36-0c169540bafe">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportCashJR" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="588a2887-2b38-4f00-ba36-0c169540bafe">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14"/>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0"/>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{C_CASH_ID_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT C_CASHBOOK.C_CASHBOOK_ID, C_CASHBOOK.NAME AS NAMECASHBOOK, C_CASH.STATEMENTDATE, C_CASH.C_CASH_ID, C_CASH.NAME AS NAMECASH,
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT C_CASHBOOK.C_CASHBOOK_ID, C_CASHBOOK.NAME AS NAMECASHBOOK, C_CASH.STATEMENTDATE, C_CASH.C_CASH_ID, C_CASH.NAME AS NAMECASH,
   C_CASH.BEGINNINGBALANCE, C_CASH.ENDINGBALANCE,  C_CURRENCY.ISO_CODE AS CURRENCY,
   C_CASHLINE.LINE, COALESCE(AD_REF_LIST_TRL.NAME,AD_REF_LIST.NAME) AS NAME, C_CASHLINE.AMOUNT, C_CASHLINE.DESCRIPTION,
   COALESCE (INITIALBALANCE.TOTAL_AMT,0) AS INITIALBALANCE
@@ -73,8 +71,7 @@ WHERE C_CASHBOOK.C_CASHBOOK_ID=C_CASH.C_CASHBOOK_ID
   AND C_CASH.AD_ORG_ID IN (0,1000000,1000002,1000003,1000004,1000005,1000006,1000007,1000008,1000009)
   AND 2=2 AND C_CASH.STATEMENTDATE >= TO_DATE('18-10-2006')
   AND C_CASH.PROCESSED='Y'
-  ORDER BY NAMECASHBOOK, STATEMENTDATE, C_CASH_ID, C_CASHLINE.LINE]]>
-	</queryString>
+  ORDER BY NAMECASHBOOK, STATEMENTDATE, C_CASH_ID, C_CASHLINE.LINE]]></query>
 	<field name="C_CASHBOOK_ID" class="java.lang.String"/>
 	<field name="NAMECASHBOOK" class="java.lang.String"/>
 	<field name="STATEMENTDATE" class="java.sql.Timestamp"/>
@@ -88,434 +85,289 @@ WHERE C_CASHBOOK.C_CASHBOOK_ID=C_CASH.C_CASHBOOK_ID
 	<field name="AMOUNT" class="java.math.BigDecimal"/>
 	<field name="DESCRIPTION" class="java.lang.String"/>
 	<field name="INITIALBALANCE" class="java.math.BigDecimal"/>
-	<variable name="totalCash" class="java.math.BigDecimal" resetType="Group" resetGroup="C_CASH_ID" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="totalCash" resetType="Group" calculation="Sum" resetGroup="C_CASH_ID" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="totalAmount" class="java.math.BigDecimal" resetType="Group" resetGroup="C_CASHBOOK_ID" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="totalAmount" resetType="Group" calculation="Sum" resetGroup="C_CASHBOOK_ID" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
 	<group name="C_CASHBOOK_ID">
-		<groupExpression><![CDATA[$F{C_CASHBOOK_ID}]]></groupExpression>
+		<expression><![CDATA[$F{C_CASHBOOK_ID}]]></expression>
 		<groupHeader>
 			<band height="33" splitType="Stretch">
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="23" width="1" height="10" forecolor="#555555" uuid="373e787e-0247-4479-9fb7-54f78a49a12b"/>
-				</line>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="534" y="23" width="1" height="10" forecolor="#555555" uuid="bc837561-0e93-42ae-8414-766939f44803"/>
-				</line>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="0" y="0" width="535" height="23" uuid="c529e443-de2d-4c07-827b-1af885929859"/>
-					<box leftPadding="5">
+				<element kind="line" uuid="373e787e-0247-4479-9fb7-54f78a49a12b" key="line-2" stretchType="ContainerHeight" x="0" y="23" width="1" height="10" forecolor="#555555"/>
+				<element kind="line" uuid="bc837561-0e93-42ae-8414-766939f44803" key="line-3" stretchType="ContainerHeight" x="534" y="23" width="1" height="10" forecolor="#555555"/>
+				<element kind="textField" uuid="c529e443-de2d-4c07-827b-1af885929859" key="textField" x="0" y="0" width="535" height="23" fontName="Bitstream Vera Sans" fontSize="12.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{NAMECASHBOOK}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="12"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NAMECASHBOOK}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-32" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="8" forecolor="#555555" uuid="246ba747-2d2e-48a0-8768-24aa6ab86fcb"/>
-				</line>
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="534" y="0" width="1" height="9" forecolor="#555555" uuid="3d0d4392-0b62-4f6f-bb17-d01cf4de2826"/>
-				</line>
-				<line>
-					<reportElement key="line-34" x="1" y="9" width="533" height="1" forecolor="#555555" uuid="46dceccc-d91c-44f2-b500-c5bab0ff1f7c"/>
-				</line>
+				<element kind="line" uuid="246ba747-2d2e-48a0-8768-24aa6ab86fcb" key="line-32" stretchType="ContainerHeight" x="0" y="0" width="1" height="8" forecolor="#555555"/>
+				<element kind="line" uuid="3d0d4392-0b62-4f6f-bb17-d01cf4de2826" key="line-33" stretchType="ContainerHeight" x="534" y="0" width="1" height="9" forecolor="#555555"/>
+				<element kind="line" uuid="46dceccc-d91c-44f2-b500-c5bab0ff1f7c" key="line-34" x="1" y="9" width="533" height="1" forecolor="#555555"/>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="C_CASH_ID">
-		<groupExpression><![CDATA[$F{C_CASH_ID}]]></groupExpression>
+		<expression><![CDATA[$F{C_CASH_ID}]]></expression>
 		<groupHeader>
 			<band height="80" splitType="Stretch">
-				<line>
-					<reportElement key="line-4" stretchType="RelativeToBandHeight" x="10" y="23" width="1" height="57" forecolor="#555555" uuid="5fd80c70-dba5-4735-adf0-5bcb2cb7ee0c"/>
-				</line>
-				<line>
-					<reportElement key="line-6" stretchType="RelativeToBandHeight" x="534" y="23" width="1" height="57" forecolor="#555555" uuid="03cd72b7-7034-4047-ad16-c9f99104314c"/>
-				</line>
-				<line>
-					<reportElement key="line-8" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="80" forecolor="#555555" uuid="0b7e5385-f2a4-498a-8aa8-efd2597438d7"/>
-				</line>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="10" y="0" width="525" height="23" uuid="26685bff-d181-46fc-8b22-22381861f59a"/>
-					<box leftPadding="5">
+				<element kind="line" uuid="5fd80c70-dba5-4735-adf0-5bcb2cb7ee0c" key="line-4" stretchType="ContainerHeight" x="10" y="23" width="1" height="57" forecolor="#555555"/>
+				<element kind="line" uuid="03cd72b7-7034-4047-ad16-c9f99104314c" key="line-6" stretchType="ContainerHeight" x="534" y="23" width="1" height="57" forecolor="#555555"/>
+				<element kind="line" uuid="0b7e5385-f2a4-498a-8aa8-efd2597438d7" key="line-8" stretchType="ContainerHeight" x="0" y="0" width="1" height="80" forecolor="#555555"/>
+				<element kind="textField" uuid="26685bff-d181-46fc-8b22-22381861f59a" key="textField" x="10" y="0" width="525" height="23" fontName="Bitstream Vera Sans" fontSize="12.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{NAMECASH}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="12"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NAMECASH}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="444" y="64" width="80" height="16" uuid="791daf23-8a0c-4ba3-bfb5-63d94113d008"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="791daf23-8a0c-4ba3-bfb5-63d94113d008" key="element-90" x="444" y="64" width="80" height="16" fontName="Bitstream Vera Sans" style="Detail_Header">
 					<text><![CDATA[Accumulated]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="67" y="64" width="98" height="16" uuid="29cfb9f3-2c3c-4609-8baa-e311bb2c4f50"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="29cfb9f3-2c3c-4609-8baa-e311bb2c4f50" key="element-90" x="67" y="64" width="98" height="16" fontName="Bitstream Vera Sans" style="Detail_Header">
 					<text><![CDATA[Cash Type]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="default" x="30" y="23" width="66" height="19" uuid="757aac17-b1b5-42d3-9174-f579bd1afd53"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font fontName="Bitstream Vera Sans" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="757aac17-b1b5-42d3-9174-f579bd1afd53" key="element-90" x="30" y="23" width="66" height="19" fontName="Bitstream Vera Sans" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" style="default">
 					<text><![CDATA[Initial Balance:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="default" x="165" y="23" width="81" height="19" uuid="bac1f92e-877e-4004-9290-ba4bfbb48582"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="bac1f92e-877e-4004-9290-ba4bfbb48582" key="element-90" x="165" y="23" width="81" height="19" fontName="Bitstream Vera Sans" pdfFontName="Helvetica-Bold" bold="true" style="default">
 					<text><![CDATA[Final Balance:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="default" x="30" y="42" width="66" height="22" uuid="ed851d49-286e-4e28-8a8e-c88d84fe0665"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font fontName="Bitstream Vera Sans" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="ed851d49-286e-4e28-8a8e-c88d84fe0665" key="element-90" x="30" y="42" width="66" height="22" fontName="Bitstream Vera Sans" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" style="default">
 					<text><![CDATA[Currency:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="30" y="64" width="37" height="16" uuid="af7889a2-d8cf-4aba-a61b-010142d77c83"/>
-					<box leftPadding="5">
+					<box leftPadding="5" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="af7889a2-d8cf-4aba-a61b-010142d77c83" key="element-90" x="30" y="64" width="37" height="16" fontName="Bitstream Vera Sans" style="Detail_Header">
 					<text><![CDATA[Line]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="165" y="64" width="81" height="16" uuid="c5f6d527-0fcd-411c-b021-c99753ca4dd5"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="c5f6d527-0fcd-411c-b021-c99753ca4dd5" key="element-90" x="165" y="64" width="81" height="16" fontName="Bitstream Vera Sans" hTextAlign="Center" style="Detail_Header">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="246" y="64" width="197" height="16" uuid="588fdc63-1211-4180-bdb1-91181bb5526b"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="588fdc63-1211-4180-bdb1-91181bb5526b" key="element-90" x="246" y="64" width="197" height="16" fontName="Bitstream Vera Sans" style="Detail_Header">
 					<text><![CDATA[Description]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-4" style="default" x="346" y="23" width="98" height="19" uuid="2e533a3b-e3e0-4aee-b66e-005e9d0ae5a3"/>
-					<box>
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font fontName="Bitstream Vera Sans" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="2e533a3b-e3e0-4aee-b66e-005e9d0ae5a3" key="staticText-4" x="346" y="23" width="98" height="19" fontName="Bitstream Vera Sans" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" style="default">
 					<text><![CDATA[Total Cash:]]></text>
-				</staticText>
-				<textField evaluationTime="Group" evaluationGroup="C_CASH_ID" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="444" y="23" width="81" height="19" uuid="943bca13-8e08-4091-a8f8-125c3fc02bb2"/>
+					<box style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="943bca13-8e08-4091-a8f8-125c3fc02bb2" key="textField" x="444" y="23" width="81" height="19" fontName="Bitstream Vera Sans" evaluationTime="Group" pattern="" evaluationGroup="C_CASH_ID" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[($V{totalCash}!=null)?$P{NUMBERFORMAT}.format($V{totalCash}):new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{totalCash}!=null)?$P{NUMBERFORMAT}.format($V{totalCash}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" x="96" y="42" width="69" height="22" uuid="a974b0a0-8c1a-4c98-a734-78ada737c185"/>
+				</element>
+				<element kind="textField" uuid="a974b0a0-8c1a-4c98-a734-78ada737c185" key="textField" x="96" y="42" width="69" height="22" fontName="Bitstream Vera Sans" textAdjust="StretchHeight" blankWhenNull="true" vTextAlign="Middle">
+					<expression><![CDATA[$F{CURRENCY}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CURRENCY}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="C_CASH_ID" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="246" y="23" width="100" height="19" uuid="9f1331ab-f84e-48b4-bb50-a0c8727d0ccc"/>
+				</element>
+				<element kind="textField" uuid="9f1331ab-f84e-48b4-bb50-a0c8727d0ccc" key="textField" x="246" y="23" width="100" height="19" fontName="Bitstream Vera Sans" evaluationTime="Group" pattern="" evaluationGroup="C_CASH_ID" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[($V{totalAmount}!=null)?$P{NUMBERFORMAT}.format($V{totalAmount}.add($F{INITIALBALANCE})):new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{totalAmount}!=null)?$P{NUMBERFORMAT}.format($V{totalAmount}.add($F{INITIALBALANCE})):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" stretchType="RelativeToBandHeight" x="96" y="23" width="69" height="19" uuid="e06595ba-8485-4c79-aeef-0e155d3b37cf"/>
+				</element>
+				<element kind="textField" uuid="e06595ba-8485-4c79-aeef-0e155d3b37cf" key="textField" stretchType="ContainerHeight" x="96" y="23" width="69" height="19" fontName="Bitstream Vera Sans" pattern="" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[($V{totalAmount}!=null)?$P{NUMBERFORMAT}.format($V{totalAmount}.add($F{INITIALBALANCE})):$P{NUMBERFORMAT}.format($F{INITIALBALANCE})]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{totalAmount}!=null)?$P{NUMBERFORMAT}.format($V{totalAmount}.add($F{INITIALBALANCE})):$P{NUMBERFORMAT}.format($F{INITIALBALANCE})]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-28" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="20" forecolor="#555555" uuid="4f883da6-45ff-4df3-9f86-bac7186bb481"/>
-				</line>
-				<line>
-					<reportElement key="line-29" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="10" forecolor="#555555" uuid="a3400168-db89-4475-a1d9-71ed0dc09241"/>
-				</line>
-				<line>
-					<reportElement key="line-30" stretchType="RelativeToBandHeight" x="534" y="0" width="1" height="20" forecolor="#555555" uuid="fb39bef1-1eb6-4bc6-9d78-2ea179a262ed"/>
-				</line>
-				<line>
-					<reportElement key="line-31" x="11" y="9" width="523" height="1" forecolor="#555555" uuid="f95d02e2-7d03-42c0-9757-b479f8b78f1a"/>
-				</line>
-				<line>
-					<reportElement key="line-35" x="30" y="0" width="495" height="1" uuid="b322dbed-f430-496c-ac66-add95129afaf"/>
-				</line>
+				<element kind="line" uuid="4f883da6-45ff-4df3-9f86-bac7186bb481" key="line-28" stretchType="ContainerHeight" x="0" y="0" width="1" height="20" forecolor="#555555"/>
+				<element kind="line" uuid="a3400168-db89-4475-a1d9-71ed0dc09241" key="line-29" stretchType="ContainerHeight" x="10" y="0" width="1" height="10" forecolor="#555555"/>
+				<element kind="line" uuid="fb39bef1-1eb6-4bc6-9d78-2ea179a262ed" key="line-30" stretchType="ContainerHeight" x="534" y="0" width="1" height="20" forecolor="#555555"/>
+				<element kind="line" uuid="f95d02e2-7d03-42c0-9757-b479f8b78f1a" key="line-31" x="11" y="9" width="523" height="1" forecolor="#555555"/>
+				<element kind="line" uuid="b322dbed-f430-496c-ac66-add95129afaf" key="line-35" x="30" y="0" width="495" height="1"/>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="71" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Title" mode="Transparent" x="0" y="0" width="535" height="20" uuid="d250364b-5ef0-4561-9b10-85baa822e0a1"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="27" width="535" height="1" uuid="3d124605-dc58-4efa-8594-68d2e4a53829"/>
-			</line>
-		</band>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader height="71" splitType="Stretch">
+		<element kind="textField" uuid="d250364b-5ef0-4561-9b10-85baa822e0a1" key="textField" mode="Transparent" x="0" y="0" width="535" height="20" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="3d124605-dc58-4efa-8594-68d2e4a53829" key="line-1" x="0" y="27" width="535" height="1"/>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="17" splitType="Stretch">
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="534" y="0" width="1" height="17" forecolor="#555555" uuid="b29f50a6-0e7f-4e88-8105-f3ae074a92c2"/>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="17" forecolor="#555555" uuid="1c692357-90cc-49de-a870-ae518d9a8d53"/>
-			</line>
-			<line>
-				<reportElement key="line-18" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="17" forecolor="#555555" uuid="f349168f-c2c7-4fa6-9463-1c2fff7934f9"/>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-2" style="Detail_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="37" height="17" uuid="4392ce65-a6fa-4c3b-b252-e01fd21855d5"/>
-				<box leftPadding="2" rightPadding="2">
+			<element kind="line" uuid="b29f50a6-0e7f-4e88-8105-f3ae074a92c2" key="line-16" stretchType="ContainerHeight" x="534" y="0" width="1" height="17" forecolor="#555555"/>
+			<element kind="line" uuid="1c692357-90cc-49de-a870-ae518d9a8d53" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="17" forecolor="#555555"/>
+			<element kind="line" uuid="f349168f-c2c7-4fa6-9463-1c2fff7934f9" key="line-18" stretchType="ContainerHeight" x="10" y="0" width="1" height="17" forecolor="#555555"/>
+			<element kind="textField" uuid="4392ce65-a6fa-4c3b-b252-e01fd21855d5" key="textField-2" stretchType="ContainerHeight" x="30" y="0" width="37" height="17" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{LINE}!=null)?$P{NUMBERFORMAT}.format($F{LINE}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{LINE}!=null)?$P{NUMBERFORMAT}.format($F{LINE}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-4" style="Detail_Line" stretchType="RelativeToBandHeight" x="165" y="0" width="81" height="17" uuid="ed09bf16-5e76-454d-858d-addab811b9e9"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="ed09bf16-5e76-454d-858d-addab811b9e9" key="textField-4" stretchType="ContainerHeight" x="165" y="0" width="81" height="17" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{AMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{AMOUNT}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{AMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{AMOUNT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="67" y="0" width="98" height="17" uuid="e94495b3-373b-4a8e-9cad-3deec4229fdc"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="e94495b3-373b-4a8e-9cad-3deec4229fdc" key="textField" stretchType="ContainerHeight" x="67" y="0" width="98" height="17" fontName="Bitstream Vera Sans" textAdjust="StretchHeight" blankWhenNull="true" style="Detail_Line">
+				<expression><![CDATA[$F{NAME}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{NAME}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="246" y="0" width="197" height="17" uuid="a59a4ef8-fd07-46dd-a20e-c62bf29ddabe"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="a59a4ef8-fd07-46dd-a20e-c62bf29ddabe" key="textField" stretchType="ContainerHeight" x="246" y="0" width="197" height="17" fontName="Bitstream Vera Sans" textAdjust="StretchHeight" blankWhenNull="true" style="Detail_Line">
+				<expression><![CDATA[($F{DESCRIPTION}==null)?new String("  "):$F{DESCRIPTION}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{DESCRIPTION}==null)?new String("  "):$F{DESCRIPTION}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="444" y="0" width="81" height="17" uuid="cee65088-6fa0-4d4d-82d8-1a8ec43577c8"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="cee65088-6fa0-4d4d-82d8-1a8ec43577c8" key="textField" stretchType="ContainerHeight" x="444" y="0" width="81" height="17" fontName="Bitstream Vera Sans" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($V{totalAmount}!=null)?$P{NUMBERFORMAT}.format($V{totalAmount}.add($F{INITIALBALANCE})):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{totalAmount}!=null)?$P{NUMBERFORMAT}.format($V{totalAmount}.add($F{INITIALBALANCE})):new String(" ")]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="16" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="27" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="400" y="4" width="95" height="19" uuid="4f452faa-4cb1-4617-9a3c-f15b75419628"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="499" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="ef288d4a-35e4-4fce-8657-9c716e834392"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="1" width="535" height="1" forecolor="#000000" uuid="b8d5da8f-cd33-4003-8ec2-5d1c2ef9edbd"/>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="277" y="4" width="69" height="19" uuid="64a05c8a-ac6a-4f74-9a82-6ad5d8da2f57"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" x="195" y="4" width="78" height="19" uuid="0be98056-4b08-466e-9d51-f0cbb4475d02"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="16" splitType="Stretch"/>
+	<pageFooter height="27" splitType="Stretch">
+		<element kind="textField" uuid="4f452faa-4cb1-4617-9a3c-f15b75419628" key="textField" x="400" y="4" width="95" height="19" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="ef288d4a-35e4-4fce-8657-9c716e834392" key="textField" x="499" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="b8d5da8f-cd33-4003-8ec2-5d1c2ef9edbd" key="line" x="0" y="1" width="535" height="1" forecolor="#000000"/>
+		<element kind="textField" uuid="64a05c8a-ac6a-4f74-9a82-6ad5d8da2f57" key="textField" x="277" y="4" width="69" height="19" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="0be98056-4b08-466e-9d51-f0cbb4475d02" key="staticText-1" x="195" y="4" width="78" height="19" hTextAlign="Right">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportCashflowForecast.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportCashflowForecast.jrxml
@@ -1,72 +1,72 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportCashflowForecast" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="fc8095f8-9f04-4661-beeb-629fcc853347">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportCashflowForecast" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="fc8095f8-9f04-4661-beeb-629fcc853347">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="ReportData" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="ReportData" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/home/david/workspace/trunk/openbravo/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat()]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale">
 		<defaultValueExpression><![CDATA[new Locale("es", "ES")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="InitialBalance" class="java.math.BigDecimal" isForPrompting="false">
+	<parameter name="InitialBalance" forPrompting="false" class="java.math.BigDecimal">
 		<defaultValueExpression><![CDATA[new BigDecimal(1111)]]></defaultValueExpression>
 	</parameter>
 	<parameter name="SUBREPORT_DIR" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{BASE_DESIGN}+"/org/openbravo/erpCommon/ad_reports/"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATE_FROM" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="DatePlanned" class="java.util.Date" isForPrompting="false"/>
+	<parameter name="DATE_FROM" forPrompting="false" class="java.lang.String"/>
+	<parameter name="DatePlanned" forPrompting="false" class="java.util.Date"/>
 	<field name="NAME" class="java.lang.String"/>
 	<field name="DATEPLANNED" class="java.lang.String"/>
 	<field name="AMOUNT" class="java.lang.Double"/>
@@ -77,570 +77,393 @@
 	<field name="DESCRIPTION" class="java.lang.String"/>
 	<field name="ISRECEIPT" class="java.lang.String"/>
 	<field name="INITIALBALANCE" class="java.lang.Double"/>
-	<variable name="SUM_AMOUNT_1" class="java.lang.Double" resetType="Group" resetGroup="receipt" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="SUM_AMOUNT_1" resetType="Group" calculation="Sum" resetGroup="receipt" class="java.lang.Double">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="SUM_AMOUNT_2" class="java.lang.Double" resetType="Group" resetGroup="bp" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="SUM_AMOUNT_2" resetType="Group" calculation="Sum" resetGroup="bp" class="java.lang.Double">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
 	<variable name="SysDate" class="java.util.Date">
-		<variableExpression><![CDATA[new Date()]]></variableExpression>
+		<expression><![CDATA[new Date()]]></expression>
 	</variable>
-	<group name="bp" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[$F{BANKACCOUNT}]]></groupExpression>
+	<group name="bp" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[$F{BANKACCOUNT}]]></expression>
 		<groupHeader>
 			<band height="36" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText-7" style="Detail_Header" mode="Opaque" x="469" y="21" width="62" height="15" uuid="a150ed9e-061c-4e3e-9aac-236b8713e972"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				<element kind="staticText" uuid="a150ed9e-061c-4e3e-9aac-236b8713e972" key="staticText-7" mode="Opaque" x="469" y="21" width="62" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-3" style="Detail_Header" x="1" y="21" width="75" height="15" uuid="143fed83-9082-4b5f-a1f4-b85647f575cf"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="143fed83-9082-4b5f-a1f4-b85647f575cf" key="staticText-3" x="1" y="21" width="75" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Date Planned]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-1" x="1" y="6" width="530" height="1" uuid="b7923f79-a2cf-4671-9189-07c2274f3330"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<textField isStretchWithOverflow="true" evaluationTime="Group" evaluationGroup="bp" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField-4" style="Detail_Header" x="0" y="5" width="531" height="16" uuid="6174718c-5115-4af4-8cbf-c1c246433490"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA["Account No " + $F{BANKACCOUNT} + "     Initial Balance  " + 
+				</element>
+				<element kind="line" uuid="b7923f79-a2cf-4671-9189-07c2274f3330" key="line-1" x="1" y="6" width="530" height="1">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="textField" uuid="6174718c-5115-4af4-8cbf-c1c246433490" key="textField-4" x="0" y="5" width="531" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" textAdjust="StretchHeight" evaluationTime="Group" pattern="" evaluationGroup="bp" blankWhenNull="true" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA["Account No " + $F{BANKACCOUNT} + "     Initial Balance  " + 
 $F{INITIALBALANCE} +"     Final  "
-+new java.lang.Double(  ($F{INITIALBALANCE}.doubleValue()) +($V{SUM_AMOUNT_2}.doubleValue()) )]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-2" style="Detail_Header" x="126" y="21" width="79" height="15" uuid="3136705f-51ba-4391-bac9-df08994b7f2a"/>
-					<box leftPadding="5">
++new java.lang.Double(  ($F{INITIALBALANCE}.doubleValue()) +($V{SUM_AMOUNT_2}.doubleValue()) )]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="3136705f-51ba-4391-bac9-df08994b7f2a" key="staticText-2" x="126" y="21" width="79" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Invoice No.]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-4" style="Detail_Header" mode="Opaque" x="76" y="21" width="50" height="15" uuid="f3ea029c-5a4a-4d7c-89ae-ccfe1cbbe14b"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="f3ea029c-5a4a-4d7c-89ae-ccfe1cbbe14b" key="staticText-4" mode="Opaque" x="76" y="21" width="50" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Date invoiced]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-20" style="Report_Footer" x="531" y="6" width="1" height="30" uuid="eb6989b6-d0c3-4b6e-9416-4ec14809d34e"/>
-				</line>
-				<staticText>
-					<reportElement key="staticText-5" style="Detail_Header" mode="Opaque" x="205" y="21" width="133" height="15" uuid="fc4451e9-e381-4bed-8ebb-18b7d9af3b84"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="eb6989b6-d0c3-4b6e-9416-4ec14809d34e" key="line-20" x="531" y="6" width="1" height="30" style="Report_Footer"/>
+				<element kind="staticText" uuid="fc4451e9-e381-4bed-8ebb-18b7d9af3b84" key="staticText-5" mode="Opaque" x="205" y="21" width="133" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[B. Partner]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-6" style="Detail_Header" mode="Opaque" x="338" y="21" width="131" height="15" uuid="2aa29fed-870d-442a-bec8-ee4f26511669"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="2aa29fed-870d-442a-bec8-ee4f26511669" key="staticText-6" mode="Opaque" x="338" y="21" width="131" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Debt Payment]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-19" style="Report_Footer" x="1" y="6" width="1" height="30" uuid="bbfc98f8-b541-44a2-8cb6-e1ce29290e40"/>
-				</line>
+					<box leftPadding="5" style="Detail_Header">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="line" uuid="bbfc98f8-b541-44a2-8cb6-e1ce29290e40" key="line-19" x="1" y="6" width="1" height="30" style="Report_Footer"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="25" splitType="Stretch">
-				<line>
-					<reportElement key="line-25" style="Report_Footer" x="2" y="15" width="530" height="2" uuid="14693716-24de-401a-9bf0-9f4aa5518ba0"/>
-				</line>
-				<textField evaluationTime="Group" evaluationGroup="bp" pattern="##0.00" isBlankWhenNull="true">
-					<reportElement key="textField-12" mode="Opaque" x="199" y="1" width="332" height="14" backcolor="#8C8DDC" uuid="f64b0804-df3a-410b-83b9-fb3f00a79717"/>
+				<element kind="line" uuid="14693716-24de-401a-9bf0-9f4aa5518ba0" key="line-25" x="2" y="15" width="530" height="2" style="Report_Footer"/>
+				<element kind="textField" uuid="f64b0804-df3a-410b-83b9-fb3f00a79717" key="textField-12" mode="Opaque" x="199" y="1" width="332" height="14" backcolor="#8C8DDC" fontSize="6.0" evaluationTime="Group" pattern="##0.00" evaluationGroup="bp" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{SUM_AMOUNT_2}!=null)?$P{NUMBERFORMAT}.format($V{SUM_AMOUNT_2}):new String(" ")]]></expression>
 					<box rightPadding="2">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{SUM_AMOUNT_2}!=null)?$P{NUMBERFORMAT}.format($V{SUM_AMOUNT_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-26" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="13" uuid="d6df029c-82ac-4281-88cf-8b0476bfedde"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-27" stretchType="RelativeToBandHeight" x="531" y="1" width="1" height="16" uuid="e5a5ad8f-4afb-466f-a4a4-9110bb6ed366"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<textField evaluationTime="Group" evaluationGroup="bp" pattern="##0.00" isBlankWhenNull="true">
-					<reportElement key="textField-13" mode="Opaque" x="1" y="1" width="198" height="14" backcolor="#8C8DDC" uuid="027b8132-8181-4044-ad49-1a017dbc7017"/>
+				</element>
+				<element kind="line" uuid="d6df029c-82ac-4281-88cf-8b0476bfedde" key="line-26" stretchType="ContainerHeight" x="1" y="0" width="1" height="13">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="e5a5ad8f-4afb-466f-a4a4-9110bb6ed366" key="line-27" stretchType="ContainerHeight" x="531" y="1" width="1" height="16">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="textField" uuid="027b8132-8181-4044-ad49-1a017dbc7017" key="textField-13" mode="Opaque" x="1" y="1" width="198" height="14" backcolor="#8C8DDC" fontSize="6.0" evaluationTime="Group" pattern="##0.00" evaluationGroup="bp" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA["Total Amount Incoming-Payments"]]></expression>
 					<box rightPadding="2">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6"/>
-					</textElement>
-					<textFieldExpression><![CDATA["Total Amount Incoming-Payments"]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-28" stretchType="RelativeToBandHeight" x="1" y="2" width="1" height="13" uuid="d19cc142-9d58-4be6-a0f9-284ec89cba8e"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				</element>
+				<element kind="line" uuid="d19cc142-9d58-4be6-a0f9-284ec89cba8e" key="line-28" stretchType="ContainerHeight" x="1" y="2" width="1" height="13">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="receipt">
-		<groupExpression><![CDATA[$F{ISRECEIPT}]]></groupExpression>
+		<expression><![CDATA[$F{ISRECEIPT}]]></expression>
 		<groupHeader>
 			<band height="16" splitType="Stretch">
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField-9" style="GroupHeader_Gray" x="1" y="0" width="530" height="13" uuid="07bd9333-4181-49fa-be04-d4c669b4a8a9"/>
-					<box leftPadding="5">
+				<element kind="textField" uuid="07bd9333-4181-49fa-be04-d4c669b4a8a9" key="textField-9" x="1" y="0" width="530" height="13" fontName="Bitstream Vera Sans" fontSize="5.0" pdfFontName="Helvetica-Bold" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_Gray">
+					<expression><![CDATA[($F{ISRECEIPT}.equals("Y"))?new String("INCOME"):new String("PAYMENT")]]></expression>
+					<box leftPadding="5" style="GroupHeader_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="5" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{ISRECEIPT}.equals("Y"))?new String("INCOME"):new String("PAYMENT")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-21" style="Report_Footer" x="1" y="0" width="1" height="16" uuid="a75d8e3e-cc8c-4e13-ac77-4bdf367208ad"/>
-				</line>
-				<line>
-					<reportElement key="line-22" style="Report_Footer" x="531" y="-1" width="1" height="17" uuid="57808b2c-fa12-436b-9038-db646d1c7142"/>
-				</line>
+				</element>
+				<element kind="line" uuid="a75d8e3e-cc8c-4e13-ac77-4bdf367208ad" key="line-21" x="1" y="0" width="1" height="16" style="Report_Footer"/>
+				<element kind="line" uuid="57808b2c-fa12-436b-9038-db646d1c7142" key="line-22" x="531" y="-1" width="1" height="17" style="Report_Footer"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="13" splitType="Stretch">
-				<textField evaluationTime="Group" evaluationGroup="receipt" pattern="##0.00" isBlankWhenNull="true">
-					<reportElement key="textField" mode="Opaque" x="199" y="0" width="332" height="13" backcolor="#8C8DDC" uuid="f9275856-7729-42fa-9636-46d0a98f941b"/>
+				<element kind="textField" uuid="f9275856-7729-42fa-9636-46d0a98f941b" key="textField" mode="Opaque" x="199" y="0" width="332" height="13" backcolor="#8C8DDC" fontSize="6.0" evaluationTime="Group" pattern="##0.00" evaluationGroup="receipt" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{SUM_AMOUNT_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_AMOUNT_1}):new String(" ")]]></expression>
 					<box rightPadding="2">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{SUM_AMOUNT_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_AMOUNT_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-23" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="13" uuid="94f8eac1-8cf5-40ba-b176-bab0baa2dc41"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-24" stretchType="RelativeToBandHeight" x="531" y="0" width="1" height="13" uuid="cf130069-ec55-4f9a-b571-e83a8541df4b"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-29" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="13" uuid="2aac95e9-bf34-416b-949a-d5f45daf92f0"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<textField evaluationTime="Group" evaluationGroup="receipt" pattern="##0.00" isBlankWhenNull="true">
-					<reportElement key="textField-14" mode="Opaque" x="1" y="0" width="198" height="13" backcolor="#8C8DDC" uuid="b8f67d1d-66b6-4838-b5ba-09b67dc34b9f"/>
+				</element>
+				<element kind="line" uuid="94f8eac1-8cf5-40ba-b176-bab0baa2dc41" key="line-23" stretchType="ContainerHeight" x="1" y="0" width="1" height="13">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="cf130069-ec55-4f9a-b571-e83a8541df4b" key="line-24" stretchType="ContainerHeight" x="531" y="0" width="1" height="13">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="2aac95e9-bf34-416b-949a-d5f45daf92f0" key="line-29" stretchType="ContainerHeight" x="1" y="0" width="1" height="13">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="textField" uuid="b8f67d1d-66b6-4838-b5ba-09b67dc34b9f" key="textField-14" mode="Opaque" x="1" y="0" width="198" height="13" backcolor="#8C8DDC" fontSize="6.0" evaluationTime="Group" pattern="##0.00" evaluationGroup="receipt" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($F{ISRECEIPT}.equals("Y"))?new String("Total Amount Incoming"):new String("Total Amount Payments")]]></expression>
 					<box rightPadding="2">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{ISRECEIPT}.equals("Y"))?new String("Total Amount Incoming"):new String("Total Amount Payments")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="80" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-17" style="Report_Footer" x="1" y="25" width="219" height="34" uuid="62aa94eb-7298-4d8d-a76a-e31a5e62c047"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="18"/>
-				</textElement>
-				<text><![CDATA[Cash Forecast]]></text>
-			</staticText>
-			<image isLazy="true">
-				<reportElement key="image-1" x="323" y="22" width="197" height="34" uuid="55770bf8-420e-44b5-b996-b8c58ac600ed"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<imageExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylogin")]]></imageExpression>
-			</image>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="80" splitType="Stretch">
+		<element kind="staticText" uuid="62aa94eb-7298-4d8d-a76a-e31a5e62c047" key="staticText-17" x="1" y="25" width="219" height="34" fontSize="18.0" style="Report_Footer">
+			<text><![CDATA[Cash Forecast]]></text>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="image" uuid="55770bf8-420e-44b5-b996-b8c58ac600ed" key="image-1" x="323" y="22" width="197" height="34" lazy="true">
+			<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylogin")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</title>
-	<pageHeader>
-		<band height="54" splitType="Stretch">
-			<subreport isUsingCache="true">
-				<reportElement key="subreport-1" style="Report_Footer" x="1" y="33" width="534" height="14" uuid="99dfbe33-cd3b-4180-b288-79cafbb8905c"/>
-				<subreportParameter name="Title">
-					<subreportParameterExpression><![CDATA[new String("Previous")]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="DatePlanned">
-					<subreportParameterExpression><![CDATA[$P{DatePlanned}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[$P{NUMBERFORMAT}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LOCALE">
-					<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="USER_CLIENT">
-					<subreportParameterExpression><![CDATA[$P{USER_CLIENT}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="USER_ORG">
-					<subreportParameterExpression><![CDATA[$P{USER_ORG}]]></subreportParameterExpression>
-				</subreportParameter>
-				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{ReportData}]]></subreportExpression>
-			</subreport>
-			<staticText>
-				<reportElement key="staticText-18" style="Detail_Header" x="0" y="21" width="157" height="12" uuid="21bad35a-7ffe-453c-9b1f-0c7a4895b59a"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Account No.]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-19" style="Detail_Header" x="0" y="9" width="157" height="12" uuid="09c18d96-64e5-48aa-b6df-1450f546c4f6"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-21" style="Detail_Header" x="157" y="9" width="89" height="12" uuid="24de70f1-7cee-43c8-b47a-dce07cb50719"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Bank Balance]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-22" style="Detail_Header" x="246" y="9" width="200" height="12" uuid="5813650a-ffed-43bc-b78e-710d08012a70"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Forecast]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-23" style="Detail_Header" x="246" y="21" width="102" height="12" uuid="7344208b-5572-4b1c-bb6b-810cc447c6ce"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Income]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-24" style="Detail_Header" x="348" y="21" width="98" height="12" uuid="687b54f3-f200-483f-9b35-f1c5a3199f1f"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Payment]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="446" y="9" width="89" height="12" uuid="97825ed4-2518-48d5-ab08-3e57e43a18d6"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Final]]></text>
-			</staticText>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-10" style="Detail_Header" x="446" y="21" width="89" height="12" uuid="a817218f-0e10-4cf8-a93b-a1df2c890ddb"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="SansSerif" size="5" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{DatePlanned}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-11" style="Detail_Header" x="157" y="21" width="89" height="12" uuid="c19fd9f6-badb-4bda-b244-9924fe6a5ac7"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="SansSerif" size="5" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-		</band>
+	<pageHeader height="54" splitType="Stretch">
+		<element kind="subreport" uuid="99dfbe33-cd3b-4180-b288-79cafbb8905c" key="subreport-1" x="1" y="33" width="534" height="14" usingCache="true" style="Report_Footer">
+			<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
+			<expression><![CDATA[$P{ReportData}]]></expression>
+			<parameter name="Title">
+				<expression><![CDATA[new String("Previous")]]></expression>
+			</parameter>
+			<parameter name="DatePlanned">
+				<expression><![CDATA[$P{DatePlanned}]]></expression>
+			</parameter>
+			<parameter name="NUMBERFORMAT">
+				<expression><![CDATA[$P{NUMBERFORMAT}]]></expression>
+			</parameter>
+			<parameter name="LOCALE">
+				<expression><![CDATA[$P{LOCALE}]]></expression>
+			</parameter>
+			<parameter name="USER_CLIENT">
+				<expression><![CDATA[$P{USER_CLIENT}]]></expression>
+			</parameter>
+			<parameter name="USER_ORG">
+				<expression><![CDATA[$P{USER_ORG}]]></expression>
+			</parameter>
+		</element>
+		<element kind="staticText" uuid="21bad35a-7ffe-453c-9b1f-0c7a4895b59a" key="staticText-18" x="0" y="21" width="157" height="12" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Account No.]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="09c18d96-64e5-48aa-b6df-1450f546c4f6" key="staticText-19" x="0" y="9" width="157" height="12" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="24de70f1-7cee-43c8-b47a-dce07cb50719" key="staticText-21" x="157" y="9" width="89" height="12" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Bank Balance]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="5813650a-ffed-43bc-b78e-710d08012a70" key="staticText-22" x="246" y="9" width="200" height="12" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Forecast]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="7344208b-5572-4b1c-bb6b-810cc447c6ce" key="staticText-23" x="246" y="21" width="102" height="12" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Income]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="687b54f3-f200-483f-9b35-f1c5a3199f1f" key="staticText-24" x="348" y="21" width="98" height="12" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Payment]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="97825ed4-2518-48d5-ab08-3e57e43a18d6" key="staticText-25" x="446" y="9" width="89" height="12" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Final]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="a817218f-0e10-4cf8-a93b-a1df2c890ddb" key="textField-10" x="446" y="21" width="89" height="12" fontName="SansSerif" fontSize="5.0" pdfFontName="Helvetica-Bold" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{DatePlanned}]]></expression>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="c19fd9f6-badb-4bda-b244-9924fe6a5ac7" key="textField-11" x="157" y="21" width="89" height="12" fontName="SansSerif" fontSize="5.0" pdfFontName="Helvetica-Bold" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[new Date()]]></expression>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-7" x="469" y="0" width="62" height="16" uuid="7f2db147-70f5-47b1-9c77-46c8aa668e4b"/>
+			<element kind="textField" uuid="7f2db147-70f5-47b1-9c77-46c8aa668e4b" key="textField-7" x="469" y="0" width="62" height="16" fontName="Bitstream Vera Sans" fontSize="6.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{AMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{AMOUNT}):new String(" ")]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="6"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{AMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{AMOUNT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Band" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" stretchType="RelativeToBandHeight" x="1" y="0" width="76" height="16" uuid="3fd4aa77-cdda-4813-af5b-30e1f2701302"/>
+			</element>
+			<element kind="textField" uuid="3fd4aa77-cdda-4813-af5b-30e1f2701302" key="textField" stretchType="ContainerHeight" x="1" y="0" width="76" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" evaluationTime="Band" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{DATEPLANNED}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DATEPLANNED}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="16" uuid="d34e6e2e-0ee6-443f-8b11-2af0f9335fed"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-1" x="76" y="0" width="50" height="16" uuid="aa79ccf3-39cd-44de-9e35-bd404552e31f"/>
+			</element>
+			<element kind="line" uuid="d34e6e2e-0ee6-443f-8b11-2af0f9335fed" key="line-17" stretchType="ContainerHeight" x="1" y="0" width="1" height="16">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="aa79ccf3-39cd-44de-9e35-bd404552e31f" key="textField-1" x="76" y="0" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{DATEINVOICED}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DATEINVOICED}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-3" x="126" y="0" width="79" height="16" uuid="a67e5dbc-3c71-44e9-8c9e-8056e701d33e"/>
+			</element>
+			<element kind="textField" uuid="a67e5dbc-3c71-44e9-8c9e-8056e701d33e" key="textField-3" x="126" y="0" width="79" height="16" fontName="Bitstream Vera Sans" fontSize="6.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{INVOICENO}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="6"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{INVOICENO}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-5" x="205" y="0" width="133" height="16" uuid="8f4c94f7-ba50-48d8-933d-77db768ac51d"/>
+			</element>
+			<element kind="textField" uuid="8f4c94f7-ba50-48d8-933d-77db768ac51d" key="textField-5" x="205" y="0" width="133" height="16" fontName="Bitstream Vera Sans" fontSize="6.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{BPARTNER}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="6"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{BPARTNER}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-6" x="338" y="0" width="95" height="16" uuid="bda3d607-96e3-42a3-b748-d3d906785b59"/>
+			</element>
+			<element kind="textField" uuid="bda3d607-96e3-42a3-b748-d3d906785b59" key="textField-6" x="338" y="0" width="95" height="16" fontName="Bitstream Vera Sans" fontSize="6.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{DESCRIPTION}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="6"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DESCRIPTION}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-8" x="433" y="0" width="36" height="16" uuid="b2baf745-af86-4ee9-b87d-68ce0b64aa45"/>
+			</element>
+			<element kind="textField" uuid="b2baf745-af86-4ee9-b87d-68ce0b64aa45" key="textField-8" x="433" y="0" width="36" height="16" fontName="Bitstream Vera Sans" fontSize="6.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{ISRECEIPT}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="6"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{ISRECEIPT}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="531" y="0" width="1" height="16" uuid="b374b015-d929-40f2-bec7-fe1c5ba2f1b5"/>
-				<graphicElement>
-					<pen lineWidth="0.5" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
+			</element>
+			<element kind="line" uuid="b374b015-d929-40f2-bec7-fe1c5ba2f1b5" key="line-16" stretchType="ContainerHeight" x="531" y="0" width="1" height="16">
+				<pen lineWidth="0.5" lineStyle="Solid"/>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="6" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="20" splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band height="21" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="279" y="13" width="69" height="8" uuid="11cd418d-ada8-4ac6-92b0-7beedc00cd56"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" style="Report_Footer" x="200" y="12" width="76" height="8" uuid="542c2355-087b-4e6b-aa15-83fbb621e19d"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="5"/>
-				</textElement>
-				<text><![CDATA[Printed on]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="6" splitType="Stretch"/>
+	<pageFooter height="20" splitType="Stretch"/>
+	<summary height="21" splitType="Stretch">
+		<element kind="textField" uuid="11cd418d-ada8-4ac6-92b0-7beedc00cd56" key="textField" x="279" y="13" width="69" height="8" fontName="Times-Roman" fontSize="5.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="542c2355-087b-4e6b-aa15-83fbb621e19d" key="staticText-1" x="200" y="12" width="76" height="8" fontSize="5.0" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Printed on]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</summary>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportCashflowForecast_perDay.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportCashflowForecast_perDay.jrxml
@@ -1,72 +1,72 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportCashflowForecast_perDay" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="b76f3c88-6b2c-495d-b121-a40bbae782fe">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportCashflowForecast_perDay" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="b76f3c88-6b2c-495d-b121-a40bbae782fe">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="ReportData" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="ReportData" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/home/david/workspace/trunk/openbravo/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat()]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale">
 		<defaultValueExpression><![CDATA[new Locale("es", "ES")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="InitialBalance" class="java.math.BigDecimal" isForPrompting="false">
+	<parameter name="InitialBalance" forPrompting="false" class="java.math.BigDecimal">
 		<defaultValueExpression><![CDATA[new BigDecimal(1111)]]></defaultValueExpression>
 	</parameter>
 	<parameter name="SUBREPORT_DIR" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{BASE_DESIGN}+"/org/openbravo/erpCommon/ad_reports/"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATE_FROM" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="DatePlanned" class="java.util.Date" isForPrompting="false"/>
+	<parameter name="DATE_FROM" forPrompting="false" class="java.lang.String"/>
+	<parameter name="DatePlanned" forPrompting="false" class="java.util.Date"/>
 	<field name="NAME" class="java.lang.String"/>
 	<field name="DATEPLANNED" class="java.lang.String"/>
 	<field name="AMOUNT" class="java.math.BigDecimal"/>
@@ -77,242 +77,168 @@
 	<field name="DESCRIPTION" class="java.lang.String"/>
 	<field name="ISRECEIPT" class="java.lang.String"/>
 	<field name="INITIALBALANCE" class="java.math.BigDecimal"/>
-	<variable name="SUM_AMOUNT_1" class="java.math.BigDecimal" resetType="Group" resetGroup="receipt" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="SUM_AMOUNT_1" resetType="Group" calculation="Sum" resetGroup="receipt" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="SUM_SUM_AMOUNT_1_1" class="java.math.BigDecimal" resetType="Group" resetGroup="bankacc" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="SUM_SUM_AMOUNT_1_1" resetType="Group" calculation="Sum" resetGroup="bankacc" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
 	<group name="bankacc">
-		<groupExpression><![CDATA[$F{BANKACCOUNT}]]></groupExpression>
+		<expression><![CDATA[$F{BANKACCOUNT}]]></expression>
 		<groupHeader>
 			<band height="13" splitType="Stretch">
-				<textField evaluationTime="Band" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField-11" style="Detail_Header" stretchType="RelativeToBandHeight" x="1" y="0" width="204" height="13" uuid="bc93078e-0262-4a9c-847a-8e15336ab3fa"/>
-					<box leftPadding="5" rightPadding="2">
+				<element kind="textField" uuid="bc93078e-0262-4a9c-847a-8e15336ab3fa" key="textField-11" stretchType="ContainerHeight" x="1" y="0" width="204" height="13" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" evaluationTime="Band" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{BANKACCOUNT}]]></expression>
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{BANKACCOUNT}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-27" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="13" uuid="95f5eb0e-c1ff-483e-af0d-46c8dfff42e8"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<textField evaluationTime="Band" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField-12" style="Detail_Header" stretchType="RelativeToBandHeight" x="275" y="0" width="108" height="13" uuid="1756853c-a2a6-40e3-8f3b-548b40176ea9"/>
-					<box leftPadding="5" rightPadding="2">
+				</element>
+				<element kind="line" uuid="95f5eb0e-c1ff-483e-af0d-46c8dfff42e8" key="line-27" stretchType="ContainerHeight" x="1" y="0" width="1" height="13">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="textField" uuid="1756853c-a2a6-40e3-8f3b-548b40176ea9" key="textField-12" stretchType="ContainerHeight" x="275" y="0" width="108" height="13" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" evaluationTime="Band" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[($F{INITIALBALANCE}!=null)?$P{NUMBERFORMAT}.format($F{INITIALBALANCE}):new String(" ")]]></expression>
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{INITIALBALANCE}!=null)?$P{NUMBERFORMAT}.format($F{INITIALBALANCE}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="bankacc" pattern="##0.00" isBlankWhenNull="false">
-					<reportElement key="textField-14" style="Detail_Header" x="475" y="0" width="56" height="13" uuid="aa6ad15d-6ab1-416e-a320-913ef5f8ea49"/>
-					<box leftPadding="5" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="aa6ad15d-6ab1-416e-a320-913ef5f8ea49" key="textField-14" x="475" y="0" width="56" height="13" fontSize="8.0" pdfFontName="Helvetica-Bold" evaluationTime="Group" pattern="##0.00" evaluationGroup="bankacc" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[new java.lang.Double(  ($F{INITIALBALANCE}.doubleValue()) +($V{SUM_SUM_AMOUNT_1_1}.doubleValue()) )]]></expression>
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[new java.lang.Double(  ($F{INITIALBALANCE}.doubleValue()) +($V{SUM_SUM_AMOUNT_1_1}.doubleValue()) )]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-28" stretchType="RelativeToBandHeight" x="531" y="0" width="1" height="13" uuid="3cf91b62-e9ee-4770-81da-47bc100b47b4"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-28" style="Detail_Header" x="205" y="0" width="70" height="13" uuid="a440a0f5-aba9-4de4-8cc8-de71f212e9c5"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="3cf91b62-e9ee-4770-81da-47bc100b47b4" key="line-28" stretchType="ContainerHeight" x="531" y="0" width="1" height="13">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="a440a0f5-aba9-4de4-8cc8-de71f212e9c5" key="staticText-28" x="205" y="0" width="70" height="13" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Bank balance:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-29" style="Detail_Header" x="383" y="0" width="92" height="13" uuid="379bcad0-e479-40a2-b292-35e4a91db407"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="379bcad0-e479-40a2-b292-35e4a91db407" key="staticText-29" x="383" y="0" width="92" height="13" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Final:]]></text>
-				</staticText>
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="36" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText-27" style="Detail_Header" mode="Opaque" x="1" y="0" width="408" height="13" forecolor="#261818" backcolor="#8C9FFE" uuid="45aa8d94-ef8c-48e4-97f6-eb519960df8b"/>
-					<box leftPadding="5" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				<element kind="staticText" uuid="45aa8d94-ef8c-48e4-97f6-eb519960df8b" key="staticText-27" mode="Opaque" x="1" y="0" width="408" height="13" forecolor="#261818" backcolor="#8C9FFE" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Total Amount Incoming - Payments:]]></text>
-				</staticText>
-				<textField evaluationTime="Group" evaluationGroup="bankacc" pattern="##0.00" isBlankWhenNull="false">
-					<reportElement key="textField-15" style="Detail_Header" x="409" y="0" width="122" height="13" uuid="2a894e10-bcb8-4e8e-b504-a50df9766d8d"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{SUM_SUM_AMOUNT_1_1}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-23" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="14" uuid="e51d5707-84ad-4d42-8ccf-91728a869b94"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-24" stretchType="RelativeToBandHeight" x="531" y="-1" width="1" height="15" uuid="f6250675-24c1-4524-ae8a-f4d3c3d4f2a4"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-30" style="Report_Footer" x="1" y="13" width="530" height="1" uuid="a0545945-72bb-4eaa-84d1-a43fcbdf3c47"/>
-				</line>
+				</element>
+				<element kind="textField" uuid="2a894e10-bcb8-4e8e-b504-a50df9766d8d" key="textField-15" x="409" y="0" width="122" height="13" fontSize="7.0" pdfFontName="Helvetica-Bold" evaluationTime="Group" pattern="##0.00" evaluationGroup="bankacc" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$V{SUM_SUM_AMOUNT_1_1}]]></expression>
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="line" uuid="e51d5707-84ad-4d42-8ccf-91728a869b94" key="line-23" stretchType="ContainerHeight" x="1" y="0" width="1" height="14">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="f6250675-24c1-4524-ae8a-f4d3c3d4f2a4" key="line-24" stretchType="ContainerHeight" x="531" y="-1" width="1" height="15">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="a0545945-72bb-4eaa-84d1-a43fcbdf3c47" key="line-30" x="1" y="13" width="530" height="1" style="Report_Footer"/>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="date">
-		<groupExpression><![CDATA[$F{DATEPLANNED}]]></groupExpression>
+		<expression><![CDATA[$F{DATEPLANNED}]]></expression>
 		<groupHeader>
 			<band height="28" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText-2" style="Detail_Header" x="126" y="13" width="79" height="15" uuid="89a206e1-cd17-41ea-a37a-1797ccf9cb1d"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="7" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				<element kind="staticText" uuid="89a206e1-cd17-41ea-a37a-1797ccf9cb1d" key="staticText-2" x="126" y="13" width="79" height="15" fontSize="7.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Invoice No.]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-3" style="Detail_Header" x="1" y="13" width="75" height="15" uuid="e87d5bbd-369a-4f26-9b7b-84cf36f901e3"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="7" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="e87d5bbd-369a-4f26-9b7b-84cf36f901e3" key="staticText-3" x="1" y="13" width="75" height="15" fontSize="7.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Date Planned]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-4" style="Detail_Header" mode="Opaque" x="76" y="13" width="50" height="15" uuid="9230f8dd-f357-42aa-91e5-1d68890cccb1"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="7" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Date invoiced]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-5" style="Detail_Header" mode="Opaque" x="205" y="13" width="133" height="15" uuid="3cc01c08-582c-45b2-8e63-0e8659e9649b"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="7" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[B. Partner]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-6" style="Detail_Header" mode="Opaque" x="338" y="13" width="131" height="15" uuid="baf909a2-8977-49be-9961-ea4953cdba05"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="7" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Debt Payment]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-7" style="Detail_Header" mode="Opaque" x="469" y="13" width="62" height="15" uuid="b1031462-f2fe-4168-8d69-e0abe7855d54"/>
-					<box leftPadding="5" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="7" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<textField evaluationTime="Band" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField-10" style="Detail_Header" stretchType="RelativeToBandHeight" x="1" y="0" width="530" height="13" uuid="1b096a4a-aeda-420e-bf93-1a6f0fa972ea"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{DATEPLANNED}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-25" style="Report_Footer" x="1" y="0" width="1" height="28" uuid="ccba8ed7-22d0-4b77-94a6-1bea1e5105bc"/>
-				</line>
-				<line>
-					<reportElement key="line-26" style="Report_Footer" x="531" y="0" width="1" height="28" uuid="04a36ef4-1c28-4b11-9d9e-781356079a47"/>
-				</line>
+				</element>
+				<element kind="staticText" uuid="9230f8dd-f357-42aa-91e5-1d68890cccb1" key="staticText-4" mode="Opaque" x="76" y="13" width="50" height="15" fontSize="7.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<text><![CDATA[Date invoiced]]></text>
+					<box leftPadding="5" style="Detail_Header">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="3cc01c08-582c-45b2-8e63-0e8659e9649b" key="staticText-5" mode="Opaque" x="205" y="13" width="133" height="15" fontSize="7.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<text><![CDATA[B. Partner]]></text>
+					<box leftPadding="5" style="Detail_Header">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="baf909a2-8977-49be-9961-ea4953cdba05" key="staticText-6" mode="Opaque" x="338" y="13" width="131" height="15" fontSize="7.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<text><![CDATA[Debt Payment]]></text>
+					<box leftPadding="5" style="Detail_Header">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="b1031462-f2fe-4168-8d69-e0abe7855d54" key="staticText-7" mode="Opaque" x="469" y="13" width="62" height="15" fontSize="7.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<text><![CDATA[Amount]]></text>
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="1b096a4a-aeda-420e-bf93-1a6f0fa972ea" key="textField-10" stretchType="ContainerHeight" x="1" y="0" width="530" height="13" fontName="Bitstream Vera Sans" fontSize="7.0" pdfFontName="Helvetica-Bold" evaluationTime="Band" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{DATEPLANNED}]]></expression>
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="line" uuid="ccba8ed7-22d0-4b77-94a6-1bea1e5105bc" key="line-25" x="1" y="0" width="1" height="28" style="Report_Footer"/>
+				<element kind="line" uuid="04a36ef4-1c28-4b11-9d9e-781356079a47" key="line-26" x="531" y="0" width="1" height="28" style="Report_Footer"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -320,332 +246,230 @@
 		</groupFooter>
 	</group>
 	<group name="receipt">
-		<groupExpression><![CDATA[$F{ISRECEIPT}]]></groupExpression>
+		<expression><![CDATA[$F{ISRECEIPT}]]></expression>
 		<groupHeader>
 			<band height="16" splitType="Stretch">
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField-9" style="GroupHeader_Gray" x="1" y="0" width="530" height="13" backcolor="#ECEBFD" uuid="abd1ebd9-0675-4640-9e3e-9b5a80cf81d2"/>
-					<box leftPadding="5">
+				<element kind="textField" uuid="abd1ebd9-0675-4640-9e3e-9b5a80cf81d2" key="textField-9" x="1" y="0" width="530" height="13" backcolor="#ECEBFD" fontName="Bitstream Vera Sans" fontSize="6.0" pdfFontName="Helvetica-Bold" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_Gray">
+					<expression><![CDATA[($F{ISRECEIPT}.equals("Y"))?new String("INCOME"):new String("PAYMENT")]]></expression>
+					<box leftPadding="5" style="GroupHeader_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="6" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{ISRECEIPT}.equals("Y"))?new String("INCOME"):new String("PAYMENT")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-21" style="Report_Footer" x="1" y="0" width="1" height="16" uuid="6d0a529e-8783-40b5-a98b-82e4a51d3d1b"/>
-				</line>
-				<line>
-					<reportElement key="line-22" style="Report_Footer" x="531" y="0" width="1" height="16" uuid="0d3afdb8-227e-46f1-881f-63a4c09d894a"/>
-				</line>
+				</element>
+				<element kind="line" uuid="6d0a529e-8783-40b5-a98b-82e4a51d3d1b" key="line-21" x="1" y="0" width="1" height="16" style="Report_Footer"/>
+				<element kind="line" uuid="0d3afdb8-227e-46f1-881f-63a4c09d894a" key="line-22" x="531" y="0" width="1" height="16" style="Report_Footer"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="114" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-17" style="Report_Footer" x="1" y="25" width="219" height="34" uuid="6a586c87-7c01-48b9-a491-5de85bf1b1e7"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="18"/>
-				</textElement>
-				<text><![CDATA[Cash Forecast]]></text>
-			</staticText>
-			<image isLazy="true">
-				<reportElement key="image-1" x="323" y="22" width="197" height="34" uuid="5db7b0f1-f07f-4971-bc80-d616959553f9"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<imageExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylogin")]]></imageExpression>
-			</image>
-			<subreport isUsingCache="true">
-				<reportElement key="subreport-1" style="Report_Footer" x="1" y="96" width="534" height="14" uuid="e218dd5b-1d73-4f9e-baa2-267780e445ac"/>
-				<subreportParameter name="Title">
-					<subreportParameterExpression><![CDATA[new String("Previous")]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="DatePlanned">
-					<subreportParameterExpression><![CDATA[$P{DatePlanned}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[$P{NUMBERFORMAT}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LOCALE">
-					<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{ReportData}]]></subreportExpression>
-			</subreport>
-			<staticText>
-				<reportElement key="staticText-18" style="Detail_Header" x="0" y="84" width="157" height="12" uuid="f563b1b4-bff1-4f28-b5a3-130f32e22944"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Bank Account]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-19" style="Detail_Header" x="0" y="72" width="157" height="12" uuid="e5ab0b50-eafe-4685-9832-0ac842b95cd5"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-21" style="Detail_Header" x="157" y="72" width="89" height="12" uuid="3d158ce9-83c9-4a14-947b-85b117f4757a"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Bank Balance]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-22" style="Detail_Header" x="246" y="72" width="200" height="12" uuid="4ce853ed-9c4d-4e72-a671-5218077ed829"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Forecast]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-23" style="Detail_Header" x="246" y="84" width="102" height="12" uuid="4636f498-7c3b-41ae-8031-c90cfd75160c"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Income]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-24" style="Detail_Header" x="348" y="84" width="98" height="12" uuid="99c60f3b-25b3-42d0-843d-f989f3c9689c"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Payment]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" x="446" y="72" width="89" height="12" uuid="c4166380-cfd8-49eb-95d3-5f0f2b43f9d1"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Final]]></text>
-			</staticText>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-18" style="Detail_Header" x="157" y="84" width="89" height="12" uuid="ffe7513d-b01e-4c26-8268-e32f6e06220f"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="SansSerif" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-19" style="Detail_Header" x="446" y="84" width="89" height="12" uuid="a1cbf326-0593-4ad6-8071-38e59b31cf3c"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="SansSerif" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{DatePlanned}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="114" splitType="Stretch">
+		<element kind="staticText" uuid="6a586c87-7c01-48b9-a491-5de85bf1b1e7" key="staticText-17" x="1" y="25" width="219" height="34" fontSize="18.0" style="Report_Footer">
+			<text><![CDATA[Cash Forecast]]></text>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="image" uuid="5db7b0f1-f07f-4971-bc80-d616959553f9" key="image-1" x="323" y="22" width="197" height="34" lazy="true">
+			<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylogin")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="subreport" uuid="e218dd5b-1d73-4f9e-baa2-267780e445ac" key="subreport-1" x="1" y="96" width="534" height="14" usingCache="true" style="Report_Footer">
+			<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
+			<expression><![CDATA[$P{ReportData}]]></expression>
+			<parameter name="Title">
+				<expression><![CDATA[new String("Previous")]]></expression>
+			</parameter>
+			<parameter name="DatePlanned">
+				<expression><![CDATA[$P{DatePlanned}]]></expression>
+			</parameter>
+			<parameter name="NUMBERFORMAT">
+				<expression><![CDATA[$P{NUMBERFORMAT}]]></expression>
+			</parameter>
+			<parameter name="LOCALE">
+				<expression><![CDATA[$P{LOCALE}]]></expression>
+			</parameter>
+		</element>
+		<element kind="staticText" uuid="f563b1b4-bff1-4f28-b5a3-130f32e22944" key="staticText-18" x="0" y="84" width="157" height="12" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Bank Account]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="e5ab0b50-eafe-4685-9832-0ac842b95cd5" key="staticText-19" x="0" y="72" width="157" height="12" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="3d158ce9-83c9-4a14-947b-85b117f4757a" key="staticText-21" x="157" y="72" width="89" height="12" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Bank Balance]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="4ce853ed-9c4d-4e72-a671-5218077ed829" key="staticText-22" x="246" y="72" width="200" height="12" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Forecast]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="4636f498-7c3b-41ae-8031-c90cfd75160c" key="staticText-23" x="246" y="84" width="102" height="12" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Income]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="99c60f3b-25b3-42d0-843d-f989f3c9689c" key="staticText-24" x="348" y="84" width="98" height="12" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Payment]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="c4166380-cfd8-49eb-95d3-5f0f2b43f9d1" key="staticText-25" x="446" y="72" width="89" height="12" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Final]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="ffe7513d-b01e-4c26-8268-e32f6e06220f" key="textField-18" x="157" y="84" width="89" height="12" fontName="SansSerif" fontSize="5.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[new Date()]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="a1cbf326-0593-4ad6-8071-38e59b31cf3c" key="textField-19" x="446" y="84" width="89" height="12" fontName="SansSerif" fontSize="5.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<expression><![CDATA[$P{DatePlanned}]]></expression>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
 	</title>
-	<pageHeader>
-		<band height="7" splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<pageHeader height="7" splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-1" x="76" y="0" width="50" height="16" uuid="024fac1e-e1dd-4ffe-829f-98a8482e0db9"/>
+			<element kind="textField" uuid="024fac1e-e1dd-4ffe-829f-98a8482e0db9" key="textField-1" x="76" y="0" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="6.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{DATEINVOICED}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="6"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DATEINVOICED}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-3" x="126" y="0" width="79" height="16" uuid="898cac5a-f973-4352-9ba5-824ce1387f74"/>
+			</element>
+			<element kind="textField" uuid="898cac5a-f973-4352-9ba5-824ce1387f74" key="textField-3" x="126" y="0" width="79" height="16" fontName="Bitstream Vera Sans" fontSize="6.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{INVOICENO}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="6"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{INVOICENO}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-5" x="205" y="0" width="133" height="16" uuid="2a2d4ba1-72b1-43f5-9aee-c71e5c275232"/>
+			</element>
+			<element kind="textField" uuid="2a2d4ba1-72b1-43f5-9aee-c71e5c275232" key="textField-5" x="205" y="0" width="133" height="16" fontName="Bitstream Vera Sans" fontSize="6.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{BPARTNER}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="6"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{BPARTNER}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-6" x="338" y="0" width="131" height="16" uuid="6e97d544-b145-4d8b-bad1-60bea965d5c3"/>
+			</element>
+			<element kind="textField" uuid="6e97d544-b145-4d8b-bad1-60bea965d5c3" key="textField-6" x="338" y="0" width="131" height="16" fontName="Bitstream Vera Sans" fontSize="6.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{DESCRIPTION}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="6"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DESCRIPTION}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-7" x="469" y="0" width="62" height="16" uuid="afec1cd4-7f12-471c-a1f2-49f3b68f7d6c"/>
+			</element>
+			<element kind="textField" uuid="afec1cd4-7f12-471c-a1f2-49f3b68f7d6c" key="textField-7" x="469" y="0" width="62" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{AMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{AMOUNT}):new String(" ")]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="7"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{AMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{AMOUNT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Band" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" stretchType="RelativeToBandHeight" x="1" y="0" width="76" height="16" uuid="0e3a0b15-1186-437f-a584-edad98289e50"/>
+			</element>
+			<element kind="textField" uuid="0e3a0b15-1186-437f-a584-edad98289e50" key="textField" stretchType="ContainerHeight" x="1" y="0" width="76" height="16" fontName="Bitstream Vera Sans" fontSize="6.0" evaluationTime="Band" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{DATEPLANNED}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="6"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DATEPLANNED}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="16" uuid="e84e5f3a-7ac4-42bd-9192-7f2d55d7a434"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-29" stretchType="RelativeToBandHeight" x="531" y="0" width="1" height="15" uuid="f526086c-e1ba-4264-8760-67da056efea4"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
+			</element>
+			<element kind="line" uuid="e84e5f3a-7ac4-42bd-9192-7f2d55d7a434" key="line-17" stretchType="ContainerHeight" x="1" y="0" width="1" height="16">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="f526086c-e1ba-4264-8760-67da056efea4" key="line-29" stretchType="ContainerHeight" x="531" y="0" width="1" height="15">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="1" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="20" splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band height="21" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="279" y="13" width="69" height="8" uuid="d7aa4cad-3460-4809-b914-b62ea4a82cb5"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" style="Report_Footer" x="200" y="12" width="76" height="8" uuid="3fffa0cf-e1eb-4c37-81fb-1ae01a69c115"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="5"/>
-				</textElement>
-				<text><![CDATA[Printed on]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="1" splitType="Stretch"/>
+	<pageFooter height="20" splitType="Stretch"/>
+	<summary height="21" splitType="Stretch">
+		<element kind="textField" uuid="d7aa4cad-3460-4809-b914-b62ea4a82cb5" key="textField" x="279" y="13" width="69" height="8" fontName="Times-Roman" fontSize="5.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="3fffa0cf-e1eb-4c37-81fb-1ae01a69c115" key="staticText-1" x="200" y="12" width="76" height="8" fontSize="5.0" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Printed on]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</summary>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportCashflowForecast_sub.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportCashflowForecast_sub.jrxml
@@ -1,66 +1,64 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportCashflowForecast_sub" pageWidth="594" pageHeight="802" columnWidth="594" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="bcc41716-ff64-4e71-986e-a637d1f0786d">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportCashflowForecast_sub" language="java" pageWidth="594" pageHeight="802" columnWidth="594" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="bcc41716-ff64-4e71-986e-a637d1f0786d">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="11">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="11.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Title" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String"/>
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Title" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="AcctID" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="DatePlanned" class="java.util.Date" isForPrompting="false"/>
-	<parameter name="Partner" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="Org" class="java.lang.String" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT BANKACCOUNT,              INITIALBALANCE,             TRUNC(NOW()) AS CURRENTDATE,              INCOME,              PAYMENT,              INCOME-PAYMENT AS INCPAY,   
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="AcctID" forPrompting="false" class="java.lang.String"/>
+	<parameter name="DatePlanned" forPrompting="false" class="java.util.Date"/>
+	<parameter name="Partner" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="Org" forPrompting="false" class="java.lang.String"/>
+	<query language="sql"><![CDATA[SELECT BANKACCOUNT,              INITIALBALANCE,             TRUNC(NOW()) AS CURRENTDATE,              INCOME,              PAYMENT,              INCOME-PAYMENT AS INCPAY,   
     INITIALBALANCE+INCOME-PAYMENT AS              FINALSUMMARY, C_BANKACCOUNT_ID,                          '' AS C_DEBT_PAYMENT_ID,              '' AS DATEPLANNED,              '' AS BPARTNER, 
     '' AS DESCRIPTION,              '' AS INVOICENO,              '' AS DATEINVOICED,             '' AS AMOUNT,             '' AS ISRECEIPT,             '' AS URL,
     '' AS ISRECEIPTMESSAGE FROM (                 SELECT (B.CODEBANK || '/' || B.CODEBRANCH || B.DIGITCONTROL || BA.CODEACCOUNT || '.' || BA.DIGITCONTROL) AS BANKACCOUNT, 
@@ -102,8 +100,7 @@ WHERE C_SETTLEMENT_CANCEL_ID IS NULL
     WHERE BS.C_BANKSTATEMENT_ID = BL.C_BANKSTATEMENT_ID        AND BA.C_BANKACCOUNT_ID = BS.C_BANKACCOUNT_ID        AND BA.C_BANK_ID = B.C_BANK_ID         AND BS.PROCESSED='Y'        
     AND BS.STATEMENTDATE <= NOW()        AND 3=3    AND B.AD_CLIENT_ID IN ($P!{USER_CLIENT})      AND B.AD_ORG_ID IN ($P!{USER_ORG})       
     GROUP BY (B.CODEBANK || '/' || B.CODEBRANCH || B.DIGITCONTROL || BA.CODEACCOUNT || '.' || BA.DIGITCONTROL), BA.C_BANKACCOUNT_ID, ba.c_Currency_ID, ba.ad_client_id, ba.ad_org_id        ) AAA        
-    ORDER BY 1]]>
-	</queryString>
+    ORDER BY 1]]></query>
 	<field name="BANKACCOUNT" class="java.lang.String"/>
 	<field name="INITIALBALANCE" class="java.math.BigDecimal"/>
 	<field name="CURRENTDATE" class="java.sql.Timestamp"/>
@@ -123,94 +120,60 @@ WHERE C_SETTLEMENT_CANCEL_ID IS NULL
 	<field name="URL" class="java.lang.String"/>
 	<field name="ISRECEIPTMESSAGE" class="java.lang.String"/>
 	<variable name="DetailFieldTotal" class="java.lang.String"/>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="0" y="0" width="156" height="16" uuid="953fbe46-c704-4642-bc14-21d4e2b7501f"/>
-				<box rightPadding="2">
+			<element kind="textField" uuid="953fbe46-c704-4642-bc14-21d4e2b7501f" key="textField" x="0" y="0" width="156" height="16" fontSize="6.0" blankWhenNull="false" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{BANKACCOUNT}]]></expression>
+				<box rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="6"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{BANKACCOUNT}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-1" style="Detail_Line" x="156" y="0" width="89" height="16" uuid="b0715211-0dfd-4a79-a3e2-6da5b2197b30"/>
-				<box rightPadding="2">
+			</element>
+			<element kind="textField" uuid="b0715211-0dfd-4a79-a3e2-6da5b2197b30" key="textField-1" x="156" y="0" width="89" height="16" fontSize="6.0" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{INITIALBALANCE}]]></expression>
+				<box rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{INITIALBALANCE}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-2" style="Detail_Line" x="245" y="0" width="102" height="16" uuid="340e85b4-874f-49cf-9001-e159e94d7c6c"/>
-				<box rightPadding="2">
+			</element>
+			<element kind="textField" uuid="340e85b4-874f-49cf-9001-e159e94d7c6c" key="textField-2" x="245" y="0" width="102" height="16" fontSize="6.0" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{INCOME}]]></expression>
+				<box rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{INCOME}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-3" style="Detail_Line" x="347" y="0" width="98" height="16" uuid="6f6f1318-876e-4945-9b4e-53ad17eedc96"/>
-				<box rightPadding="2">
+			</element>
+			<element kind="textField" uuid="6f6f1318-876e-4945-9b4e-53ad17eedc96" key="textField-3" x="347" y="0" width="98" height="16" fontSize="6.0" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{PAYMENT}]]></expression>
+				<box rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PAYMENT}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-4" style="Detail_Line" x="445" y="0" width="89" height="16" uuid="9a5abe95-40e4-4ec2-81f9-b0c598e09f4c"/>
-				<box rightPadding="2">
+			</element>
+			<element kind="textField" uuid="9a5abe95-40e4-4ec2-81f9-b0c598e09f4c" key="textField-4" x="445" y="0" width="89" height="16" fontSize="6.0" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{FINALSUMMARY}]]></expression>
+				<box rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="6"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{FINALSUMMARY}]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportDebtPayment.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportDebtPayment.jrxml
@@ -1,71 +1,71 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportDebtPayment" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="014c66be-c06a-431e-b27a-64772c0d85b6">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportDebtPayment" language="java" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="014c66be-c06a-431e-b27a-64772c0d85b6">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/home/david/workspace/trunk/openbravo/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat()]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale">
 		<defaultValueExpression><![CDATA[new Locale("es", "ES")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="InitialBalance" class="java.math.BigDecimal" isForPrompting="false">
+	<parameter name="InitialBalance" forPrompting="false" class="java.math.BigDecimal">
 		<defaultValueExpression><![CDATA[new BigDecimal(1111)]]></defaultValueExpression>
 	</parameter>
 	<parameter name="SUBREPORT_DIR" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{BASE_DESIGN}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATE_FROM" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="group" class="java.lang.String" isForPrompting="false"/>
+	<parameter name="DATE_FROM" forPrompting="false" class="java.lang.String"/>
+	<parameter name="group" forPrompting="false" class="java.lang.String"/>
 	<field name="DESCRIPTION" class="java.lang.String"/>
 	<field name="AMOUNT" class="java.math.BigDecimal"/>
 	<field name="CONVAMOUNT" class="java.math.BigDecimal"/>
@@ -81,555 +81,385 @@
 	<field name="SALESREPNAME" class="java.lang.String"/>
 	<field name="DEBTCANCEL" class="java.lang.String"/>
 	<field name="ACCOUNTSTR" class="java.lang.String"/>
-	<variable name="SUM_AMOUNT_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="SUM_AMOUNT_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="SUM_AMOUNT_2" class="java.math.BigDecimal" incrementType="Report" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="SUM_AMOUNT_2" incrementType="Report" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="SUM_SUM_AMOUNT_1_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$V{SUM_AMOUNT_1}]]></variableExpression>
+	<variable name="SUM_SUM_AMOUNT_1_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{SUM_AMOUNT_1}]]></expression>
 	</variable>
-	<variable name="SUM_AMOUNT_3" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="SUM_AMOUNT_3" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
 	<group name="bp">
-		<groupExpression><![CDATA[$F{BPARTNER}]]></groupExpression>
+		<expression><![CDATA[$F{BPARTNER}]]></expression>
 		<groupHeader>
 			<band height="30" splitType="Stretch">
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-15" style="Detail_Header" x="1" y="0" width="599" height="15" uuid="fb9284d2-eb56-4600-b5d8-a2acf1b41f62"/>
-					<box leftPadding="5">
+				<element kind="textField" uuid="fb9284d2-eb56-4600-b5d8-a2acf1b41f62" key="textField-15" x="1" y="0" width="599" height="15" blankWhenNull="false" style="Detail_Header">
+					<expression><![CDATA[$F{BPARTNER}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{BPARTNER}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-20" style="Detail_Header" x="1" y="15" width="64" height="15" uuid="b3d51566-a8fb-48c1-a9ad-65af0bf7916b"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="4" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="b3d51566-a8fb-48c1-a9ad-65af0bf7916b" key="staticText-20" x="1" y="15" width="64" height="15" fontSize="4.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Description]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-18" style="Detail_Header" mode="Opaque" x="102" y="15" width="30" height="15" uuid="d348c0cc-a79e-474f-8168-c1131f3aa2e4"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="4" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="d348c0cc-a79e-474f-8168-c1131f3aa2e4" key="staticText-18" mode="Opaque" x="102" y="15" width="30" height="15" fontSize="4.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-19" style="Detail_Header" x="65" y="15" width="37" height="15" uuid="ef19873c-d03a-451c-9f67-08b7779c5d22"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="4" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="ef19873c-d03a-451c-9f67-08b7779c5d22" key="staticText-19" x="65" y="15" width="37" height="15" fontSize="4.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Invoice]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-21" style="Detail_Header" mode="Opaque" x="132" y="15" width="30" height="15" uuid="b1899322-4cc2-4839-addc-dfeb9e790088"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="4" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="b1899322-4cc2-4839-addc-dfeb9e790088" key="staticText-21" mode="Opaque" x="132" y="15" width="30" height="15" fontSize="4.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-22" style="Detail_Header" mode="Opaque" x="162" y="15" width="30" height="15" uuid="0a99d9e4-82c5-4f0c-8019-f2b5c8a06845"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="4" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="0a99d9e4-82c5-4f0c-8019-f2b5c8a06845" key="staticText-22" mode="Opaque" x="162" y="15" width="30" height="15" fontSize="4.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[cancelled]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-23" style="Detail_Header" mode="Opaque" x="192" y="15" width="30" height="15" uuid="3c5775c9-8ddc-4906-a829-ac624701f7cc"/>
-					<box leftPadding="5" rightPadding="1">
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="4" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="3c5775c9-8ddc-4906-a829-ac624701f7cc" key="staticText-23" mode="Opaque" x="192" y="15" width="30" height="15" fontSize="4.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Currency]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-31" style="Detail_Header" mode="Opaque" x="222" y="15" width="30" height="15" uuid="87d9949e-3fb4-4cac-aea6-f528225677d2"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" rightPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="4" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="87d9949e-3fb4-4cac-aea6-f528225677d2" key="staticText-31" mode="Opaque" x="222" y="15" width="30" height="15" fontSize="4.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Original Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-32" style="Detail_Header" mode="Opaque" x="252" y="15" width="30" height="15" uuid="913c9ff6-9e89-4334-b96d-05b465884b14"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="4" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="913c9ff6-9e89-4334-b96d-05b465884b14" key="staticText-32" mode="Opaque" x="252" y="15" width="30" height="15" fontSize="4.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Original Currency]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-24" style="Detail_Header" mode="Opaque" x="282" y="15" width="40" height="15" uuid="dde2ca32-f715-49e7-af32-d65c8159f94a"/>
-					<box leftPadding="5">
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="4" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="dde2ca32-f715-49e7-af32-d65c8159f94a" key="staticText-24" mode="Opaque" x="282" y="15" width="40" height="15" fontSize="4.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Payment rule]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-25" style="Detail_Header" mode="Opaque" x="362" y="15" width="30" height="15" uuid="565d1fec-8810-491a-9c9a-59d33d55457b"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="4" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="565d1fec-8810-491a-9c9a-59d33d55457b" key="staticText-25" mode="Opaque" x="362" y="15" width="30" height="15" fontSize="4.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Debt cancel]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-26" style="Detail_Header" mode="Opaque" x="392" y="15" width="48" height="15" uuid="715eeda2-8388-4cab-b3a6-db1e2b4f50e2"/>
-					<box leftPadding="5">
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="4" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="715eeda2-8388-4cab-b3a6-db1e2b4f50e2" key="staticText-26" mode="Opaque" x="392" y="15" width="48" height="15" fontSize="4.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Debt Generate]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-27" style="Detail_Header" mode="Opaque" x="440" y="15" width="25" height="15" uuid="2fa073ef-6363-407e-8e79-c16ceec368fd"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="4" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="2fa073ef-6363-407e-8e79-c16ceec368fd" key="staticText-27" mode="Opaque" x="440" y="15" width="25" height="15" fontSize="4.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Is Paid]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-28" style="Detail_Header" mode="Opaque" x="465" y="15" width="32" height="15" uuid="0cff710f-7433-4aab-a66f-93f07bc191c1"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="4" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="0cff710f-7433-4aab-a66f-93f07bc191c1" key="staticText-28" mode="Opaque" x="465" y="15" width="32" height="15" fontSize="4.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Status]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-29" style="Detail_Header" mode="Opaque" x="497" y="15" width="103" height="15" uuid="e167d7b3-bce9-4cab-ad90-5454844bf4c0"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="4" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="e167d7b3-bce9-4cab-ad90-5454844bf4c0" key="staticText-29" mode="Opaque" x="497" y="15" width="103" height="15" fontSize="4.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Sales Rep.]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-18" stretchType="RelativeToBandHeight" x="600" y="0" width="1" height="30" uuid="e7cd9c2a-38af-4d27-9d56-40d0d1c45a52"/>
-					<graphicElement>
-						<pen lineWidth="0.5" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-20" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="30" uuid="ae34e96d-804c-4c72-975c-049c02364274"/>
-					<graphicElement>
-						<pen lineWidth="0.5" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-30" style="Detail_Header" mode="Opaque" x="322" y="15" width="40" height="15" uuid="494cd52f-8a1b-41ff-9a4b-006e8c94c6d3"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="4" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="e7cd9c2a-38af-4d27-9d56-40d0d1c45a52" key="line-18" stretchType="ContainerHeight" x="600" y="0" width="1" height="30">
+					<pen lineWidth="0.5" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="ae34e96d-804c-4c72-975c-049c02364274" key="line-20" stretchType="ContainerHeight" x="1" y="0" width="1" height="30">
+					<pen lineWidth="0.5" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="494cd52f-8a1b-41ff-9a4b-006e8c94c6d3" key="staticText-30" mode="Opaque" x="322" y="15" width="40" height="15" fontSize="4.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Bank Account]]></text>
-				</staticText>
+					<box leftPadding="5" style="Detail_Header">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="35" splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="93" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-17" style="Report_Footer" x="1" y="60" width="189" height="30" uuid="23aec3eb-a308-4b3e-93e6-d00f3409698e"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="18"/>
-				</textElement>
-				<text><![CDATA[Payment Report]]></text>
-			</staticText>
-			<image isLazy="true">
-				<reportElement key="image-1" x="336" y="33" width="197" height="55" uuid="6fc3790f-84dd-4b1a-8179-b9525eb016ef"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<imageExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylogin")]]></imageExpression>
-			</image>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="93" splitType="Stretch">
+		<element kind="staticText" uuid="23aec3eb-a308-4b3e-93e6-d00f3409698e" key="staticText-17" x="1" y="60" width="189" height="30" fontSize="18.0" style="Report_Footer">
+			<text><![CDATA[Payment Report]]></text>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="image" uuid="6fc3790f-84dd-4b1a-8179-b9525eb016ef" key="image-1" x="336" y="33" width="197" height="55" lazy="true">
+			<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylogin")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</title>
-	<pageHeader>
-		<band height="4" splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<pageHeader height="4" splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="17" splitType="Stretch">
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-3" x="1" y="0" width="64" height="16" uuid="511f5845-057f-4dbf-938a-4de897d35d20"/>
+			<element kind="textField" uuid="511f5845-057f-4dbf-938a-4de897d35d20" key="textField-3" x="1" y="0" width="64" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{DESCRIPTION}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DESCRIPTION}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="16" uuid="6c3da6ba-434a-4cf7-b7c8-ebaee7f55cab"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-1" x="102" y="0" width="30" height="16" uuid="f9b6cd77-495a-4c5c-bfaa-5b02384dab35"/>
+			</element>
+			<element kind="line" uuid="6c3da6ba-434a-4cf7-b7c8-ebaee7f55cab" key="line-17" stretchType="ContainerHeight" x="1" y="0" width="1" height="16">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="f9b6cd77-495a-4c5c-bfaa-5b02384dab35" key="textField-1" x="102" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{DATEPLANNED}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DATEPLANNED}]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Band" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" stretchType="RelativeToBandHeight" x="65" y="0" width="37" height="16" uuid="353bcaec-03e6-4ec7-9b12-c3f100827921"/>
+			</element>
+			<element kind="textField" uuid="353bcaec-03e6-4ec7-9b12-c3f100827921" key="textField" stretchType="ContainerHeight" x="65" y="0" width="37" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" evaluationTime="Band" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{INVOICE}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{INVOICE}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-5" x="132" y="0" width="30" height="16" uuid="91bd4f18-7e24-4710-bf75-7833aa3c172f"/>
+			</element>
+			<element kind="textField" uuid="91bd4f18-7e24-4710-bf75-7833aa3c172f" key="textField-5" x="132" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{CONVAMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{CONVAMOUNT}):new String(" ")]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVAMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{CONVAMOUNT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-7" x="192" y="0" width="30" height="16" uuid="febc1961-43ff-4fa9-90bf-9a4f28b6057f"/>
+			</element>
+			<element kind="textField" uuid="febc1961-43ff-4fa9-90bf-9a4f28b6057f" key="textField-7" x="192" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{CONVISOSYM}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-17" x="222" y="0" width="30" height="16" uuid="72df415b-4921-47f5-9329-d8bb5e26470e"/>
+			</element>
+			<element kind="textField" uuid="72df415b-4921-47f5-9329-d8bb5e26470e" key="textField-17" x="222" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{AMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{AMOUNT}):new String(" ")]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{AMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{AMOUNT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-18" x="252" y="0" width="30" height="16" uuid="aab7e545-f308-4d5b-a820-f4dec8377d2c"/>
+			</element>
+			<element kind="textField" uuid="aab7e545-f308-4d5b-a820-f4dec8377d2c" key="textField-18" x="252" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{CURRENCY}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CURRENCY}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-8" x="282" y="0" width="40" height="16" uuid="96a482b4-9f4a-4a9f-9355-265294c0cf07"/>
+			</element>
+			<element kind="textField" uuid="96a482b4-9f4a-4a9f-9355-265294c0cf07" key="textField-8" x="282" y="0" width="40" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{PAYMENTRULE}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PAYMENTRULE}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-9" x="362" y="0" width="30" height="16" uuid="9c022e3d-b14d-490a-8a4a-bb4bcc741697"/>
+			</element>
+			<element kind="textField" uuid="9c022e3d-b14d-490a-8a4a-bb4bcc741697" key="textField-9" x="362" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{PAYMENTRULE}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PAYMENTRULE}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-10" x="392" y="0" width="48" height="16" uuid="874bc7a9-ad4a-40e3-af1a-a862178c676f"/>
+			</element>
+			<element kind="textField" uuid="874bc7a9-ad4a-40e3-af1a-a862178c676f" key="textField-10" x="392" y="0" width="48" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{DEBTGENERATE}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DEBTGENERATE}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-11" x="440" y="0" width="25" height="16" uuid="f6a8ab95-f235-4110-bba3-d1ff1ec62682"/>
+			</element>
+			<element kind="textField" uuid="f6a8ab95-f235-4110-bba3-d1ff1ec62682" key="textField-11" x="440" y="0" width="25" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{ISPAID}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{ISPAID}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-12" x="465" y="0" width="32" height="16" uuid="edfa6cb2-6212-4b2b-ae8a-0fa223b4f38c"/>
+			</element>
+			<element kind="textField" uuid="edfa6cb2-6212-4b2b-ae8a-0fa223b4f38c" key="textField-12" x="465" y="0" width="32" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{STATUS}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{STATUS}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-13" x="497" y="0" width="103" height="16" uuid="c9b7b133-f052-47ec-9291-cb31c0cc58cc"/>
+			</element>
+			<element kind="textField" uuid="c9b7b133-f052-47ec-9291-cb31c0cc58cc" key="textField-13" x="497" y="0" width="103" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{SALESREPNAME}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{SALESREPNAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-14" x="162" y="0" width="30" height="16" uuid="10af5bd5-9d3b-41f5-9461-4a2b63ffcbfb"/>
+			</element>
+			<element kind="textField" uuid="10af5bd5-9d3b-41f5-9461-4a2b63ffcbfb" key="textField-14" x="162" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{DEBTCANCEL}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DEBTCANCEL}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-19" stretchType="RelativeToBandHeight" x="600" y="0" width="1" height="16" uuid="0b098845-0137-46db-a427-35d657cd8c77"/>
-				<graphicElement>
-					<pen lineWidth="0.5" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-21" style="Report_Footer" x="2" y="16" width="598" height="1" uuid="832846f6-4916-4ef5-84cb-5ae743925c84"/>
-			</line>
-			<textField evaluationTime="Band" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-16" stretchType="RelativeToBandHeight" x="322" y="0" width="40" height="16" uuid="d72af794-4186-4b69-a857-7c15e5ebeda7"/>
+			</element>
+			<element kind="line" uuid="0b098845-0137-46db-a427-35d657cd8c77" key="line-19" stretchType="ContainerHeight" x="600" y="0" width="1" height="16">
+				<pen lineWidth="0.5" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="832846f6-4916-4ef5-84cb-5ae743925c84" key="line-21" x="2" y="16" width="598" height="1" style="Report_Footer"/>
+			<element kind="textField" uuid="d72af794-4186-4b69-a857-7c15e5ebeda7" key="textField-16" stretchType="ContainerHeight" x="322" y="0" width="40" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" evaluationTime="Band" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{ACCOUNTSTR}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{ACCOUNTSTR}]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="6" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="20" splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band height="21" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-15" style="GroupHeader_Gray" x="1" y="1" width="85" height="15" uuid="9401681b-3fde-42ce-a504-05e247eebc3f"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="10" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Total]]></text>
-			</staticText>
-			<textField evaluationTime="Report" pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="87" y="1" width="76" height="15" uuid="0562a9cf-4d7d-40ff-b2f0-c83c31606ec1"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUM_AMOUNT_3}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="279" y="12" width="69" height="8" uuid="b318c65c-0bbc-4bd5-94ce-0c8f128f3501"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" style="Report_Footer" x="200" y="12" width="76" height="8" uuid="141539ef-be09-4af3-98c4-a6cefd2f2fda"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="5"/>
-				</textElement>
-				<text><![CDATA[Printed on]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="6" splitType="Stretch"/>
+	<pageFooter height="20" splitType="Stretch"/>
+	<summary height="21" splitType="Stretch">
+		<element kind="staticText" uuid="9401681b-3fde-42ce-a504-05e247eebc3f" key="staticText-15" x="1" y="1" width="85" height="15" fontSize="10.0" bold="true" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_Gray">
+			<text><![CDATA[Total]]></text>
+			<box style="GroupHeader_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="0562a9cf-4d7d-40ff-b2f0-c83c31606ec1" key="textField" x="87" y="1" width="76" height="15" fontSize="10.0" evaluationTime="Report" pattern="##0.00" blankWhenNull="false">
+			<expression><![CDATA[$V{SUM_AMOUNT_3}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="b318c65c-0bbc-4bd5-94ce-0c8f128f3501" key="textField" x="279" y="12" width="69" height="8" fontName="Times-Roman" fontSize="5.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="141539ef-be09-4af3-98c4-a6cefd2f2fda" key="staticText-1" x="200" y="12" width="76" height="8" fontSize="5.0" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Printed on]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</summary>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportDebtPaymentTracker.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportDebtPaymentTracker.jrxml
@@ -1,70 +1,70 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportDebtPaymentTracker" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="9568dfef-336c-4616-b632-e8f11045fbd9">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportDebtPaymentTracker" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="9568dfef-336c-4616-b632-e8f11045fbd9">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/home/david/workspace/trunk/openbravo/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat()]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale">
 		<defaultValueExpression><![CDATA[new Locale("es", "ES")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="InitialBalance" class="java.math.BigDecimal" isForPrompting="false">
+	<parameter name="InitialBalance" forPrompting="false" class="java.math.BigDecimal">
 		<defaultValueExpression><![CDATA[new BigDecimal(1111)]]></defaultValueExpression>
 	</parameter>
 	<parameter name="SUBREPORT_DIR" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{BASE_DESIGN}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATE_FROM" class="java.lang.String" isForPrompting="false"/>
+	<parameter name="DATE_FROM" forPrompting="false" class="java.lang.String"/>
 	<field name="DESCRIPTION" class="java.lang.String"/>
 	<field name="NAME" class="java.lang.String"/>
 	<field name="DOCUMENTNO" class="java.lang.String"/>
@@ -75,384 +75,262 @@
 	<field name="AMOUNT" class="java.math.BigDecimal"/>
 	<field name="AMT_DOC_PPA" class="java.math.BigDecimal"/>
 	<field name="AMT_DOC_BP" class="java.math.BigDecimal"/>
-	<variable name="SUM_AMT_DOC_BP_1" class="java.math.BigDecimal" resetType="Group" resetGroup="bp" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMT_DOC_BP}]]></variableExpression>
+	<variable name="SUM_AMT_DOC_BP_1" resetType="Group" calculation="Sum" resetGroup="bp" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMT_DOC_BP}]]></expression>
 	</variable>
-	<variable name="SUM_AMT_DOC_PPA_1" class="java.math.BigDecimal" resetType="Group" resetGroup="bp" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMT_DOC_PPA}]]></variableExpression>
+	<variable name="SUM_AMT_DOC_PPA_1" resetType="Group" calculation="Sum" resetGroup="bp" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMT_DOC_PPA}]]></expression>
 	</variable>
-	<group name="bp" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[$F{NAME}]]></groupExpression>
+	<group name="bp" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[$F{NAME}]]></expression>
 		<groupHeader>
 			<band height="38" splitType="Stretch">
-				<line>
-					<reportElement key="line-1" x="1" y="6" width="530" height="1" uuid="18aa249d-101c-42f9-a7fe-47a36098f773"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField-4" style="Detail_Header" x="0" y="5" width="531" height="16" uuid="eb0fdc74-e875-493b-a19e-e6653497d36c"/>
-					<box leftPadding="5">
+				<element kind="line" uuid="18aa249d-101c-42f9-a7fe-47a36098f773" key="line-1" x="1" y="6" width="530" height="1">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="textField" uuid="eb0fdc74-e875-493b-a19e-e6653497d36c" key="textField-4" x="0" y="5" width="531" height="16" fontName="Bitstream Vera Sans" fontSize="10.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{NAME}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NAME}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-2" style="Detail_Header" x="126" y="21" width="79" height="15" uuid="623fa4b8-f6d1-4c6f-8270-bfa5144299a8"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="623fa4b8-f6d1-4c6f-8270-bfa5144299a8" key="staticText-2" x="126" y="21" width="79" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Description]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-3" style="Detail_Header" x="1" y="21" width="75" height="15" uuid="eada7f3e-4110-432e-b412-979ce243c463"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="eada7f3e-4110-432e-b412-979ce243c463" key="staticText-3" x="1" y="21" width="75" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<text><![CDATA[Document]]></text>
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Document]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-4" style="Detail_Header" mode="Opaque" x="76" y="21" width="50" height="15" uuid="74fba26b-a6af-4e5e-b384-0e17bc035d97"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="74fba26b-a6af-4e5e-b384-0e17bc035d97" key="staticText-4" mode="Opaque" x="76" y="21" width="50" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Document No.]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-19" style="Report_Footer" x="1" y="6" width="1" height="31" uuid="da3d5508-b17b-4884-9899-18253c10b118"/>
-				</line>
-				<line>
-					<reportElement key="line-20" style="Report_Footer" x="531" y="6" width="1" height="32" uuid="bfa84538-90a0-4978-aa3e-bff4d7819b1e"/>
-				</line>
-				<staticText>
-					<reportElement key="staticText-5" style="Detail_Header" mode="Opaque" x="205" y="21" width="48" height="15" uuid="4a901873-d14a-48b1-98dd-903f3131c6e5"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="da3d5508-b17b-4884-9899-18253c10b118" key="line-19" x="1" y="6" width="1" height="31" style="Report_Footer"/>
+				<element kind="line" uuid="bfa84538-90a0-4978-aa3e-bff4d7819b1e" key="line-20" x="531" y="6" width="1" height="32" style="Report_Footer"/>
+				<element kind="staticText" uuid="4a901873-d14a-48b1-98dd-903f3131c6e5" key="staticText-5" mode="Opaque" x="205" y="21" width="48" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Transaction date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-6" style="Detail_Header" mode="Opaque" x="253" y="21" width="51" height="15" uuid="c40cc68b-6cbc-4d91-b53b-b842eb919236"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="c40cc68b-6cbc-4d91-b53b-b842eb919236" key="staticText-6" mode="Opaque" x="253" y="21" width="51" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Planned date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-7" style="Detail_Header" mode="Opaque" x="304" y="21" width="101" height="15" uuid="b74b0cd6-011d-47da-9028-6fee993bc7cd"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="b74b0cd6-011d-47da-9028-6fee993bc7cd" key="staticText-7" mode="Opaque" x="304" y="21" width="101" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Observations]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-8" style="Detail_Header" mode="Opaque" x="404" y="21" width="39" height="15" uuid="822172e1-cef5-4c52-8b8d-185997372596"/>
-					<box leftPadding="5" rightPadding="3">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="822172e1-cef5-4c52-8b8d-185997372596" key="staticText-8" mode="Opaque" x="404" y="21" width="39" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-9" style="Detail_Header" mode="Opaque" x="443" y="21" width="42" height="15" uuid="14642fc3-2345-4b02-8201-14058061c179"/>
-					<box leftPadding="5" rightPadding="3">
+					<box leftPadding="5" rightPadding="3" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="14642fc3-2345-4b02-8201-14058061c179" key="staticText-9" mode="Opaque" x="443" y="21" width="42" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Customer balance  ]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-10" style="Detail_Header" mode="Opaque" x="485" y="21" width="46" height="15" uuid="f52c9af0-f571-41bc-b90b-fba476861182"/>
-					<box leftPadding="5" rightPadding="3">
+					<box leftPadding="5" rightPadding="3" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="f52c9af0-f571-41bc-b90b-fba476861182" key="staticText-10" mode="Opaque" x="485" y="21" width="46" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[PPA balance]]></text>
-				</staticText>
+					<box leftPadding="5" rightPadding="3" style="Detail_Header">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="19" splitType="Stretch">
-				<line direction="BottomUp">
-					<reportElement key="line-18" style="Report_Footer" x="1" y="0" width="530" height="1" uuid="1f6ea119-b970-43fa-ba0e-bc27d354bf14"/>
-				</line>
-				<staticText>
-					<reportElement key="staticText-16" style="GroupHeader_Gray" x="1" y="1" width="530" height="9" uuid="61d0682a-72a6-48fe-9790-4e946accb37d"/>
-					<box>
+				<element kind="line" uuid="1f6ea119-b970-43fa-ba0e-bc27d354bf14" key="line-18" x="1" y="0" width="530" height="1" direction="BottomUp" style="Report_Footer"/>
+				<element kind="staticText" uuid="61d0682a-72a6-48fe-9790-4e946accb37d" key="staticText-16" x="1" y="1" width="530" height="9" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="GroupHeader_Gray">
+					<text><![CDATA[]]></text>
+					<box style="GroupHeader_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[]]></text>
-				</staticText>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="93" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-17" style="Report_Footer" x="1" y="22" width="219" height="42" uuid="de850531-1b18-4603-8a1b-3787e6e9250f"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="18"/>
-				</textElement>
-				<text><![CDATA[Payment Tracker Report]]></text>
-			</staticText>
-			<image isLazy="true">
-				<reportElement key="image-1" x="323" y="22" width="197" height="55" uuid="53ce1845-59ec-4ca6-a574-12c8fbb9b109"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<imageExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylogin")]]></imageExpression>
-			</image>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="93" splitType="Stretch">
+		<element kind="staticText" uuid="de850531-1b18-4603-8a1b-3787e6e9250f" key="staticText-17" x="1" y="22" width="219" height="42" fontSize="18.0" style="Report_Footer">
+			<text><![CDATA[Payment Tracker Report]]></text>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="image" uuid="53ce1845-59ec-4ca6-a574-12c8fbb9b109" key="image-1" x="323" y="22" width="197" height="55" lazy="true">
+			<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylogin")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</title>
-	<pageHeader>
-		<band height="3" splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<pageHeader height="3" splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="531" y="0" width="1" height="16" uuid="1ee83c26-e34e-44c3-ace8-d577ceec1803"/>
-				<graphicElement>
-					<pen lineWidth="0.5" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="16" uuid="6a25a4c4-e1e6-4df8-ab80-00934a445380"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-1" x="76" y="0" width="50" height="16" uuid="0ba39dd1-2aaa-4908-aed2-024c4d0a5432"/>
+			<element kind="line" uuid="1ee83c26-e34e-44c3-ace8-d577ceec1803" key="line-16" stretchType="ContainerHeight" x="531" y="0" width="1" height="16">
+				<pen lineWidth="0.5" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="6a25a4c4-e1e6-4df8-ab80-00934a445380" key="line-17" stretchType="ContainerHeight" x="1" y="0" width="1" height="16">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="0ba39dd1-2aaa-4908-aed2-024c4d0a5432" key="textField-1" x="76" y="0" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{DOCUMENTNO}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DOCUMENTNO}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-3" x="126" y="0" width="79" height="16" uuid="53fdc260-d572-4820-9fc4-fa36c5c9a13b"/>
+			</element>
+			<element kind="textField" uuid="53fdc260-d572-4820-9fc4-fa36c5c9a13b" key="textField-3" x="126" y="0" width="79" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{DESCRIPTION}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DESCRIPTION}]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Band" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" stretchType="RelativeToBandHeight" x="1" y="0" width="76" height="16" uuid="26ee602d-f928-44c8-b0b0-30d6d9409888"/>
+			</element>
+			<element kind="textField" uuid="26ee602d-f928-44c8-b0b0-30d6d9409888" key="textField" stretchType="ContainerHeight" x="1" y="0" width="76" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" evaluationTime="Band" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{TIPO}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{TIPO}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-5" x="205" y="0" width="48" height="16" uuid="fdfff75a-574a-4dba-b58c-ae9eb298626a"/>
+			</element>
+			<element kind="textField" uuid="fdfff75a-574a-4dba-b58c-ae9eb298626a" key="textField-5" x="205" y="0" width="48" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{DATETRX}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DATETRX}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-6" x="253" y="0" width="51" height="16" uuid="b856c951-b60e-467e-ab26-c2ba720bcdf1"/>
+			</element>
+			<element kind="textField" uuid="b856c951-b60e-467e-ab26-c2ba720bcdf1" key="textField-6" x="253" y="0" width="51" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{DATEPLANNED}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DATEPLANNED}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-7" x="304" y="0" width="101" height="16" uuid="604351ce-0edb-49fc-813e-4e98ffc4d220"/>
+			</element>
+			<element kind="textField" uuid="604351ce-0edb-49fc-813e-4e98ffc4d220" key="textField-7" x="304" y="0" width="101" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle">
+				<expression><![CDATA[$F{OBS}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{OBS}]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="405" y="0" width="37" height="16" uuid="20c2f57d-5f3d-45a4-9792-1d717031f502"/>
+			</element>
+			<element kind="textField" uuid="20c2f57d-5f3d-45a4-9792-1d717031f502" key="textField" x="405" y="0" width="37" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="##0.00" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{AMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{AMOUNT}):new String(" ")]]></expression>
 				<box leftPadding="5" rightPadding="3">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{AMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{AMOUNT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="443" y="0" width="42" height="16" uuid="fed8e39c-ad9a-4048-a317-bcc5b2e78d8a"/>
+			</element>
+			<element kind="textField" uuid="fed8e39c-ad9a-4048-a317-bcc5b2e78d8a" key="textField" x="443" y="0" width="42" height="16" fontName="DejaVu Serif" fontSize="5.0" pattern="##0.00" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($V{SUM_AMT_DOC_BP_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_AMT_DOC_BP_1}):new String(" ")]]></expression>
 				<box leftPadding="5" rightPadding="3">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="DejaVu Serif" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_AMT_DOC_BP_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_AMT_DOC_BP_1}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="485" y="0" width="44" height="16" uuid="168d2b6f-5bb1-4ea9-a05b-ed3a34a408e8"/>
+			</element>
+			<element kind="textField" uuid="168d2b6f-5bb1-4ea9-a05b-ed3a34a408e8" key="textField" x="485" y="0" width="44" height="16" fontSize="5.0" pattern="##0.00" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($V{SUM_AMT_DOC_PPA_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_AMT_DOC_PPA_1}):new String(" ")]]></expression>
 				<box rightPadding="3">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_AMT_DOC_PPA_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_AMT_DOC_PPA_1}):new String(" ")]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="6" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="20" splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band height="21" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="279" y="12" width="69" height="8" uuid="52d9848a-656f-4437-b1d1-0261229a2e54"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" style="Report_Footer" x="200" y="12" width="76" height="8" uuid="9d46c1e7-412b-4e72-8eca-710ef2ffa20d"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="5"/>
-				</textElement>
-				<text><![CDATA[Printed on]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="6" splitType="Stretch"/>
+	<pageFooter height="20" splitType="Stretch"/>
+	<summary height="21" splitType="Stretch">
+		<element kind="textField" uuid="52d9848a-656f-4437-b1d1-0261229a2e54" key="textField" x="279" y="12" width="69" height="8" fontName="Times-Roman" fontSize="5.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="9d46c1e7-412b-4e72-8eca-710ef2ffa20d" key="staticText-1" x="200" y="12" width="76" height="8" fontSize="5.0" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Printed on]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</summary>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportDebtPayment_BankAcc.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportDebtPayment_BankAcc.jrxml
@@ -1,71 +1,71 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportDebtPayment_BankAcc" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="59e4ea3c-3363-4fe8-b243-ed305621d781">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportDebtPayment_BankAcc" language="java" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="59e4ea3c-3363-4fe8-b243-ed305621d781">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/home/david/workspace/trunk/openbravo/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat()]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale">
 		<defaultValueExpression><![CDATA[new Locale("es", "ES")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="InitialBalance" class="java.math.BigDecimal" isForPrompting="false">
+	<parameter name="InitialBalance" forPrompting="false" class="java.math.BigDecimal">
 		<defaultValueExpression><![CDATA[new BigDecimal(1111)]]></defaultValueExpression>
 	</parameter>
 	<parameter name="SUBREPORT_DIR" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{BASE_DESIGN}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATE_FROM" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="group" class="java.lang.String" isForPrompting="false"/>
+	<parameter name="DATE_FROM" forPrompting="false" class="java.lang.String"/>
+	<parameter name="group" forPrompting="false" class="java.lang.String"/>
 	<field name="DESCRIPTION" class="java.lang.String"/>
 	<field name="AMOUNT" class="java.math.BigDecimal"/>
 	<field name="CONVAMOUNT" class="java.math.BigDecimal"/>
@@ -81,591 +81,414 @@
 	<field name="SALESREPNAME" class="java.lang.String"/>
 	<field name="DEBTCANCEL" class="java.lang.String"/>
 	<field name="BANKACC" class="java.lang.String"/>
-	<variable name="SUM_AMOUNT_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="SUM_AMOUNT_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="SUM_AMOUNT_2" class="java.math.BigDecimal" incrementType="Report" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="SUM_AMOUNT_2" incrementType="Report" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="SUM_SUM_AMOUNT_1_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$V{SUM_AMOUNT_1}]]></variableExpression>
+	<variable name="SUM_SUM_AMOUNT_1_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{SUM_AMOUNT_1}]]></expression>
 	</variable>
-	<variable name="SUM_AMOUNT_3" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="SUM_AMOUNT_3" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="SUM_AMOUNT_4" class="java.math.BigDecimal" resetType="Group" resetGroup="BA" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="SUM_AMOUNT_4" resetType="Group" calculation="Sum" resetGroup="BA" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
 	<group name="bp">
-		<groupExpression><![CDATA[$F{BPARTNER}]]></groupExpression>
+		<expression><![CDATA[$F{BPARTNER}]]></expression>
 		<groupHeader>
 			<band height="30" splitType="Stretch">
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-15" style="Detail_Header" x="1" y="0" width="567" height="15" uuid="cac87143-cc79-427e-8f82-fad96724daea"/>
-					<box leftPadding="5">
+				<element kind="textField" uuid="cac87143-cc79-427e-8f82-fad96724daea" key="textField-15" x="1" y="0" width="567" height="15" blankWhenNull="false" style="Detail_Header">
+					<expression><![CDATA[$F{BPARTNER}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{BPARTNER}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-18" stretchType="RelativeToBandHeight" x="568" y="0" width="1" height="30" uuid="c374efa5-5367-4ff4-b3b3-d5d4a85a5660"/>
-					<graphicElement>
-						<pen lineWidth="0.5" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-23" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="30" uuid="b04373f9-d641-4ad2-a0d7-d59eed253fa7"/>
-					<graphicElement>
-						<pen lineWidth="0.5" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				</element>
+				<element kind="line" uuid="c374efa5-5367-4ff4-b3b3-d5d4a85a5660" key="line-18" stretchType="ContainerHeight" x="568" y="0" width="1" height="30">
+					<pen lineWidth="0.5" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="b04373f9-d641-4ad2-a0d7-d59eed253fa7" key="line-23" stretchType="ContainerHeight" x="1" y="0" width="1" height="30">
+					<pen lineWidth="0.5" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="35" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText-15" style="GroupHeader_Gray" x="1" y="1" width="173" height="12" uuid="de1c935e-9725-45ae-b954-cef5f5d2e163"/>
-					<box rightPadding="4">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="10" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				<element kind="staticText" uuid="de1c935e-9725-45ae-b954-cef5f5d2e163" key="staticText-15" x="1" y="1" width="173" height="12" fontSize="10.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="GroupHeader_Gray">
 					<text><![CDATA[Total]]></text>
-				</staticText>
-				<textField evaluationTime="Group" evaluationGroup="bp" pattern="##0.00" isBlankWhenNull="false">
-					<reportElement key="textField" x="174" y="1" width="30" height="12" uuid="9ef1c0e7-b764-4fa7-a496-df450951e53a"/>
+					<box rightPadding="4" style="GroupHeader_Gray">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="9ef1c0e7-b764-4fa7-a496-df450951e53a" key="textField" x="174" y="1" width="30" height="12" fontSize="6.0" evaluationTime="Group" pattern="##0.00" evaluationGroup="bp" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{SUM_AMOUNT_4}!=null)?$P{NUMBERFORMAT}.format($V{SUM_AMOUNT_4}):new String(" ")]]></expression>
 					<box rightPadding="2">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{SUM_AMOUNT_4}!=null)?$P{NUMBERFORMAT}.format($V{SUM_AMOUNT_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-32" style="GroupHeader_Gray" x="204" y="1" width="364" height="12" uuid="fc22c0f7-52d1-4a15-a3e0-3bec66823949"/>
-					<box rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="10" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="fc22c0f7-52d1-4a15-a3e0-3bec66823949" key="staticText-32" x="204" y="1" width="364" height="12" fontSize="10.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="GroupHeader_Gray">
 					<text><![CDATA[]]></text>
-				</staticText>
+					<box rightPadding="2" style="GroupHeader_Gray">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="BA">
-		<groupExpression><![CDATA[$F{BANKACC}]]></groupExpression>
+		<expression><![CDATA[$F{BANKACC}]]></expression>
 		<groupHeader>
 			<band height="30" splitType="Stretch">
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-16" style="Detail_Header" x="1" y="0" width="567" height="15" uuid="85790387-5016-4f1f-97e1-316940651f30"/>
-					<box leftPadding="5">
+				<element kind="textField" uuid="85790387-5016-4f1f-97e1-316940651f30" key="textField-16" x="1" y="0" width="567" height="15" blankWhenNull="false" style="Detail_Header">
+					<expression><![CDATA[$F{BANKACC}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{BANKACC}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-20" style="Detail_Header" x="1" y="15" width="85" height="15" uuid="ea1ccf23-f913-415d-8814-6ff5bbbf1fbe"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="ea1ccf23-f913-415d-8814-6ff5bbbf1fbe" key="staticText-20" x="1" y="15" width="85" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Description]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-18" style="Detail_Header" mode="Opaque" x="137" y="15" width="30" height="15" uuid="eca46fa3-c335-4176-a02e-9d89b7e96d1e"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="eca46fa3-c335-4176-a02e-9d89b7e96d1e" key="staticText-18" mode="Opaque" x="137" y="15" width="30" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-19" style="Detail_Header" x="86" y="15" width="51" height="15" uuid="1e0ece82-398f-46f2-b3e8-9b85029e7a75"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="1e0ece82-398f-46f2-b3e8-9b85029e7a75" key="staticText-19" x="86" y="15" width="51" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Invoice]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-21" style="Detail_Header" mode="Opaque" x="167" y="15" width="30" height="15" uuid="1469be62-d46e-4644-a5ba-06063e8721c4"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="1469be62-d46e-4644-a5ba-06063e8721c4" key="staticText-21" mode="Opaque" x="167" y="15" width="30" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-31" style="Detail_Header" mode="Opaque" x="257" y="15" width="30" height="15" uuid="198856cd-c93b-4047-a345-f4882f3c302f"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="198856cd-c93b-4047-a345-f4882f3c302f" key="staticText-31" mode="Opaque" x="257" y="15" width="30" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Original Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-22" style="Detail_Header" mode="Opaque" x="197" y="15" width="30" height="15" uuid="8bccd526-b3d8-43a7-bc37-cf53406584ae"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="8bccd526-b3d8-43a7-bc37-cf53406584ae" key="staticText-22" mode="Opaque" x="197" y="15" width="30" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[cancelled]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-23" style="Detail_Header" mode="Opaque" x="227" y="15" width="30" height="15" uuid="8f4f0121-8831-4c80-b8eb-68ee808219fb"/>
-					<box leftPadding="5" rightPadding="1">
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="8f4f0121-8831-4c80-b8eb-68ee808219fb" key="staticText-23" mode="Opaque" x="227" y="15" width="30" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Currency]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-32" style="Detail_Header" mode="Opaque" x="287" y="15" width="30" height="15" uuid="ab33941d-f724-4bf9-ade6-ae39237b8bc3"/>
-					<box leftPadding="5" rightPadding="1">
+					<box leftPadding="5" rightPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="ab33941d-f724-4bf9-ade6-ae39237b8bc3" key="staticText-32" mode="Opaque" x="287" y="15" width="30" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Original Currency]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-24" style="Detail_Header" mode="Opaque" x="317" y="15" width="41" height="15" uuid="9b2667c1-81c4-4b5d-8996-1118ff74b6c0"/>
-					<box leftPadding="5">
+					<box leftPadding="5" rightPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="9b2667c1-81c4-4b5d-8996-1118ff74b6c0" key="staticText-24" mode="Opaque" x="317" y="15" width="41" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Payment rule]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-25" style="Detail_Header" mode="Opaque" x="358" y="15" width="50" height="15" uuid="2844f47e-cc88-45b0-8d53-60b6f9abe722"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="2844f47e-cc88-45b0-8d53-60b6f9abe722" key="staticText-25" mode="Opaque" x="358" y="15" width="50" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Debt cancel]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-26" style="Detail_Header" mode="Opaque" x="408" y="15" width="63" height="15" uuid="f1c7c7ad-922b-4fd1-8b50-51755d24580e"/>
-					<box leftPadding="5">
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="f1c7c7ad-922b-4fd1-8b50-51755d24580e" key="staticText-26" mode="Opaque" x="408" y="15" width="63" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Debt Generate]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-27" style="Detail_Header" mode="Opaque" x="471" y="15" width="27" height="15" uuid="0d962f2b-2222-4500-9398-e23923d0cf2a"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="0d962f2b-2222-4500-9398-e23923d0cf2a" key="staticText-27" mode="Opaque" x="471" y="15" width="27" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Is Paid]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-28" style="Detail_Header" mode="Opaque" x="498" y="15" width="37" height="15" uuid="87df5202-853b-4d92-9550-768a9a61e51d"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="87df5202-853b-4d92-9550-768a9a61e51d" key="staticText-28" mode="Opaque" x="498" y="15" width="37" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Status]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-29" style="Detail_Header" mode="Opaque" x="535" y="15" width="33" height="15" uuid="aa956f1c-02bd-41f6-9609-2a98c10883e2"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="aa956f1c-02bd-41f6-9609-2a98c10883e2" key="staticText-29" mode="Opaque" x="535" y="15" width="33" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Sales Rep.]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-20" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="30" uuid="54f518f2-cc73-48a6-b7e1-29fe8bbef0b6"/>
-					<graphicElement>
-						<pen lineWidth="0.5" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-22" stretchType="RelativeToBandHeight" x="568" y="0" width="1" height="30" uuid="249ce393-1602-403a-a6d8-58bf99149f95"/>
-					<graphicElement>
-						<pen lineWidth="0.5" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+					<box leftPadding="5" style="Detail_Header">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="line" uuid="54f518f2-cc73-48a6-b7e1-29fe8bbef0b6" key="line-20" stretchType="ContainerHeight" x="1" y="0" width="1" height="30">
+					<pen lineWidth="0.5" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="249ce393-1602-403a-a6d8-58bf99149f95" key="line-22" stretchType="ContainerHeight" x="568" y="0" width="1" height="30">
+					<pen lineWidth="0.5" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="93" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-17" style="Report_Footer" x="1" y="60" width="189" height="30" uuid="79ce7cf9-1f40-4e15-929a-cf7fc8f48cdc"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="18"/>
-				</textElement>
-				<text><![CDATA[Payment Report]]></text>
-			</staticText>
-			<image isLazy="true">
-				<reportElement key="image-1" x="336" y="33" width="197" height="55" uuid="af032f60-1f85-4a6a-b346-f80dceade50b"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<imageExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylogin")]]></imageExpression>
-			</image>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="93" splitType="Stretch">
+		<element kind="staticText" uuid="79ce7cf9-1f40-4e15-929a-cf7fc8f48cdc" key="staticText-17" x="1" y="60" width="189" height="30" fontSize="18.0" style="Report_Footer">
+			<text><![CDATA[Payment Report]]></text>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="image" uuid="af032f60-1f85-4a6a-b346-f80dceade50b" key="image-1" x="336" y="33" width="197" height="55" lazy="true">
+			<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylogin")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</title>
-	<pageHeader>
-		<band height="4" splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<pageHeader height="4" splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="17" splitType="Stretch">
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-3" x="1" y="0" width="85" height="16" uuid="da395aa4-6031-4354-8238-6e166cecc7b7"/>
+			<element kind="textField" uuid="da395aa4-6031-4354-8238-6e166cecc7b7" key="textField-3" x="1" y="0" width="85" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{DESCRIPTION}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DESCRIPTION}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="16" uuid="c54d2837-4cb6-4193-899f-bcbfd26ff875"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-1" x="137" y="0" width="30" height="16" uuid="e3d17636-68ac-43b3-a6cf-278885ed19e5"/>
+			</element>
+			<element kind="line" uuid="c54d2837-4cb6-4193-899f-bcbfd26ff875" key="line-17" stretchType="ContainerHeight" x="1" y="0" width="1" height="16">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="e3d17636-68ac-43b3-a6cf-278885ed19e5" key="textField-1" x="137" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{DATEPLANNED}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DATEPLANNED}]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Band" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" stretchType="RelativeToBandHeight" x="86" y="0" width="51" height="16" uuid="c7f6cef6-1e84-4a84-8d8c-1b971b06260f"/>
+			</element>
+			<element kind="textField" uuid="c7f6cef6-1e84-4a84-8d8c-1b971b06260f" key="textField" stretchType="ContainerHeight" x="86" y="0" width="51" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" evaluationTime="Band" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{INVOICE}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{INVOICE}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-5" x="167" y="0" width="30" height="16" uuid="90fb830b-ed3d-4316-8149-8641f1116091"/>
+			</element>
+			<element kind="textField" uuid="90fb830b-ed3d-4316-8149-8641f1116091" key="textField-5" x="167" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{CONVAMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{CONVAMOUNT}):new String(" ")]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVAMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{CONVAMOUNT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-17" x="257" y="0" width="30" height="16" uuid="acdca01c-1561-48b5-b94a-fc8c71e9cfaa"/>
+			</element>
+			<element kind="textField" uuid="acdca01c-1561-48b5-b94a-fc8c71e9cfaa" key="textField-17" x="257" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{AMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{AMOUNT}):new String(" ")]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{AMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{AMOUNT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-7" x="227" y="0" width="30" height="16" uuid="3cc933fc-f6ef-47d5-90ae-fa7f1e39ab78"/>
+			</element>
+			<element kind="textField" uuid="3cc933fc-f6ef-47d5-90ae-fa7f1e39ab78" key="textField-7" x="227" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{CONVISOSYM}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-18" x="287" y="0" width="30" height="16" uuid="74f43d9c-d5d8-4d91-b293-1bcbe126135e"/>
+			</element>
+			<element kind="textField" uuid="74f43d9c-d5d8-4d91-b293-1bcbe126135e" key="textField-18" x="287" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{CURRENCY}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CURRENCY}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-8" x="317" y="0" width="41" height="16" uuid="718fb150-d529-4d26-8547-7ca8c9860ba7"/>
+			</element>
+			<element kind="textField" uuid="718fb150-d529-4d26-8547-7ca8c9860ba7" key="textField-8" x="317" y="0" width="41" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{PAYMENTRULE}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PAYMENTRULE}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-9" x="358" y="0" width="50" height="16" uuid="8e3a2c14-5810-4cd2-a10b-77ac29418b24"/>
+			</element>
+			<element kind="textField" uuid="8e3a2c14-5810-4cd2-a10b-77ac29418b24" key="textField-9" x="358" y="0" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{PAYMENTRULE}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PAYMENTRULE}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-10" x="408" y="0" width="63" height="16" uuid="1a239b7e-cd3a-4650-85d5-4063ecf8bb87"/>
+			</element>
+			<element kind="textField" uuid="1a239b7e-cd3a-4650-85d5-4063ecf8bb87" key="textField-10" x="408" y="0" width="63" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{DEBTGENERATE}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DEBTGENERATE}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-11" x="471" y="0" width="27" height="16" uuid="cf082328-7708-4188-99ed-d5d39d7712f9"/>
+			</element>
+			<element kind="textField" uuid="cf082328-7708-4188-99ed-d5d39d7712f9" key="textField-11" x="471" y="0" width="27" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{ISPAID}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{ISPAID}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-12" x="498" y="0" width="37" height="16" uuid="ce073bc9-a464-4428-b29f-faec5929d153"/>
+			</element>
+			<element kind="textField" uuid="ce073bc9-a464-4428-b29f-faec5929d153" key="textField-12" x="498" y="0" width="37" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{STATUS}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{STATUS}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-13" x="535" y="0" width="33" height="16" uuid="cd433b43-d085-4584-9dbf-72d685ff6365"/>
+			</element>
+			<element kind="textField" uuid="cd433b43-d085-4584-9dbf-72d685ff6365" key="textField-13" x="535" y="0" width="33" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{SALESREPNAME}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{SALESREPNAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-14" x="197" y="0" width="30" height="16" uuid="2feb3abb-f4dc-45aa-b46c-77087c03f199"/>
+			</element>
+			<element kind="textField" uuid="2feb3abb-f4dc-45aa-b46c-77087c03f199" key="textField-14" x="197" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{DEBTCANCEL}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DEBTCANCEL}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-19" stretchType="RelativeToBandHeight" x="568" y="0" width="1" height="16" uuid="8131b48b-ffd6-45c6-8900-c157eb59bd5c"/>
-				<graphicElement>
-					<pen lineWidth="0.5" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-21" style="Report_Footer" x="2" y="16" width="567" height="1" uuid="dc80c37e-77e6-4329-ab6e-f4f01f25dc0f"/>
-			</line>
+			</element>
+			<element kind="line" uuid="8131b48b-ffd6-45c6-8900-c157eb59bd5c" key="line-19" stretchType="ContainerHeight" x="568" y="0" width="1" height="16">
+				<pen lineWidth="0.5" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="dc80c37e-77e6-4329-ab6e-f4f01f25dc0f" key="line-21" x="2" y="16" width="567" height="1" style="Report_Footer"/>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="6" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="20" splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band height="21" splitType="Stretch">
-			<textField evaluationTime="Report" pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="87" y="1" width="76" height="15" uuid="952f8511-eec0-454f-9124-20fdf8ff3d50"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUM_AMOUNT_3}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="279" y="12" width="69" height="8" uuid="d7dea7de-39eb-4fda-afcb-3612055134f2"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" style="Report_Footer" x="200" y="12" width="76" height="8" uuid="3b6b5cc7-387c-4c2a-b812-7f0036e13730"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="5"/>
-				</textElement>
-				<text><![CDATA[Printed on]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="6" splitType="Stretch"/>
+	<pageFooter height="20" splitType="Stretch"/>
+	<summary height="21" splitType="Stretch">
+		<element kind="textField" uuid="952f8511-eec0-454f-9124-20fdf8ff3d50" key="textField" x="87" y="1" width="76" height="15" fontSize="10.0" evaluationTime="Report" pattern="##0.00" blankWhenNull="false">
+			<expression><![CDATA[$V{SUM_AMOUNT_3}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="d7dea7de-39eb-4fda-afcb-3612055134f2" key="textField" x="279" y="12" width="69" height="8" fontName="Times-Roman" fontSize="5.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="3b6b5cc7-387c-4c2a-b812-7f0036e13730" key="staticText-1" x="200" y="12" width="76" height="8" fontSize="5.0" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Printed on]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</summary>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportDebtPayment_NoBP.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportDebtPayment_NoBP.jrxml
@@ -1,71 +1,71 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportDebtPayment_NoBP" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="cbac2900-62d0-4827-a55f-e5cecb1d0155">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportDebtPayment_NoBP" language="java" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="cbac2900-62d0-4827-a55f-e5cecb1d0155">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/home/david/workspace/trunk/openbravo/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat()]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale">
 		<defaultValueExpression><![CDATA[new Locale("es", "ES")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="InitialBalance" class="java.math.BigDecimal" isForPrompting="false">
+	<parameter name="InitialBalance" forPrompting="false" class="java.math.BigDecimal">
 		<defaultValueExpression><![CDATA[new BigDecimal(1111)]]></defaultValueExpression>
 	</parameter>
 	<parameter name="SUBREPORT_DIR" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{BASE_DESIGN}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATE_FROM" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="group" class="java.lang.String" isForPrompting="false"/>
+	<parameter name="DATE_FROM" forPrompting="false" class="java.lang.String"/>
+	<parameter name="group" forPrompting="false" class="java.lang.String"/>
 	<field name="DESCRIPTION" class="java.lang.String"/>
 	<field name="AMOUNT" class="java.math.BigDecimal"/>
 	<field name="CONVAMOUNT" class="java.math.BigDecimal"/>
@@ -81,562 +81,385 @@
 	<field name="SALESREPNAME" class="java.lang.String"/>
 	<field name="DEBTCANCEL" class="java.lang.String"/>
 	<field name="ACCOUNTSTR" class="java.lang.String"/>
-	<variable name="SUM_AMOUNT_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="SUM_AMOUNT_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="SUM_AMOUNT_2" class="java.math.BigDecimal" incrementType="Report" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="SUM_AMOUNT_2" incrementType="Report" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="SUM_SUM_AMOUNT_1_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$V{SUM_AMOUNT_1}]]></variableExpression>
+	<variable name="SUM_SUM_AMOUNT_1_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{SUM_AMOUNT_1}]]></expression>
 	</variable>
-	<variable name="SUM_AMOUNT_3" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="SUM_AMOUNT_3" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="93" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-17" style="Report_Footer" x="1" y="60" width="189" height="30" uuid="19060a1d-67a7-4624-b604-336f6277315b"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="18"/>
-				</textElement>
-				<text><![CDATA[Payment Report]]></text>
-			</staticText>
-			<image isLazy="true">
-				<reportElement key="image-1" x="336" y="33" width="197" height="55" uuid="fec04255-c523-4edf-8a1a-a7d506ace360"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<imageExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylogin")]]></imageExpression>
-			</image>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="93" splitType="Stretch">
+		<element kind="staticText" uuid="19060a1d-67a7-4624-b604-336f6277315b" key="staticText-17" x="1" y="60" width="189" height="30" fontSize="18.0" style="Report_Footer">
+			<text><![CDATA[Payment Report]]></text>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="image" uuid="fec04255-c523-4edf-8a1a-a7d506ace360" key="image-1" x="336" y="33" width="197" height="55" lazy="true">
+			<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylogin")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</title>
-	<pageHeader>
-		<band height="4" splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band height="17" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-18" style="Detail_Header" mode="Opaque" x="137" y="2" width="30" height="15" uuid="3f0ba653-cbd3-45c3-adce-91094a9ba6ee"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Date]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-19" style="Detail_Header" x="57" y="2" width="39" height="15" uuid="3415770e-49c8-4cda-9c39-3300876e54f3"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Invoice]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-20" style="Detail_Header" x="1" y="2" width="56" height="15" uuid="947dfa03-91c6-4f4a-9e78-1bb3b730e831"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Description]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-21" style="Detail_Header" mode="Opaque" x="167" y="2" width="30" height="15" uuid="bc2c0b5d-1f7a-4915-b2aa-a98cfde12b4a"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Amount]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-31" style="Detail_Header" mode="Opaque" x="257" y="2" width="30" height="15" uuid="98906e23-cf9e-4321-b365-df90e8e05922"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Original Amount]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-22" style="Detail_Header" mode="Opaque" x="197" y="2" width="30" height="15" uuid="5a50bd04-1fe3-4b07-8ccf-101d2930285a"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[cancelled]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-23" style="Detail_Header" mode="Opaque" x="227" y="2" width="30" height="15" uuid="7a978bf6-31f1-4ff8-a733-61831fae7436"/>
-				<box leftPadding="5" rightPadding="1">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Currency]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-32" style="Detail_Header" mode="Opaque" x="287" y="2" width="30" height="15" uuid="2cd48e22-925e-4de6-be2a-2a3ba360eecd"/>
-				<box leftPadding="5" rightPadding="1">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Original Currency]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-24" style="Detail_Header" mode="Opaque" x="317" y="2" width="41" height="15" uuid="35b0d21d-f2cb-4085-991e-f53f47b57dfd"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Payment rule]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-25" style="Detail_Header" mode="Opaque" x="398" y="2" width="40" height="15" uuid="bbddece0-6fc1-4bbc-b933-3d353c521bcf"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Debt cancel]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-26" style="Detail_Header" mode="Opaque" x="438" y="2" width="51" height="15" uuid="a36ccbad-dd2d-4e57-8b0e-59c1b985b07e"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Debt Generate]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-27" style="Detail_Header" mode="Opaque" x="489" y="2" width="27" height="15" uuid="714447aa-048f-44b5-859e-1a5d8f9cd864"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Is Paid]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-28" style="Detail_Header" mode="Opaque" x="516" y="2" width="31" height="15" uuid="822ff7f8-7b2b-4339-8bfa-15f33ea7cd3d"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Status]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-29" style="Detail_Header" mode="Opaque" x="547" y="2" width="81" height="15" uuid="a41295d4-7bb3-4664-bb4f-89f7a005a7e2"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Sales Rep.]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-30" style="Detail_Header" mode="Opaque" x="358" y="2" width="40" height="15" uuid="2f6bb597-7e15-4d15-b3fa-662371d62ca8"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Bank Account]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-31" style="Detail_Header" x="96" y="2" width="41" height="15" uuid="18682d26-be05-4109-8f71-53dc2f05e699"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Business Partner]]></text>
-			</staticText>
-		</band>
+	<pageHeader height="4" splitType="Stretch"/>
+	<columnHeader height="17" splitType="Stretch">
+		<element kind="staticText" uuid="3f0ba653-cbd3-45c3-adce-91094a9ba6ee" key="staticText-18" mode="Opaque" x="137" y="2" width="30" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Date]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="3415770e-49c8-4cda-9c39-3300876e54f3" key="staticText-19" x="57" y="2" width="39" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Invoice]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="947dfa03-91c6-4f4a-9e78-1bb3b730e831" key="staticText-20" x="1" y="2" width="56" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Description]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="bc2c0b5d-1f7a-4915-b2aa-a98cfde12b4a" key="staticText-21" mode="Opaque" x="167" y="2" width="30" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Amount]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="98906e23-cf9e-4321-b365-df90e8e05922" key="staticText-31" mode="Opaque" x="257" y="2" width="30" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Original Amount]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="5a50bd04-1fe3-4b07-8ccf-101d2930285a" key="staticText-22" mode="Opaque" x="197" y="2" width="30" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[cancelled]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="7a978bf6-31f1-4ff8-a733-61831fae7436" key="staticText-23" mode="Opaque" x="227" y="2" width="30" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Currency]]></text>
+			<box leftPadding="5" rightPadding="1" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="2cd48e22-925e-4de6-be2a-2a3ba360eecd" key="staticText-32" mode="Opaque" x="287" y="2" width="30" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Original Currency]]></text>
+			<box leftPadding="5" rightPadding="1" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="35b0d21d-f2cb-4085-991e-f53f47b57dfd" key="staticText-24" mode="Opaque" x="317" y="2" width="41" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Payment rule]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="bbddece0-6fc1-4bbc-b933-3d353c521bcf" key="staticText-25" mode="Opaque" x="398" y="2" width="40" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Debt cancel]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="a36ccbad-dd2d-4e57-8b0e-59c1b985b07e" key="staticText-26" mode="Opaque" x="438" y="2" width="51" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Debt Generate]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="714447aa-048f-44b5-859e-1a5d8f9cd864" key="staticText-27" mode="Opaque" x="489" y="2" width="27" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Is Paid]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="822ff7f8-7b2b-4339-8bfa-15f33ea7cd3d" key="staticText-28" mode="Opaque" x="516" y="2" width="31" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Status]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="a41295d4-7bb3-4664-bb4f-89f7a005a7e2" key="staticText-29" mode="Opaque" x="547" y="2" width="81" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Sales Rep.]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="2f6bb597-7e15-4d15-b3fa-662371d62ca8" key="staticText-30" mode="Opaque" x="358" y="2" width="40" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Bank Account]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="18682d26-be05-4109-8f71-53dc2f05e699" key="staticText-31" x="96" y="2" width="41" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Business Partner]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
 	</columnHeader>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-3" x="1" y="0" width="56" height="16" uuid="8f649592-c22b-4871-8a63-88ff2fbeb7b7"/>
+			<element kind="textField" uuid="8f649592-c22b-4871-8a63-88ff2fbeb7b7" key="textField-3" x="1" y="0" width="56" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{DESCRIPTION}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DESCRIPTION}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="628" y="0" width="1" height="16" uuid="0719554c-111b-4d20-a20a-b66351b313af"/>
-				<graphicElement>
-					<pen lineWidth="0.5" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="16" uuid="9e17fe00-bb50-451a-a495-fcf855d7071e"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-1" x="137" y="0" width="30" height="16" uuid="2fe4865b-f2c3-4d17-a71d-27caa3bc6319"/>
+			</element>
+			<element kind="line" uuid="0719554c-111b-4d20-a20a-b66351b313af" key="line-16" stretchType="ContainerHeight" x="628" y="0" width="1" height="16">
+				<pen lineWidth="0.5" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="9e17fe00-bb50-451a-a495-fcf855d7071e" key="line-17" stretchType="ContainerHeight" x="1" y="0" width="1" height="16">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="2fe4865b-f2c3-4d17-a71d-27caa3bc6319" key="textField-1" x="137" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{DATEPLANNED}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DATEPLANNED}]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Band" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" stretchType="RelativeToBandHeight" x="57" y="0" width="39" height="16" uuid="99b1e8a1-a96a-4c52-acdb-9ce1827b9794"/>
+			</element>
+			<element kind="textField" uuid="99b1e8a1-a96a-4c52-acdb-9ce1827b9794" key="textField" stretchType="ContainerHeight" x="57" y="0" width="39" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" evaluationTime="Band" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{INVOICE}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{INVOICE}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-5" x="167" y="0" width="30" height="16" uuid="681d1264-293d-412d-b2a4-fe28031ea068"/>
+			</element>
+			<element kind="textField" uuid="681d1264-293d-412d-b2a4-fe28031ea068" key="textField-5" x="167" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{CONVAMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{CONVAMOUNT}):new String(" ")]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVAMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{CONVAMOUNT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-7" x="227" y="0" width="30" height="16" uuid="92780f6d-53e3-4060-8dc8-9866179b2f35"/>
+			</element>
+			<element kind="textField" uuid="92780f6d-53e3-4060-8dc8-9866179b2f35" key="textField-7" x="227" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{CONVISOSYM}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-17" x="257" y="0" width="30" height="16" uuid="f581c6f9-eb14-42b7-a923-fc99014151d5"/>
+			</element>
+			<element kind="textField" uuid="f581c6f9-eb14-42b7-a923-fc99014151d5" key="textField-17" x="257" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{AMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{AMOUNT}):new String(" ")]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{AMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{AMOUNT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-18" x="287" y="0" width="30" height="16" uuid="6a0ce04e-b77b-4a1e-bdf8-13a37de5b740"/>
+			</element>
+			<element kind="textField" uuid="6a0ce04e-b77b-4a1e-bdf8-13a37de5b740" key="textField-18" x="287" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{CURRENCY}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CURRENCY}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-8" x="317" y="0" width="41" height="16" uuid="83fac3e7-352a-44a2-828e-e915b6f2f3da"/>
+			</element>
+			<element kind="textField" uuid="83fac3e7-352a-44a2-828e-e915b6f2f3da" key="textField-8" x="317" y="0" width="41" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{PAYMENTRULE}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PAYMENTRULE}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-9" x="398" y="0" width="40" height="16" uuid="43bfa22d-caa8-4fde-8ae7-0a8637e9e977"/>
+			</element>
+			<element kind="textField" uuid="43bfa22d-caa8-4fde-8ae7-0a8637e9e977" key="textField-9" x="398" y="0" width="40" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{PAYMENTRULE}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PAYMENTRULE}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-10" x="438" y="0" width="51" height="16" uuid="edf37f44-1815-4b1a-baf9-9ba44d8294cb"/>
+			</element>
+			<element kind="textField" uuid="edf37f44-1815-4b1a-baf9-9ba44d8294cb" key="textField-10" x="438" y="0" width="51" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{DEBTGENERATE}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DEBTGENERATE}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-11" x="489" y="0" width="27" height="16" uuid="20b0aa59-c24c-4930-81c5-090c8c5fce72"/>
+			</element>
+			<element kind="textField" uuid="20b0aa59-c24c-4930-81c5-090c8c5fce72" key="textField-11" x="489" y="0" width="27" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{ISPAID}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{ISPAID}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-12" x="516" y="0" width="31" height="16" uuid="ac905bc7-f3d8-4646-81ef-5bea6a3d9b68"/>
+			</element>
+			<element kind="textField" uuid="ac905bc7-f3d8-4646-81ef-5bea6a3d9b68" key="textField-12" x="516" y="0" width="31" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{STATUS}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{STATUS}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-13" x="547" y="0" width="81" height="16" uuid="11ed8b98-3b91-4b25-a0b2-c7bf53bb67c0"/>
+			</element>
+			<element kind="textField" uuid="11ed8b98-3b91-4b25-a0b2-c7bf53bb67c0" key="textField-13" x="547" y="0" width="81" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{SALESREPNAME}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{SALESREPNAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-14" x="197" y="0" width="30" height="16" uuid="e2296ebf-b9ea-42ac-a98c-3d57eb813acf"/>
+			</element>
+			<element kind="textField" uuid="e2296ebf-b9ea-42ac-a98c-3d57eb813acf" key="textField-14" x="197" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{DEBTCANCEL}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DEBTCANCEL}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-18" stretchType="RelativeToBandHeight" x="628" y="-15" width="1" height="16" uuid="45fd17c8-5ea6-4a4a-bc0e-2575473d925e"/>
-				<graphicElement>
-					<pen lineWidth="0.5" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-19" stretchType="RelativeToBandHeight" x="1" y="-15" width="1" height="16" uuid="7a974d6a-9ebd-479b-8371-fb5a5a417ce9"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-20" style="Report_Footer" x="1" y="15" width="627" height="1" uuid="efbd9f49-0c50-41e4-9c5f-1275000432c3"/>
-			</line>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-15" x="358" y="-1" width="40" height="16" uuid="41bba663-c2a1-4a3f-b6ae-3d303dc7339d"/>
+			</element>
+			<element kind="line" uuid="45fd17c8-5ea6-4a4a-bc0e-2575473d925e" key="line-18" stretchType="ContainerHeight" x="628" y="-15" width="1" height="16">
+				<pen lineWidth="0.5" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="7a974d6a-9ebd-479b-8371-fb5a5a417ce9" key="line-19" stretchType="ContainerHeight" x="1" y="-15" width="1" height="16">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="efbd9f49-0c50-41e4-9c5f-1275000432c3" key="line-20" x="1" y="15" width="627" height="1" style="Report_Footer"/>
+			<element kind="textField" uuid="41bba663-c2a1-4a3f-b6ae-3d303dc7339d" key="textField-15" x="358" y="-1" width="40" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{ACCOUNTSTR}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{ACCOUNTSTR}]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Band" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-16" stretchType="RelativeToBandHeight" x="96" y="0" width="41" height="16" uuid="bda39c96-f5b0-43a7-8e9d-1a58231800e6"/>
+			</element>
+			<element kind="textField" uuid="bda39c96-f5b0-43a7-8e9d-1a58231800e6" key="textField-16" stretchType="ContainerHeight" x="96" y="0" width="41" height="16" fontName="Bitstream Vera Sans" fontSize="4.0" evaluationTime="Band" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{BPARTNER}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="4"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{BPARTNER}]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="6" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="20" splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band height="21" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-15" style="GroupHeader_Gray" x="1" y="1" width="85" height="15" uuid="ad4bc2a0-c897-4db3-b71d-39a95d23b33a"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="10" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Total]]></text>
-			</staticText>
-			<textField evaluationTime="Report" pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="87" y="1" width="76" height="15" uuid="483c095f-e992-43d3-8582-4ee659e9c3c1"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUM_AMOUNT_3}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="279" y="12" width="69" height="8" uuid="76c12527-671c-4220-be67-5bb6a61229b1"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" style="Report_Footer" x="200" y="12" width="76" height="8" uuid="8a98e3d7-aeb1-40f1-bcbc-05daff24fe4c"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="5"/>
-				</textElement>
-				<text><![CDATA[Printed on]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="6" splitType="Stretch"/>
+	<pageFooter height="20" splitType="Stretch"/>
+	<summary height="21" splitType="Stretch">
+		<element kind="staticText" uuid="ad4bc2a0-c897-4db3-b71d-39a95d23b33a" key="staticText-15" x="1" y="1" width="85" height="15" fontSize="10.0" bold="true" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_Gray">
+			<text><![CDATA[Total]]></text>
+			<box style="GroupHeader_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="483c095f-e992-43d3-8582-4ee659e9c3c1" key="textField" x="87" y="1" width="76" height="15" fontSize="10.0" evaluationTime="Report" pattern="##0.00" blankWhenNull="false">
+			<expression><![CDATA[$V{SUM_AMOUNT_3}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="76c12527-671c-4220-be67-5bb6a61229b1" key="textField" x="279" y="12" width="69" height="8" fontName="Times-Roman" fontSize="5.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="8a98e3d7-aeb1-40f1-bcbc-05daff24fe4c" key="staticText-1" x="200" y="12" width="76" height="8" fontSize="5.0" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Printed on]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</summary>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportDebtPayment_NoBP_BankAcc.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportDebtPayment_NoBP_BankAcc.jrxml
@@ -1,71 +1,71 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportDebtPayment_NoBP_BankAcc" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="05b06125-43c6-42da-a22d-e3203e118eac">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportDebtPayment_NoBP_BankAcc" language="java" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="05b06125-43c6-42da-a22d-e3203e118eac">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/home/david/workspace/trunk/openbravo/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat()]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale">
 		<defaultValueExpression><![CDATA[new Locale("es", "ES")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="InitialBalance" class="java.math.BigDecimal" isForPrompting="false">
+	<parameter name="InitialBalance" forPrompting="false" class="java.math.BigDecimal">
 		<defaultValueExpression><![CDATA[new BigDecimal(1111)]]></defaultValueExpression>
 	</parameter>
 	<parameter name="SUBREPORT_DIR" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{BASE_DESIGN}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATE_FROM" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="group" class="java.lang.String" isForPrompting="false"/>
+	<parameter name="DATE_FROM" forPrompting="false" class="java.lang.String"/>
+	<parameter name="group" forPrompting="false" class="java.lang.String"/>
 	<field name="DESCRIPTION" class="java.lang.String"/>
 	<field name="AMOUNT" class="java.math.BigDecimal"/>
 	<field name="CONVAMOUNT" class="java.math.BigDecimal"/>
@@ -82,569 +82,396 @@
 	<field name="DEBTCANCEL" class="java.lang.String"/>
 	<field name="BANKACC" class="java.lang.String"/>
 	<field name="ACCOUNTSTR" class="java.lang.String"/>
-	<variable name="SUM_AMOUNT_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="SUM_AMOUNT_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="SUM_AMOUNT_2" class="java.math.BigDecimal" incrementType="Report" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="SUM_AMOUNT_2" incrementType="Report" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="SUM_SUM_AMOUNT_1_1" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$V{SUM_AMOUNT_1}]]></variableExpression>
+	<variable name="SUM_SUM_AMOUNT_1_1" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{SUM_AMOUNT_1}]]></expression>
 	</variable>
-	<variable name="SUM_AMOUNT_3" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="SUM_AMOUNT_3" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="SUM_AMOUNT_4" class="java.math.BigDecimal" resetType="Group" resetGroup="BA" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="SUM_AMOUNT_4" resetType="Group" calculation="Sum" resetGroup="BA" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
 	<group name="BA">
-		<groupExpression><![CDATA[$F{BANKACC}]]></groupExpression>
+		<expression><![CDATA[$F{BANKACC}]]></expression>
 		<groupHeader>
 			<band height="30" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText-29" style="Detail_Header" mode="Opaque" x="543" y="15" width="34" height="15" uuid="f2a571d1-adbc-4a74-a009-aff07f486f34"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				<element kind="staticText" uuid="f2a571d1-adbc-4a74-a009-aff07f486f34" key="staticText-29" mode="Opaque" x="543" y="15" width="34" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Sales Rep.]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-18" style="Detail_Header" mode="Opaque" x="174" y="15" width="30" height="15" uuid="fcd7c42d-60e7-485b-abae-9a64fe4e3e4e"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="fcd7c42d-60e7-485b-abae-9a64fe4e3e4e" key="staticText-18" mode="Opaque" x="174" y="15" width="30" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-19" style="Detail_Header" x="75" y="15" width="44" height="15" uuid="e1259074-ce44-47cd-a0ae-cc1905009713"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="e1259074-ce44-47cd-a0ae-cc1905009713" key="staticText-19" x="75" y="15" width="44" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Invoice]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-20" style="Detail_Header" x="1" y="15" width="74" height="15" uuid="e69fb74e-b524-4bde-9240-e2e80f07834b"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="e69fb74e-b524-4bde-9240-e2e80f07834b" key="staticText-20" x="1" y="15" width="74" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Description]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-21" style="Detail_Header" mode="Opaque" x="204" y="15" width="30" height="15" uuid="58fac9a3-a040-474a-9d59-1a72a9cc3700"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="58fac9a3-a040-474a-9d59-1a72a9cc3700" key="staticText-21" mode="Opaque" x="204" y="15" width="30" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-31" style="Detail_Header" mode="Opaque" x="294" y="15" width="30" height="15" uuid="bed12d82-1367-4bf3-8da1-bbe2053c0d88"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="bed12d82-1367-4bf3-8da1-bbe2053c0d88" key="staticText-31" mode="Opaque" x="294" y="15" width="30" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Original Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-22" style="Detail_Header" mode="Opaque" x="234" y="15" width="30" height="15" uuid="554475a9-b728-443b-af9a-633762693261"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="554475a9-b728-443b-af9a-633762693261" key="staticText-22" mode="Opaque" x="234" y="15" width="30" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[cancelled]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-23" style="Detail_Header" mode="Opaque" x="264" y="15" width="30" height="15" uuid="82f35f61-bf88-4827-937b-88c02b51b53c"/>
-					<box leftPadding="5" rightPadding="1">
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="82f35f61-bf88-4827-937b-88c02b51b53c" key="staticText-23" mode="Opaque" x="264" y="15" width="30" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Currency]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-32" style="Detail_Header" mode="Opaque" x="324" y="15" width="30" height="15" uuid="a15aed73-133a-4858-9bcc-59a4a044a42c"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" rightPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="a15aed73-133a-4858-9bcc-59a4a044a42c" key="staticText-32" mode="Opaque" x="324" y="15" width="30" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Original Currency]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-24" style="Detail_Header" mode="Opaque" x="354" y="15" width="67" height="15" uuid="fb9d67ab-3f3e-4563-88ca-3d2cb4b57d1f"/>
-					<box leftPadding="5">
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="fb9d67ab-3f3e-4563-88ca-3d2cb4b57d1f" key="staticText-24" mode="Opaque" x="354" y="15" width="67" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Payment rule]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-25" style="Detail_Header" mode="Opaque" x="116" y="14" width="59" height="16" uuid="5a8c640f-8fc3-4525-9292-b277a20574f2"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="5a8c640f-8fc3-4525-9292-b277a20574f2" key="staticText-25" mode="Opaque" x="116" y="14" width="59" height="16" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Business Partner]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-26" style="Detail_Header" mode="Opaque" x="421" y="15" width="58" height="15" uuid="05ed1ab5-66e5-4068-8671-5463a6e7ae25"/>
-					<box leftPadding="5">
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="05ed1ab5-66e5-4068-8671-5463a6e7ae25" key="staticText-26" mode="Opaque" x="421" y="15" width="58" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Debt Generate]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-27" style="Detail_Header" mode="Opaque" x="479" y="15" width="27" height="15" uuid="3e4e3dec-f149-4678-8a18-11f2664b3023"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="3e4e3dec-f149-4678-8a18-11f2664b3023" key="staticText-27" mode="Opaque" x="479" y="15" width="27" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Is Paid]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-28" style="Detail_Header" mode="Opaque" x="506" y="15" width="37" height="15" uuid="09ba6be7-bfaf-42f1-827a-44a1aa83b912"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="5" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="09ba6be7-bfaf-42f1-827a-44a1aa83b912" key="staticText-28" mode="Opaque" x="506" y="15" width="37" height="15" fontSize="5.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Status]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-15" style="Detail_Header" x="1" y="0" width="576" height="17" uuid="86313e01-7814-47a3-ba5a-05f4b5aee084"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{BANKACC}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-18" stretchType="RelativeToBandHeight" x="577" y="0" width="1" height="29" uuid="c1ba43c3-b4c0-4d17-9043-47b1b694f156"/>
-					<graphicElement>
-						<pen lineWidth="0.5" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-19" style="Report_Footer" x="1" y="0" width="1" height="30" uuid="d7880fa4-8d75-4c82-9c9a-a4004f95e8e8"/>
-				</line>
+				</element>
+				<element kind="textField" uuid="86313e01-7814-47a3-ba5a-05f4b5aee084" key="textField-15" x="1" y="0" width="576" height="17" blankWhenNull="false" style="Detail_Header">
+					<expression><![CDATA[$F{BANKACC}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="line" uuid="c1ba43c3-b4c0-4d17-9043-47b1b694f156" key="line-18" stretchType="ContainerHeight" x="577" y="0" width="1" height="29">
+					<pen lineWidth="0.5" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="d7880fa4-8d75-4c82-9c9a-a4004f95e8e8" key="line-19" x="1" y="0" width="1" height="30" style="Report_Footer"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="24" splitType="Stretch">
-				<textField evaluationTime="Group" evaluationGroup="BA" pattern="##0.00" isBlankWhenNull="false">
-					<reportElement key="textField" x="204" y="0" width="34" height="11" uuid="c6a43106-da17-4359-81c5-8314750171e7"/>
+				<element kind="textField" uuid="c6a43106-da17-4359-81c5-8314750171e7" key="textField" x="204" y="0" width="34" height="11" fontSize="6.0" evaluationTime="Group" pattern="##0.00" evaluationGroup="BA" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($V{SUM_AMOUNT_4}!=null)?$P{NUMBERFORMAT}.format($V{SUM_AMOUNT_4}):new String(" ")]]></expression>
 					<box rightPadding="2">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="6"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{SUM_AMOUNT_4}!=null)?$P{NUMBERFORMAT}.format($V{SUM_AMOUNT_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-30" style="GroupHeader_Gray" x="1" y="0" width="203" height="11" uuid="4e28f097-9bda-4257-a766-089205c92cc1"/>
-					<box rightPadding="4">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="4e28f097-9bda-4257-a766-089205c92cc1" key="staticText-30" x="1" y="0" width="203" height="11" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="GroupHeader_Gray">
 					<text><![CDATA[Total]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-31" style="GroupHeader_Gray" x="238" y="0" width="339" height="11" uuid="ef1a5137-9b71-4951-8060-9940c80aa886"/>
-					<box rightPadding="4">
+					<box rightPadding="4" style="GroupHeader_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="ef1a5137-9b71-4951-8060-9940c80aa886" key="staticText-31" x="238" y="0" width="339" height="11" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" vTextAlign="Middle" style="GroupHeader_Gray">
 					<text><![CDATA[]]></text>
-				</staticText>
+					<box rightPadding="4" style="GroupHeader_Gray">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="93" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-17" style="Report_Footer" x="1" y="60" width="189" height="30" uuid="aa9d7550-d943-4942-9cff-2f410b90ce7d"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="18"/>
-				</textElement>
-				<text><![CDATA[Payment Report]]></text>
-			</staticText>
-			<image isLazy="true">
-				<reportElement key="image-1" x="336" y="33" width="197" height="55" uuid="94925d84-43b6-4541-90e9-40cc8967826c"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<imageExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylogin")]]></imageExpression>
-			</image>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="93" splitType="Stretch">
+		<element kind="staticText" uuid="aa9d7550-d943-4942-9cff-2f410b90ce7d" key="staticText-17" x="1" y="60" width="189" height="30" fontSize="18.0" style="Report_Footer">
+			<text><![CDATA[Payment Report]]></text>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="image" uuid="94925d84-43b6-4541-90e9-40cc8967826c" key="image-1" x="336" y="33" width="197" height="55" lazy="true">
+			<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylogin")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</title>
-	<pageHeader>
-		<band height="4" splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band height="1" splitType="Stretch"/>
-	</columnHeader>
+	<pageHeader height="4" splitType="Stretch"/>
+	<columnHeader height="1" splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-3" x="1" y="0" width="74" height="16" isPrintWhenDetailOverflows="true" uuid="01362dc3-a600-48f7-8e11-4384e454dcf9"/>
+			<element kind="textField" uuid="01362dc3-a600-48f7-8e11-4384e454dcf9" key="textField-3" x="1" y="0" width="74" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" printWhenDetailOverflows="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{DESCRIPTION}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DESCRIPTION}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="577" y="0" width="1" height="16" uuid="e4b6567f-56d6-4ffe-bd49-a963f2139626"/>
-				<graphicElement>
-					<pen lineWidth="0.5" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="16" uuid="c1c5f803-9706-4562-a2bd-90d0d0f69360"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-1" x="174" y="0" width="30" height="16" uuid="54fd6e06-49c2-48d7-97af-e9d88c4e9957"/>
+			</element>
+			<element kind="line" uuid="e4b6567f-56d6-4ffe-bd49-a963f2139626" key="line-16" stretchType="ContainerHeight" x="577" y="0" width="1" height="16">
+				<pen lineWidth="0.5" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="c1c5f803-9706-4562-a2bd-90d0d0f69360" key="line-17" stretchType="ContainerHeight" x="1" y="0" width="1" height="16">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="54fd6e06-49c2-48d7-97af-e9d88c4e9957" key="textField-1" x="174" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{DATEPLANNED}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DATEPLANNED}]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Band" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" stretchType="RelativeToBandHeight" x="75" y="0" width="44" height="16" uuid="7e269ec3-3530-4a03-8a23-979b4b911a81"/>
+			</element>
+			<element kind="textField" uuid="7e269ec3-3530-4a03-8a23-979b4b911a81" key="textField" stretchType="ContainerHeight" x="75" y="0" width="44" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" evaluationTime="Band" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{INVOICE}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{INVOICE}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-5" x="204" y="0" width="30" height="16" uuid="e0f7d26c-0da9-4998-8726-8f5551830058"/>
+			</element>
+			<element kind="textField" uuid="e0f7d26c-0da9-4998-8726-8f5551830058" key="textField-5" x="204" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{CONVAMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{CONVAMOUNT}):new String(" ")]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVAMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{CONVAMOUNT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-17" x="294" y="0" width="30" height="16" uuid="11366ce1-15b6-402e-b307-94c4c48cac99"/>
+			</element>
+			<element kind="textField" uuid="11366ce1-15b6-402e-b307-94c4c48cac99" key="textField-17" x="294" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{AMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{AMOUNT}):new String(" ")]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{AMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{AMOUNT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-7" x="264" y="0" width="30" height="16" uuid="8f0a418a-70af-4682-9fb8-6f5cedfa0677"/>
+			</element>
+			<element kind="textField" uuid="8f0a418a-70af-4682-9fb8-6f5cedfa0677" key="textField-7" x="264" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{CONVISOSYM}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-18" x="324" y="0" width="30" height="16" uuid="cdf6a26e-08c8-475b-891b-e809f6bb2be8"/>
+			</element>
+			<element kind="textField" uuid="cdf6a26e-08c8-475b-891b-e809f6bb2be8" key="textField-18" x="324" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{CURRENCY}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CURRENCY}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-8" x="354" y="0" width="67" height="16" uuid="691c4e71-efef-404b-b633-4b0e69ccde79"/>
+			</element>
+			<element kind="textField" uuid="691c4e71-efef-404b-b633-4b0e69ccde79" key="textField-8" x="354" y="0" width="67" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{PAYMENTRULE}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PAYMENTRULE}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-9" x="119" y="0" width="55" height="16" uuid="ed26dc1b-2d92-4860-be71-a2ff1e8debc0"/>
+			</element>
+			<element kind="textField" uuid="ed26dc1b-2d92-4860-be71-a2ff1e8debc0" key="textField-9" x="119" y="0" width="55" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{BPARTNER}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{BPARTNER}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-10" x="421" y="0" width="58" height="16" uuid="78f6a59a-606e-4647-b7c9-e139b04d4c8c"/>
+			</element>
+			<element kind="textField" uuid="78f6a59a-606e-4647-b7c9-e139b04d4c8c" key="textField-10" x="421" y="0" width="58" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{DEBTGENERATE}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DEBTGENERATE}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-11" x="479" y="0" width="27" height="16" uuid="0c997dcb-9ff5-45f3-be85-a6b5a8cbe870"/>
+			</element>
+			<element kind="textField" uuid="0c997dcb-9ff5-45f3-be85-a6b5a8cbe870" key="textField-11" x="479" y="0" width="27" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{ISPAID}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{ISPAID}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-12" x="506" y="0" width="37" height="16" uuid="fe45f828-5dc6-472d-beaf-f43c55f477eb"/>
+			</element>
+			<element kind="textField" uuid="fe45f828-5dc6-472d-beaf-f43c55f477eb" key="textField-12" x="506" y="0" width="37" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{STATUS}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{STATUS}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-13" x="543" y="0" width="34" height="16" uuid="4edd05ca-9218-4448-87aa-e94f021d59fb"/>
+			</element>
+			<element kind="textField" uuid="4edd05ca-9218-4448-87aa-e94f021d59fb" key="textField-13" x="543" y="0" width="34" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{SALESREPNAME}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{SALESREPNAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-14" x="234" y="0" width="30" height="16" uuid="d786fbee-03c3-4201-a45f-59ee5fc797e8"/>
+			</element>
+			<element kind="textField" uuid="d786fbee-03c3-4201-a45f-59ee5fc797e8" key="textField-14" x="234" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="5.0" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[$F{DEBTCANCEL}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DEBTCANCEL}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-20" style="Report_Footer" x="1" y="15" width="576" height="1" uuid="7f53a4d1-ace5-4f31-ad06-7ffd83627048"/>
-			</line>
+			</element>
+			<element kind="line" uuid="7f53a4d1-ace5-4f31-ad06-7ffd83627048" key="line-20" x="1" y="15" width="576" height="1" style="Report_Footer"/>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="6" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="20" splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band height="21" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-15" style="GroupHeader_Gray" x="1" y="1" width="85" height="15" uuid="7cff7bb8-60ba-41dc-b64c-c67b943befcf"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="10" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Total]]></text>
-			</staticText>
-			<textField evaluationTime="Report" pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="87" y="1" width="76" height="15" uuid="732ffb27-452f-4120-8cba-40ca876c84e5"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{SUM_AMOUNT_3}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="279" y="12" width="69" height="8" uuid="ecebac64-a93f-4517-8154-081007358a2c"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" style="Report_Footer" x="200" y="12" width="76" height="8" uuid="c78a7a89-1d63-4319-820c-a5f98c78b99f"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="5"/>
-				</textElement>
-				<text><![CDATA[Printed on]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="6" splitType="Stretch"/>
+	<pageFooter height="20" splitType="Stretch"/>
+	<summary height="21" splitType="Stretch">
+		<element kind="staticText" uuid="7cff7bb8-60ba-41dc-b64c-c67b943befcf" key="staticText-15" x="1" y="1" width="85" height="15" fontSize="10.0" bold="true" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_Gray">
+			<text><![CDATA[Total]]></text>
+			<box style="GroupHeader_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="732ffb27-452f-4120-8cba-40ca876c84e5" key="textField" x="87" y="1" width="76" height="15" fontSize="10.0" evaluationTime="Report" pattern="##0.00" blankWhenNull="false">
+			<expression><![CDATA[$V{SUM_AMOUNT_3}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="ecebac64-a93f-4517-8154-081007358a2c" key="textField" x="279" y="12" width="69" height="8" fontName="Times-Roman" fontSize="5.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="c78a7a89-1d63-4319-820c-a5f98c78b99f" key="staticText-1" x="200" y="12" width="76" height="8" fontSize="5.0" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Printed on]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</summary>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportExpense.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportExpense.jrxml
@@ -1,58 +1,56 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportExpense" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="513ef7fc-7930-4b9f-8b3a-9c66c70094fb">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportExpense" language="java" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="513ef7fc-7930-4b9f-8b3a-9c66c70094fb">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{PROJECTNAME_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT C_CURRENCY_ISOSYM('102') AS CONVISOSYM, CBE.NAME AS EMPLOYEE, (CASE S_L.ISTIMEREPORT WHEN 'Y' THEN S_L.QTY ELSE 0 END) * 
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT C_CURRENCY_ISOSYM('102') AS CONVISOSYM, CBE.NAME AS EMPLOYEE, (CASE S_L.ISTIMEREPORT WHEN 'Y' THEN S_L.QTY ELSE 0 END) * 
       	  C_CURRENCY_CONVERT(C_CALCULATECOST_CATSALARY(C_CALCULATE_CATSALARY(s.c_bpartner_id,  (CASE WHEN S_L.DATEEXPENSE IS NULL THEN S.DATEREPORT ELSE S_L.DATEEXPENSE END)), (CASE WHEN S_L.DATEEXPENSE IS NULL THEN S.DATEREPORT ELSE S_L.DATEEXPENSE END)),
       	  '100', '102', (CASE WHEN S_L.DATEEXPENSE IS NULL THEN S.DATEREPORT ELSE S_L.DATEEXPENSE END), NULL, S_L.AD_CLIENT_ID, S_L.AD_ORG_ID) AS COST, 
 	      CBC.NAME AS NAME, (P.VALUE || ' - ' ||P.NAME) AS DESCR, M_PRODUCT.NAME AS PRODUCTNAME, C_UOM.NAME AS UOMNAME,
@@ -70,8 +68,7 @@
 	      AND S.AD_CLIENT_ID IN ('1')
 	      AND S.AD_ORG_ID IN ('1')
 	      AND 1=1
-      ORDER BY NAME, DESCR, EMPLOYEE, PRODUCTNAME, DATEEXPENSE DESC]]>
-	</queryString>
+      ORDER BY NAME, DESCR, EMPLOYEE, PRODUCTNAME, DATEEXPENSE DESC]]></query>
 	<field name="convisosym" class="java.lang.String"/>
 	<field name="employee" class="java.lang.String"/>
 	<field name="cost" class="java.math.BigDecimal"/>
@@ -87,760 +84,514 @@
 	<field name="description" class="java.lang.String"/>
 	<field name="s_timeexpenseline_id" class="java.lang.String"/>
 	<field name="documentno" class="java.lang.String"/>
-	<variable name="SumaHorasProject" class="java.math.BigDecimal" resetType="Group" resetGroup="PROJECTNAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{horas}]]></variableExpression>
+	<variable name="SumaHorasProject" resetType="Group" calculation="Sum" resetGroup="PROJECTNAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{horas}]]></expression>
 		<initialValueExpression><![CDATA[$F{horas}]]></initialValueExpression>
 	</variable>
-	<variable name="SumaHorasProduct" class="java.math.BigDecimal" resetType="Group" resetGroup="PRODUCTNAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{horas}]]></variableExpression>
+	<variable name="SumaHorasProduct" resetType="Group" calculation="Sum" resetGroup="PRODUCTNAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{horas}]]></expression>
 		<initialValueExpression><![CDATA[$F{horas}]]></initialValueExpression>
 	</variable>
-	<variable name="SumaHorasEmployee" class="java.math.BigDecimal" resetType="Group" resetGroup="EMPLOYEENAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{horas}]]></variableExpression>
+	<variable name="SumaHorasEmployee" resetType="Group" calculation="Sum" resetGroup="EMPLOYEENAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{horas}]]></expression>
 		<initialValueExpression><![CDATA[$F{horas}]]></initialValueExpression>
 	</variable>
-	<variable name="SumaAmountProject" class="java.math.BigDecimal" resetType="Group" resetGroup="PROJECTNAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{invoiceprice}]]></variableExpression>
+	<variable name="SumaAmountProject" resetType="Group" calculation="Sum" resetGroup="PROJECTNAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{invoiceprice}]]></expression>
 		<initialValueExpression><![CDATA[$F{invoiceprice}]]></initialValueExpression>
 	</variable>
-	<variable name="SumaAmountEmployee" class="java.math.BigDecimal" resetType="Group" resetGroup="EMPLOYEENAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{invoiceprice}]]></variableExpression>
+	<variable name="SumaAmountEmployee" resetType="Group" calculation="Sum" resetGroup="EMPLOYEENAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{invoiceprice}]]></expression>
 		<initialValueExpression><![CDATA[$F{invoiceprice}]]></initialValueExpression>
 	</variable>
-	<variable name="SumaAmountProduct" class="java.math.BigDecimal" resetType="Group" resetGroup="PRODUCTNAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{invoiceprice}]]></variableExpression>
+	<variable name="SumaAmountProduct" resetType="Group" calculation="Sum" resetGroup="PRODUCTNAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{invoiceprice}]]></expression>
 		<initialValueExpression><![CDATA[$F{invoiceprice}]]></initialValueExpression>
 	</variable>
-	<group name="BPARTNERNAME" isStartNewPage="true">
-		<groupExpression><![CDATA[$F{name}]]></groupExpression>
+	<group name="BPARTNERNAME" startNewPage="true">
+		<expression><![CDATA[$F{name}]]></expression>
 		<groupHeader>
 			<band height="39" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="0" y="0" width="87" height="29" uuid="7149f321-2c52-42ad-b37d-0e32972640be"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="7149f321-2c52-42ad-b37d-0e32972640be" key="staticText" x="0" y="0" width="87" height="29" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" vTextAlign="Middle" style="GroupHeader_DarkGray">
 					<text><![CDATA[Customer:]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="87" y="0" width="691" height="29" uuid="e3462f33-f8ef-4b24-8a63-8a7cbbd47273"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{name}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-32" style="default" x="0" y="19" width="1" height="20" forecolor="#555555" uuid="e4551096-dd0a-4247-a3ec-843b079c9072"/>
-				</line>
+				</element>
+				<element kind="textField" uuid="e3462f33-f8ef-4b24-8a63-8a7cbbd47273" key="textField" x="87" y="0" width="691" height="29" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{name}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="e4551096-dd0a-4247-a3ec-843b079c9072" key="line-32" x="0" y="19" width="1" height="20" forecolor="#555555" style="default"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="8" splitType="Stretch">
-				<line>
-					<reportElement key="line-17" style="default" x="16" y="0" width="762" height="1" forecolor="#555555" uuid="ee109eb1-fe54-4f16-bab6-33e459bc3622"/>
-				</line>
-				<line>
-					<reportElement key="line-25" style="default" x="778" y="-6" width="1" height="13" forecolor="#555555" uuid="a8e5599a-e801-4f12-9b21-6f36e3a45908"/>
-				</line>
-				<line>
-					<reportElement key="line-26" style="default" x="0" y="6" width="778" height="1" forecolor="#555555" uuid="ab0916f2-bc37-4d2c-96cf-726933089dac"/>
-				</line>
-				<line>
-					<reportElement key="line-27" style="default" x="0" y="0" width="1" height="7" forecolor="#555555" uuid="7f07e6d0-d138-4c7d-b56c-2196edc16c9e"/>
-				</line>
-				<line>
-					<reportElement key="line-28" style="default" x="0" y="-18" width="1" height="21" forecolor="#555555" uuid="e14ca532-dff6-44ce-a1a1-8bbbe63af30b"/>
-				</line>
+				<element kind="line" uuid="ee109eb1-fe54-4f16-bab6-33e459bc3622" key="line-17" x="16" y="0" width="762" height="1" forecolor="#555555" style="default"/>
+				<element kind="line" uuid="a8e5599a-e801-4f12-9b21-6f36e3a45908" key="line-25" x="778" y="-6" width="1" height="13" forecolor="#555555" style="default"/>
+				<element kind="line" uuid="ab0916f2-bc37-4d2c-96cf-726933089dac" key="line-26" x="0" y="6" width="778" height="1" forecolor="#555555" style="default"/>
+				<element kind="line" uuid="7f07e6d0-d138-4c7d-b56c-2196edc16c9e" key="line-27" x="0" y="0" width="1" height="7" forecolor="#555555" style="default"/>
+				<element kind="line" uuid="e14ca532-dff6-44ce-a1a1-8bbbe63af30b" key="line-28" x="0" y="-18" width="1" height="21" forecolor="#555555" style="default"/>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="PROJECTNAME">
-		<groupExpression><![CDATA[$F{descr}]]></groupExpression>
+		<expression><![CDATA[$F{descr}]]></expression>
 		<groupHeader>
 			<band height="28" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="16" y="0" width="71" height="17" uuid="e8f9f39a-ebd6-4900-ac0c-2a8ffdee615c"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="e8f9f39a-ebd6-4900-ac0c-2a8ffdee615c" key="staticText" x="16" y="0" width="71" height="17" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[Project:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-6" style="GroupHeader_DarkGray" x="276" y="0" width="134" height="17" uuid="0782bf8a-ab0a-41c4-8743-d829fd181761"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="0782bf8a-ab0a-41c4-8743-d829fd181761" key="staticText-6" x="276" y="0" width="134" height="17" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[Employees hours:]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" evaluationTime="Group" evaluationGroup="PROJECTNAME" pattern="#,##0.00" isBlankWhenNull="true">
-					<reportElement key="textField-21" style="GroupHeader_DarkGray" x="410" y="0" width="108" height="17" uuid="45e19e3f-6437-499d-a00e-4041c40e7d94"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{SumaHorasProject}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-7" style="GroupHeader_DarkGray" x="518" y="0" width="108" height="17" uuid="2ed33a6c-17b1-421a-b620-dd1186082bf1"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="45e19e3f-6437-499d-a00e-4041c40e7d94" key="textField-21" x="410" y="0" width="108" height="17" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" textAdjust="StretchHeight" evaluationTime="Group" pattern="#,##0.00" evaluationGroup="PROJECTNAME" blankWhenNull="true" bold="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$V{SumaHorasProject}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="2ed33a6c-17b1-421a-b620-dd1186082bf1" key="staticText-7" x="518" y="0" width="108" height="17" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[Total amount:]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" evaluationTime="Group" evaluationGroup="PROJECTNAME" pattern="#,##0.00" isBlankWhenNull="true">
-					<reportElement key="textField-22" style="GroupHeader_DarkGray" x="626" y="0" width="152" height="17" uuid="775030db-4278-4184-9db7-f41f1843eb98"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{SumaAmountProject}]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="87" y="0" width="189" height="17" uuid="6a06865c-740c-41fa-acc6-d790083567e6"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="775030db-4278-4184-9db7-f41f1843eb98" key="textField-22" x="626" y="0" width="152" height="17" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" textAdjust="StretchHeight" evaluationTime="Group" pattern="#,##0.00" evaluationGroup="PROJECTNAME" blankWhenNull="true" bold="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$V{SumaAmountProject}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{descr}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-24" style="default" x="16" y="6" width="1" height="14" forecolor="#555555" uuid="99b6398f-f9fa-4e5d-adcd-bc2cf506502d"/>
-				</line>
-				<line>
-					<reportElement key="line-33" style="default" x="0" y="0" width="1" height="17" forecolor="#555555" uuid="02343817-e32b-48c1-8568-e108bc75c6df"/>
-				</line>
+				</element>
+				<element kind="textField" uuid="6a06865c-740c-41fa-acc6-d790083567e6" key="textField" x="87" y="0" width="189" height="17" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{descr}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="99b6398f-f9fa-4e5d-adcd-bc2cf506502d" key="line-24" x="16" y="6" width="1" height="14" forecolor="#555555" style="default"/>
+				<element kind="line" uuid="02343817-e32b-48c1-8568-e108bc75c6df" key="line-33" x="0" y="0" width="1" height="17" forecolor="#555555" style="default"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="4" splitType="Stretch">
-				<line>
-					<reportElement key="line-22" style="default" x="16" y="-1" width="1" height="5" forecolor="#555555" uuid="1c2cc27e-0c38-4df7-838b-a234b4110e06"/>
-				</line>
+				<element kind="line" uuid="1c2cc27e-0c38-4df7-838b-a234b4110e06" key="line-22" x="16" y="-1" width="1" height="5" forecolor="#555555" style="default"/>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="EMPLOYEENAME">
-		<groupExpression><![CDATA[$F{employee}]]></groupExpression>
+		<expression><![CDATA[$F{employee}]]></expression>
 		<groupHeader>
 			<band height="28" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText-8" style="GroupHeader_DarkGray" x="27" y="0" width="82" height="17" uuid="2165ed0b-cb33-4c23-877a-808eb2da9968"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="2165ed0b-cb33-4c23-877a-808eb2da9968" key="staticText-8" x="27" y="0" width="82" height="17" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[Employee:]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField-23" style="GroupHeader_DarkGray" x="109" y="0" width="167" height="17" uuid="74bc5dc1-a80e-49b7-99d0-3f42e30e6719"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{employee}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-9" style="GroupHeader_DarkGray" x="276" y="0" width="127" height="17" uuid="cf9b05a5-da10-46b9-8bfa-e54aced30c6a"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="74bc5dc1-a80e-49b7-99d0-3f42e30e6719" key="textField-23" x="109" y="0" width="167" height="17" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{employee}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="cf9b05a5-da10-46b9-8bfa-e54aced30c6a" key="staticText-9" x="276" y="0" width="127" height="17" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[Employee hours:]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" evaluationTime="Group" evaluationGroup="EMPLOYEENAME" pattern="#,##0.00" isBlankWhenNull="true">
-					<reportElement key="textField-24" style="GroupHeader_DarkGray" x="403" y="0" width="115" height="17" uuid="7e13493d-a222-4ac7-8c24-a52be28120fc"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{SumaHorasEmployee}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-10" style="GroupHeader_DarkGray" x="518" y="0" width="108" height="17" uuid="b2a85a0c-b68e-46f3-a919-46c856b50d48"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="7e13493d-a222-4ac7-8c24-a52be28120fc" key="textField-24" x="403" y="0" width="115" height="17" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" textAdjust="StretchHeight" evaluationTime="Group" pattern="#,##0.00" evaluationGroup="EMPLOYEENAME" blankWhenNull="true" bold="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$V{SumaHorasEmployee}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="b2a85a0c-b68e-46f3-a919-46c856b50d48" key="staticText-10" x="518" y="0" width="108" height="17" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[Total amount:]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" evaluationTime="Group" evaluationGroup="EMPLOYEENAME" pattern="#,##0.00" isBlankWhenNull="true">
-					<reportElement key="textField-25" style="GroupHeader_DarkGray" x="626" y="0" width="152" height="17" uuid="0000fe3e-12d4-47c7-b82e-801e9b9d8e62"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{SumaAmountEmployee}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-12" style="default" x="27" y="10" width="1" height="10" forecolor="#555555" uuid="2371b7a5-ba95-49ea-9012-c4d5150d60de"/>
-				</line>
-				<line>
-					<reportElement key="line-23" style="default" x="16" y="-9" width="1" height="26" forecolor="#555555" uuid="e68ba84c-7c89-4aae-bbf2-50df42ac83a1"/>
-				</line>
-				<line>
-					<reportElement key="line-31" style="default" x="0" y="-22" width="1" height="34" forecolor="#555555" uuid="430482d3-a07e-4536-a89a-e59e0aedaf23"/>
-				</line>
+				</element>
+				<element kind="textField" uuid="0000fe3e-12d4-47c7-b82e-801e9b9d8e62" key="textField-25" x="626" y="0" width="152" height="17" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" textAdjust="StretchHeight" evaluationTime="Group" pattern="#,##0.00" evaluationGroup="EMPLOYEENAME" blankWhenNull="true" bold="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$V{SumaAmountEmployee}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="2371b7a5-ba95-49ea-9012-c4d5150d60de" key="line-12" x="27" y="10" width="1" height="10" forecolor="#555555" style="default"/>
+				<element kind="line" uuid="e68ba84c-7c89-4aae-bbf2-50df42ac83a1" key="line-23" x="16" y="-9" width="1" height="26" forecolor="#555555" style="default"/>
+				<element kind="line" uuid="430482d3-a07e-4536-a89a-e59e0aedaf23" key="line-31" x="0" y="-22" width="1" height="34" forecolor="#555555" style="default"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="8" splitType="Stretch">
-				<line>
-					<reportElement key="line-10" style="default" x="27" y="5" width="751" height="1" forecolor="#555555" uuid="78633a55-4d09-4519-8694-c3fabde8207a"/>
-				</line>
-				<line>
-					<reportElement key="line-11" style="default" x="778" y="0" width="1" height="6" forecolor="#555555" uuid="cdc072e7-967a-482d-8e0a-6dcb51e85cbb"/>
-				</line>
-				<line>
-					<reportElement key="line-16" style="default" x="27" y="0" width="1" height="5" forecolor="#555555" uuid="c7a678da-5578-497c-9da1-b6199306683c"/>
-				</line>
-				<line>
-					<reportElement key="line-21" style="default" x="16" y="-1" width="1" height="8" forecolor="#555555" uuid="9effb7e7-4583-4508-b2ea-2ebf33a2f5b6"/>
-				</line>
+				<element kind="line" uuid="78633a55-4d09-4519-8694-c3fabde8207a" key="line-10" x="27" y="5" width="751" height="1" forecolor="#555555" style="default"/>
+				<element kind="line" uuid="cdc072e7-967a-482d-8e0a-6dcb51e85cbb" key="line-11" x="778" y="0" width="1" height="6" forecolor="#555555" style="default"/>
+				<element kind="line" uuid="c7a678da-5578-497c-9da1-b6199306683c" key="line-16" x="27" y="0" width="1" height="5" forecolor="#555555" style="default"/>
+				<element kind="line" uuid="9effb7e7-4583-4508-b2ea-2ebf33a2f5b6" key="line-21" x="16" y="-1" width="1" height="8" forecolor="#555555" style="default"/>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="PRODUCTNAME">
-		<groupExpression><![CDATA[$F{productname}]]></groupExpression>
+		<expression><![CDATA[$F{productname}]]></expression>
 		<groupHeader>
 			<band height="39" splitType="Stretch">
-				<staticText>
-					<reportElement key="element-90" style="GroupHeader_Gray" x="44" y="21" width="226" height="16" uuid="e98afcb2-9765-45bf-ac1c-0609c790533c"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				<element kind="staticText" uuid="e98afcb2-9765-45bf-ac1c-0609c790533c" key="element-90" x="44" y="21" width="226" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" vTextAlign="Middle" style="GroupHeader_Gray">
 					<text><![CDATA[Doc No.]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="GroupHeader_Gray" x="270" y="21" width="236" height="16" uuid="5c188f6e-a0cc-4433-871c-5d5e72345286"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_Gray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="5c188f6e-a0cc-4433-871c-5d5e72345286" key="element-90" x="270" y="21" width="236" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Left" vTextAlign="Middle" style="GroupHeader_Gray">
 					<text><![CDATA[Description]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="GroupHeader_Gray" x="506" y="21" width="58" height="16" uuid="d18eed8a-c3ff-4b5c-a2a6-2709c6fb5b16"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_Gray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="d18eed8a-c3ff-4b5c-a2a6-2709c6fb5b16" key="element-90" x="506" y="21" width="58" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Left" vTextAlign="Middle" style="GroupHeader_Gray">
 					<text><![CDATA[Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="GroupHeader_Gray" x="602" y="21" width="57" height="16" uuid="e128a6da-f4c2-4c28-8629-26b3d6b66c69"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_Gray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="e128a6da-f4c2-4c28-8629-26b3d6b66c69" key="element-90" x="602" y="21" width="57" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Left" vTextAlign="Middle" style="GroupHeader_Gray">
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-92" style="GroupHeader_Gray" x="659" y="21" width="59" height="16" uuid="31c25a68-55bc-4a79-bcc5-1869465249e6"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_Gray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="31c25a68-55bc-4a79-bcc5-1869465249e6" key="element-92" x="659" y="21" width="59" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Left" vTextAlign="Middle" style="GroupHeader_Gray">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-93" style="GroupHeader_Gray" x="564" y="21" width="38" height="16" uuid="ae4d88e9-0323-4054-b5b1-be8893ea9b8b"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_Gray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="ae4d88e9-0323-4054-b5b1-be8893ea9b8b" key="element-93" x="564" y="21" width="38" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Left" vTextAlign="Middle" style="GroupHeader_Gray">
 					<text><![CDATA[Hours]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-11" style="GroupHeader_DarkGray" x="39" y="0" width="67" height="17" uuid="f1432a89-610d-447d-87b6-b072bd216358"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" pdfFontName="Helvetica"/>
-					</textElement>
-					<text><![CDATA[Product:]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField-26" style="GroupHeader_DarkGray" x="106" y="0" width="169" height="17" uuid="3e5fec43-6483-4653-b6d2-78be0ddf1c4e"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{productname}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-12" style="GroupHeader_DarkGray" x="275" y="0" width="121" height="17" uuid="ad96d7e4-20a2-4bbd-b460-c4e71440a2b8"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" pdfFontName="Helvetica"/>
-					</textElement>
-					<text><![CDATA[Product hours:]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" evaluationTime="Group" evaluationGroup="PRODUCTNAME" pattern="#,##0.00" isBlankWhenNull="true">
-					<reportElement key="textField-27" style="GroupHeader_DarkGray" x="396" y="0" width="122" height="17" uuid="0a9039d6-c4f3-43bb-b414-3c797db0bc7e"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{SumaHorasProduct}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-13" style="GroupHeader_DarkGray" x="518" y="0" width="108" height="17" uuid="b0030151-087c-4027-8e81-f2e9d15a8554"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" pdfFontName="Helvetica"/>
-					</textElement>
-					<text><![CDATA[Total amount:]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" evaluationTime="Group" evaluationGroup="PRODUCTNAME" pattern="#,##0.00" isBlankWhenNull="true">
-					<reportElement key="textField-28" style="GroupHeader_DarkGray" x="626" y="0" width="152" height="17" uuid="635a50ae-85f0-4206-ad77-a49e71f269ab"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{SumaAmountProduct}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-94" style="GroupHeader_Gray" x="716" y="21" width="62" height="16" uuid="9a663a36-c246-457e-9df6-f35efcd312b4"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_Gray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="f1432a89-610d-447d-87b6-b072bd216358" key="staticText-11" x="39" y="0" width="67" height="17" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
+					<text><![CDATA[Product:]]></text>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="3e5fec43-6483-4653-b6d2-78be0ddf1c4e" key="textField-26" x="106" y="0" width="169" height="17" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{productname}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="ad96d7e4-20a2-4bbd-b460-c4e71440a2b8" key="staticText-12" x="275" y="0" width="121" height="17" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
+					<text><![CDATA[Product hours:]]></text>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="0a9039d6-c4f3-43bb-b414-3c797db0bc7e" key="textField-27" x="396" y="0" width="122" height="17" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" textAdjust="StretchHeight" evaluationTime="Group" pattern="#,##0.00" evaluationGroup="PRODUCTNAME" blankWhenNull="true" bold="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$V{SumaHorasProduct}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="b0030151-087c-4027-8e81-f2e9d15a8554" key="staticText-13" x="518" y="0" width="108" height="17" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
+					<text><![CDATA[Total amount:]]></text>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="635a50ae-85f0-4206-ad77-a49e71f269ab" key="textField-28" x="626" y="0" width="152" height="17" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" textAdjust="StretchHeight" evaluationTime="Group" pattern="#,##0.00" evaluationGroup="PRODUCTNAME" blankWhenNull="true" bold="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$V{SumaAmountProduct}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="9a663a36-c246-457e-9df6-f35efcd312b4" key="element-94" x="716" y="21" width="62" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Left" vTextAlign="Middle" style="GroupHeader_Gray">
 					<text><![CDATA[Processed]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-2" style="default" x="39" y="11" width="1" height="28" forecolor="#555555" uuid="824ce3e5-5fab-47e4-887d-a53e051bd8e9"/>
-				</line>
-				<line>
-					<reportElement key="line-9" style="default" x="778" y="-95" width="1" height="56" forecolor="#555555" uuid="a3eb3892-6e11-4700-a1e6-a466a21578a3"/>
-				</line>
-				<line>
-					<reportElement key="line-13" style="default" x="27" y="-12" width="1" height="51" forecolor="#555555" uuid="02a5fd32-1533-4cd8-b220-4f6af3bba507"/>
-				</line>
-				<line>
-					<reportElement key="line-18" style="default" x="16" y="-11" width="1" height="50" forecolor="#555555" uuid="7caa8867-827a-46ed-b451-1f85a294c135"/>
-				</line>
-				<line>
-					<reportElement key="line-30" style="default" x="0" y="-18" width="1" height="49" forecolor="#555555" uuid="273e54d2-a364-46ca-8641-54c46100ecf1"/>
-				</line>
-				<line>
-					<reportElement key="line-34" style="default" x="778" y="-39" width="1" height="27" forecolor="#555555" uuid="bb9249af-c4e7-43b1-82da-da067b1f6e80"/>
-				</line>
-				<line>
-					<reportElement key="line-35" style="default" x="778" y="-12" width="1" height="27" forecolor="#555555" uuid="80f99f60-1e2d-4942-8b9b-d4f769193f7d"/>
-				</line>
-				<line>
-					<reportElement key="line-36" style="default" x="778" y="11" width="1" height="28" forecolor="#555555" uuid="7e39b816-1613-46c8-9518-11d43114dfb6"/>
-				</line>
+					<box leftPadding="5" style="GroupHeader_Gray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="line" uuid="824ce3e5-5fab-47e4-887d-a53e051bd8e9" key="line-2" x="39" y="11" width="1" height="28" forecolor="#555555" style="default"/>
+				<element kind="line" uuid="a3eb3892-6e11-4700-a1e6-a466a21578a3" key="line-9" x="778" y="-95" width="1" height="56" forecolor="#555555" style="default"/>
+				<element kind="line" uuid="02a5fd32-1533-4cd8-b220-4f6af3bba507" key="line-13" x="27" y="-12" width="1" height="51" forecolor="#555555" style="default"/>
+				<element kind="line" uuid="7caa8867-827a-46ed-b451-1f85a294c135" key="line-18" x="16" y="-11" width="1" height="50" forecolor="#555555" style="default"/>
+				<element kind="line" uuid="273e54d2-a364-46ca-8641-54c46100ecf1" key="line-30" x="0" y="-18" width="1" height="49" forecolor="#555555" style="default"/>
+				<element kind="line" uuid="bb9249af-c4e7-43b1-82da-da067b1f6e80" key="line-34" x="778" y="-39" width="1" height="27" forecolor="#555555" style="default"/>
+				<element kind="line" uuid="80f99f60-1e2d-4942-8b9b-d4f769193f7d" key="line-35" x="778" y="-12" width="1" height="27" forecolor="#555555" style="default"/>
+				<element kind="line" uuid="7e39b816-1613-46c8-9518-11d43114dfb6" key="line-36" x="778" y="11" width="1" height="28" forecolor="#555555" style="default"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="6" splitType="Stretch">
-				<line>
-					<reportElement key="line-4" style="default" x="39" y="5" width="740" height="1" forecolor="#555555" uuid="5d6873b6-2c54-472f-941c-c81a75a34947"/>
-				</line>
-				<line>
-					<reportElement key="line-6" style="default" x="39" y="0" width="1" height="5" forecolor="#555555" uuid="829e8a25-fcb6-49fb-954c-4bc1db04dfae"/>
-				</line>
-				<line>
-					<reportElement key="line-7" style="default" x="778" y="0" width="1" height="5" forecolor="#555555" uuid="12487fce-2dd8-4835-b90a-d9b34b26fdfd"/>
-				</line>
-				<line>
-					<reportElement key="line-15" style="default" x="27" y="0" width="1" height="6" forecolor="#555555" uuid="cbd85743-87c5-42bd-8423-ef4689f67418"/>
-				</line>
-				<line>
-					<reportElement key="line-20" style="default" x="16" y="0" width="1" height="6" forecolor="#555555" uuid="8b8d8563-25a5-41e3-bfa7-51a2c11255df"/>
-				</line>
+				<element kind="line" uuid="5d6873b6-2c54-472f-941c-c81a75a34947" key="line-4" x="39" y="5" width="740" height="1" forecolor="#555555" style="default"/>
+				<element kind="line" uuid="829e8a25-fcb6-49fb-954c-4bc1db04dfae" key="line-6" x="39" y="0" width="1" height="5" forecolor="#555555" style="default"/>
+				<element kind="line" uuid="12487fce-2dd8-4835-b90a-d9b34b26fdfd" key="line-7" x="778" y="0" width="1" height="5" forecolor="#555555" style="default"/>
+				<element kind="line" uuid="cbd85743-87c5-42bd-8423-ef4689f67418" key="line-15" x="27" y="0" width="1" height="6" forecolor="#555555" style="default"/>
+				<element kind="line" uuid="8b8d8563-25a5-41e3-bfa7-51a2c11255df" key="line-20" x="16" y="0" width="1" height="6" forecolor="#555555" style="default"/>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="20" splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="23" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Title" mode="Transparent" x="0" y="0" width="778" height="20" uuid="72d5ba5a-76e2-47ed-8ae3-7fbdf84fdb51"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="20" width="778" height="1" uuid="4fb93cbc-7fa0-443c-96ba-8e0a32cc2356"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="20" splitType="Stretch"/>
+	<pageHeader height="23" splitType="Stretch">
+		<element kind="textField" uuid="72d5ba5a-76e2-47ed-8ae3-7fbdf84fdb51" key="textField" mode="Transparent" x="0" y="0" width="778" height="20" fontName="Bitstream Vera Sans" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="4fb93cbc-7fa0-443c-96ba-8e0a32cc2356" key="line-1" x="0" y="20" width="778" height="1">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="14" splitType="Stretch">
-			<textField pattern="dd/MM/yyyy" isBlankWhenNull="false">
-				<reportElement key="textField-3" style="Detail_Line" stretchType="RelativeToBandHeight" x="506" y="0" width="58" height="14" uuid="cdea96ef-398c-4fdf-954b-6becd91bb410"/>
-				<box leftPadding="2" rightPadding="2">
+			<element kind="textField" uuid="cdea96ef-398c-4fdf-954b-6becd91bb410" key="textField-3" stretchType="ContainerHeight" x="506" y="0" width="58" height="14" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="dd/MM/yyyy" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{dateexpense}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{dateexpense}]]></textFieldExpression>
-			</textField>
-			<textField pattern="#,##0.00" isBlankWhenNull="false">
-				<reportElement key="textField-11" style="Detail_Line" stretchType="RelativeToBandHeight" x="659" y="0" width="57" height="14" uuid="7b36c720-6303-479d-9806-23e1bd3ed76b"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="7b36c720-6303-479d-9806-23e1bd3ed76b" key="textField-11" stretchType="ContainerHeight" x="659" y="0" width="57" height="14" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="#,##0.00" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{invoiceprice}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{invoiceprice}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-12" style="Detail_Line" stretchType="RelativeToBandHeight" x="564" y="0" width="38" height="14" uuid="46d36f1a-7328-4867-9ef6-48d26f7ddabe"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="46d36f1a-7328-4867-9ef6-48d26f7ddabe" key="textField-12" stretchType="ContainerHeight" x="564" y="0" width="38" height="14" fontName="Bitstream Vera Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{horas}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{horas}]]></textFieldExpression>
-			</textField>
-			<textField pattern="dd/MM/yyyy" isBlankWhenNull="false">
-				<reportElement key="textField-30" style="Detail_Line" stretchType="RelativeToBandHeight" x="270" y="0" width="236" height="14" uuid="702ec6cd-6b39-488a-ab96-2093ebbaa399"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="702ec6cd-6b39-488a-ab96-2093ebbaa399" key="textField-30" stretchType="ContainerHeight" x="270" y="0" width="236" height="14" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="dd/MM/yyyy" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{description}==null)?new String("  "):$F{description}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{description}==null)?new String("  "):$F{description}]]></textFieldExpression>
-			</textField>
-			<textField pattern="dd/MM/yyyy" isBlankWhenNull="false">
-				<reportElement key="textField-31" style="Detail_Line" stretchType="RelativeToBandHeight" x="44" y="0" width="226" height="14" uuid="55ab7f9a-173b-422c-8f05-37ec529f9408"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="55ab7f9a-173b-422c-8f05-37ec529f9408" key="textField-31" stretchType="ContainerHeight" x="44" y="0" width="226" height="14" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="dd/MM/yyyy" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{documentno}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{documentno}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-33" style="Detail_Line" stretchType="RelativeToBandHeight" x="718" y="0" width="59" height="14" uuid="3654b3ff-b4ff-4ad6-8d19-4185cb93d0c7"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="3654b3ff-b4ff-4ad6-8d19-4185cb93d0c7" key="textField-33" stretchType="ContainerHeight" x="718" y="0" width="59" height="14" fontName="Bitstream Vera Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{processed}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{processed}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-34" style="Detail_Line" stretchType="RelativeToBandHeight" x="602" y="0" width="29" height="14" uuid="ec42296a-2a17-4447-bf00-09ccf37f743b"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="ec42296a-2a17-4447-bf00-09ccf37f743b" key="textField-34" stretchType="ContainerHeight" x="602" y="0" width="29" height="14" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{qty}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{qty}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-35" style="Detail_Line" stretchType="RelativeToBandHeight" x="631" y="0" width="28" height="14" uuid="eb0be12f-d306-4edf-8c51-33bc5516164e"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="eb0be12f-d306-4edf-8c51-33bc5516164e" key="textField-35" stretchType="ContainerHeight" x="631" y="0" width="28" height="14" fontName="Bitstream Vera Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{uomname}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{uomname}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-3" style="default" x="39" y="0" width="1" height="14" forecolor="#555555" uuid="4d04b413-902e-4532-98f2-3eeae50353a6"/>
-			</line>
-			<line>
-				<reportElement key="line-8" style="default" x="778" y="0" width="1" height="14" forecolor="#555555" uuid="1257f7a6-8dba-48e7-847f-19003a79a1fe"/>
-			</line>
-			<line>
-				<reportElement key="line-14" style="default" x="27" y="0" width="1" height="14" forecolor="#555555" uuid="084644ac-e818-4d14-8370-6b16a7ac4885"/>
-			</line>
-			<line>
-				<reportElement key="line-19" style="default" x="16" y="0" width="1" height="14" forecolor="#555555" uuid="eba7f4a6-98cb-4a17-afe7-e44f7428a172"/>
-			</line>
-			<line>
-				<reportElement key="line-29" style="default" x="0" y="-9" width="1" height="23" forecolor="#555555" uuid="89235c77-cc1f-494b-87c3-fd263a1a4719"/>
-			</line>
+			</element>
+			<element kind="line" uuid="4d04b413-902e-4532-98f2-3eeae50353a6" key="line-3" x="39" y="0" width="1" height="14" forecolor="#555555" style="default"/>
+			<element kind="line" uuid="1257f7a6-8dba-48e7-847f-19003a79a1fe" key="line-8" x="778" y="0" width="1" height="14" forecolor="#555555" style="default"/>
+			<element kind="line" uuid="084644ac-e818-4d14-8370-6b16a7ac4885" key="line-14" x="27" y="0" width="1" height="14" forecolor="#555555" style="default"/>
+			<element kind="line" uuid="eba7f4a6-98cb-4a17-afe7-e44f7428a172" key="line-19" x="16" y="0" width="1" height="14" forecolor="#555555" style="default"/>
+			<element kind="line" uuid="89235c77-cc1f-494b-87c3-fd263a1a4719" key="line-29" x="0" y="-9" width="1" height="23" forecolor="#555555" style="default"/>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="16" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="27" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="642" y="4" width="95" height="19" uuid="c12fbbb5-cd66-47fc-9030-4a3a1103ae61"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="741" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="b2d0aa31-e160-4ca8-aa06-c9bdeaa75dbd"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Bottom" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="1" width="777" height="1" forecolor="#000000" uuid="30d8ae67-b6f8-4d3b-9af2-84377cf04096"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="277" y="4" width="69" height="19" uuid="998ff1d2-9ae7-4d00-808b-bd4dcc2f51a8"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Bottom">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" x="195" y="4" width="78" height="19" uuid="d9b9dd1e-4c0d-48cd-8ba6-14c854faf0ee"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="16" splitType="Stretch"/>
+	<pageFooter height="27" splitType="Stretch">
+		<element kind="textField" uuid="c12fbbb5-cd66-47fc-9030-4a3a1103ae61" key="textField" x="642" y="4" width="95" height="19" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Bottom">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="b2d0aa31-e160-4ca8-aa06-c9bdeaa75dbd" key="textField" x="741" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Bottom">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="30d8ae67-b6f8-4d3b-9af2-84377cf04096" key="line" x="0" y="1" width="777" height="1" forecolor="#000000">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="998ff1d2-9ae7-4d00-808b-bd4dcc2f51a8" key="textField" x="277" y="4" width="69" height="19" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Bottom">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="d9b9dd1e-4c0d-48cd-8ba6-14c854faf0ee" key="staticText-1" x="195" y="4" width="78" height="19" hTextAlign="Right" vTextAlign="Bottom">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band height="20" splitType="Stretch"/>
-	</summary>
+	<summary height="20" splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportGeneralLedger.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportGeneralLedger.jrxml
@@ -1,79 +1,77 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportGeneralLedger" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="4af4e236-85be-48e3-a4a6-c993069f011d">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportGeneralLedger" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="4af4e236-85be-48e3-a4a6-c993069f011d">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="11">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="11.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{AccountGroup_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/opt/Apps230/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'0','1000000'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'1000000','1000001'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="ShowGrouping" class="java.lang.Boolean" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="ShowGrouping" forPrompting="false" class="java.lang.Boolean">
 		<defaultValueExpression><![CDATA[new Boolean(false)]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat("###,##0.00", new DecimalFormatSymbols())]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="strDateFormat" class="java.lang.String" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="strDateFormat" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["dd/MM/yyyy"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="Previous" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="Total" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="GroupByText" class="java.lang.String" isForPrompting="false">
+	<parameter name="Previous" forPrompting="false" class="java.lang.String"/>
+	<parameter name="Total" forPrompting="false" class="java.lang.String"/>
+	<parameter name="GroupByText" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="PageNo" class="java.lang.String" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT value, name, dateacct,
+	<parameter name="PageNo" forPrompting="false" class="java.lang.String"/>
+	<query language="sql"><![CDATA[SELECT value, name, dateacct,
               SUM(AMTACCTDR) AS amtacctdr, SUM(AMTACCTCR) AS amtacctcr, (SUM(AMTACCTDR)-SUM(AMTACCTCR)) AS total,
               FACT_ACCT_GROUP_ID, id, groupbyid, groupbyname,
               MIN(DESCRIPTION) AS description,
@@ -111,8 +109,7 @@
             WHERE 6=6
             GROUP BY groupbyname, groupbyid, VALUE, NAME, ID, DATEACCT, FACT_ACCT_GROUP_ID, ISDEBIT
             HAVING SUM(AMTACCTDR) - SUM(AMTACCTCR) <> 0
-            ORDER  BY groupbyname, groupbyid, VALUE, NAME, ID, DATEACCT,  FACT_ACCT_GROUP_ID, ISDEBIT]]>
-	</queryString>
+            ORDER  BY groupbyname, groupbyid, VALUE, NAME, ID, DATEACCT,  FACT_ACCT_GROUP_ID, ISDEBIT]]></query>
 	<field name="VALUE" class="java.lang.String"/>
 	<field name="NAME" class="java.lang.String"/>
 	<field name="DATEACCT" class="java.util.Date"/>
@@ -135,618 +132,420 @@
 	<field name="FINALTOTAL" class="java.math.BigDecimal"/>
 	<field name="DATEACCTNUMBER" class="java.lang.String"/>
 	<field name="GROUPBY" class="java.lang.String"/>
-	<variable name="AMTACCTDR" class="java.math.BigDecimal" resetType="Group" resetGroup="AccountGroup" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMTACCTDR}]]></variableExpression>
+	<variable name="AMTACCTDR" resetType="Group" calculation="Sum" resetGroup="AccountGroup" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMTACCTDR}]]></expression>
 	</variable>
-	<variable name="AMTACCTCR" class="java.math.BigDecimal" resetType="Group" resetGroup="AccountGroup" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMTACCTCR}]]></variableExpression>
+	<variable name="AMTACCTCR" resetType="Group" calculation="Sum" resetGroup="AccountGroup" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMTACCTCR}]]></expression>
 	</variable>
-	<variable name="TOTAL" class="java.math.BigDecimal" resetType="Group" resetGroup="AccountGroup" calculation="Sum">
-		<variableExpression><![CDATA[$F{TOTAL}]]></variableExpression>
+	<variable name="TOTAL" resetType="Group" calculation="Sum" resetGroup="AccountGroup" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{TOTAL}]]></expression>
 	</variable>
 	<group name="Grouping" minHeightToStartNewPage="159">
-		<groupExpression><![CDATA[$F{GROUPBYID}]]></groupExpression>
+		<expression><![CDATA[$F{GROUPBYID}]]></expression>
 		<groupHeader>
 			<band height="25" splitType="Stretch">
 				<printWhenExpression><![CDATA[$P{ShowGrouping}]]></printWhenExpression>
-				<textField isBlankWhenNull="false">
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="0" y="0" width="150" height="18" uuid="93050208-dd2a-4f85-8e0e-d167a2ab15e4"/>
-					<box leftPadding="5">
+				<element kind="textField" uuid="93050208-dd2a-4f85-8e0e-d167a2ab15e4" key="staticText" x="0" y="0" width="150" height="18" fontSize="14.0" pdfFontName="Helvetica" blankWhenNull="false" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{GROUPBY}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font size="14" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{GROUPBY}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="25" forecolor="#555555" uuid="e195ace7-ed26-4242-88b6-1c5302eac12f"/>
-				</line>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="150" y="0" width="385" height="18" uuid="6dc63a01-e967-4bbb-ab2f-b7a865f5caa2"/>
-					<box leftPadding="5" rightPadding="2">
+				</element>
+				<element kind="line" uuid="e195ace7-ed26-4242-88b6-1c5302eac12f" key="line-2" stretchType="ContainerHeight" x="0" y="0" width="1" height="25" forecolor="#555555"/>
+				<element kind="textField" uuid="6dc63a01-e967-4bbb-ab2f-b7a865f5caa2" key="textField" x="150" y="0" width="385" height="18" fontName="Times-Roman" fontSize="14.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{GROUPBYNAME}]]></expression>
+					<box leftPadding="5" rightPadding="2" style="GroupHeader_DarkGray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Times-Roman" size="14"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{GROUPBYNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-45" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="25" forecolor="#555555" uuid="2e4eb6ef-b8c2-4387-bd80-3b28efa7f3e8"/>
-				</line>
+				</element>
+				<element kind="line" uuid="2e4eb6ef-b8c2-4387-bd80-3b28efa7f3e8" key="line-45" stretchType="ContainerHeight" x="535" y="0" width="1" height="25" forecolor="#555555"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="10" splitType="Stretch">
 				<printWhenExpression><![CDATA[$P{ShowGrouping}]]></printWhenExpression>
-				<line>
-					<reportElement key="line-34" x="0" y="0" width="535" height="1" forecolor="#555555" uuid="cf82edcd-ddc7-4217-a2d8-3abf92f33a15"/>
-				</line>
+				<element kind="line" uuid="cf82edcd-ddc7-4217-a2d8-3abf92f33a15" key="line-34" x="0" y="0" width="535" height="1" forecolor="#555555"/>
 			</band>
 		</groupFooter>
 	</group>
-	<group name="AccountGroup" isReprintHeaderOnEachPage="true" minHeightToStartNewPage="124">
-		<groupExpression><![CDATA[$F{VALUE}]]></groupExpression>
+	<group name="AccountGroup" minHeightToStartNewPage="124" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[$F{VALUE}]]></expression>
 		<groupHeader>
 			<band height="56" splitType="Stretch">
-				<frame>
-					<reportElement key="frame-4" style="Total_Gray" x="18" y="43" width="517" height="12" uuid="bbaf85a6-0274-44f4-9056-a3c997807a0d"/>
-					<box>
+				<element kind="frame" uuid="bbaf85a6-0274-44f4-9056-a3c997807a0d" key="frame-4" x="18" y="43" width="517" height="12" style="Total_Gray">
+					<element kind="textField" uuid="3611f492-64c5-41c5-ae6c-88f1ff3b4328" key="staticText-8" x="0" y="0" width="65" height="12" fontSize="8.0" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="true" bold="true" vTextAlign="Middle" style="Total_Gray">
+						<expression><![CDATA[$P{Previous}]]></expression>
+						<box leftPadding="2" style="Total_Gray">
+							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+							<bottomPen lineWidth="0.0" lineColor="#000000"/>
+							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						</box>
+					</element>
+					<element kind="textField" uuid="7bddf5e7-1df5-496d-a3a1-a0de34e69925" key="textField-34" x="65" y="0" width="65" height="12" fontSize="8.0" pdfFontName="Helvetica-Bold" pattern="##0.00" blankWhenNull="false" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Data_Field">
+						<expression><![CDATA[($F{TOTALACCTDR}!=null)?$P{NUMBERFORMAT}.format($F{TOTALACCTDR}.subtract($F{AMTACCTDR})).toString():new String(" ")]]></expression>
+						<box style="Detail_Data_Field">
+							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+							<bottomPen lineWidth="0.0" lineColor="#000000"/>
+							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						</box>
+					</element>
+					<element kind="textField" uuid="1edc3b99-c4f0-4d34-9e66-10bd6740c1aa" key="textField-35" x="130" y="0" width="65" height="12" fontSize="8.0" pdfFontName="Helvetica-Bold" pattern="##0.00" blankWhenNull="false" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Data_Field">
+						<expression><![CDATA[($F{TOTALACCTCR}!=null)?$P{NUMBERFORMAT}.format($F{TOTALACCTCR}.subtract($F{AMTACCTCR})).toString():new String(" ")]]></expression>
+						<box style="Detail_Data_Field">
+							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+							<bottomPen lineWidth="0.0" lineColor="#000000"/>
+							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						</box>
+					</element>
+					<element kind="textField" uuid="d5e963e4-9403-4d4b-85a9-50b25e489877" key="textField-36" x="195" y="0" width="65" height="12" fontSize="8.0" pdfFontName="Helvetica-Bold" pattern="##0.00" blankWhenNull="false" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Data_Field">
+						<expression><![CDATA[($F{TOTALACCTSUB}!=null)?$P{NUMBERFORMAT}.format($F{TOTALACCTSUB}.subtract($F{TOTAL})).toString():new String(" ")]]></expression>
+						<box style="Detail_Data_Field">
+							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+							<bottomPen lineWidth="0.0" lineColor="#000000"/>
+							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						</box>
+					</element>
+					<box style="Total_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textField pattern="" isBlankWhenNull="true">
-						<reportElement key="staticText-8" style="Total_Gray" x="0" y="0" width="65" height="12" uuid="3611f492-64c5-41c5-ae6c-88f1ff3b4328"/>
-						<box leftPadding="2">
-							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-							<bottomPen lineWidth="0.0" lineColor="#000000"/>
-							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						</box>
-						<textElement verticalAlignment="Middle">
-							<font size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-						</textElement>
-						<textFieldExpression><![CDATA[$P{Previous}]]></textFieldExpression>
-					</textField>
-					<textField pattern="##0.00" isBlankWhenNull="false">
-						<reportElement key="textField-34" style="Detail_Data_Field" x="65" y="0" width="65" height="12" uuid="7bddf5e7-1df5-496d-a3a1-a0de34e69925"/>
-						<box>
-							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-							<bottomPen lineWidth="0.0" lineColor="#000000"/>
-							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						</box>
-						<textElement textAlignment="Right" verticalAlignment="Middle">
-							<font size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-						</textElement>
-						<textFieldExpression><![CDATA[($F{TOTALACCTDR}!=null)?$P{NUMBERFORMAT}.format($F{TOTALACCTDR}.subtract($F{AMTACCTDR})).toString():new String(" ")]]></textFieldExpression>
-					</textField>
-					<textField pattern="##0.00" isBlankWhenNull="false">
-						<reportElement key="textField-35" style="Detail_Data_Field" x="130" y="0" width="65" height="12" uuid="1edc3b99-c4f0-4d34-9e66-10bd6740c1aa"/>
-						<box>
-							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-							<bottomPen lineWidth="0.0" lineColor="#000000"/>
-							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						</box>
-						<textElement textAlignment="Right" verticalAlignment="Middle">
-							<font size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-						</textElement>
-						<textFieldExpression><![CDATA[($F{TOTALACCTCR}!=null)?$P{NUMBERFORMAT}.format($F{TOTALACCTCR}.subtract($F{AMTACCTCR})).toString():new String(" ")]]></textFieldExpression>
-					</textField>
-					<textField pattern="##0.00" isBlankWhenNull="false">
-						<reportElement key="textField-36" style="Detail_Data_Field" x="195" y="0" width="65" height="12" uuid="d5e963e4-9403-4d4b-85a9-50b25e489877"/>
-						<box>
-							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-							<bottomPen lineWidth="0.0" lineColor="#000000"/>
-							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						</box>
-						<textElement textAlignment="Right" verticalAlignment="Middle">
-							<font size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-						</textElement>
-						<textFieldExpression><![CDATA[($F{TOTALACCTSUB}!=null)?$P{NUMBERFORMAT}.format($F{TOTALACCTSUB}.subtract($F{TOTAL})).toString():new String(" ")]]></textFieldExpression>
-					</textField>
-				</frame>
-				<line>
-					<reportElement key="line-6" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="56" forecolor="#555555" uuid="b7d1619c-792b-491e-a36a-17b0a99c0e31"/>
-				</line>
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="10" y="0" width="90" height="16" uuid="9e286d8c-6e71-4ca7-93b0-354a483ef02b"/>
-					<box topPadding="2" leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement verticalAlignment="Middle">
-						<font size="10" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="b7d1619c-792b-491e-a36a-17b0a99c0e31" key="line-6" stretchType="ContainerHeight" x="535" y="0" width="1" height="56" forecolor="#555555"/>
+				<element kind="staticText" uuid="9e286d8c-6e71-4ca7-93b0-354a483ef02b" key="staticText" x="10" y="0" width="90" height="16" fontSize="10.0" pdfFontName="Helvetica" vTextAlign="Middle" style="GroupHeader_DarkGray">
 					<text><![CDATA[Acct. No.]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="100" y="0" width="79" height="16" uuid="c264e9e4-11f6-4001-b275-ec4de1da3e10"/>
-					<box topPadding="2" leftPadding="5">
+					<box topPadding="2" leftPadding="5" style="GroupHeader_DarkGray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{VALUE}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-4" stretchType="RelativeToBandHeight" x="10" y="1" width="1" height="55" forecolor="#555555" uuid="bc2d7511-3fa9-4502-901c-89d9689d9193"/>
-				</line>
-				<line>
-					<reportElement key="line-8" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="56" forecolor="#555555" uuid="a7dd8986-cfa2-416f-9844-647e5a02193c">
-						<printWhenExpression><![CDATA[$P{ShowGrouping}]]></printWhenExpression>
-					</reportElement>
-				</line>
-				<textField pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="179" y="0" width="356" height="16" uuid="6e1b6c32-af6e-46b5-92eb-bca46daa9d04"/>
-					<box leftPadding="5" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c264e9e4-11f6-4001-b275-ec4de1da3e10" key="textField" x="100" y="0" width="79" height="16" fontSize="10.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{VALUE}]]></expression>
+					<box topPadding="2" leftPadding="5" style="GroupHeader_DarkGray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NAME}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="18" y="27" width="65" height="16" uuid="12c85c44-ddf6-468b-9359-4b45caa0c192"/>
-					<box leftPadding="5" rightPadding="2">
+				</element>
+				<element kind="line" uuid="bc2d7511-3fa9-4502-901c-89d9689d9193" key="line-4" stretchType="ContainerHeight" x="10" y="1" width="1" height="55" forecolor="#555555"/>
+				<element kind="line" uuid="a7dd8986-cfa2-416f-9844-647e5a02193c" key="line-8" stretchType="ContainerHeight" x="0" y="0" width="1" height="56" forecolor="#555555">
+					<printWhenExpression><![CDATA[$P{ShowGrouping}]]></printWhenExpression>
+				</element>
+				<element kind="textField" uuid="6e1b6c32-af6e-46b5-92eb-bca46daa9d04" key="textField" x="179" y="0" width="356" height="16" fontName="DejaVu Sans" fontSize="10.0" pattern="" blankWhenNull="true" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{NAME}]]></expression>
+					<box leftPadding="5" rightPadding="2" style="GroupHeader_DarkGray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="10"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="12c85c44-ddf6-468b-9359-4b45caa0c192" key="element-90" x="18" y="27" width="65" height="16" fontSize="10.0" style="Detail_Header">
 					<text><![CDATA[Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="83" y="27" width="65" height="16" uuid="30aa410c-80af-401d-ad38-d7616b48a27f"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="10"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="30aa410c-80af-401d-ad38-d7616b48a27f" key="element-90" x="83" y="27" width="65" height="16" fontSize="10.0" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[Debit]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="148" y="27" width="65" height="16" uuid="d2684a81-9f81-49bd-a66b-148d0b425e86"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="10"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="d2684a81-9f81-49bd-a66b-148d0b425e86" key="element-90" x="148" y="27" width="65" height="16" fontSize="10.0" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[Credit]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="213" y="27" width="65" height="16" uuid="85da8f91-64f9-4c7a-bd2c-2cea572ce1e3"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="10"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="85da8f91-64f9-4c7a-bd2c-2cea572ce1e3" key="element-90" x="213" y="27" width="65" height="16" fontSize="10.0" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[Balance]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-37" stretchType="RelativeToBandHeight" x="17" y="27" width="1" height="29" forecolor="#555555" uuid="e639b964-5a40-4b4f-b165-9d7b3f5d4bbf"/>
-				</line>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="278" y="27" width="257" height="16" uuid="efca4e30-aa15-40d2-952f-61d2fc30c4f5"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="10"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="e639b964-5a40-4b4f-b165-9d7b3f5d4bbf" key="line-37" stretchType="ContainerHeight" x="17" y="27" width="1" height="29" forecolor="#555555"/>
+				<element kind="staticText" uuid="efca4e30-aa15-40d2-952f-61d2fc30c4f5" key="element-90" x="278" y="27" width="257" height="16" fontSize="10.0" style="Detail_Header">
 					<text><![CDATA[Description]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-42" x="18" y="55" width="517" height="1" forecolor="#555555" uuid="7f781cc6-dc9b-4be8-baa8-aaf368c25cbe"/>
-				</line>
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="7f781cc6-dc9b-4be8-baa8-aaf368c25cbe" key="line-42" x="18" y="55" width="517" height="1" forecolor="#555555"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="44" splitType="Stretch">
-				<frame>
-					<reportElement key="frame-5" style="Total_Gray" mode="Opaque" x="18" y="1" width="517" height="12" uuid="82dd0c76-4ecd-4c59-b9ea-76c8a2cb6a53"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<staticText>
-						<reportElement key="staticText-9" style="Report_Footer" x="0" y="0" width="65" height="12" uuid="95e4cbbd-ddf2-4326-92d4-b3c54735e093"/>
-						<box leftPadding="2">
-							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-							<bottomPen lineWidth="0.0" lineColor="#000000"/>
-							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						</box>
-						<textElement verticalAlignment="Middle">
-							<font fontName="SansSerif" size="8"/>
-						</textElement>
+				<element kind="frame" uuid="82dd0c76-4ecd-4c59-b9ea-76c8a2cb6a53" key="frame-5" mode="Opaque" x="18" y="1" width="517" height="12" style="Total_Gray">
+					<element kind="staticText" uuid="95e4cbbd-ddf2-4326-92d4-b3c54735e093" key="staticText-9" x="0" y="0" width="65" height="12" fontName="SansSerif" fontSize="8.0" vTextAlign="Middle" style="Report_Footer">
 						<text><![CDATA[Subtotal]]></text>
-					</staticText>
-					<textField pattern="" isBlankWhenNull="false">
-						<reportElement key="textField-38" x="65" y="0" width="65" height="12" uuid="456d7a50-60ed-4687-ac1b-59f0040c1b84"/>
+						<box leftPadding="2" style="Report_Footer">
+							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+							<bottomPen lineWidth="0.0" lineColor="#000000"/>
+							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						</box>
+					</element>
+					<element kind="textField" uuid="456d7a50-60ed-4687-ac1b-59f0040c1b84" key="textField-38" x="65" y="0" width="65" height="12" fontSize="8.0" pdfFontName="Helvetica" pattern="" blankWhenNull="false" bold="false" hTextAlign="Right" vTextAlign="Middle">
+						<expression><![CDATA[($V{AMTACCTDR}!=null)?$P{NUMBERFORMAT}.format($V{AMTACCTDR}).toString():new String(" ")]]></expression>
 						<box>
 							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<bottomPen lineWidth="0.0" lineColor="#000000"/>
 							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						</box>
-						<textElement textAlignment="Right" verticalAlignment="Middle">
-							<font size="8" isBold="false" pdfFontName="Helvetica"/>
-						</textElement>
-						<textFieldExpression><![CDATA[($V{AMTACCTDR}!=null)?$P{NUMBERFORMAT}.format($V{AMTACCTDR}).toString():new String(" ")]]></textFieldExpression>
-					</textField>
-					<textField pattern="" isBlankWhenNull="false">
-						<reportElement key="textField-39" x="195" y="0" width="65" height="12" uuid="13bbc2ed-4181-410f-af36-aac86304aadb"/>
+					</element>
+					<element kind="textField" uuid="13bbc2ed-4181-410f-af36-aac86304aadb" key="textField-39" x="195" y="0" width="65" height="12" fontSize="8.0" pdfFontName="Helvetica" pattern="" blankWhenNull="false" bold="false" hTextAlign="Right" vTextAlign="Middle">
+						<expression><![CDATA[($V{TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{TOTAL}).toString():new String(" ")]]></expression>
 						<box>
 							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<bottomPen lineWidth="0.0" lineColor="#000000"/>
 							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						</box>
-						<textElement textAlignment="Right" verticalAlignment="Middle">
-							<font size="8" isBold="false" pdfFontName="Helvetica"/>
-						</textElement>
-						<textFieldExpression><![CDATA[($V{TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{TOTAL}).toString():new String(" ")]]></textFieldExpression>
-					</textField>
-					<textField pattern="" isBlankWhenNull="false">
-						<reportElement key="textField-40" x="130" y="0" width="65" height="12" uuid="ac596726-d07c-47d2-9d4d-3a7124630579"/>
+					</element>
+					<element kind="textField" uuid="ac596726-d07c-47d2-9d4d-3a7124630579" key="textField-40" x="130" y="0" width="65" height="12" fontSize="8.0" pdfFontName="Helvetica" pattern="" blankWhenNull="false" bold="false" hTextAlign="Right" vTextAlign="Middle">
+						<expression><![CDATA[($V{AMTACCTCR}!=null)?$P{NUMBERFORMAT}.format($V{AMTACCTCR}).toString():new String(" ")]]></expression>
 						<box>
 							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<bottomPen lineWidth="0.0" lineColor="#000000"/>
 							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						</box>
-						<textElement textAlignment="Right" verticalAlignment="Middle">
-							<font size="8" isBold="false" pdfFontName="Helvetica"/>
-						</textElement>
-						<textFieldExpression><![CDATA[($V{AMTACCTCR}!=null)?$P{NUMBERFORMAT}.format($V{AMTACCTCR}).toString():new String(" ")]]></textFieldExpression>
-					</textField>
-				</frame>
-				<frame>
-					<reportElement key="frame-3" style="Total_Gray" mode="Opaque" x="18" y="13" width="517" height="12" uuid="7c705b1a-04db-4b33-aec9-5e802451c195"/>
-					<box>
+					</element>
+					<box style="Total_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textField isBlankWhenNull="false">
-						<reportElement key="textField-30" x="0" y="0" width="65" height="12" uuid="e5d1e183-c722-4810-a5a1-128a232f87b7"/>
+				</element>
+				<element kind="frame" uuid="7c705b1a-04db-4b33-aec9-5e802451c195" key="frame-3" mode="Opaque" x="18" y="13" width="517" height="12" style="Total_Gray">
+					<element kind="textField" uuid="e5d1e183-c722-4810-a5a1-128a232f87b7" key="textField-30" x="0" y="0" width="65" height="12" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" bold="true" vTextAlign="Middle">
+						<expression><![CDATA[$P{Total}]]></expression>
 						<box leftPadding="2">
 							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<bottomPen lineWidth="0.0" lineColor="#000000"/>
 							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						</box>
-						<textElement verticalAlignment="Middle">
-							<font size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-						</textElement>
-						<textFieldExpression><![CDATA[$P{Total}]]></textFieldExpression>
-					</textField>
-					<textField pattern="" isBlankWhenNull="false">
-						<reportElement key="textField-31" x="65" y="0" width="65" height="12" uuid="42d15892-c440-4f6d-9d5b-7b22738b94bf"/>
+					</element>
+					<element kind="textField" uuid="42d15892-c440-4f6d-9d5b-7b22738b94bf" key="textField-31" x="65" y="0" width="65" height="12" fontSize="8.0" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" bold="true" hTextAlign="Right" vTextAlign="Middle">
+						<expression><![CDATA[($F{TOTALACCTDR}!=null)?$P{NUMBERFORMAT}.format($F{TOTALACCTDR}).toString():new String(" ")]]></expression>
 						<box>
 							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<bottomPen lineWidth="0.0" lineColor="#000000"/>
 							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						</box>
-						<textElement textAlignment="Right" verticalAlignment="Middle">
-							<font size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-						</textElement>
-						<textFieldExpression><![CDATA[($F{TOTALACCTDR}!=null)?$P{NUMBERFORMAT}.format($F{TOTALACCTDR}).toString():new String(" ")]]></textFieldExpression>
-					</textField>
-					<textField pattern="" isBlankWhenNull="false">
-						<reportElement key="textField-32" x="130" y="0" width="65" height="12" uuid="cbeaee50-aa7f-4b58-b633-7f160174dbd0"/>
+					</element>
+					<element kind="textField" uuid="cbeaee50-aa7f-4b58-b633-7f160174dbd0" key="textField-32" x="130" y="0" width="65" height="12" fontSize="8.0" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" bold="true" hTextAlign="Right" vTextAlign="Middle">
+						<expression><![CDATA[($F{TOTALACCTCR}!=null)?$P{NUMBERFORMAT}.format($F{TOTALACCTCR}).toString():new String(" ")]]></expression>
 						<box>
 							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<bottomPen lineWidth="0.0" lineColor="#000000"/>
 							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						</box>
-						<textElement textAlignment="Right" verticalAlignment="Middle">
-							<font size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-						</textElement>
-						<textFieldExpression><![CDATA[($F{TOTALACCTCR}!=null)?$P{NUMBERFORMAT}.format($F{TOTALACCTCR}).toString():new String(" ")]]></textFieldExpression>
-					</textField>
-					<textField pattern="" isBlankWhenNull="false">
-						<reportElement key="textField-33" x="195" y="0" width="65" height="12" uuid="165ec33c-ca9e-4048-ab1a-cce99a2eb6d9"/>
+					</element>
+					<element kind="textField" uuid="165ec33c-ca9e-4048-ab1a-cce99a2eb6d9" key="textField-33" x="195" y="0" width="65" height="12" fontSize="8.0" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" bold="true" hTextAlign="Right" vTextAlign="Middle">
+						<expression><![CDATA[($F{TOTALACCTSUB}!=null)?$P{NUMBERFORMAT}.format($F{TOTALACCTSUB}).toString():new String(" ")]]></expression>
 						<box>
 							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<bottomPen lineWidth="0.0" lineColor="#000000"/>
 							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						</box>
-						<textElement textAlignment="Right" verticalAlignment="Middle">
-							<font size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-						</textElement>
-						<textFieldExpression><![CDATA[($F{TOTALACCTSUB}!=null)?$P{NUMBERFORMAT}.format($F{TOTALACCTSUB}).toString():new String(" ")]]></textFieldExpression>
-					</textField>
-				</frame>
-				<line>
-					<reportElement key="line-28" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="44" forecolor="#555555" uuid="1c4dc059-3cfa-4a8b-9354-c29e40f8e4c5">
-						<printWhenExpression><![CDATA[$P{ShowGrouping}]]></printWhenExpression>
-					</reportElement>
-				</line>
-				<line>
-					<reportElement key="line-29" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="35" forecolor="#555555" uuid="d40b9148-a3c2-4d12-b500-74cc5664fbbc"/>
-				</line>
-				<line>
-					<reportElement key="line-30" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="35" forecolor="#555555" uuid="ea20d8a7-a079-4677-b872-fc4539a97ca3"/>
-				</line>
-				<line>
-					<reportElement key="line-35" x="18" y="13" width="517" height="1" forecolor="#555555" uuid="b12db6ed-f0a5-42f4-b59c-d97a21cf3293"/>
-				</line>
-				<line>
-					<reportElement key="line-38" stretchType="RelativeToBandHeight" x="17" y="0" width="1" height="24" forecolor="#555555" uuid="82c5d65b-0322-4761-98d2-757e700141e4"/>
-				</line>
-				<line>
-					<reportElement key="line-39" x="10" y="34" width="525" height="1" forecolor="#555555" uuid="587a7734-bb67-42f2-9a7e-895aa0cfca07"/>
-				</line>
-				<line>
-					<reportElement key="line-31" x="17" y="25" width="518" height="1" forecolor="#555555" uuid="33d5ba92-a14a-4c59-bff9-853015c9d3ad"/>
-				</line>
-				<line>
-					<reportElement key="line-44" stretchType="RelativeToBandHeight" x="535" y="34" width="1" height="10" forecolor="#555555" uuid="5c1ec6ae-ad1b-4268-9c17-bdaf080d850c">
-						<printWhenExpression><![CDATA[$P{ShowGrouping}]]></printWhenExpression>
-					</reportElement>
-				</line>
-				<line>
-					<reportElement key="line-46" x="18" y="1" width="517" height="1" forecolor="#555555" uuid="a324e87b-82b8-46dd-9730-b5af96ba38a8"/>
-				</line>
+					</element>
+					<box style="Total_Gray">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="1c4dc059-3cfa-4a8b-9354-c29e40f8e4c5" key="line-28" stretchType="ContainerHeight" x="0" y="0" width="1" height="44" forecolor="#555555">
+					<printWhenExpression><![CDATA[$P{ShowGrouping}]]></printWhenExpression>
+				</element>
+				<element kind="line" uuid="d40b9148-a3c2-4d12-b500-74cc5664fbbc" key="line-29" stretchType="ContainerHeight" x="10" y="0" width="1" height="35" forecolor="#555555"/>
+				<element kind="line" uuid="ea20d8a7-a079-4677-b872-fc4539a97ca3" key="line-30" stretchType="ContainerHeight" x="535" y="0" width="1" height="35" forecolor="#555555"/>
+				<element kind="line" uuid="b12db6ed-f0a5-42f4-b59c-d97a21cf3293" key="line-35" x="18" y="13" width="517" height="1" forecolor="#555555"/>
+				<element kind="line" uuid="82c5d65b-0322-4761-98d2-757e700141e4" key="line-38" stretchType="ContainerHeight" x="17" y="0" width="1" height="24" forecolor="#555555"/>
+				<element kind="line" uuid="587a7734-bb67-42f2-9a7e-895aa0cfca07" key="line-39" x="10" y="34" width="525" height="1" forecolor="#555555"/>
+				<element kind="line" uuid="33d5ba92-a14a-4c59-bff9-853015c9d3ad" key="line-31" x="17" y="25" width="518" height="1" forecolor="#555555"/>
+				<element kind="line" uuid="5c1ec6ae-ad1b-4268-9c17-bdaf080d850c" key="line-44" stretchType="ContainerHeight" x="535" y="34" width="1" height="10" forecolor="#555555">
+					<printWhenExpression><![CDATA[$P{ShowGrouping}]]></printWhenExpression>
+				</element>
+				<element kind="line" uuid="a324e87b-82b8-46dd-9730-b5af96ba38a8" key="line-46" x="18" y="1" width="517" height="1" forecolor="#555555"/>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="20" splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="45" splitType="Stretch">
-			<line>
-				<reportElement key="line-1" x="0" y="20" width="535" height="1" uuid="abd11a8d-1736-4a21-94ac-d6058d4ef1e3"/>
-			</line>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Report_Subtitle" x="0" y="21" width="535" height="20" uuid="900c0371-2780-4c01-9677-755e5ceaec3b"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{REPORT_SUBTITLE}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-10" style="Report_Footer" x="0" y="-5" width="535" height="25" uuid="cba4b8b7-7383-4611-af14-bf0c82548271"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="SansSerif" size="18"/>
-				</textElement>
-				<text><![CDATA[General Ledger Report]]></text>
-			</staticText>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="20" splitType="Stretch"/>
+	<pageHeader height="45" splitType="Stretch">
+		<element kind="line" uuid="abd11a8d-1736-4a21-94ac-d6058d4ef1e3" key="line-1" x="0" y="20" width="535" height="1"/>
+		<element kind="textField" uuid="900c0371-2780-4c01-9677-755e5ceaec3b" key="textField" x="0" y="21" width="535" height="20" fontSize="10.0" textAdjust="StretchHeight" blankWhenNull="true" vTextAlign="Middle" style="Report_Subtitle">
+			<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="cba4b8b7-7383-4611-af14-bf0c82548271" key="staticText-10" x="0" y="-5" width="535" height="25" fontName="SansSerif" fontSize="18.0" style="Report_Footer">
+			<text><![CDATA[General Ledger Report]]></text>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="12" splitType="Stretch">
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="12" forecolor="#555555" uuid="7ad611f7-693a-4633-b173-92153343fbba">
-					<printWhenExpression><![CDATA[$P{ShowGrouping}]]></printWhenExpression>
-				</reportElement>
-			</line>
-			<line>
-				<reportElement key="line-18" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="12" forecolor="#555555" uuid="ef92af35-e11f-4e3c-a109-707e52840a7a"/>
-			</line>
-			<frame>
-				<reportElement key="frame-1" style="Detail_Line" stretchType="RelativeToBandHeight" x="18" y="0" width="516" height="12" uuid="83dd21a1-ab3c-4173-935f-1ebc68df067a"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField-13" stretchType="RelativeToBandHeight" x="263" y="0" width="250" height="12" uuid="06afb663-e162-408f-b49d-30f0a1c57a54"/>
+			<element kind="line" uuid="7ad611f7-693a-4633-b173-92153343fbba" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="12" forecolor="#555555">
+				<printWhenExpression><![CDATA[$P{ShowGrouping}]]></printWhenExpression>
+			</element>
+			<element kind="line" uuid="ef92af35-e11f-4e3c-a109-707e52840a7a" key="line-18" stretchType="ContainerHeight" x="10" y="0" width="1" height="12" forecolor="#555555"/>
+			<element kind="frame" uuid="83dd21a1-ab3c-4173-935f-1ebc68df067a" key="frame-1" stretchType="ContainerHeight" x="18" y="0" width="516" height="12" style="Detail_Line">
+				<element kind="textField" uuid="06afb663-e162-408f-b49d-30f0a1c57a54" key="textField-13" stretchType="ContainerHeight" x="263" y="0" width="250" height="12" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle">
+					<expression><![CDATA[$F{DESCRIPTION}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{DESCRIPTION}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-14" stretchType="RelativeToBandHeight" x="65" y="0" width="65" height="12" uuid="895d34d2-e926-463a-af4c-73a4c2114f2c"/>
+				</element>
+				<element kind="textField" uuid="895d34d2-e926-463a-af4c-73a4c2114f2c" key="textField-14" stretchType="ContainerHeight" x="65" y="0" width="65" height="12" fontSize="8.0" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($F{AMTACCTDR}!=BigDecimal.ZERO && $F{AMTACCTDR}!=null)?$P{NUMBERFORMAT}.format($F{AMTACCTDR}).toString():new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{AMTACCTDR}!=BigDecimal.ZERO && $F{AMTACCTDR}!=null)?$P{NUMBERFORMAT}.format($F{AMTACCTDR}).toString():new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-15" stretchType="RelativeToBandHeight" x="130" y="0" width="65" height="12" uuid="917bc45e-26f7-4793-8001-e0188aa63954"/>
+				</element>
+				<element kind="textField" uuid="917bc45e-26f7-4793-8001-e0188aa63954" key="textField-15" stretchType="ContainerHeight" x="130" y="0" width="65" height="12" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($F{AMTACCTCR}!=BigDecimal.ZERO && $F{AMTACCTCR}!=null)?$P{NUMBERFORMAT}.format($F{AMTACCTCR}).toString():new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{AMTACCTCR}!=BigDecimal.ZERO && $F{AMTACCTCR}!=null)?$P{NUMBERFORMAT}.format($F{AMTACCTCR}).toString():new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Band" isBlankWhenNull="false">
-					<reportElement key="textField-16" stretchType="RelativeToBandHeight" x="195" y="0" width="65" height="12" uuid="1195a9e3-6524-4877-be6e-dbcb421d2c9e"/>
+				</element>
+				<element kind="textField" uuid="1195a9e3-6524-4877-be6e-dbcb421d2c9e" key="textField-16" stretchType="ContainerHeight" x="195" y="0" width="65" height="12" fontSize="8.0" evaluationTime="Band" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($F{TOTALACCTSUB}!=null)?$P{NUMBERFORMAT}.format($F{TOTALACCTSUB}).toString():new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{TOTALACCTSUB}!=null)?$P{NUMBERFORMAT}.format($F{TOTALACCTSUB}).toString():new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="dd/MM/yyyy" isBlankWhenNull="false">
-					<reportElement key="textField-17" stretchType="RelativeToBandHeight" x="0" y="0" width="65" height="12" uuid="293c2eb0-8d5b-44ce-957c-a410613c8920"/>
+				</element>
+				<element kind="textField" uuid="293c2eb0-8d5b-44ce-957c-a410613c8920" key="textField-17" stretchType="ContainerHeight" x="0" y="0" width="65" height="12" fontSize="8.0" pattern="dd/MM/yyyy" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle">
+					<expression><![CDATA[(new SimpleDateFormat($P{strDateFormat})).format($F{DATEACCT})]]></expression>
 					<box leftPadding="2">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(new SimpleDateFormat($P{strDateFormat})).format($F{DATEACCT})]]></textFieldExpression>
-				</textField>
-			</frame>
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="12" forecolor="#555555" uuid="916e2cf6-5a3c-4475-848b-74ad93877327"/>
-			</line>
-			<line>
-				<reportElement key="line-15" stretchType="RelativeToBandHeight" x="17" y="0" width="1" height="12" forecolor="#555555" uuid="ad616ef1-96ab-482d-9c65-d7709a0de9e4"/>
-			</line>
+				</element>
+				<box style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="line" uuid="916e2cf6-5a3c-4475-848b-74ad93877327" key="line-16" stretchType="ContainerHeight" x="535" y="0" width="1" height="12" forecolor="#555555"/>
+			<element kind="line" uuid="ad616ef1-96ab-482d-9c65-d7709a0de9e4" key="line-15" stretchType="ContainerHeight" x="17" y="0" width="1" height="12" forecolor="#555555"/>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="16" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="20" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-12" style="Report_Footer" x="418" y="4" width="57" height="16" uuid="89d80a19-5710-4290-bb88-8639ae8f2724"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom">
-					<font fontName="Bitstream Vera Sans" size="10"/>
-				</textElement>
-				<text><![CDATA[Page]]></text>
-			</staticText>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="475" y="4" width="58" height="16" uuid="ab7d3ac9-6d0b-4d99-973f-d65e423e7912"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom">
-					<font fontName="Bitstream Vera Sans" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new java.lang.Integer(($V{PAGE_NUMBER}.intValue()) +(Integer.parseInt($P{PageNo}))-(1) )]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="2" width="535" height="1" forecolor="#000000" uuid="1e9b51cc-6c7c-4aac-957b-6cd88472117d"/>
-			</line>
-			<textField pattern="dd/MM/yyyy" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="275" y="4" width="79" height="16" uuid="e172b704-f5db-484c-a6c9-8262095dd249"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Bottom">
-					<font fontName="Bitstream Vera Sans" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" style="Report_Footer" x="198" y="4" width="76" height="16" uuid="3ffb0864-3d6f-4145-9404-d951d49e2ecb"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom">
-					<font fontName="Bitstream Vera Sans" size="10"/>
-				</textElement>
-				<text><![CDATA[Printed on]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-5" style="Report_Footer" x="1" y="4" width="140" height="16" uuid="9e45c076-7b2d-4f5b-ba22-6e39ee3bb9c5">
-					<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
-				</reportElement>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<text><![CDATA[other footer data]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="16" splitType="Stretch"/>
+	<pageFooter height="20" splitType="Stretch">
+		<element kind="staticText" uuid="89d80a19-5710-4290-bb88-8639ae8f2724" key="staticText-12" x="418" y="4" width="57" height="16" fontName="Bitstream Vera Sans" fontSize="10.0" hTextAlign="Right" vTextAlign="Bottom" style="Report_Footer">
+			<text><![CDATA[Page]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="ab7d3ac9-6d0b-4d99-973f-d65e423e7912" key="textField" x="475" y="4" width="58" height="16" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Bottom" style="Report_Footer">
+			<expression><![CDATA[new java.lang.Integer(($V{PAGE_NUMBER}.intValue()) +(Integer.parseInt($P{PageNo}))-(1) )]]></expression>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="1e9b51cc-6c7c-4aac-957b-6cd88472117d" key="line" x="0" y="2" width="535" height="1" forecolor="#000000"/>
+		<element kind="textField" uuid="e172b704-f5db-484c-a6c9-8262095dd249" key="textField" x="275" y="4" width="79" height="16" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="dd/MM/yyyy" blankWhenNull="false" vTextAlign="Bottom" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="3ffb0864-3d6f-4145-9404-d951d49e2ecb" key="staticText-1" x="198" y="4" width="76" height="16" fontName="Bitstream Vera Sans" fontSize="10.0" hTextAlign="Right" vTextAlign="Bottom" style="Report_Footer">
+			<text><![CDATA[Printed on]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="9e45c076-7b2d-4f5b-ba22-6e39ee3bb9c5" key="staticText-5" x="1" y="4" width="140" height="16" style="Report_Footer">
+			<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
+			<text><![CDATA[other footer data]]></text>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportGeneralLedgerExcel.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportGeneralLedgerExcel.jrxml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportGeneralLedgerExcel" pageWidth="1500" pageHeight="842" orientation="Landscape" columnWidth="1500" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" isIgnorePagination="true" uuid="9e3ebcf7-143e-46f6-bcdd-683d183a424c">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportGeneralLedgerExcel" language="java" pageWidth="1500" pageHeight="842" orientation="Landscape" columnWidth="1500" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="9e3ebcf7-143e-46f6-bcdd-683d183a424c" ignorePagination="true">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
@@ -7,68 +7,66 @@
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
 	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="11">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="11.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/opt/Apps230/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'0','1000000'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'1000000','1000001'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat("###,##0.00", new DecimalFormatSymbols())]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="strDateFormat" class="java.lang.String" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="strDateFormat" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["dd/MM/yyyy"]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[SELECT value, name, dateacct,
+	<query language="sql"><![CDATA[SELECT value, name, dateacct,
   SUM(AMTACCTDR) AS amtacctdr, SUM(AMTACCTCR) AS amtacctcr, (SUM(AMTACCTDR)-SUM(AMTACCTCR)) AS total,
   FACT_ACCT_GROUP_ID, id, bpname, bpid, pdname, pdid, pjname, pjid,
   MIN(DESCRIPTION) AS description
@@ -93,8 +91,7 @@ FROM
 WHERE 6=6
 GROUP BY VALUE, NAME, ID, DATEACCT, FACT_ACCT_GROUP_ID, bpname, bpid, pdname, pdid, pjname, pjid, ISDEBIT
 HAVING SUM(AMTACCTDR) - SUM(AMTACCTCR) <> 0
-ORDER BY VALUE, NAME, ID, DATEACCT, FACT_ACCT_GROUP_ID, bpname, bpid, pdname, pdid, pjname, pjid, ISDEBIT]]>
-	</queryString>
+ORDER BY VALUE, NAME, ID, DATEACCT, FACT_ACCT_GROUP_ID, bpname, bpid, pdname, pdid, pjname, pjid, ISDEBIT]]></query>
 	<field name="VALUE" class="java.lang.String"/>
 	<field name="NAME" class="java.lang.String"/>
 	<field name="DATEACCT" class="java.util.Date"/>
@@ -110,311 +107,205 @@ ORDER BY VALUE, NAME, ID, DATEACCT, FACT_ACCT_GROUP_ID, bpname, bpid, pdname, pd
 	<field name="PJNAME" class="java.lang.String"/>
 	<field name="PJID" class="java.lang.String"/>
 	<field name="DESCRIPTION" class="java.lang.String"/>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="60" splitType="Stretch">
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="280" y="45" width="70" height="15" uuid="7a86e1c9-32a4-46c1-95fc-2ab92a9702f6"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Date]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="350" y="45" width="80" height="15" uuid="f8d18465-92bf-4425-947e-b4ea83db1805"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Debit]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="430" y="45" width="80" height="15" uuid="695aafc2-8796-46eb-acbf-e63d2712139a"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Credit]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="510" y="45" width="390" height="15" uuid="5d069bc9-8c82-4390-aa00-542048a9e23d"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Description]]></text>
-			</staticText>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Report_Subtitle" x="0" y="25" width="1500" height="20" uuid="9a04c402-0b6d-460a-b60d-984f7bb5b4ed"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{REPORT_SUBTITLE}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="element-91" style="Detail_Header" x="900" y="45" width="200" height="15" uuid="1ef12aeb-3449-4d18-8d98-3c4a878e22ff"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Business Partner]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-92" style="Detail_Header" x="1100" y="45" width="200" height="15" uuid="881b758e-4d1e-4a19-a350-a897914588c5"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Product]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-92" style="Detail_Header" x="1100" y="45" width="200" height="15" uuid="5adebecc-1304-46a0-b69f-9a4ef327c236"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Product]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-93" style="Detail_Header" x="1300" y="45" width="200" height="15" uuid="e0728994-9dd6-479f-b9df-e21c4f841261"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Project]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-93" style="Detail_Header" x="1300" y="45" width="200" height="15" uuid="2ab8c906-95c9-4dcb-be6f-d16bc40557a6"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Project]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-94" style="Detail_Header" x="0" y="45" width="50" height="15" uuid="6be9f927-d17e-40df-8f37-18099925058c"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Acct. No.]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-94" style="Detail_Header" x="0" y="45" width="50" height="15" uuid="d1589650-564e-4deb-8b46-c67b67ef063b"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Acct. No.]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-95" style="Detail_Header" x="50" y="45" width="230" height="15" uuid="766fe0a0-bb37-4e26-8b2d-957f6a7bc4f6"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Account Name]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-1" style="Report_Footer" x="0" y="0" width="1500" height="25" uuid="bb17c37e-b9fa-4ff5-9580-35dba7ef746b"/>
-				<textElement>
-					<font fontName="SansSerif" size="18"/>
-				</textElement>
-				<text><![CDATA[General Ledger Report]]></text>
-			</staticText>
-		</band>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader height="60" splitType="Stretch">
+		<element kind="staticText" uuid="7a86e1c9-32a4-46c1-95fc-2ab92a9702f6" key="element-90" x="280" y="45" width="70" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Date]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="f8d18465-92bf-4425-947e-b4ea83db1805" key="element-90" x="350" y="45" width="80" height="15" fontSize="8.0" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Debit]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="695aafc2-8796-46eb-acbf-e63d2712139a" key="element-90" x="430" y="45" width="80" height="15" fontSize="8.0" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Credit]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="5d069bc9-8c82-4390-aa00-542048a9e23d" key="element-90" x="510" y="45" width="390" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Description]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="9a04c402-0b6d-460a-b60d-984f7bb5b4ed" key="textField" x="0" y="25" width="1500" height="20" fontSize="10.0" textAdjust="StretchHeight" blankWhenNull="true" style="Report_Subtitle">
+			<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="1ef12aeb-3449-4d18-8d98-3c4a878e22ff" key="element-91" x="900" y="45" width="200" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Business Partner]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="881b758e-4d1e-4a19-a350-a897914588c5" key="element-92" x="1100" y="45" width="200" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Product]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="5adebecc-1304-46a0-b69f-9a4ef327c236" key="element-92" x="1100" y="45" width="200" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Product]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="e0728994-9dd6-479f-b9df-e21c4f841261" key="element-93" x="1300" y="45" width="200" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Project]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="2ab8c906-95c9-4dcb-be6f-d16bc40557a6" key="element-93" x="1300" y="45" width="200" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Project]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="6be9f927-d17e-40df-8f37-18099925058c" key="element-94" x="0" y="45" width="50" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Acct. No.]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="d1589650-564e-4deb-8b46-c67b67ef063b" key="element-94" x="0" y="45" width="50" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Acct. No.]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="766fe0a0-bb37-4e26-8b2d-957f6a7bc4f6" key="element-95" x="50" y="45" width="230" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Account Name]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="bb17c37e-b9fa-4ff5-9580-35dba7ef746b" key="staticText-1" x="0" y="0" width="1500" height="25" fontName="SansSerif" fontSize="18.0" style="Report_Footer">
+			<text><![CDATA[General Ledger Report]]></text>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="13" splitType="Stretch">
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" stretchType="RelativeToBandHeight" x="0" y="0" width="50" height="13" uuid="c16ab572-350b-455d-886a-309e16477a82"/>
+			<element kind="textField" uuid="c16ab572-350b-455d-886a-309e16477a82" key="textField" stretchType="ContainerHeight" x="0" y="0" width="50" height="13" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false">
+				<expression><![CDATA[$F{VALUE}]]></expression>
 				<box topPadding="2" leftPadding="5">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="8" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{VALUE}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" stretchType="RelativeToBandHeight" x="50" y="0" width="230" height="13" uuid="1c1b1c87-819a-4270-97f9-ce465e29590b"/>
+			</element>
+			<element kind="textField" uuid="1c1b1c87-819a-4270-97f9-ce465e29590b" key="textField" stretchType="ContainerHeight" x="50" y="0" width="230" height="13" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false">
+				<expression><![CDATA[$F{NAME}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="8" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{NAME}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-18" stretchType="RelativeToBandHeight" x="510" y="0" width="390" height="13" uuid="5a10a784-b5be-468b-ae9e-994b22a8344b"/>
+			</element>
+			<element kind="textField" uuid="5a10a784-b5be-468b-ae9e-994b22a8344b" key="textField-18" stretchType="ContainerHeight" x="510" y="0" width="390" height="13" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left">
+				<expression><![CDATA[$F{DESCRIPTION}]]></expression>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DESCRIPTION}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-20" stretchType="RelativeToBandHeight" x="430" y="0" width="80" height="13" uuid="b5e2a29e-63bf-4491-abcc-769d985f502a"/>
-				<box rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AMTACCTCR}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="b5e2a29e-63bf-4491-abcc-769d985f502a" key="textField-20" stretchType="ContainerHeight" x="430" y="0" width="80" height="13" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[$F{AMTACCTCR}]]></expression>
 				<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-21" stretchType="RelativeToBandHeight" x="350" y="0" width="80" height="13" uuid="61ebce32-48ca-4823-911f-c009e581b4e1"/>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AMTACCTDR}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="61ebce32-48ca-4823-911f-c009e581b4e1" key="textField-21" stretchType="ContainerHeight" x="350" y="0" width="80" height="13" fontSize="8.0" pattern="" blankWhenNull="true" hTextAlign="Right">
+				<expression><![CDATA[$F{AMTACCTDR}]]></expression>
 				<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField pattern="dd/MM/yyyy" isBlankWhenNull="false">
-				<reportElement key="textField-22" stretchType="RelativeToBandHeight" x="280" y="0" width="70" height="13" uuid="5afdc4b7-edf6-4e06-960b-ca4914f50e5c"/>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[(new SimpleDateFormat($P{strDateFormat})).format($F{DATEACCT})]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" stretchType="RelativeToBandHeight" x="900" y="0" width="200" height="13" uuid="939d4644-0f74-4736-be08-f6ce99e0aa7d"/>
+			</element>
+			<element kind="textField" uuid="5afdc4b7-edf6-4e06-960b-ca4914f50e5c" key="textField-22" stretchType="ContainerHeight" x="280" y="0" width="70" height="13" fontSize="8.0" pattern="dd/MM/yyyy" blankWhenNull="false" hTextAlign="Left">
+				<expression><![CDATA[(new SimpleDateFormat($P{strDateFormat})).format($F{DATEACCT})]]></expression>
+				<box rightPadding="2">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="939d4644-0f74-4736-be08-f6ce99e0aa7d" key="textField" stretchType="ContainerHeight" x="900" y="0" width="200" height="13" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true">
+				<expression><![CDATA[$F{BPNAME}]]></expression>
 				<box rightPadding="2"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{BPNAME}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" stretchType="RelativeToBandHeight" x="1100" y="0" width="200" height="13" uuid="b425a42a-ec4b-48dd-99b3-cf2fbd5012c0"/>
+			</element>
+			<element kind="textField" uuid="b425a42a-ec4b-48dd-99b3-cf2fbd5012c0" key="textField" stretchType="ContainerHeight" x="1100" y="0" width="200" height="13" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true">
+				<expression><![CDATA[$F{PDNAME}]]></expression>
 				<box rightPadding="2"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PDNAME}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" stretchType="RelativeToBandHeight" x="1300" y="0" width="200" height="13" uuid="7423ac0c-75f8-4722-a922-806f1357c07c"/>
+			</element>
+			<element kind="textField" uuid="7423ac0c-75f8-4722-a922-806f1357c07c" key="textField" stretchType="ContainerHeight" x="1300" y="0" width="200" height="13" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true">
+				<expression><![CDATA[$F{PJNAME}]]></expression>
 				<box rightPadding="2"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PJNAME}]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportGeneralLedgerJournal.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportGeneralLedgerJournal.jrxml
@@ -1,56 +1,54 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportGeneralLedgerJournal" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="9a1a78fc-40e4-4147-8515-d6fde6eb3bdc">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportGeneralLedgerJournal" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="9a1a78fc-40e4-4147-8515-d6fde6eb3bdc">
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.5"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="DejaVu Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="DejaVu Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="DejaVu Sans" fontSize="14"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="DejaVu Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="DejaVu Sans" fontSize="11" isBold="true"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="DejaVu Sans" fontSize="18" isBold="true"/>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="DejaVu Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="DejaVu Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="DejaVu Sans" fontSize="14.0"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="DejaVu Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="DejaVu Sans" fontSize="11.0" bold="true"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="DejaVu Sans" fontSize="18.0" bold="true"/>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
-	<style name="Detail_Line" fontName="DejaVu Sans" fontSize="11">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="DejaVu Sans" fontSize="11.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="DejaVu Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="DejaVu Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="DejaVu Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="DejaVu Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="DejaVu Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="DejaVu Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="DejaVu Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="DejaVu Sans" fontSize="11" isBold="true"/>
-	<parameter name="Subtitle" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="DejaVu Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="DejaVu Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="DejaVu Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="DejaVu Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="DejaVu Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="DejaVu Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="DejaVu Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="DejaVu Sans" fontSize="11.0" bold="true"/>
+	<parameter name="Subtitle" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat("#,##0.00",new DecimalFormatSymbols(Locale.US))]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="PageNo" class="java.lang.String" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="PageNo" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="InitialBalance" class="java.math.BigDecimal" isForPrompting="false">
+	<parameter name="InitialBalance" forPrompting="false" class="java.math.BigDecimal">
 		<defaultValueExpression><![CDATA[BigDecimal.ZERO]]></defaultValueExpression>
 	</parameter>
-	<parameter name="InitialEntryNumber" class="java.lang.String" isForPrompting="false">
+	<parameter name="InitialEntryNumber" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="TaxID" class="java.lang.String" isForPrompting="false"/>
+	<parameter name="TaxID" forPrompting="false" class="java.lang.String"/>
 	<parameter name="ShowDescription" class="java.lang.String"/>
-	<parameter name="strDateFormat" class="java.lang.String" isForPrompting="false">
+	<parameter name="strDateFormat" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["dd/MM/yyyy"]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[SELECT SCHEMA_ID, SCHEMA_NAME, IDENTIFIER, DATEACCT, VALUE, NAME, ID, AD_TABLE_ID, DOCBASETYPE, SEQNO, '' AS TOTAL, '' AS DESCRIPTION,
+	<query language="sql"><![CDATA[SELECT SCHEMA_ID, SCHEMA_NAME, IDENTIFIER, DATEACCT, VALUE, NAME, ID, AD_TABLE_ID, DOCBASETYPE, SEQNO, '' AS TOTAL, '' AS DESCRIPTION,
       (CASE FACTACCTTYPE WHEN 'O' THEN 1 WHEN 'N' THEN 2 WHEN 'R' THEN 3 ELSE 4 END) AS FACTACCTTYPE2,
       (CASE AMTACCTDR WHEN 0 THEN NULL ELSE AMTACCTDR END) AS AMTACCTDR, (CASE AMTACCTCR WHEN 0 THEN NULL ELSE AMTACCTCR END) AS AMTACCTCR
       FROM
@@ -62,8 +60,7 @@
       GROUP BY f.C_ACCTSCHEMA_ID, SC.NAME, F.AD_TABLE_ID, F.DATEACCT, F.ACCTDESCRIPTION || F.DESCRIPTION, F.ACCTVALUE, F.DOCBASETYPE, F.RECORD_ID,
       F.FACT_ACCT_GROUP_ID, F.ACCOUNT_ID,F.FACTACCTTYPE,
       (CASE F.AMTACCTDR WHEN 0 THEN (CASE SIGN(F.AMTACCTCR) WHEN -1 THEN 1 ELSE 2 END) ELSE (CASE SIGN(F.AMTACCTDR) WHEN -1 THEN 3 ELSE 4 END) END)) AA
-      ORDER BY SCHEMA_NAME, DATEACCT, FACTACCTTYPE2, IDENTIFIER, SEQNO]]>
-	</queryString>
+      ORDER BY SCHEMA_NAME, DATEACCT, FACTACCTTYPE2, IDENTIFIER, SEQNO]]></query>
 	<field name="SCHEMA_ID" class="java.lang.String"/>
 	<field name="SCHEMA_NAME" class="java.lang.String"/>
 	<field name="IDENTIFIER" class="java.lang.String"/>
@@ -80,21 +77,21 @@
 	<field name="AMTACCTDR" class="java.math.BigDecimal"/>
 	<field name="AMTACCTCR" class="java.math.BigDecimal"/>
 	<field name="DOCNAME" class="java.lang.String"/>
-	<variable name="entry" class="java.math.BigDecimal" calculation="DistinctCount">
-		<variableExpression><![CDATA[$F{IDENTIFIER}]]></variableExpression>
+	<variable name="entry" calculation="DistinctCount" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{IDENTIFIER}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="AcumDebit" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMTACCTDR}]]></variableExpression>
+	<variable name="AcumDebit" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMTACCTDR}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="AcumCredit" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMTACCTCR}]]></variableExpression>
+	<variable name="AcumCredit" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMTACCTCR}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="NumPage" class="java.lang.Integer" resetType="None" incrementType="Page" calculation="Count"/>
+	<variable name="NumPage" resetType="None" incrementType="Page" calculation="Count" class="java.lang.Integer"/>
 	<group name="JournalEntry" keepTogether="true">
-		<groupExpression><![CDATA[$F{IDENTIFIER}]]></groupExpression>
+		<expression><![CDATA[$F{IDENTIFIER}]]></expression>
 		<groupHeader>
 			<band splitType="Stretch"/>
 		</groupHeader>
@@ -102,529 +99,345 @@
 			<band height="10" splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="71" splitType="Stretch">
-			<line>
-				<reportElement key="line-1" x="0" y="19" width="535" height="1" uuid="6d274fea-1d86-425d-a810-b685c5b00350"/>
-			</line>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField-4" style="Report_Subtitle" x="0" y="28" width="534" height="43" forecolor="#000000" uuid="f60c908d-d38e-4d28-bf28-48a16d3d75dd"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left">
-					<font fontName="DejaVu Sans" size="12"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{Subtitle}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-11" style="Report_Footer" x="5" y="2" width="530" height="25" uuid="ab8f7de6-55dc-4da6-bcd4-b0876322283e"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="DejaVu Sans" size="12" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Journal Entries Report]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-8" style="Report_Footer" x="431" y="1" width="53" height="16" uuid="1bbed04b-ef03-49e4-9c58-f8b7f5a736f0"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<text><![CDATA[Printed on]]></text>
-			</staticText>
-			<textField pattern="dd/MM/yyyy" isBlankWhenNull="false">
-				<reportElement key="textField-15" style="Report_Footer" x="487" y="2" width="47" height="16" uuid="ab6e36ad-7901-4d94-b499-d49098aea838"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[(new SimpleDateFormat($P{strDateFormat})).format(new Date())]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="71" splitType="Stretch">
+		<element kind="line" uuid="6d274fea-1d86-425d-a810-b685c5b00350" key="line-1" x="0" y="19" width="535" height="1"/>
+		<element kind="textField" uuid="f60c908d-d38e-4d28-bf28-48a16d3d75dd" key="textField-4" x="0" y="28" width="534" height="43" forecolor="#000000" fontName="DejaVu Sans" fontSize="12.0" textAdjust="StretchHeight" blankWhenNull="true" hTextAlign="Left" style="Report_Subtitle">
+			<expression><![CDATA[$P{Subtitle}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="ab8f7de6-55dc-4da6-bcd4-b0876322283e" key="staticText-11" x="5" y="2" width="530" height="25" fontName="DejaVu Sans" fontSize="12.0" pdfFontName="Helvetica-Bold" bold="true" style="Report_Footer">
+			<text><![CDATA[Journal Entries Report]]></text>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="1bbed04b-ef03-49e4-9c58-f8b7f5a736f0" key="staticText-8" x="431" y="1" width="53" height="16" fontName="DejaVu Sans" fontSize="8.0" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
+			<text><![CDATA[Printed on]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="ab6e36ad-7901-4d94-b499-d49098aea838" key="textField-15" x="487" y="2" width="47" height="16" fontName="DejaVu Sans" fontSize="8.0" pattern="dd/MM/yyyy" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[(new SimpleDateFormat($P{strDateFormat})).format(new Date())]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</title>
-	<pageHeader>
-		<band height="20" splitType="Stretch">
-			<frame>
-				<reportElement x="1" y="-2" width="535" height="21" uuid="b459dfa4-5613-4fa8-a538-821cc488216a">
-					<printWhenExpression><![CDATA[$P{ShowDescription}.equals( "" )]]></printWhenExpression>
-				</reportElement>
-				<staticText>
-					<reportElement key="staticText-9" style="GroupHeader_DarkGray" x="4" y="2" width="69" height="18" forecolor="#000000" backcolor="#FFFFFF" uuid="a7b03a65-89c5-451f-9de0-358726142114"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font fontName="DejaVu Sans" size="8" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Entry]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-10" style="GroupHeader_DarkGray" x="73" y="2" width="54" height="18" forecolor="#000000" backcolor="#FFFFFF" uuid="43e1cbd1-3299-4fde-bc0d-c1c2630b9184"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font fontName="DejaVu Sans" size="8" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-3" style="GroupHeader_Gray" x="214" y="2" width="76" height="18" backcolor="#FFFFFF" uuid="9f2e42c2-3338-4449-a4d2-ca9573a5d60e"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="8" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Account No]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-4" style="GroupHeader_Gray" x="291" y="2" width="118" height="18" backcolor="#FFFFFF" uuid="75646070-a7ea-4d5f-a825-becb1504b834"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="8" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Name]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-6" style="GroupHeader_Gray" x="409" y="2" width="62" height="18" backcolor="#FFFFFF" uuid="2460352c-ecc5-4d94-b64d-d91e7a11320a"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="8" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Debit]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-7" style="GroupHeader_Gray" x="471" y="2" width="62" height="18" backcolor="#FFFFFF" uuid="a191c313-0bad-4dc5-b84d-c39f30188efc"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="8" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Credit]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="129" y="2" width="84" height="18" isPrintWhenDetailOverflows="true" forecolor="#000000" backcolor="#FFFFFF" uuid="26ed677c-2d2a-4f62-871e-949e1794d7b9"/>
-					<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None" markup="none">
-						<font fontName="DejaVu Sans" size="8" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-						<paragraph lineSpacing="Single"/>
-					</textElement>
-					<text><![CDATA[Document]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-1" x="0" y="1" width="535" height="1" uuid="63bf4984-8415-425f-a66a-f8cec8b74650"/>
-				</line>
-				<line>
-					<reportElement key="line-1" x="0" y="20" width="535" height="1" uuid="75c2bcae-1c5b-4276-9062-71b07f7247d3"/>
-				</line>
-			</frame>
-			<frame>
-				<reportElement x="1" y="-2" width="535" height="21" uuid="af880d63-c07f-49d5-99a5-f13bfaae10d7">
-					<printWhenExpression><![CDATA[$P{ShowDescription}.equals( "Y" )]]></printWhenExpression>
-				</reportElement>
-				<staticText>
-					<reportElement key="staticText-9" style="GroupHeader_DarkGray" x="1" y="2" width="70" height="18" forecolor="#000000" backcolor="#FFFFFF" uuid="c237e475-eacf-47f6-987e-96ffe7ad5143"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font fontName="DejaVu Sans" size="8" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Entry]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-10" style="GroupHeader_DarkGray" x="74" y="2" width="54" height="18" forecolor="#000000" backcolor="#FFFFFF" uuid="66f18b7d-f2bc-49cb-98c8-56b838d160dd"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font fontName="DejaVu Sans" size="8" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-3" style="GroupHeader_Gray" x="213" y="2" width="76" height="18" backcolor="#FFFFFF" uuid="217e14ee-9945-4ba3-92d4-bb3855264cd9"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="8" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Account No]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-4" style="GroupHeader_Gray" x="290" y="2" width="118" height="18" backcolor="#FFFFFF" uuid="75753b5f-99e0-403d-87c1-19d5107f4cfc"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="8" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Name]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-6" style="GroupHeader_Gray" x="408" y="2" width="62" height="18" backcolor="#FFFFFF" uuid="e76301fe-40f3-492d-90b8-b00b3872e8ee"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="8" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Debit]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-7" style="GroupHeader_Gray" x="470" y="2" width="62" height="18" backcolor="#FFFFFF" uuid="682573b6-bde3-4fc2-b475-ec5295cab597"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="8" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Credit]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="130" y="2" width="85" height="18" isPrintWhenDetailOverflows="true" forecolor="#000000" backcolor="#FFFFFF" uuid="e64251f0-5668-4902-87be-4061dea6edef"/>
-					<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None" markup="none">
-						<font fontName="DejaVu Sans" size="8" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-						<paragraph lineSpacing="Single"/>
-					</textElement>
-					<text><![CDATA[Description]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-1" x="0" y="2" width="535" height="1" uuid="7d84045f-ccc7-4901-9c5b-7625a2a6352d"/>
-				</line>
-				<line>
-					<reportElement key="line-1" x="0" y="20" width="535" height="1" uuid="8cd5cc8e-914d-4941-8a38-29e9cf64b207"/>
-				</line>
-			</frame>
-		</band>
+	<pageHeader height="20" splitType="Stretch">
+		<element kind="frame" uuid="b459dfa4-5613-4fa8-a538-821cc488216a" x="1" y="-2" width="535" height="21">
+			<printWhenExpression><![CDATA[$P{ShowDescription}.equals( "" )]]></printWhenExpression>
+			<element kind="staticText" uuid="a7b03a65-89c5-451f-9de0-358726142114" key="staticText-9" x="4" y="2" width="69" height="18" forecolor="#000000" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="8.0" bold="true" style="GroupHeader_DarkGray">
+				<text><![CDATA[Entry]]></text>
+				<box leftPadding="5" style="GroupHeader_DarkGray">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="43e1cbd1-3299-4fde-bc0d-c1c2630b9184" key="staticText-10" x="73" y="2" width="54" height="18" forecolor="#000000" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="8.0" bold="true" style="GroupHeader_DarkGray">
+				<text><![CDATA[Date]]></text>
+				<box leftPadding="5" style="GroupHeader_DarkGray">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="9f2e42c2-3338-4449-a4d2-ca9573a5d60e" key="staticText-3" x="214" y="2" width="76" height="18" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="8.0" bold="true" vTextAlign="Middle" style="GroupHeader_Gray">
+				<text><![CDATA[Account No]]></text>
+				<box leftPadding="2" rightPadding="2" style="GroupHeader_Gray">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="75646070-a7ea-4d5f-a825-becb1504b834" key="staticText-4" x="291" y="2" width="118" height="18" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="8.0" bold="true" vTextAlign="Middle" style="GroupHeader_Gray">
+				<text><![CDATA[Name]]></text>
+				<box leftPadding="2" rightPadding="2" style="GroupHeader_Gray">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="2460352c-ecc5-4d94-b64d-d91e7a11320a" key="staticText-6" x="409" y="2" width="62" height="18" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="8.0" bold="true" hTextAlign="Right" vTextAlign="Middle" style="GroupHeader_Gray">
+				<text><![CDATA[Debit]]></text>
+				<box leftPadding="2" rightPadding="2" style="GroupHeader_Gray">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="a191c313-0bad-4dc5-b84d-c39f30188efc" key="staticText-7" x="471" y="2" width="62" height="18" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="8.0" bold="true" hTextAlign="Right" vTextAlign="Middle" style="GroupHeader_Gray">
+				<text><![CDATA[Credit]]></text>
+				<box leftPadding="2" rightPadding="2" style="GroupHeader_Gray">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="26ed677c-2d2a-4f62-871e-949e1794d7b9" mode="Opaque" x="129" y="2" width="84" height="18" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="8.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" printWhenDetailOverflows="true" pdfEmbedded="false" underline="false" strikeThrough="false" bold="true" italic="false" hTextAlign="Left" vTextAlign="Middle">
+				<paragraph lineSpacing="Single"/>
+				<text><![CDATA[Document]]></text>
+			</element>
+			<element kind="line" uuid="63bf4984-8415-425f-a66a-f8cec8b74650" key="line-1" x="0" y="1" width="535" height="1"/>
+			<element kind="line" uuid="75c2bcae-1c5b-4276-9062-71b07f7247d3" key="line-1" x="0" y="20" width="535" height="1"/>
+		</element>
+		<element kind="frame" uuid="af880d63-c07f-49d5-99a5-f13bfaae10d7" x="1" y="-2" width="535" height="21">
+			<printWhenExpression><![CDATA[$P{ShowDescription}.equals( "Y" )]]></printWhenExpression>
+			<element kind="staticText" uuid="c237e475-eacf-47f6-987e-96ffe7ad5143" key="staticText-9" x="1" y="2" width="70" height="18" forecolor="#000000" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="8.0" bold="true" style="GroupHeader_DarkGray">
+				<text><![CDATA[Entry]]></text>
+				<box leftPadding="5" style="GroupHeader_DarkGray">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="66f18b7d-f2bc-49cb-98c8-56b838d160dd" key="staticText-10" x="74" y="2" width="54" height="18" forecolor="#000000" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="8.0" bold="true" style="GroupHeader_DarkGray">
+				<text><![CDATA[Date]]></text>
+				<box leftPadding="5" style="GroupHeader_DarkGray">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="217e14ee-9945-4ba3-92d4-bb3855264cd9" key="staticText-3" x="213" y="2" width="76" height="18" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="8.0" bold="true" vTextAlign="Middle" style="GroupHeader_Gray">
+				<text><![CDATA[Account No]]></text>
+				<box leftPadding="2" rightPadding="2" style="GroupHeader_Gray">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="75753b5f-99e0-403d-87c1-19d5107f4cfc" key="staticText-4" x="290" y="2" width="118" height="18" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="8.0" bold="true" vTextAlign="Middle" style="GroupHeader_Gray">
+				<text><![CDATA[Name]]></text>
+				<box leftPadding="2" rightPadding="2" style="GroupHeader_Gray">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="e76301fe-40f3-492d-90b8-b00b3872e8ee" key="staticText-6" x="408" y="2" width="62" height="18" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="8.0" bold="true" hTextAlign="Right" vTextAlign="Middle" style="GroupHeader_Gray">
+				<text><![CDATA[Debit]]></text>
+				<box leftPadding="2" rightPadding="2" style="GroupHeader_Gray">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="682573b6-bde3-4fc2-b475-ec5295cab597" key="staticText-7" x="470" y="2" width="62" height="18" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="8.0" bold="true" hTextAlign="Right" vTextAlign="Middle" style="GroupHeader_Gray">
+				<text><![CDATA[Credit]]></text>
+				<box leftPadding="2" rightPadding="2" style="GroupHeader_Gray">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="e64251f0-5668-4902-87be-4061dea6edef" mode="Opaque" x="130" y="2" width="85" height="18" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="8.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" printWhenDetailOverflows="true" pdfEmbedded="false" underline="false" strikeThrough="false" bold="true" italic="false" hTextAlign="Left" vTextAlign="Middle">
+				<paragraph lineSpacing="Single"/>
+				<text><![CDATA[Description]]></text>
+			</element>
+			<element kind="line" uuid="7d84045f-ccc7-4901-9c5b-7625a2a6352d" key="line-1" x="0" y="2" width="535" height="1"/>
+			<element kind="line" uuid="8cd5cc8e-914d-4941-8a38-29e9cf64b207" key="line-1" x="0" y="20" width="535" height="1"/>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="12">
-			<frame>
-				<reportElement x="1" y="2" width="532" height="10" uuid="7fd11619-716e-43a0-a942-8ba91c720f3b">
-					<printWhenExpression><![CDATA[$P{ShowDescription}.equals( "" )]]></printWhenExpression>
-				</reportElement>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField" x="215" y="0" width="76" height="10" uuid="04e5f597-a18b-4dad-b9c6-1b06955de23f"/>
+			<element kind="frame" uuid="7fd11619-716e-43a0-a942-8ba91c720f3b" x="1" y="2" width="532" height="10">
+				<printWhenExpression><![CDATA[$P{ShowDescription}.equals( "" )]]></printWhenExpression>
+				<element kind="textField" uuid="04e5f597-a18b-4dad-b9c6-1b06955de23f" key="textField" x="215" y="0" width="76" height="10" fontName="DejaVu Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle">
+					<expression><![CDATA[$F{VALUE}]]></expression>
 					<box leftPadding="2" rightPadding="2">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{VALUE}]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-					<reportElement key="textField" x="291" y="0" width="118" height="10" uuid="c4271d45-311d-402a-8dc5-ad0da6a11baf"/>
+				</element>
+				<element kind="textField" uuid="c4271d45-311d-402a-8dc5-ad0da6a11baf" key="textField" x="291" y="0" width="118" height="10" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[$F{NAME}]]></expression>
 					<box leftPadding="2" rightPadding="2">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NAME}]]></textFieldExpression>
-				</textField>
-				<textField pattern="#,##0.00" isBlankWhenNull="true">
-					<reportElement key="textField" x="407" y="0" width="62" height="10" uuid="09630e83-ce43-4a9b-8705-641a0282faa9"/>
+				</element>
+				<element kind="textField" uuid="09630e83-ce43-4a9b-8705-641a0282faa9" key="textField" x="407" y="0" width="62" height="10" fontName="DejaVu Sans" fontSize="8.0" pattern="#,##0.00" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($F{AMTACCTDR}!=null)?$P{NUMBERFORMAT}.format($F{AMTACCTDR}):new String(" ")]]></expression>
 					<box leftPadding="2" rightPadding="2">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{AMTACCTDR}!=null)?$P{NUMBERFORMAT}.format($F{AMTACCTDR}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="469" y="0" width="61" height="10" uuid="74a6f28d-6bb1-4e79-91f4-896316581c90"/>
+				</element>
+				<element kind="textField" uuid="74a6f28d-6bb1-4e79-91f4-896316581c90" key="textField" x="469" y="0" width="61" height="10" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($F{AMTACCTCR}!=null)?$P{NUMBERFORMAT}.format($F{AMTACCTCR}):new String(" ")]]></expression>
 					<box leftPadding="2" rightPadding="2">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{AMTACCTCR}!=null)?$P{NUMBERFORMAT}.format($F{AMTACCTCR}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<frame>
-					<reportElement isPrintRepeatedValues="false" x="0" y="0" width="217" height="10" uuid="db1bb7ef-fa6d-4c0b-8441-21d1e19f113d"/>
-					<textField pattern="" isBlankWhenNull="false">
-						<reportElement key="textField-1" style="GroupHeader_DarkGray" mode="Opaque" x="4" y="0" width="69" height="10" printWhenGroupChanges="JournalEntry" forecolor="#000000" backcolor="#FFFFFF" uuid="1556a697-e814-473e-bd8c-c6033e738b98"/>
-						<box leftPadding="5">
+				</element>
+				<element kind="frame" uuid="db1bb7ef-fa6d-4c0b-8441-21d1e19f113d" x="0" y="0" width="217" height="10" printRepeatedValues="false">
+					<element kind="textField" uuid="1556a697-e814-473e-bd8c-c6033e738b98" key="textField-1" mode="Opaque" x="4" y="0" width="69" height="10" forecolor="#000000" backcolor="#FFFFFF" printWhenGroupChanges="JournalEntry" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" bold="false" hTextAlign="Left" style="GroupHeader_DarkGray">
+						<expression><![CDATA[($V{entry}!=null)?$V{entry}.add(new BigDecimal($P{InitialEntryNumber})).subtract(BigDecimal.ONE): BigDecimal.ONE]]></expression>
+						<box leftPadding="5" style="GroupHeader_DarkGray">
 							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<bottomPen lineWidth="0.0" lineColor="#000000"/>
 							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						</box>
-						<textElement textAlignment="Left">
-							<font fontName="DejaVu Sans" size="8" isBold="false"/>
-						</textElement>
-						<textFieldExpression><![CDATA[($V{entry}!=null)?$V{entry}.add(new BigDecimal($P{InitialEntryNumber})).subtract(BigDecimal.ONE): BigDecimal.ONE]]></textFieldExpression>
-					</textField>
-					<textField isBlankWhenNull="false">
-						<reportElement key="textField-2" style="GroupHeader_DarkGray" mode="Opaque" x="73" y="0" width="54" height="10" printWhenGroupChanges="JournalEntry" forecolor="#000000" backcolor="#FFFFFF" uuid="1d854acd-515a-4595-96a6-eb3d5a0188d9"/>
-						<box leftPadding="5">
+					</element>
+					<element kind="textField" uuid="1d854acd-515a-4595-96a6-eb3d5a0188d9" key="textField-2" mode="Opaque" x="73" y="0" width="54" height="10" forecolor="#000000" backcolor="#FFFFFF" printWhenGroupChanges="JournalEntry" fontName="DejaVu Sans" fontSize="8.0" pdfFontName="Helvetica" blankWhenNull="false" bold="false" hTextAlign="Left" style="GroupHeader_DarkGray">
+						<expression><![CDATA[$F{DATEACCT}]]></expression>
+						<box leftPadding="5" style="GroupHeader_DarkGray">
 							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<bottomPen lineWidth="0.0" lineColor="#000000"/>
 							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						</box>
-						<textElement textAlignment="Left">
-							<font fontName="DejaVu Sans" size="8" isBold="false" pdfFontName="Helvetica"/>
-						</textElement>
-						<textFieldExpression><![CDATA[$F{DATEACCT}]]></textFieldExpression>
-					</textField>
-					<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-						<reportElement key="textField" x="129" y="0" width="84" height="10" isPrintWhenDetailOverflows="true" printWhenGroupChanges="JournalEntry" uuid="ff745a00-4227-4ba8-be36-8d11a89414ef"/>
+					</element>
+					<element kind="textField" uuid="ff745a00-4227-4ba8-be36-8d11a89414ef" key="textField" x="129" y="0" width="84" height="10" printWhenGroupChanges="JournalEntry" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" printWhenDetailOverflows="true" bold="false" hTextAlign="Left" vTextAlign="Middle">
+						<expression><![CDATA[$F{DOCNAME}]]></expression>
 						<box leftPadding="2" rightPadding="2">
 							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<bottomPen lineWidth="0.0" lineColor="#000000"/>
 							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						</box>
-						<textElement textAlignment="Left" verticalAlignment="Middle">
-							<font fontName="DejaVu Sans" size="8" isBold="false"/>
-						</textElement>
-						<textFieldExpression><![CDATA[$F{DOCNAME}]]></textFieldExpression>
-					</textField>
-				</frame>
-			</frame>
-			<frame>
-				<reportElement x="1" y="2" width="532" height="10" uuid="783bb910-83e1-4487-9a4a-7a2060915666">
-					<printWhenExpression><![CDATA[$P{ShowDescription}.equals( "Y" )]]></printWhenExpression>
-				</reportElement>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField" x="215" y="0" width="76" height="10" uuid="4af6d80e-48ed-405a-9f8e-bf39f60d9e23"/>
+					</element>
+				</element>
+			</element>
+			<element kind="frame" uuid="783bb910-83e1-4487-9a4a-7a2060915666" x="1" y="2" width="532" height="10">
+				<printWhenExpression><![CDATA[$P{ShowDescription}.equals( "Y" )]]></printWhenExpression>
+				<element kind="textField" uuid="4af6d80e-48ed-405a-9f8e-bf39f60d9e23" key="textField" x="215" y="0" width="76" height="10" fontName="DejaVu Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle">
+					<expression><![CDATA[$F{VALUE}]]></expression>
 					<box leftPadding="2" rightPadding="2">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{VALUE}]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-					<reportElement key="textField" x="291" y="0" width="118" height="10" uuid="f5c7ade9-abed-4a98-8d45-19e8a7120c31"/>
+				</element>
+				<element kind="textField" uuid="f5c7ade9-abed-4a98-8d45-19e8a7120c31" key="textField" x="291" y="0" width="118" height="10" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[$F{NAME}]]></expression>
 					<box leftPadding="2" rightPadding="2">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NAME}]]></textFieldExpression>
-				</textField>
-				<textField pattern="#,##0.00" isBlankWhenNull="true">
-					<reportElement key="textField" x="407" y="0" width="62" height="10" uuid="57fbdd7d-376f-41ff-ac07-71b8d9d685e5"/>
+				</element>
+				<element kind="textField" uuid="57fbdd7d-376f-41ff-ac07-71b8d9d685e5" key="textField" x="407" y="0" width="62" height="10" fontName="DejaVu Sans" fontSize="8.0" pattern="#,##0.00" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($F{AMTACCTDR}!=null)?$P{NUMBERFORMAT}.format($F{AMTACCTDR}):new String(" ")]]></expression>
 					<box leftPadding="2" rightPadding="2">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{AMTACCTDR}!=null)?$P{NUMBERFORMAT}.format($F{AMTACCTDR}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="469" y="0" width="61" height="10" uuid="40ca275d-b16f-44bb-a322-49d568212a15"/>
+				</element>
+				<element kind="textField" uuid="40ca275d-b16f-44bb-a322-49d568212a15" key="textField" x="469" y="0" width="61" height="10" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($F{AMTACCTCR}!=null)?$P{NUMBERFORMAT}.format($F{AMTACCTCR}):new String(" ")]]></expression>
 					<box leftPadding="2" rightPadding="2">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{AMTACCTCR}!=null)?$P{NUMBERFORMAT}.format($F{AMTACCTCR}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<frame>
-					<reportElement isPrintRepeatedValues="false" x="0" y="0" width="217" height="10" uuid="921ea556-9635-4474-ac14-dbb31113d788"/>
-					<textField pattern="" isBlankWhenNull="false">
-						<reportElement key="textField-1" style="GroupHeader_DarkGray" mode="Opaque" x="1" y="0" width="70" height="10" printWhenGroupChanges="JournalEntry" forecolor="#000000" backcolor="#FFFFFF" uuid="87d3bdd9-2809-495b-8799-b7b93337051d"/>
-						<box leftPadding="5">
+				</element>
+				<element kind="frame" uuid="921ea556-9635-4474-ac14-dbb31113d788" x="0" y="0" width="217" height="10" printRepeatedValues="false">
+					<element kind="textField" uuid="87d3bdd9-2809-495b-8799-b7b93337051d" key="textField-1" mode="Opaque" x="1" y="0" width="70" height="10" forecolor="#000000" backcolor="#FFFFFF" printWhenGroupChanges="JournalEntry" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" bold="false" hTextAlign="Left" style="GroupHeader_DarkGray">
+						<expression><![CDATA[($V{entry}!=null)?$V{entry}.add(new BigDecimal($P{InitialEntryNumber})).subtract(BigDecimal.ONE): BigDecimal.ONE]]></expression>
+						<box leftPadding="5" style="GroupHeader_DarkGray">
 							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<bottomPen lineWidth="0.0" lineColor="#000000"/>
 							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						</box>
-						<textElement textAlignment="Left">
-							<font fontName="DejaVu Sans" size="8" isBold="false"/>
-						</textElement>
-						<textFieldExpression><![CDATA[($V{entry}!=null)?$V{entry}.add(new BigDecimal($P{InitialEntryNumber})).subtract(BigDecimal.ONE): BigDecimal.ONE]]></textFieldExpression>
-					</textField>
-					<textField isBlankWhenNull="false">
-						<reportElement key="textField-2" style="GroupHeader_DarkGray" mode="Opaque" x="74" y="0" width="54" height="10" printWhenGroupChanges="JournalEntry" forecolor="#000000" backcolor="#FFFFFF" uuid="1d32cd84-965b-4f48-9b73-1eea3aa2bc47"/>
-						<box leftPadding="5">
+					</element>
+					<element kind="textField" uuid="1d32cd84-965b-4f48-9b73-1eea3aa2bc47" key="textField-2" mode="Opaque" x="74" y="0" width="54" height="10" forecolor="#000000" backcolor="#FFFFFF" printWhenGroupChanges="JournalEntry" fontName="DejaVu Sans" fontSize="8.0" pdfFontName="Helvetica" blankWhenNull="false" bold="false" hTextAlign="Left" style="GroupHeader_DarkGray">
+						<expression><![CDATA[$F{DATEACCT}]]></expression>
+						<box leftPadding="5" style="GroupHeader_DarkGray">
 							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<bottomPen lineWidth="0.0" lineColor="#000000"/>
 							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						</box>
-						<textElement textAlignment="Left">
-							<font fontName="DejaVu Sans" size="8" isBold="false" pdfFontName="Helvetica"/>
-						</textElement>
-						<textFieldExpression><![CDATA[$F{DATEACCT}]]></textFieldExpression>
-					</textField>
-					<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-						<reportElement key="textField" x="129" y="0" width="87" height="10" isPrintWhenDetailOverflows="true" printWhenGroupChanges="JournalEntry" uuid="a428eb40-b79e-452b-a7fc-d91224bf392e"/>
+					</element>
+					<element kind="textField" uuid="a428eb40-b79e-452b-a7fc-d91224bf392e" key="textField" x="129" y="0" width="87" height="10" printWhenGroupChanges="JournalEntry" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" printWhenDetailOverflows="true" bold="false" hTextAlign="Left" vTextAlign="Middle">
+						<expression><![CDATA[$F{DESCRIPTION}]]></expression>
 						<box leftPadding="2" rightPadding="2">
 							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<bottomPen lineWidth="0.0" lineColor="#000000"/>
 							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						</box>
-						<textElement textAlignment="Left" verticalAlignment="Middle">
-							<font fontName="DejaVu Sans" size="8" isBold="false"/>
-						</textElement>
-						<textFieldExpression><![CDATA[$F{DESCRIPTION}]]></textFieldExpression>
-					</textField>
-				</frame>
-			</frame>
+					</element>
+				</element>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="18" splitType="Stretch">
-			<line>
-				<reportElement key="line-4" style="Report_Footer" x="5" y="0" width="530" height="1" uuid="1e8b648f-2be6-4b74-aeb8-d7ae2ba89635"/>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-5" style="Report_Footer" x="353" y="1" width="141" height="12" uuid="0123a031-0acc-4154-8f29-20e01e0b2ddd"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page "+new java.lang.Integer(($V{PAGE_NUMBER}.intValue()) +(Integer.parseInt($P{PageNo}))-(1)).toString()+" of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report">
-				<reportElement x="496" y="1" width="39" height="12" uuid="6284cd4a-8a85-4092-b9cf-86ca9c8b38ec"/>
-				<textElement verticalAlignment="Bottom">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new java.lang.Integer($V{PAGE_NUMBER})]]></textFieldExpression>
-			</textField>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="18" splitType="Stretch">
+		<element kind="line" uuid="1e8b648f-2be6-4b74-aeb8-d7ae2ba89635" key="line-4" x="5" y="0" width="530" height="1" style="Report_Footer"/>
+		<element kind="textField" uuid="0123a031-0acc-4154-8f29-20e01e0b2ddd" key="textField-5" x="353" y="1" width="141" height="12" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Bottom" style="Report_Footer">
+			<expression><![CDATA["Page "+new java.lang.Integer(($V{PAGE_NUMBER}.intValue()) +(Integer.parseInt($P{PageNo}))-(1)).toString()+" of "]]></expression>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="6284cd4a-8a85-4092-b9cf-86ca9c8b38ec" x="496" y="1" width="39" height="12" fontName="DejaVu Sans" fontSize="8.0" evaluationTime="Report" vTextAlign="Bottom">
+			<expression><![CDATA[new java.lang.Integer($V{PAGE_NUMBER})]]></expression>
+		</element>
 	</pageFooter>
-	<lastPageFooter>
-		<band height="20" splitType="Stretch">
-			<line>
-				<reportElement key="line-4" style="Report_Footer" x="1" y="1" width="530" height="1" uuid="3286c4ac-f788-4f93-9975-3bb93cd09981"/>
-			</line>
-			<textField evaluationTime="Report">
-				<reportElement x="496" y="2" width="40" height="12" uuid="06deae2f-700e-48fa-8a5b-e54229045d42"/>
-				<textElement verticalAlignment="Bottom">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new java.lang.Integer($V{PAGE_NUMBER})]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-5" style="Report_Footer" x="353" y="2" width="141" height="12" uuid="9856c220-92cb-41dc-adbc-8e2281ba9df5"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page "+new java.lang.Integer(($V{PAGE_NUMBER}.intValue()) +(Integer.parseInt($P{PageNo}))-(1)).toString()+" of "]]></textFieldExpression>
-			</textField>
-		</band>
+	<lastPageFooter height="20" splitType="Stretch">
+		<element kind="line" uuid="3286c4ac-f788-4f93-9975-3bb93cd09981" key="line-4" x="1" y="1" width="530" height="1" style="Report_Footer"/>
+		<element kind="textField" uuid="06deae2f-700e-48fa-8a5b-e54229045d42" x="496" y="2" width="40" height="12" fontName="DejaVu Sans" fontSize="8.0" evaluationTime="Report" vTextAlign="Bottom">
+			<expression><![CDATA[new java.lang.Integer($V{PAGE_NUMBER})]]></expression>
+		</element>
+		<element kind="textField" uuid="9856c220-92cb-41dc-adbc-8e2281ba9df5" key="textField-5" x="353" y="2" width="141" height="12" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Bottom" style="Report_Footer">
+			<expression><![CDATA["Page "+new java.lang.Integer(($V{PAGE_NUMBER}.intValue()) +(Integer.parseInt($P{PageNo}))-(1)).toString()+" of "]]></expression>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</lastPageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportGeneralLedgerJournalExcel.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportGeneralLedgerJournalExcel.jrxml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportGeneralLedgerJournal" pageWidth="1133" pageHeight="842" orientation="Landscape" columnWidth="1133" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="6b4bb55a-5204-496f-b1c0-f518ab749f0d">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportGeneralLedgerJournal" language="java" pageWidth="1133" pageHeight="842" orientation="Landscape" columnWidth="1133" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="6b4bb55a-5204-496f-b1c0-f518ab749f0d">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
@@ -7,49 +7,47 @@
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
 	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true"/>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true"/>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="11">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="11.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="Subtitle" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="Subtitle" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat("#,##0.00",new DecimalFormatSymbols(Locale.US))]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="PageNo" class="java.lang.String" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="PageNo" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="InitialBalance" class="java.math.BigDecimal" isForPrompting="false">
+	<parameter name="InitialBalance" forPrompting="false" class="java.math.BigDecimal">
 		<defaultValueExpression><![CDATA[BigDecimal.ZERO]]></defaultValueExpression>
 	</parameter>
-	<parameter name="InitialEntryNumber" class="java.lang.String" isForPrompting="false">
+	<parameter name="InitialEntryNumber" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["1"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="TaxID" class="java.lang.String" isForPrompting="false"/>
+	<parameter name="TaxID" forPrompting="false" class="java.lang.String"/>
 	<parameter name="ShowDescription" class="java.lang.String"/>
-	<queryString>
-		<![CDATA[SELECT SCHEMA_ID, SCHEMA_NAME, IDENTIFIER, DATEACCT, VALUE, NAME, ID, AD_TABLE_ID, DOCBASETYPE, SEQNO, '' AS TOTAL, '' AS DESCRIPTION,
+	<query language="sql"><![CDATA[SELECT SCHEMA_ID, SCHEMA_NAME, IDENTIFIER, DATEACCT, VALUE, NAME, ID, AD_TABLE_ID, DOCBASETYPE, SEQNO, '' AS TOTAL, '' AS DESCRIPTION,
       (CASE FACTACCTTYPE WHEN 'O' THEN 1 WHEN 'N' THEN 2 WHEN 'R' THEN 3 ELSE 4 END) AS FACTACCTTYPE2,
       (CASE AMTACCTDR WHEN 0 THEN NULL ELSE AMTACCTDR END) AS AMTACCTDR, (CASE AMTACCTCR WHEN 0 THEN NULL ELSE AMTACCTCR END) AS AMTACCTCR
       FROM
@@ -61,8 +59,7 @@
       GROUP BY f.C_ACCTSCHEMA_ID, SC.NAME, F.AD_TABLE_ID, F.DATEACCT, F.ACCTDESCRIPTION || F.DESCRIPTION, F.ACCTVALUE, F.DOCBASETYPE, F.RECORD_ID,
       F.FACT_ACCT_GROUP_ID, F.ACCOUNT_ID,F.FACTACCTTYPE,
       (CASE F.AMTACCTDR WHEN 0 THEN (CASE SIGN(F.AMTACCTCR) WHEN -1 THEN 1 ELSE 2 END) ELSE (CASE SIGN(F.AMTACCTDR) WHEN -1 THEN 3 ELSE 4 END) END)) AA
-      ORDER BY SCHEMA_NAME, DATEACCT, FACTACCTTYPE2, IDENTIFIER, SEQNO]]>
-	</queryString>
+      ORDER BY SCHEMA_NAME, DATEACCT, FACTACCTTYPE2, IDENTIFIER, SEQNO]]></query>
 	<field name="SCHEMA_ID" class="java.lang.String"/>
 	<field name="SCHEMA_NAME" class="java.lang.String"/>
 	<field name="IDENTIFIER" class="java.lang.String"/>
@@ -79,21 +76,21 @@
 	<field name="AMTACCTDR" class="java.math.BigDecimal"/>
 	<field name="AMTACCTCR" class="java.math.BigDecimal"/>
 	<field name="DOCNAME" class="java.lang.String"/>
-	<variable name="entry" class="java.math.BigDecimal" calculation="DistinctCount">
-		<variableExpression><![CDATA[$F{IDENTIFIER}]]></variableExpression>
+	<variable name="entry" calculation="DistinctCount" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{IDENTIFIER}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="AcumDebit" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMTACCTDR}]]></variableExpression>
+	<variable name="AcumDebit" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMTACCTDR}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="AcumCredit" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMTACCTCR}]]></variableExpression>
+	<variable name="AcumCredit" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMTACCTCR}]]></expression>
 		<initialValueExpression><![CDATA[BigDecimal.ZERO]]></initialValueExpression>
 	</variable>
-	<variable name="NumPage" class="java.lang.Integer" resetType="None" incrementType="Page" calculation="Count"/>
+	<variable name="NumPage" resetType="None" incrementType="Page" calculation="Count" class="java.lang.Integer"/>
 	<group name="entry">
-		<groupExpression><![CDATA[$F{IDENTIFIER}]]></groupExpression>
+		<expression><![CDATA[$F{IDENTIFIER}]]></expression>
 		<groupHeader>
 			<band splitType="Stretch"/>
 		</groupHeader>
@@ -101,241 +98,169 @@
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="100" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-3" style="GroupHeader_Gray" x="360" y="81" width="100" height="18" backcolor="#FFFFFF" uuid="886b0f7e-9f87-43bb-9b9e-bbbd8b30a74a"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle"/>
-				<text><![CDATA[Account No]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-4" style="GroupHeader_Gray" x="460" y="81" width="315" height="18" backcolor="#FFFFFF" uuid="7ef2ad8b-6f53-4017-badc-222e71b86206"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle"/>
-				<text><![CDATA[Name]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-6" style="GroupHeader_Gray" x="775" y="81" width="100" height="18" backcolor="#FFFFFF" uuid="59bbce98-1ee7-4838-b778-e1bd523af4f5"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle"/>
-				<text><![CDATA[Debit]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-7" style="GroupHeader_Gray" x="875" y="81" width="100" height="18" backcolor="#FFFFFF" uuid="489c1761-8b5e-464a-a7d5-3bd0377bf43c"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle"/>
-				<text><![CDATA[Credit]]></text>
-			</staticText>
-			<line>
-				<reportElement key="line-1" x="0" y="18" width="535" height="1" uuid="748c22fe-5c06-4eb0-95c3-da3063ca62ba"/>
-			</line>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField-4" style="Report_Subtitle" x="0" y="28" width="975" height="50" uuid="075561ac-5f53-4b49-b911-df15609be4a8"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left">
-					<font size="12"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{Subtitle}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-11" style="Report_Footer" x="0" y="2" width="975" height="25" uuid="d6e84f8e-cf0f-41f5-bacc-92a52d6cb4bd"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="12" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Journal Entries Report]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-18" style="GroupHeader_Gray" x="39" y="81" width="100" height="18" backcolor="#FFFFFF" uuid="05f4b579-c9a1-4a29-aa45-23d75df010a1"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle"/>
-				<text><![CDATA[Date]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-19" style="GroupHeader_Gray" x="0" y="81" width="39" height="18" backcolor="#FFFFFF" uuid="530b2ea2-2f3b-4793-a558-be9fe26c2348"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle"/>
-				<text><![CDATA[Entry]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-3" style="GroupHeader_Gray" x="139" y="81" width="221" height="18" backcolor="#FFFFFF" uuid="10e2e528-9685-40b5-b748-a6070cb14710">
-					<printWhenExpression><![CDATA[$P{ShowDescription}.equalsIgnoreCase("Y")]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle"/>
-				<text><![CDATA[Description]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-3" style="GroupHeader_Gray" x="139" y="81" width="221" height="18" backcolor="#FFFFFF" uuid="e3a1d502-fb7d-4f4b-b40a-a795f99196d5">
-					<printWhenExpression><![CDATA[!$P{ShowDescription}.equalsIgnoreCase("Y")]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle"/>
-				<text><![CDATA[Document]]></text>
-			</staticText>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="100" splitType="Stretch">
+		<element kind="staticText" uuid="886b0f7e-9f87-43bb-9b9e-bbbd8b30a74a" key="staticText-3" x="360" y="81" width="100" height="18" backcolor="#FFFFFF" vTextAlign="Middle" style="GroupHeader_Gray">
+			<text><![CDATA[Account No]]></text>
+			<box leftPadding="2" rightPadding="2" style="GroupHeader_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="7ef2ad8b-6f53-4017-badc-222e71b86206" key="staticText-4" x="460" y="81" width="315" height="18" backcolor="#FFFFFF" vTextAlign="Middle" style="GroupHeader_Gray">
+			<text><![CDATA[Name]]></text>
+			<box leftPadding="2" rightPadding="2" style="GroupHeader_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="59bbce98-1ee7-4838-b778-e1bd523af4f5" key="staticText-6" x="775" y="81" width="100" height="18" backcolor="#FFFFFF" hTextAlign="Right" vTextAlign="Middle" style="GroupHeader_Gray">
+			<text><![CDATA[Debit]]></text>
+			<box leftPadding="2" rightPadding="2" style="GroupHeader_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="489c1761-8b5e-464a-a7d5-3bd0377bf43c" key="staticText-7" x="875" y="81" width="100" height="18" backcolor="#FFFFFF" hTextAlign="Right" vTextAlign="Middle" style="GroupHeader_Gray">
+			<text><![CDATA[Credit]]></text>
+			<box leftPadding="2" rightPadding="2" style="GroupHeader_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="748c22fe-5c06-4eb0-95c3-da3063ca62ba" key="line-1" x="0" y="18" width="535" height="1"/>
+		<element kind="textField" uuid="075561ac-5f53-4b49-b911-df15609be4a8" key="textField-4" x="0" y="28" width="975" height="50" fontSize="12.0" textAdjust="StretchHeight" blankWhenNull="true" hTextAlign="Left" style="Report_Subtitle">
+			<expression><![CDATA[$P{Subtitle}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="d6e84f8e-cf0f-41f5-bacc-92a52d6cb4bd" key="staticText-11" x="0" y="2" width="975" height="25" fontSize="12.0" pdfFontName="Helvetica-Bold" bold="true" style="Report_Footer">
+			<text><![CDATA[Journal Entries Report]]></text>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="05f4b579-c9a1-4a29-aa45-23d75df010a1" key="staticText-18" x="39" y="81" width="100" height="18" backcolor="#FFFFFF" vTextAlign="Middle" style="GroupHeader_Gray">
+			<text><![CDATA[Date]]></text>
+			<box leftPadding="2" rightPadding="2" style="GroupHeader_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="530b2ea2-2f3b-4793-a558-be9fe26c2348" key="staticText-19" x="0" y="81" width="39" height="18" backcolor="#FFFFFF" hTextAlign="Right" vTextAlign="Middle" style="GroupHeader_Gray">
+			<text><![CDATA[Entry]]></text>
+			<box leftPadding="2" rightPadding="2" style="GroupHeader_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="10e2e528-9685-40b5-b748-a6070cb14710" key="staticText-3" x="139" y="81" width="221" height="18" backcolor="#FFFFFF" vTextAlign="Middle" style="GroupHeader_Gray">
+			<printWhenExpression><![CDATA[$P{ShowDescription}.equalsIgnoreCase("Y")]]></printWhenExpression>
+			<text><![CDATA[Description]]></text>
+			<box leftPadding="2" rightPadding="2" style="GroupHeader_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="e3a1d502-fb7d-4f4b-b40a-a795f99196d5" key="staticText-3" x="139" y="81" width="221" height="18" backcolor="#FFFFFF" vTextAlign="Middle" style="GroupHeader_Gray">
+			<printWhenExpression><![CDATA[!$P{ShowDescription}.equalsIgnoreCase("Y")]]></printWhenExpression>
+			<text><![CDATA[Document]]></text>
+			<box leftPadding="2" rightPadding="2" style="GroupHeader_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" x="460" y="0" width="315" height="16" isPrintWhenDetailOverflows="true" uuid="a6cbabe2-47c2-47c6-84da-81626742977d"/>
+			<element kind="textField" uuid="a6cbabe2-47c2-47c6-84da-81626742977d" key="textField" x="460" y="0" width="315" height="16" fontSize="10.0" textAdjust="StretchHeight" blankWhenNull="false" printWhenDetailOverflows="true">
+				<expression><![CDATA[$F{NAME}]]></expression>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{NAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="#,##0.00" isBlankWhenNull="true">
-				<reportElement key="textField" x="775" y="0" width="100" height="16" uuid="84cfae21-e563-4e8f-a39b-6b911e6e0ceb"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AMTACCTDR}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="84cfae21-e563-4e8f-a39b-6b911e6e0ceb" key="textField" x="775" y="0" width="100" height="16" fontSize="10.0" pattern="#,##0.00" blankWhenNull="true" hTextAlign="Right">
+				<expression><![CDATA[$F{AMTACCTDR}]]></expression>
 				<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField pattern="#,##0.00" isBlankWhenNull="true">
-				<reportElement key="textField" x="875" y="0" width="100" height="16" uuid="3fce8a4b-e1d8-45f8-916b-950c7afaff04"/>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AMTACCTCR}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="3fce8a4b-e1d8-45f8-916b-950c7afaff04" key="textField" x="875" y="0" width="100" height="16" fontSize="10.0" pattern="#,##0.00" blankWhenNull="true" hTextAlign="Right">
+				<expression><![CDATA[$F{AMTACCTCR}]]></expression>
 				<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-23" x="0" y="0" width="39" height="16" uuid="3d3e32f3-b500-468b-bb60-90d7320f131f"/>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{entry}!=null)?$V{entry}.add(new BigDecimal($P{InitialEntryNumber})).subtract(BigDecimal.ONE): BigDecimal.ONE]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-22" x="39" y="0" width="100" height="16" uuid="fce8a370-63f2-40bd-b8eb-dc5d6ef37112"/>
+			</element>
+			<element kind="textField" uuid="3d3e32f3-b500-468b-bb60-90d7320f131f" key="textField-23" x="0" y="0" width="39" height="16" fontSize="10.0" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[($V{entry}!=null)?$V{entry}.add(new BigDecimal($P{InitialEntryNumber})).subtract(BigDecimal.ONE): BigDecimal.ONE]]></expression>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left">
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DATEACCT}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" x="360" y="0" width="100" height="16" uuid="a71d3d78-8163-404e-b661-3c4bf7854f23"/>
+			</element>
+			<element kind="textField" uuid="fce8a370-63f2-40bd-b8eb-dc5d6ef37112" key="textField-22" x="39" y="0" width="100" height="16" fontSize="10.0" blankWhenNull="false" hTextAlign="Left">
+				<expression><![CDATA[$F{DATEACCT}]]></expression>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left">
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{VALUE}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement x="139" y="0" width="221" height="16" isPrintWhenDetailOverflows="true" uuid="620fa07a-252d-4029-8b26-a6b32c5c9f53"/>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{ShowDescription}.equalsIgnoreCase("Y") ? $F{DESCRIPTION} : $F{DOCNAME}]]></textFieldExpression>
-			</textField>
+			</element>
+			<element kind="textField" uuid="a71d3d78-8163-404e-b661-3c4bf7854f23" key="textField" x="360" y="0" width="100" height="16" fontSize="10.0" blankWhenNull="false" hTextAlign="Left">
+				<expression><![CDATA[$F{VALUE}]]></expression>
+				<box leftPadding="2" rightPadding="2">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="620fa07a-252d-4029-8b26-a6b32c5c9f53" x="139" y="0" width="221" height="16" fontSize="10.0" textAdjust="StretchHeight" blankWhenNull="true" printWhenDetailOverflows="true">
+				<expression><![CDATA[$P{ShowDescription}.equalsIgnoreCase("Y") ? $F{DESCRIPTION} : $F{DOCNAME}]]></expression>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<lastPageFooter>
-		<band height="33" splitType="Stretch"/>
-	</lastPageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<lastPageFooter height="33" splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportGuaranteeDateJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportGuaranteeDateJR.jrxml
@@ -1,57 +1,55 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportGuaranteeDateJR" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="7e242fa6-0b5f-475c-9f7c-0caabf228a68">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportGuaranteeDateJR" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="7e242fa6-0b5f-475c-9f7c-0caabf228a68">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5"/>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat()]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale">
 		<defaultValueExpression><![CDATA[new Locale("en","US")]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[SELECT M_PRODUCT.NAME, C_BPARTNER.NAME AS PARTNERNAME, M_ATTRIBUTESETINSTANCE.GUARANTEEDATE AS GUARANTEEDATE, S.QTYONHAND  AS MOVEMENTQTY, C1.NAME AS UOM,
+	<query language="sql"><![CDATA[SELECT M_PRODUCT.NAME, C_BPARTNER.NAME AS PARTNERNAME, M_ATTRIBUTESETINSTANCE.GUARANTEEDATE AS GUARANTEEDATE, S.QTYONHAND  AS MOVEMENTQTY, C1.NAME AS UOM,
         (CASE WHEN S.M_PRODUCT_UOM_ID IS NULL THEN (CASE C1.C_UOM_ID WHEN 1000001 THEN NULL ELSE ((CASE WHEN M_PRODUCT.WEIGHT=0 THEN NULL WHEN M_PRODUCT.WEIGHT IS NULL THEN NULL ELSE M_PRODUCT.WEIGHT*S.QTYONHAND END)) END) ELSE S.QTYORDERONHAND END) AS WEIGHT, C2.NAME AS UOM2
         FROM M_STORAGE_DETAIL S left join M_PRODUCT on S.M_PRODUCT_ID = M_PRODUCT.M_PRODUCT_ID
                                 left join M_PRODUCT_UOM on S.M_PRODUCT_UOM_ID = M_PRODUCT_UOM.M_PRODUCT_UOM_ID
@@ -63,8 +61,7 @@
         AND M_LOCATOR.M_WAREHOUSE_ID = M_WAREHOUSE.M_WAREHOUSE_ID
         AND S.C_UOM_ID = C1.C_UOM_ID      
         AND S.QTYONHAND <>0 
-        ORDER BY C_BPARTNER.NAME, GUARANTEEDATE DESC]]>
-	</queryString>
+        ORDER BY C_BPARTNER.NAME, GUARANTEEDATE DESC]]></query>
 	<field name="NAME" class="java.lang.String"/>
 	<field name="PARTNERNAME" class="java.lang.String"/>
 	<field name="GUARANTEEDATE" class="java.util.Date"/>
@@ -73,251 +70,166 @@
 	<field name="WEIGHT" class="java.math.BigDecimal"/>
 	<field name="UOM2" class="java.lang.String"/>
 	<variable name="UOM2" class="java.lang.String">
-		<variableExpression><![CDATA[($F{WEIGHT}!=null && $F{UOM2} == null)?"Kgs":$F{UOM2}]]></variableExpression>
+		<expression><![CDATA[($F{WEIGHT}!=null && $F{UOM2} == null)?"Kgs":$F{UOM2}]]></expression>
 	</variable>
-	<group name="PARTNERNAME" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[$F{PARTNERNAME}]]></groupExpression>
+	<group name="PARTNERNAME" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[$F{PARTNERNAME}]]></expression>
 		<groupHeader>
 			<band height="50" splitType="Stretch">
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="113" y="34" width="215" height="16" uuid="0e5e717a-d08e-4511-8483-8366b48eb417"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
+				<element kind="staticText" uuid="0e5e717a-d08e-4511-8483-8366b48eb417" key="element-90" x="113" y="34" width="215" height="16" fontName="Bitstream Vera Sans" style="Detail_Header">
 					<text><![CDATA[Description]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="Detail_Header" x="0" y="0" width="535" height="23" uuid="817cbe87-078e-4db2-a952-5423e95d4b75"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="12"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{PARTNERNAME}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="6" y="34" width="107" height="16" uuid="f3aa8288-bd36-4d42-87b6-7ba8c36c2149"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="817cbe87-078e-4db2-a952-5423e95d4b75" key="textField" x="0" y="0" width="535" height="23" fontName="Bitstream Vera Sans" fontSize="12.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{PARTNERNAME}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="f3aa8288-bd36-4d42-87b6-7ba8c36c2149" key="element-90" x="6" y="34" width="107" height="16" fontName="Bitstream Vera Sans" style="Detail_Header">
 					<text><![CDATA[Shell-by-date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="328" y="34" width="107" height="16" uuid="18d9604f-97bf-4fe3-a627-8a084b53fe9f"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="18d9604f-97bf-4fe3-a627-8a084b53fe9f" key="element-90" x="328" y="34" width="107" height="16" fontName="Bitstream Vera Sans" style="Detail_Header">
 					<text><![CDATA[Article unit]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="435" y="34" width="98" height="16" uuid="2d602344-eee3-41a8-b505-996afc2bef37"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="2d602344-eee3-41a8-b505-996afc2bef37" key="element-90" x="435" y="34" width="98" height="16" fontName="Bitstream Vera Sans" style="Detail_Header">
 					<text><![CDATA[Other units]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-2" x="1" y="23" width="1" height="27" forecolor="#555555" backcolor="#555555" uuid="80716db6-c922-40de-a04c-56ed94715d36"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-3" x="535" y="23" width="1" height="27" forecolor="#555555" backcolor="#555555" uuid="e156db4a-9625-4fe2-90e1-2dda9e7518fd"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="line" uuid="80716db6-c922-40de-a04c-56ed94715d36" key="line-2" x="1" y="23" width="1" height="27" forecolor="#555555" backcolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="e156db4a-9625-4fe2-90e1-2dda9e7518fd" key="line-3" x="535" y="23" width="1" height="27" forecolor="#555555" backcolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="20" splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="50" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-2" style="Report_Title" mode="Transparent" x="0" y="0" width="535" height="26" uuid="03830a8d-7920-45ad-a6e0-0cd24f8ac40b"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0"/>
-					<leftPen lineWidth="0.0"/>
-					<bottomPen lineWidth="0.0"/>
-					<rightPen lineWidth="0.0"/>
-				</box>
-				<textElement>
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="32" width="535" height="1" uuid="32d331c4-3c76-47ba-a550-20d2d121d330"/>
-			</line>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="20" splitType="Stretch"/>
+	<pageHeader height="50" splitType="Stretch">
+		<element kind="textField" uuid="03830a8d-7920-45ad-a6e0-0cd24f8ac40b" key="textField-2" mode="Transparent" x="0" y="0" width="535" height="26" fontName="Bitstream Vera Sans" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0"/>
+				<leftPen lineWidth="0.0"/>
+				<bottomPen lineWidth="0.0"/>
+				<rightPen lineWidth="0.0"/>
+			</box>
+		</element>
+		<element kind="line" uuid="32d331c4-3c76-47ba-a550-20d2d121d330" key="line-1" x="0" y="32" width="535" height="1"/>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="6" y="0" width="107" height="16" uuid="193575bb-1afa-4536-8c13-a391a7d16ef5"/>
-				<box leftPadding="2" rightPadding="2">
+			<element kind="textField" uuid="193575bb-1afa-4536-8c13-a391a7d16ef5" key="textField" stretchType="ContainerHeight" x="6" y="0" width="107" height="16" fontName="Bitstream Vera Sans" textAdjust="StretchHeight" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{GUARANTEEDATE}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{GUARANTEEDATE}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="113" y="0" width="215" height="16" uuid="9aa2b8a3-a25b-4541-8db3-6fda60ed189f"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="9aa2b8a3-a25b-4541-8db3-6fda60ed189f" key="textField" stretchType="ContainerHeight" x="113" y="0" width="215" height="16" fontName="Bitstream Vera Sans" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{NAME}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{NAME}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="328" y="0" width="107" height="16" uuid="abaec504-8601-4c42-905a-cc0e6581a5c1"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="abaec504-8601-4c42-905a-cc0e6581a5c1" key="textField" stretchType="ContainerHeight" x="328" y="0" width="107" height="16" fontName="Bitstream Vera Sans" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{MOVEMENTQTY}!=null)?$P{NUMBERFORMAT}.format($F{MOVEMENTQTY})+" "+$F{UOM}:new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{MOVEMENTQTY}!=null)?$P{NUMBERFORMAT}.format($F{MOVEMENTQTY})+" "+$F{UOM}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="435" y="0" width="98" height="16" uuid="5704c692-6456-4196-803c-c7bd6eef4645"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="5704c692-6456-4196-803c-c7bd6eef4645" key="textField" stretchType="ContainerHeight" x="435" y="0" width="98" height="16" fontName="Bitstream Vera Sans" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{WEIGHT}!=null)?$P{NUMBERFORMAT}.format($F{WEIGHT})+" "+$V{UOM2}:new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{WEIGHT}!=null)?$P{NUMBERFORMAT}.format($F{WEIGHT})+" "+$V{UOM2}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-4" x="535" y="0" width="1" height="16" forecolor="#555555" backcolor="#555555" uuid="9ed5a520-5f9e-4fce-a027-0d70d0876138"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-5" x="1" y="0" width="1" height="16" forecolor="#555555" backcolor="#555555" uuid="8cc28533-3382-472a-84a6-803cfd67703b"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
+			</element>
+			<element kind="line" uuid="9ed5a520-5f9e-4fce-a027-0d70d0876138" key="line-4" x="535" y="0" width="1" height="16" forecolor="#555555" backcolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="8cc28533-3382-472a-84a6-803cfd67703b" key="line-5" x="1" y="0" width="1" height="16" forecolor="#555555" backcolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="35" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="400" y="13" width="95" height="19" uuid="dcd15fe1-1202-413a-ae93-ad452b918fda"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="499" y="13" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="0c52a2b6-6354-46e6-993d-7e32a4db6cc4"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="1" y="8" width="534" height="1" forecolor="#555555" backcolor="#555555" uuid="4a454e5a-6da9-4720-99c8-6bb93f549ed5"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-6" x="1" y="0" width="1" height="8" forecolor="#555555" backcolor="#555555" uuid="2ec80e65-c53e-4b48-9e76-db59dd23503a"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-7" x="535" y="0" width="1" height="8" forecolor="#555555" uuid="889004e4-625a-468b-9221-fb125e449321"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="35" splitType="Stretch">
+		<element kind="textField" uuid="dcd15fe1-1202-413a-ae93-ad452b918fda" key="textField" x="400" y="13" width="95" height="19" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="0c52a2b6-6354-46e6-993d-7e32a4db6cc4" key="textField" x="499" y="13" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="4a454e5a-6da9-4720-99c8-6bb93f549ed5" key="line" x="1" y="8" width="534" height="1" forecolor="#555555" backcolor="#555555">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="line" uuid="2ec80e65-c53e-4b48-9e76-db59dd23503a" key="line-6" x="1" y="0" width="1" height="8" forecolor="#555555" backcolor="#555555">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="line" uuid="889004e4-625a-468b-9221-fb125e449321" key="line-7" x="535" y="0" width="1" height="8" forecolor="#555555">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesComparativeJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesComparativeJR.jrxml
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
-<!-- 2017-03-02T13:15:56 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportInvoiceCustomerDimensionalAnalysesComparativeJR" pageWidth="1108" pageHeight="595" orientation="Landscape" columnWidth="970" leftMargin="14" rightMargin="14" topMargin="56" bottomMargin="28" uuid="8fac4b02-733e-45dd-b883-668ce5862e8c">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportInvoiceCustomerDimensionalAnalysesComparativeJR" language="java" pageWidth="1108" pageHeight="595" orientation="Landscape" columnWidth="970" leftMargin="14" rightMargin="14" topMargin="56" bottomMargin="28" uuid="8fac4b02-733e-45dd-b883-668ce5862e8c">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
@@ -9,171 +7,140 @@
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
 	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="true"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8" isBold="true">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Report_Data_Label" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="true"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0" bold="true">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level1_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level1_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==1)&&($V{NIVEL1_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==1)&&($V{NIVEL1_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level2_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level2_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==2)&&($V{NIVEL1_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==2)&&($V{NIVEL1_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level3_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level3_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==3)&&($V{NIVEL2_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==3)&&($V{NIVEL2_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level4_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level4_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==4)&&($V{NIVEL3_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==4)&&($V{NIVEL3_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level5_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level5_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==5)&&($V{NIVEL4_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==5)&&($V{NIVEL4_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level6_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level6_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==6)&&($V{NIVEL5_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==6)&&($V{NIVEL5_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level7_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level7_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==7)&&($V{NIVEL6_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==7)&&($V{NIVEL6_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level8_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level8_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==8)&&($V{NIVEL7_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==8)&&($V{NIVEL7_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level9_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level9_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==9)&&($V{NIVEL8_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==9)&&($V{NIVEL8_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level10_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level10_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==10)&&($V{NIVEL9_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==10)&&($V{NIVEL9_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Report_Footer" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
+	<style name="Report_Footer" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
 	<style name="Detail_Border" forecolor="#8A8A8A"/>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["0,1000000"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["0,1000000"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_client" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_client" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{USER_CLIENT}.equals("") ? " " : " AND C_INVOICE.AD_CLIENT_ID IN(" + $P{USER_CLIENT} + ")"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="ORGANIZATION" class="java.lang.String"/>
@@ -181,97 +148,97 @@
 	<parameter name="PRODUCTGROUP" class="java.lang.String"/>
 	<parameter name="C_CURRENCY_ID" class="java.lang.String"/>
 	<parameter name="AD_ORG_ID" class="java.lang.String"/>
-	<parameter name="aux_org" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_org" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{AD_ORG_ID}.equals("") ? " " : " AND C_INVOICE.AD_ORG_ID IN(" + $P{AD_ORG_ID} + ")"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="DateFrom" class="java.lang.String"/>
 	<parameter name="DateTo" class="java.lang.String"/>
-	<parameter name="aux_DateFrom" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_DateFrom" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{DateFrom} == null || $P{DateFrom}.equals("")) ? "" : "AND C_INVOICE.DATEINVOICED >= TO_DATE('" + $P{DateFrom} + "', 'YYYY-MM-DD')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_DateTo" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_DateTo" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{DateTo} == null || $P{DateTo}.equals("")) ? "" : "AND C_INVOICE.DATEINVOICED <= TO_DATE('" + $P{DateTo} + "', 'YYYY-MM-DD')"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="C_BP_GROUP_ID" class="java.lang.String"/>
-	<parameter name="aux_bpgroup" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_bpgroup" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{C_BP_GROUP_ID}.equals("") ? " " : " AND C_BPARTNER.C_BP_GROUP_ID = '" + $P{C_BP_GROUP_ID} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="C_BPARTNER_ID" class="java.lang.String"/>
-	<parameter name="aux_partner" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_partner" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{C_BPARTNER_ID}.equals("") ? " " : " AND C_BPARTNER.C_BPARTNER_ID IN" + $P{C_BPARTNER_ID}]]></defaultValueExpression>
 	</parameter>
 	<parameter name="M_PRODUCT_CATEGORY_ID" class="java.lang.String"/>
-	<parameter name="aux_productcategory" class="java.lang.String" isForPrompting="false">
-		<defaultValueExpression><![CDATA[$P{M_PRODUCT_CATEGORY_ID}.equals("") ? " " : " AND M_PRODUCT_CATEGORY.M_PRODUCT_CATEGORY_ID IN " + $P{M_PRODUCT_CATEGORY_ID} ]]></defaultValueExpression>
+	<parameter name="aux_productcategory" forPrompting="false" class="java.lang.String">
+		<defaultValueExpression><![CDATA[$P{M_PRODUCT_CATEGORY_ID}.equals("") ? " " : " AND M_PRODUCT_CATEGORY.M_PRODUCT_CATEGORY_ID IN " + $P{M_PRODUCT_CATEGORY_ID}]]></defaultValueExpression>
 	</parameter>
 	<parameter name="M_PRODUCT_ID" class="java.lang.String"/>
-	<parameter name="aux_product" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_product" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{M_PRODUCT_ID}.equals("") ? " " : "  AND M_PRODUCT.M_PRODUCT_ID IN" + $P{M_PRODUCT_ID}]]></defaultValueExpression>
 	</parameter>
 	<parameter name="SALESREP_ID" class="java.lang.String"/>
-	<parameter name="aux_salesrep" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_salesrep" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{SALESREP_ID}.equals("") ? " " : " AND C_INVOICE.SALESREP_ID = '" + $P{SALESREP_ID} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="PARTNER_SALESREP_ID" class="java.lang.String"/>
-	<parameter name="aux_partnersalesrep" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_partnersalesrep" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{PARTNER_SALESREP_ID}.equals("") ? " " : " AND CB.C_BPARTNER_ID = '" + $P{PARTNER_SALESREP_ID} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="C_PROJECT_ID" class="java.lang.String"/>
-	<parameter name="aux_project" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_project" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{C_PROJECT_ID}.equals("") ? " " : " AND C_INVOICE.C_PROJECT_ID = '" + $P{C_PROJECT_ID} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="PRODUCTTYPE" class="java.lang.String"/>
-	<parameter name="aux_producttype" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_producttype" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{PRODUCTTYPE}.equals("") ? " " : " AND M_PRODUCT.PRODUCTTYPE = '" + $P{PRODUCTTYPE} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="C_DOCTYPE_ID" class="java.lang.String"/>
-	<parameter name="aux_doctype" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_doctype" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{C_DOCTYPE_ID}.equals("") ? " " : " AND C_INVOICE.C_DOCTYPE_ID IN" + $P{C_DOCTYPE_ID}]]></defaultValueExpression>
 	</parameter>
 	<parameter name="DOCSTATUS" class="java.lang.String"/>
-	<parameter name="aux_docstatus" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_docstatus" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{DOCSTATUS}.equals("") ? " " : " AND C_INVOICE.DOCSTATUS <> '" + $P{DOCSTATUS} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="LANGUAGE" class="java.lang.String"/>
-	<parameter name="SR_LINES" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="orderBy" class="java.lang.String" isForPrompting="false">
+	<parameter name="SR_LINES" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="orderBy" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[" ORDER BY 1 "]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Purchase Orders Report"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="PRODUCT_LEVEL" class="java.lang.Integer" isForPrompting="false">
+	<parameter name="PRODUCT_LEVEL" forPrompting="false" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[new Integer(3)]]></defaultValueExpression>
 	</parameter>
-	<parameter name="THEME" class="java.lang.String" isForPrompting="false">
+	<parameter name="THEME" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Default"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false">
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/var/lib/tomcat-5.5/webapps/alerts/web"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL1_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL1_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Partner Group"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL2_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL2_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Product Category"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL3_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL3_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Product"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL4_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL4_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Partner"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL5_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL6_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL7_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL8_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL9_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL10_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="DIMENSIONS" class="java.lang.Integer" isForPrompting="false">
+	<parameter name="LEVEL5_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL6_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL7_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL8_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL9_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL10_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="DIMENSIONS" forPrompting="false" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[new Integer(5)]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["1.- "+$P{LEVEL1_LABEL}
 +($P{LEVEL2_LABEL}==""?"":", 2.- "+$P{LEVEL2_LABEL})
 +($P{LEVEL3_LABEL}==""?"":", 3.- "+$P{LEVEL3_LABEL})
@@ -283,12 +250,11 @@
 +($P{LEVEL9_LABEL}==""?"":", 9.- "+$P{LEVEL9_LABEL})
 +($P{LEVEL10_LABEL}==""?"":", 10.- "+$P{LEVEL10_LABEL})]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale">
 		<defaultValueExpression><![CDATA[new Locale("en","US")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10,
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<query language="sql"><![CDATA[SELECT NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10,
       SUM(AMOUNT) AS AMOUNT, SUM(QTY) AS QTY, SUM(WEIGHT) AS WEIGHT, SUM(COST) AS COST,
       SUM(AMOUNTREF) AS AMOUNTREF, SUM(QTYREF) AS QTYREF, SUM(WEIGHTREF) AS WEIGHTREF, SUM(COSTREF) AS COSTREF, UOMSYMBOL,
       SUM(CONVAMOUNT) AS CONVAMOUNT,
@@ -358,8 +324,7 @@
       AND 2=2
       ORDER BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10) AA
       GROUP BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10, UOMSYMBOL, TRCURRENCYID, TRDATE, TRCLIENTID, TRORGID) ZZ
-      GROUP BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10, UOMSYMBOL, CONVSYM, CONVISOSYM, 1]]>
-	</queryString>
+      GROUP BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10, UOMSYMBOL, CONVSYM, CONVISOSYM, 1]]></query>
 	<field name="NIVEL1" class="java.lang.String"/>
 	<field name="NIVEL2" class="java.lang.String"/>
 	<field name="NIVEL3" class="java.lang.String"/>
@@ -388,996 +353,895 @@
 	<field name="CONVSYM" class="java.lang.String"/>
 	<field name="CONVISOSYM" class="java.lang.String"/>
 	<field name="COSTCALCULATED" class="java.lang.Integer"/>
-	<variable name="QTY_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="AMOUNT_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="COST_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="PROFIT_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM1}.subtract($V{COST_SUM1})]]></variableExpression>
+	<variable name="PROFIT_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM1}.subtract($V{COST_SUM1})]]></expression>
 	</variable>
-	<variable name="PROFIT_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM2}.subtract($V{COST_SUM2})]]></variableExpression>
+	<variable name="PROFIT_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM2}.subtract($V{COST_SUM2})]]></expression>
 	</variable>
-	<variable name="PROFIT_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM3}.subtract($V{COST_SUM3})]]></variableExpression>
+	<variable name="PROFIT_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM3}.subtract($V{COST_SUM3})]]></expression>
 	</variable>
-	<variable name="PROFIT_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM4}.subtract($V{COST_SUM4})]]></variableExpression>
+	<variable name="PROFIT_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM4}.subtract($V{COST_SUM4})]]></expression>
 	</variable>
-	<variable name="PROFIT_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM5}.subtract($V{COST_SUM5})]]></variableExpression>
+	<variable name="PROFIT_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM5}.subtract($V{COST_SUM5})]]></expression>
 	</variable>
-	<variable name="PROFIT_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM6}.subtract($V{COST_SUM6})]]></variableExpression>
+	<variable name="PROFIT_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM6}.subtract($V{COST_SUM6})]]></expression>
 	</variable>
-	<variable name="PROFIT_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM7}.subtract($V{COST_SUM7})]]></variableExpression>
+	<variable name="PROFIT_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM7}.subtract($V{COST_SUM7})]]></expression>
 	</variable>
-	<variable name="PROFIT_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM8}.subtract($V{COST_SUM8})]]></variableExpression>
+	<variable name="PROFIT_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM8}.subtract($V{COST_SUM8})]]></expression>
 	</variable>
-	<variable name="PROFIT_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM9}.subtract($V{COST_SUM9})]]></variableExpression>
+	<variable name="PROFIT_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM9}.subtract($V{COST_SUM9})]]></expression>
 	</variable>
-	<variable name="PROFIT_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM10}.subtract($V{COST_SUM10})]]></variableExpression>
+	<variable name="PROFIT_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM10}.subtract($V{COST_SUM10})]]></expression>
 	</variable>
-	<variable name="PROFITREF_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM1}.subtract($V{COSTREF_SUM1})]]></variableExpression>
+	<variable name="PROFITREF_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM1}.subtract($V{COSTREF_SUM1})]]></expression>
 	</variable>
-	<variable name="PROFITREF_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM2}.subtract($V{COSTREF_SUM2})]]></variableExpression>
+	<variable name="PROFITREF_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM2}.subtract($V{COSTREF_SUM2})]]></expression>
 	</variable>
-	<variable name="PROFITREF_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM3}.subtract($V{COSTREF_SUM3})]]></variableExpression>
+	<variable name="PROFITREF_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM3}.subtract($V{COSTREF_SUM3})]]></expression>
 	</variable>
-	<variable name="PROFITREF_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM4}.subtract($V{COSTREF_SUM4})]]></variableExpression>
+	<variable name="PROFITREF_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM4}.subtract($V{COSTREF_SUM4})]]></expression>
 	</variable>
-	<variable name="PROFITREF_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM5}.subtract($V{COSTREF_SUM5})]]></variableExpression>
+	<variable name="PROFITREF_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM5}.subtract($V{COSTREF_SUM5})]]></expression>
 	</variable>
-	<variable name="PROFITREF_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM6}.subtract($V{COSTREF_SUM6})]]></variableExpression>
+	<variable name="PROFITREF_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM6}.subtract($V{COSTREF_SUM6})]]></expression>
 	</variable>
-	<variable name="PROFITREF_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM7}.subtract($V{COSTREF_SUM7})]]></variableExpression>
+	<variable name="PROFITREF_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM7}.subtract($V{COSTREF_SUM7})]]></expression>
 	</variable>
-	<variable name="PROFITREF_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM8}.subtract($V{COSTREF_SUM8})]]></variableExpression>
+	<variable name="PROFITREF_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM8}.subtract($V{COSTREF_SUM8})]]></expression>
 	</variable>
-	<variable name="PROFITREF_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM9}.subtract($V{COSTREF_SUM9})]]></variableExpression>
+	<variable name="PROFITREF_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM9}.subtract($V{COSTREF_SUM9})]]></expression>
 	</variable>
-	<variable name="PROFITREF_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM10}.subtract($V{COSTREF_SUM10})]]></variableExpression>
+	<variable name="PROFITREF_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM10}.subtract($V{COSTREF_SUM10})]]></expression>
 	</variable>
-	<variable name="MARGIN_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_1}.divide( $V{AMOUNT_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_1}.signum()))]]></variableExpression>
+	<variable name="MARGIN_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_1}.divide( $V{AMOUNT_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_1}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_2}.divide( $V{AMOUNT_SUM2}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_2}.signum()))]]></variableExpression>
+	<variable name="MARGIN_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_2}.divide( $V{AMOUNT_SUM2}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_2}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_3}.divide( $V{AMOUNT_SUM3}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_3}.signum()))]]></variableExpression>
+	<variable name="MARGIN_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_3}.divide( $V{AMOUNT_SUM3}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_3}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_4}.divide( $V{AMOUNT_SUM4}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_4}.signum()))]]></variableExpression>
+	<variable name="MARGIN_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_4}.divide( $V{AMOUNT_SUM4}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_4}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_5}.divide( $V{AMOUNT_SUM5}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_5}.signum()))]]></variableExpression>
+	<variable name="MARGIN_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_5}.divide( $V{AMOUNT_SUM5}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_5}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_6}.divide( $V{AMOUNT_SUM6}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_6}.signum()))]]></variableExpression>
+	<variable name="MARGIN_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_6}.divide( $V{AMOUNT_SUM6}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_6}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_7}.divide( $V{AMOUNT_SUM7}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_7}.signum()))]]></variableExpression>
+	<variable name="MARGIN_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_7}.divide( $V{AMOUNT_SUM7}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_7}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_8}.divide( $V{AMOUNT_SUM8}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_8}.signum()))]]></variableExpression>
+	<variable name="MARGIN_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_8}.divide( $V{AMOUNT_SUM8}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_8}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_9}.divide( $V{AMOUNT_SUM9}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_9}.signum()))]]></variableExpression>
+	<variable name="MARGIN_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_9}.divide( $V{AMOUNT_SUM9}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_9}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{PROFIT_10}.divide( $V{AMOUNT_SUM10}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_10}.signum()))]]></variableExpression>
+	<variable name="MARGIN_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{PROFIT_10}.divide( $V{AMOUNT_SUM10}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_10}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM1}.compareTo(BigDecimal.ZERO)==0)?BigDecimal.ZERO:$V{PROFITREF_1}.divide( $V{AMOUNTREF_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_1}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM1}.compareTo(BigDecimal.ZERO)==0)?BigDecimal.ZERO:$V{PROFITREF_1}.divide( $V{AMOUNTREF_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_1}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_2}.divide( $V{AMOUNTREF_SUM2}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_2}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_2}.divide( $V{AMOUNTREF_SUM2}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_2}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_3}.divide( $V{AMOUNTREF_SUM3}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_3}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_3}.divide( $V{AMOUNTREF_SUM3}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_3}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_4}.divide( $V{AMOUNTREF_SUM4}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_4}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_4}.divide( $V{AMOUNTREF_SUM4}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_4}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_5}.divide( $V{AMOUNTREF_SUM5}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_5}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_5}.divide( $V{AMOUNTREF_SUM5}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_5}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_6}.divide( $V{AMOUNTREF_SUM6}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_6}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_6}.divide( $V{AMOUNTREF_SUM6}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_6}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_7}.divide( $V{AMOUNTREF_SUM7}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_7}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_7}.divide( $V{AMOUNTREF_SUM7}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_7}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_8}.divide( $V{AMOUNTREF_SUM8}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_8}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_8}.divide( $V{AMOUNTREF_SUM8}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_8}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_9}.divide( $V{AMOUNTREF_SUM9}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_9}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_9}.divide( $V{AMOUNTREF_SUM9}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_9}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{PROFITREF_10}.divide( $V{AMOUNTREF_SUM10}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_10}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{PROFITREF_10}.divide( $V{AMOUNTREF_SUM10}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_10}.signum()))]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM1}.subtract($V{AMOUNTREF_SUM1}).divide( $V{AMOUNTREF_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM1}.subtract($V{AMOUNTREF_SUM1}).divide( $V{AMOUNTREF_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM2}.subtract($V{AMOUNTREF_SUM2}).divide( $V{AMOUNTREF_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM2}.subtract($V{AMOUNTREF_SUM2}).divide( $V{AMOUNTREF_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM3}.subtract($V{AMOUNTREF_SUM3}).divide( $V{AMOUNTREF_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM3}.subtract($V{AMOUNTREF_SUM3}).divide( $V{AMOUNTREF_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM4}.subtract($V{AMOUNTREF_SUM4}).divide( $V{AMOUNTREF_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM4}.subtract($V{AMOUNTREF_SUM4}).divide( $V{AMOUNTREF_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM5}.subtract($V{AMOUNTREF_SUM5}).divide( $V{AMOUNTREF_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM5}.subtract($V{AMOUNTREF_SUM5}).divide( $V{AMOUNTREF_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM6}.subtract($V{AMOUNTREF_SUM6}).divide( $V{AMOUNTREF_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM6}.subtract($V{AMOUNTREF_SUM6}).divide( $V{AMOUNTREF_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM7}.subtract($V{AMOUNTREF_SUM7}).divide( $V{AMOUNTREF_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM7}.subtract($V{AMOUNTREF_SUM7}).divide( $V{AMOUNTREF_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM8}.subtract($V{AMOUNTREF_SUM8}).divide( $V{AMOUNTREF_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM8}.subtract($V{AMOUNTREF_SUM8}).divide( $V{AMOUNTREF_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM9}.subtract($V{AMOUNTREF_SUM9}).divide( $V{AMOUNTREF_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM9}.subtract($V{AMOUNTREF_SUM9}).divide( $V{AMOUNTREF_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM10}.subtract($V{AMOUNTREF_SUM10}).divide( $V{AMOUNTREF_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM10}.subtract($V{AMOUNTREF_SUM10}).divide( $V{AMOUNTREF_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
 	<variable name="AMOUNT_PERTOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[($V{AMOUNTREF_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_TOTAL}.subtract($V{AMOUNTREF_TOTAL}).divide( $V{AMOUNTREF_TOTAL}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+		<expression><![CDATA[($V{AMOUNTREF_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_TOTAL}.subtract($V{AMOUNTREF_TOTAL}).divide( $V{AMOUNTREF_TOTAL}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{QTYREF_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM1}.subtract($V{QTYREF_SUM1}).divide( $V{QTYREF_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM1}.subtract($V{QTYREF_SUM1}).divide( $V{QTYREF_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{QTYREF_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM2}.subtract($V{QTYREF_SUM2}).divide( $V{QTYREF_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM2}.subtract($V{QTYREF_SUM2}).divide( $V{QTYREF_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{QTYREF_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM3}.subtract($V{QTYREF_SUM3}).divide( $V{QTYREF_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM3}.subtract($V{QTYREF_SUM3}).divide( $V{QTYREF_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{QTYREF_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM4}.subtract($V{QTYREF_SUM4}).divide( $V{QTYREF_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM4}.subtract($V{QTYREF_SUM4}).divide( $V{QTYREF_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{QTYREF_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM5}.subtract($V{QTYREF_SUM5}).divide( $V{QTYREF_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM5}.subtract($V{QTYREF_SUM5}).divide( $V{QTYREF_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{QTYREF_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM6}.subtract($V{QTYREF_SUM6}).divide( $V{QTYREF_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM6}.subtract($V{QTYREF_SUM6}).divide( $V{QTYREF_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{QTYREF_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM7}.subtract($V{QTYREF_SUM7}).divide( $V{QTYREF_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM7}.subtract($V{QTYREF_SUM7}).divide( $V{QTYREF_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{QTYREF_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM8}.subtract($V{QTYREF_SUM8}).divide( $V{QTYREF_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM8}.subtract($V{QTYREF_SUM8}).divide( $V{QTYREF_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{QTYREF_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM9}.subtract($V{QTYREF_SUM9}).divide( $V{QTYREF_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM9}.subtract($V{QTYREF_SUM9}).divide( $V{QTYREF_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{QTYREF_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM10}.subtract($V{QTYREF_SUM10}).divide( $V{QTYREF_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM10}.subtract($V{QTYREF_SUM10}).divide( $V{QTYREF_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{MARGIN_1}!=null && $V{MARGINREF_1}!=null )?$V{MARGIN_1}.subtract( $V{MARGINREF_1}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_1}!=null && $V{MARGINREF_1}!=null )?$V{MARGIN_1}.subtract( $V{MARGINREF_1}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{MARGIN_2}!=null && $V{MARGINREF_2}!=null )?$V{MARGIN_2}.subtract( $V{MARGINREF_2}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_2}!=null && $V{MARGINREF_2}!=null )?$V{MARGIN_2}.subtract( $V{MARGINREF_2}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{MARGIN_3}!=null && $V{MARGINREF_3}!=null )?$V{MARGIN_3}.subtract( $V{MARGINREF_3}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_3}!=null && $V{MARGINREF_3}!=null )?$V{MARGIN_3}.subtract( $V{MARGINREF_3}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{MARGIN_4}!=null && $V{MARGINREF_4}!=null )?$V{MARGIN_4}.subtract( $V{MARGINREF_4}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_4}!=null && $V{MARGINREF_4}!=null )?$V{MARGIN_4}.subtract( $V{MARGINREF_4}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{MARGIN_5}!=null && $V{MARGINREF_5}!=null )?$V{MARGIN_5}.subtract( $V{MARGINREF_5}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_5}!=null && $V{MARGINREF_5}!=null )?$V{MARGIN_5}.subtract( $V{MARGINREF_5}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{MARGIN_6}!=null && $V{MARGINREF_6}!=null )?$V{MARGIN_6}.subtract( $V{MARGINREF_6}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_6}!=null && $V{MARGINREF_6}!=null )?$V{MARGIN_6}.subtract( $V{MARGINREF_6}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{MARGIN_7}!=null && $V{MARGINREF_7}!=null )?$V{MARGIN_7}.subtract( $V{MARGINREF_7}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_7}!=null && $V{MARGINREF_7}!=null )?$V{MARGIN_7}.subtract( $V{MARGINREF_7}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{MARGIN_8}!=null && $V{MARGINREF_8}!=null )?$V{MARGIN_8}.subtract( $V{MARGINREF_8}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_8}!=null && $V{MARGINREF_8}!=null )?$V{MARGIN_8}.subtract( $V{MARGINREF_8}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{MARGIN_9}!=null && $V{MARGINREF_9}!=null )?$V{MARGIN_9}.subtract( $V{MARGINREF_9}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_9}!=null && $V{MARGINREF_9}!=null )?$V{MARGIN_9}.subtract( $V{MARGINREF_9}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{MARGIN_10}!=null && $V{MARGINREF_10}!=null )?$V{MARGIN_10}.subtract( $V{MARGINREF_10}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_10}!=null && $V{MARGINREF_10}!=null )?$V{MARGIN_10}.subtract( $V{MARGINREF_10}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="QTY_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="COST_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
 	<variable name="PROFIT_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{AMOUNT_TOTAL}.subtract($V{COST_TOTAL})]]></variableExpression>
+		<expression><![CDATA[$V{AMOUNT_TOTAL}.subtract($V{COST_TOTAL})]]></expression>
 	</variable>
 	<variable name="MARGIN_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[($V{AMOUNT_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_TOTAL}.divide($V{AMOUNT_TOTAL}, 10, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).abs().multiply(new BigDecimal($V{PROFIT_TOTAL}.signum()))]]></variableExpression>
+		<expression><![CDATA[($V{AMOUNT_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_TOTAL}.divide($V{AMOUNT_TOTAL}, 10, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).abs().multiply(new BigDecimal($V{PROFIT_TOTAL}.signum()))]]></expression>
 	</variable>
-	<variable name="COSTREF_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
 	<variable name="PROREF_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{AMOUNTREF_TOTAL}.subtract($V{COSTREF_TOTAL})]]></variableExpression>
+		<expression><![CDATA[$V{AMOUNTREF_TOTAL}.subtract($V{COSTREF_TOTAL})]]></expression>
 	</variable>
 	<variable name="MARGINREF_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[($V{AMOUNTREF_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROREF_TOTAL}.divide($V{AMOUNTREF_TOTAL}, 10, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROREF_TOTAL}.signum()))]]></variableExpression>
+		<expression><![CDATA[($V{AMOUNTREF_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROREF_TOTAL}.divide($V{AMOUNTREF_TOTAL}, 10, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROREF_TOTAL}.signum()))]]></expression>
 	</variable>
 	<variable name="MARGINDIFF_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{MARGIN_TOTAL}.subtract($V{MARGINREF_TOTAL})]]></variableExpression>
+		<expression><![CDATA[$V{MARGIN_TOTAL}.subtract($V{MARGINREF_TOTAL})]]></expression>
 	</variable>
 	<group name="DocumentType"/>
 	<group name="TOTALIZE">
-		<groupExpression><![CDATA[]]></groupExpression>
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band splitType="Stretch"/>
 		</groupHeader>
 		<groupFooter>
 			<band height="23" splitType="Stretch">
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-21" style="Total_Field" x="224" y="1" width="71" height="16" uuid="57cacc90-ac90-4ddb-aaa8-347d7df7a24d"/>
-					<box leftPadding="0">
+				<element kind="textField" uuid="57cacc90-ac90-4ddb-aaa8-347d7df7a24d" key="textField-21" x="224" y="1" width="71" height="16" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{AMOUNT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-8" style="Report_Data_Label" x="150" y="1" width="74" height="16" uuid="47ada3f5-8ae7-4f61-ad04-bc26fa4e3ee9"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle"/>
+				</element>
+				<element kind="staticText" uuid="47ada3f5-8ae7-4f61-ad04-bc26fa4e3ee9" key="staticText-8" x="150" y="1" width="74" height="16" hTextAlign="Right" vTextAlign="Middle" style="Report_Data_Label">
 					<text><![CDATA[Total:]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-3" x="0" y="0" width="980" height="1" uuid="174f9c2c-4e55-474e-844a-89b1df0fb078"/>
-				</line>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-23" style="Detail_Header" mode="Opaque" x="15" y="1" width="15" height="16" uuid="71224feb-b32d-44bc-bc44-8c970e09455c">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+					<box style="Report_Data_Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" evaluationTime="Report" pattern="##0.00" isBlankWhenNull="true">
-					<reportElement key="textField-22" style="Detail_Header" x="0" y="1" width="15" height="16" uuid="3766a8af-ecc9-4ab4-9ff8-e5cf31a846ca">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="line" uuid="174f9c2c-4e55-474e-844a-89b1df0fb078" key="line-3" x="0" y="0" width="980" height="1"/>
+				<element kind="textField" uuid="71224feb-b32d-44bc-bc44-8c970e09455c" key="textField-23" mode="Opaque" x="15" y="1" width="15" height="16" rotation="None" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-24" style="Detail_Header" mode="Opaque" x="30" y="1" width="15" height="16" uuid="3d358d59-8ccb-4d5e-8dfe-9619c3695ffc">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="3766a8af-ecc9-4ab4-9ff8-e5cf31a846ca" key="textField-22" x="0" y="1" width="15" height="16" rotation="None" textAdjust="StretchHeight" evaluationTime="Report" pattern="##0.00" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-25" style="Detail_Header" mode="Opaque" x="45" y="1" width="15" height="16" uuid="6952b509-da12-46c8-ad9d-b25427e87da7">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="3d358d59-8ccb-4d5e-8dfe-9619c3695ffc" key="textField-24" mode="Opaque" x="30" y="1" width="15" height="16" rotation="None" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-26" style="Detail_Header" mode="Opaque" x="60" y="1" width="15" height="16" uuid="8f41229a-c87e-42ca-a309-9e322262d766">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="6952b509-da12-46c8-ad9d-b25427e87da7" key="textField-25" mode="Opaque" x="45" y="1" width="15" height="16" rotation="None" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-204" style="Total_Field" x="740" y="1" width="50" height="16" uuid="fd4bead2-d69c-4787-aab4-c6c1f6bfb966"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="8f41229a-c87e-42ca-a309-9e322262d766" key="textField-26" mode="Opaque" x="60" y="1" width="15" height="16" rotation="None" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":" ")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-300" style="Total_Field" x="790" y="1" width="42" height="16" uuid="5c263f92-3825-440a-b563-00d0de8998a6"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="fd4bead2-d69c-4787-aab4-c6c1f6bfb966" key="textField-204" x="740" y="1" width="50" height="16" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{WEIGHT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-301" style="Total_Field" x="447" y="1" width="71" height="16" uuid="eacce2b9-5a98-451e-9423-86d345dc84cb"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="5c263f92-3825-440a-b563-00d0de8998a6" key="textField-300" x="790" y="1" width="42" height="16" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{WEIGHTREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-302" style="Total_Field" x="670" y="1" width="40" height="16" uuid="de560cef-b3d2-44ba-bb55-2416f56d2d20"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="eacce2b9-5a98-451e-9423-86d345dc84cb" key="textField-301" x="447" y="1" width="71" height="16" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{AMOUNTREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PERTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PERTOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-303" style="Detail_Header" mode="Opaque" x="75" y="1" width="15" height="16" uuid="d1435d2e-853a-44c3-99c3-0ac1f072d812">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=6)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="de560cef-b3d2-44ba-bb55-2416f56d2d20" key="textField-302" x="670" y="1" width="40" height="16" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{AMOUNT_PERTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PERTOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(6))>=0)?"6":" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-304" style="Detail_Header" mode="Opaque" x="90" y="1" width="15" height="16" uuid="01ff3a5c-b085-45cb-b3c7-2b6a00bf6622">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=7)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="d1435d2e-853a-44c3-99c3-0ac1f072d812" key="textField-303" mode="Opaque" x="75" y="1" width="15" height="16" rotation="None" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=6)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(6))>=0)?"6":" ")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(7))>=0)?"7":" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-305" style="Detail_Header" mode="Opaque" x="105" y="1" width="15" height="16" uuid="a242cfd0-8e64-4358-a005-de3e6a3d00b7">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=8)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="01ff3a5c-b085-45cb-b3c7-2b6a00bf6622" key="textField-304" mode="Opaque" x="90" y="1" width="15" height="16" rotation="None" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=7)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(7))>=0)?"7":" ")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(8))>=0)?"8":" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-306" style="Detail_Header" mode="Opaque" x="120" y="1" width="15" height="16" uuid="4e510cb9-a006-41a7-b71a-de0a2b322e4b">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=9)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="a242cfd0-8e64-4358-a005-de3e6a3d00b7" key="textField-305" mode="Opaque" x="105" y="1" width="15" height="16" rotation="None" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=8)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(8))>=0)?"8":" ")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(9))>=0)?"9":" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-307" style="Detail_Header" mode="Opaque" x="135" y="1" width="15" height="16" uuid="4f73f3ec-f58c-4c5f-aa5d-eb0f51b1e94e">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=10)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="4e510cb9-a006-41a7-b71a-de0a2b322e4b" key="textField-306" mode="Opaque" x="120" y="1" width="15" height="16" rotation="None" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=9)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(9))>=0)?"9":" ")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(10))>=0)?"10":" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-21" style="Total_Field" x="295" y="1" width="61" height="16" uuid="a228b992-9fb1-409d-8d6d-b86a1a2ee36b"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="4f73f3ec-f58c-4c5f-aa5d-eb0f51b1e94e" key="textField-307" mode="Opaque" x="135" y="1" width="15" height="16" rotation="None" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=10)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(10))>=0)?"10":" ")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COST_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COST_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-21" style="Total_Field" x="356" y="1" width="61" height="16" uuid="034f64d3-ae0c-4d75-ad0c-8c65ffc0ec7b"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="a228b992-9fb1-409d-8d6d-b86a1a2ee36b" key="textField-21" x="295" y="1" width="61" height="16" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{COST_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COST_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFIT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-21" style="Total_Field" x="417" y="1" width="30" height="16" uuid="7c9d75cf-0d45-4ca9-ba85-9ffc37f6a365"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="034f64d3-ae0c-4d75-ad0c-8c65ffc0ec7b" key="textField-21" x="356" y="1" width="61" height="16" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{PROFIT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGIN_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-204" style="Total_Field" x="832" y="1" width="61" height="16" uuid="450effa0-d702-4031-af50-47d6d7481f57">
-						<printWhenExpression><![CDATA[$P{LEVEL1_LABEL}.equals("Product") || $P{LEVEL2_LABEL}.equals("Product") || $P{LEVEL3_LABEL}.equals("Product") || $P{LEVEL4_LABEL}.equals("Product") || $P{LEVEL5_LABEL}.equals("Product") || $P{LEVEL6_LABEL}.equals("Product") || $P{LEVEL7_LABEL}.equals("Product") || $P{LEVEL8_LABEL}.equals("Product") || $P{LEVEL9_LABEL}.equals("Product") || $P{LEVEL10_LABEL}.equals("Product")]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="7c9d75cf-0d45-4ca9-ba85-9ffc37f6a365" key="textField-21" x="417" y="1" width="30" height="16" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{MARGIN_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{QTY_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-301" style="Total_Field" x="640" y="1" width="30" height="16" uuid="7ea10d58-32b3-4149-bf00-33f6f67fc9d6"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="450effa0-d702-4031-af50-47d6d7481f57" key="textField-204" x="832" y="1" width="61" height="16" evaluationTime="Report" pattern="" blankWhenNull="false" bold="false" hTextAlign="Right" style="Total_Field">
+					<printWhenExpression><![CDATA[$P{LEVEL1_LABEL}.equals("Product") || $P{LEVEL2_LABEL}.equals("Product") || $P{LEVEL3_LABEL}.equals("Product") || $P{LEVEL4_LABEL}.equals("Product") || $P{LEVEL5_LABEL}.equals("Product") || $P{LEVEL6_LABEL}.equals("Product") || $P{LEVEL7_LABEL}.equals("Product") || $P{LEVEL8_LABEL}.equals("Product") || $P{LEVEL9_LABEL}.equals("Product") || $P{LEVEL10_LABEL}.equals("Product")]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{QTY_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGINREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-301" style="Total_Field" x="579" y="1" width="61" height="16" uuid="3edee097-752d-4f6e-af3d-d4b98f448080"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="7ea10d58-32b3-4149-bf00-33f6f67fc9d6" key="textField-301" x="640" y="1" width="30" height="16" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{MARGINREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PROREF_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-301" style="Total_Field" x="518" y="1" width="61" height="16" uuid="fc9349ef-8077-4b76-88bf-1347954b37f7"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="3edee097-752d-4f6e-af3d-d4b98f448080" key="textField-301" x="579" y="1" width="61" height="16" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{PROREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PROREF_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COSTREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-301" style="Total_Field" x="710" y="1" width="30" height="16" uuid="b93d472a-0411-44cf-9afd-d2688a31eaf1"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="fc9349ef-8077-4b76-88bf-1347954b37f7" key="textField-301" x="518" y="1" width="61" height="16" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{COSTREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="b93d472a-0411-44cf-9afd-d2688a31eaf1" key="textField-301" x="710" y="1" width="30" height="16" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{MARGINDIFF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="NIVEL1">
-		<groupExpression><![CDATA[$F{NIVEL1}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL1}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="182" height="18" uuid="c5b7e38a-5dbb-4a6d-aa17-009b9c54cdb0"/>
-					<box rightPadding="2">
+				<element kind="textField" uuid="c5b7e38a-5dbb-4a6d-aa17-009b9c54cdb0" key="textField" stretchType="ContainerHeight" x="0" y="0" width="182" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[$F{NIVEL1}]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL1}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-155" style="Level1_Line" stretchType="RelativeToBandHeight" x="224" y="0" width="71" height="18" uuid="eb20c96d-501d-42f9-ba0d-9662491a29c8"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="eb20c96d-501d-42f9-ba0d-9662491a29c8" key="textField-155" stretchType="ContainerHeight" x="224" y="0" width="71" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-154" style="Level1_Line" stretchType="RelativeToBandHeight" x="295" y="0" width="61" height="18" uuid="e2ca1f1b-c631-4357-9e2b-d1d0b6908129"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e2ca1f1b-c631-4357-9e2b-d1d0b6908129" key="textField-154" stretchType="ContainerHeight" x="295" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{COST_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COST_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-153" style="Level1_Line" stretchType="RelativeToBandHeight" x="356" y="0" width="61" height="18" uuid="08d768bf-2ba3-443a-97a4-88ca3cca871f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="08d768bf-2ba3-443a-97a4-88ca3cca871f" key="textField-153" stretchType="ContainerHeight" x="356" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{PROFIT_1}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFIT_1}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" x="417" y="0" width="30" height="18" uuid="38afd357-d66c-4c3f-93b6-e11256c0fdf2"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="38afd357-d66c-4c3f-93b6-e11256c0fdf2" key="textField" stretchType="ContainerHeight" x="417" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{MARGIN_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGIN_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-152" style="Level1_Line" stretchType="RelativeToBandHeight" x="740" y="0" width="49" height="18" uuid="f1bf8404-ce43-486f-8df1-b04f61641627"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f1bf8404-ce43-486f-8df1-b04f61641627" key="textField-152" stretchType="ContainerHeight" x="740" y="0" width="49" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" x="832" y="0" width="61" height="18" uuid="a71e7ee7-440b-4d70-a7a0-5d31c8008d12">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a71e7ee7-440b-4d70-a7a0-5d31c8008d12" key="textField" stretchType="ContainerHeight" x="832" y="0" width="61" height="18" evaluationTime="Group" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-210" style="Level1_Line" stretchType="RelativeToBandHeight" x="942" y="0" width="38" height="18" uuid="b0127499-3819-43af-abc6-1227a2b618ea">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b0127499-3819-43af-abc6-1227a2b618ea" key="textField-210" stretchType="ContainerHeight" x="942" y="0" width="38" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER1}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_PER1}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" isBlankWhenNull="false">
-					<reportElement key="textField-220" style="Level1_Line" stretchType="RelativeToBandHeight" x="893" y="0" width="49" height="18" uuid="65936c9e-9b88-4565-891c-1b9643145f1c">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="65936c9e-9b88-4565-891c-1b9643145f1c" key="textField-220" stretchType="ContainerHeight" x="893" y="0" width="49" height="18" evaluationTime="Group" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-230" style="Level1_Line" stretchType="RelativeToBandHeight" x="789" y="0" width="43" height="18" uuid="1735b783-8176-49ef-9af5-5277e027c985"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1735b783-8176-49ef-9af5-5277e027c985" key="textField-230" stretchType="ContainerHeight" x="789" y="0" width="43" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-240" style="Level1_Line" stretchType="RelativeToBandHeight" x="710" y="0" width="30" height="18" uuid="94bd9de6-6f9b-4b67-bc1a-60f146246cff"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="94bd9de6-6f9b-4b67-bc1a-60f146246cff" key="textField-240" stretchType="ContainerHeight" x="710" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{MARGINDIFF_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-250" style="Level1_Line" stretchType="RelativeToBandHeight" x="670" y="0" width="40" height="18" uuid="4b5e0716-63ee-47f5-b4fe-48e9d527fe80"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4b5e0716-63ee-47f5-b4fe-48e9d527fe80" key="textField-250" stretchType="ContainerHeight" x="670" y="0" width="40" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{AMOUNT_PER1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-260" style="Level1_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="30" height="18" uuid="f3bc6783-926d-41fb-baa9-03fd1c60f8dc"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f3bc6783-926d-41fb-baa9-03fd1c60f8dc" key="textField-260" stretchType="ContainerHeight" x="640" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{MARGINREF_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGINREF_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-270" style="Level1_Line" stretchType="RelativeToBandHeight" x="579" y="0" width="61" height="18" uuid="a269a983-5c02-4922-a98c-7e8a29bd97cb"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a269a983-5c02-4922-a98c-7e8a29bd97cb" key="textField-270" stretchType="ContainerHeight" x="579" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{PROFITREF_1}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFITREF_1}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-280" style="Level1_Line" stretchType="RelativeToBandHeight" x="518" y="0" width="61" height="18" uuid="613b5d00-7ed0-4dd8-8916-4e6f0ce43087"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="613b5d00-7ed0-4dd8-8916-4e6f0ce43087" key="textField-280" stretchType="ContainerHeight" x="518" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{COSTREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-290" style="Level1_Line" stretchType="RelativeToBandHeight" x="447" y="0" width="71" height="18" uuid="acce17cd-3250-4b5e-a4c6-573daacb24b1"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="acce17cd-3250-4b5e-a4c6-573daacb24b1" key="textField-290" stretchType="ContainerHeight" x="447" y="0" width="71" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Auto" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-309" style="Level1_Line" stretchType="RelativeToBandHeight" x="182" y="0" width="42" height="18" uuid="d7cfc842-75b0-43a7-8853-cdf7a04aac63"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="d7cfc842-75b0-43a7-8853-cdf7a04aac63" key="textField-309" stretchType="ContainerHeight" x="182" y="0" width="42" height="18" fontSize="7.0" evaluationTime="Auto" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Level1_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM1}!=null && $V{AMOUNT_TOTAL}!=null)?new String("(") + $P{NUMBERFORMAT}.format($V{AMOUNT_SUM1}.doubleValue() / $V{AMOUNT_TOTAL}.doubleValue() * 100.00 ) + new String(" %)"):new String(" ")]]></expression>
+					<box rightPadding="3" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM1}!=null && $V{AMOUNT_TOTAL}!=null)?new String("(") + $P{NUMBERFORMAT}.format($V{AMOUNT_SUM1}.doubleValue() / $V{AMOUNT_TOTAL}.doubleValue() * 100.00 ) + new String(" %)"):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -1387,202 +1251,166 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL2">
-		<groupExpression><![CDATA[$F{NIVEL2}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL2}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-2" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="9dc86b69-e7ec-4566-9032-9d96ee974c89"/>
-					<box>
+				<element kind="textField" uuid="9dc86b69-e7ec-4566-9032-9d96ee974c89" key="textField-2" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="209" height="18" uuid="179cce38-da3b-46b5-b184-80865c1879cb"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="179cce38-da3b-46b5-b184-80865c1879cb" key="textField" stretchType="ContainerHeight" x="15" y="0" width="209" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[$F{NIVEL2}]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL2}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" x="224" y="0" width="71" height="18" uuid="0002853c-7461-4788-a491-fafd6e8b5a1b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0002853c-7461-4788-a491-fafd6e8b5a1b" key="textField" stretchType="ContainerHeight" x="224" y="0" width="71" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" x="832" y="0" width="61" height="18" uuid="f4162356-4429-4d21-94f8-c9879ccc7bdc">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f4162356-4429-4d21-94f8-c9879ccc7bdc" key="textField" stretchType="ContainerHeight" x="832" y="0" width="61" height="18" evaluationTime="Group" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-156" style="Level2_Line" stretchType="RelativeToBandHeight" x="295" y="0" width="61" height="18" uuid="ae0eaa66-094a-4513-97c2-929e9777185f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ae0eaa66-094a-4513-97c2-929e9777185f" key="textField-156" stretchType="ContainerHeight" x="295" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{COST_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COST_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-157" style="Level2_Line" stretchType="RelativeToBandHeight" x="356" y="0" width="61" height="18" uuid="753f3027-32b1-4624-b5cc-1be60810ae1a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="753f3027-32b1-4624-b5cc-1be60810ae1a" key="textField-157" stretchType="ContainerHeight" x="356" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{PROFIT_2}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFIT_2}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-158" style="Level2_Line" stretchType="RelativeToBandHeight" x="417" y="0" width="30" height="18" uuid="9f13969b-713b-41b3-9bf7-839ba1e32ca9"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9f13969b-713b-41b3-9bf7-839ba1e32ca9" key="textField-158" stretchType="ContainerHeight" x="417" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{MARGIN_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGIN_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-159" style="Level2_Line" stretchType="RelativeToBandHeight" x="740" y="0" width="50" height="18" uuid="7cf8ba12-df39-4a33-853a-8ba7fd445556"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7cf8ba12-df39-4a33-853a-8ba7fd445556" key="textField-159" stretchType="ContainerHeight" x="740" y="0" width="50" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-211" style="Level2_Line" stretchType="RelativeToBandHeight" x="942" y="0" width="38" height="18" uuid="17c906da-4342-4c92-b4e2-3c4bfed5fb6f">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="17c906da-4342-4c92-b4e2-3c4bfed5fb6f" key="textField-211" stretchType="ContainerHeight" x="942" y="0" width="38" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER2}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_PER2}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" isBlankWhenNull="false">
-					<reportElement key="textField-221" style="Level2_Line" stretchType="RelativeToBandHeight" x="893" y="0" width="49" height="18" uuid="f1b8346b-88d1-400d-a0b2-71bf8720e222">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f1b8346b-88d1-400d-a0b2-71bf8720e222" key="textField-221" stretchType="ContainerHeight" x="893" y="0" width="49" height="18" evaluationTime="Group" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-231" style="Level2_Line" stretchType="RelativeToBandHeight" x="790" y="0" width="42" height="18" uuid="f6c99b34-fbc2-4bf9-96b8-b58906c22a78"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f6c99b34-fbc2-4bf9-96b8-b58906c22a78" key="textField-231" stretchType="ContainerHeight" x="790" y="0" width="42" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-241" style="Level2_Line" stretchType="RelativeToBandHeight" x="710" y="0" width="30" height="18" uuid="d112e6e3-1534-4797-8b11-9477f0bf0a1f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d112e6e3-1534-4797-8b11-9477f0bf0a1f" key="textField-241" stretchType="ContainerHeight" x="710" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{MARGINDIFF_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-251" style="Level2_Line" stretchType="RelativeToBandHeight" x="670" y="0" width="40" height="18" uuid="4d253085-204d-43eb-ac83-a6a6e856b42a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4d253085-204d-43eb-ac83-a6a6e856b42a" key="textField-251" stretchType="ContainerHeight" x="670" y="0" width="40" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{AMOUNT_PER2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-261" style="Level2_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="30" height="18" uuid="23f3773f-482b-44bf-aa62-9f88a357e563"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="23f3773f-482b-44bf-aa62-9f88a357e563" key="textField-261" stretchType="ContainerHeight" x="640" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{MARGINREF_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGINREF_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-271" style="Level2_Line" stretchType="RelativeToBandHeight" x="579" y="0" width="61" height="18" uuid="2424ad97-6a49-4bc4-831d-6608c93314a7"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2424ad97-6a49-4bc4-831d-6608c93314a7" key="textField-271" stretchType="ContainerHeight" x="579" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{PROFITREF_2}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFITREF_2}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-281" style="Level2_Line" stretchType="RelativeToBandHeight" x="518" y="0" width="61" height="18" uuid="705ebd6a-c391-4214-aa92-c84c74eaab13"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="705ebd6a-c391-4214-aa92-c84c74eaab13" key="textField-281" stretchType="ContainerHeight" x="518" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{COSTREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-291" style="Level2_Line" stretchType="RelativeToBandHeight" x="447" y="0" width="71" height="18" uuid="acdadf6f-d051-47d9-9c1e-0faac11942e3"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="acdadf6f-d051-47d9-9c1e-0faac11942e3" key="textField-291" stretchType="ContainerHeight" x="447" y="0" width="71" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -1592,213 +1420,175 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL3">
-		<groupExpression><![CDATA[$F{NIVEL3}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL3}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-3" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="7dc3c877-877c-48f4-9031-fcf0741c3362"/>
-					<box>
+				<element kind="textField" uuid="7dc3c877-877c-48f4-9031-fcf0741c3362" key="textField-3" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-8" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="7795729c-1f87-4ef4-9850-9ddf1300923e"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="7795729c-1f87-4ef4-9850-9ddf1300923e" key="textField-8" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="194" height="18" uuid="312ea578-520c-49b1-8b52-56368bea5c20"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="312ea578-520c-49b1-8b52-56368bea5c20" key="textField" stretchType="ContainerHeight" x="30" y="0" width="194" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[$F{NIVEL3}]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL3}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" x="224" y="0" width="71" height="18" uuid="37d72728-a606-4446-9d65-39acd6c7ced9"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="37d72728-a606-4446-9d65-39acd6c7ced9" key="textField" stretchType="ContainerHeight" x="224" y="0" width="71" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" x="832" y="0" width="61" height="18" uuid="416cdff9-ce4f-4fcc-bc94-843e253685e8">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="416cdff9-ce4f-4fcc-bc94-843e253685e8" key="textField" stretchType="ContainerHeight" x="832" y="0" width="61" height="18" evaluationTime="Group" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-160" style="Level3_Line" stretchType="RelativeToBandHeight" x="295" y="0" width="61" height="18" uuid="8153f3f5-73ec-4645-be19-83a723cc2b5e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="8153f3f5-73ec-4645-be19-83a723cc2b5e" key="textField-160" stretchType="ContainerHeight" x="295" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{COST_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COST_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-161" style="Level3_Line" stretchType="RelativeToBandHeight" x="356" y="0" width="61" height="18" uuid="44738dc2-af3c-4558-876d-79ae12a68f47"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="44738dc2-af3c-4558-876d-79ae12a68f47" key="textField-161" stretchType="ContainerHeight" x="356" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{PROFIT_3}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFIT_3}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-162" style="Level3_Line" stretchType="RelativeToBandHeight" x="417" y="0" width="30" height="18" uuid="13f0fa2a-7f84-40ef-bfec-4cb43a149bb7"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="13f0fa2a-7f84-40ef-bfec-4cb43a149bb7" key="textField-162" stretchType="ContainerHeight" x="417" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{MARGIN_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGIN_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-163" style="Level3_Line" stretchType="RelativeToBandHeight" x="740" y="0" width="50" height="18" uuid="dda1904c-11f5-46e1-bc17-6d6f84783796"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="dda1904c-11f5-46e1-bc17-6d6f84783796" key="textField-163" stretchType="ContainerHeight" x="740" y="0" width="50" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-212" style="Level3_Line" stretchType="RelativeToBandHeight" x="942" y="0" width="38" height="18" uuid="4b41b481-dabb-41aa-8910-9e1973a3cfbc">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4b41b481-dabb-41aa-8910-9e1973a3cfbc" key="textField-212" stretchType="ContainerHeight" x="942" y="0" width="38" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER3}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_PER3}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" isBlankWhenNull="false">
-					<reportElement key="textField-222" style="Level3_Line" stretchType="RelativeToBandHeight" x="893" y="0" width="49" height="18" uuid="0fc4dac8-eefc-46aa-840c-88964d809533">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0fc4dac8-eefc-46aa-840c-88964d809533" key="textField-222" stretchType="ContainerHeight" x="893" y="0" width="49" height="18" evaluationTime="Group" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-232" style="Level3_Line" stretchType="RelativeToBandHeight" x="790" y="0" width="42" height="18" uuid="cb133795-362e-4889-bd5d-d7c79353692b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="cb133795-362e-4889-bd5d-d7c79353692b" key="textField-232" stretchType="ContainerHeight" x="790" y="0" width="42" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-242" style="Level3_Line" stretchType="RelativeToBandHeight" x="710" y="0" width="30" height="18" uuid="ccae8f39-c9fe-4b02-8fc0-976de270051f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ccae8f39-c9fe-4b02-8fc0-976de270051f" key="textField-242" stretchType="ContainerHeight" x="710" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{MARGINDIFF_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-252" style="Level3_Line" stretchType="RelativeToBandHeight" x="670" y="0" width="40" height="18" uuid="4b712e52-f497-4e91-ac49-737f08eb2786"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4b712e52-f497-4e91-ac49-737f08eb2786" key="textField-252" stretchType="ContainerHeight" x="670" y="0" width="40" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{AMOUNT_PER3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-262" style="Level3_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="30" height="18" uuid="e4fd9954-3de8-4c7d-a8d9-a0d13c06be9a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e4fd9954-3de8-4c7d-a8d9-a0d13c06be9a" key="textField-262" stretchType="ContainerHeight" x="640" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{MARGINREF_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGINREF_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-272" style="Level3_Line" stretchType="RelativeToBandHeight" x="579" y="0" width="61" height="18" uuid="375cb44c-6e78-4909-b5e5-98090cf2013b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="375cb44c-6e78-4909-b5e5-98090cf2013b" key="textField-272" stretchType="ContainerHeight" x="579" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{PROFITREF_3}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFITREF_3}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-282" style="Level3_Line" stretchType="RelativeToBandHeight" x="518" y="0" width="61" height="18" uuid="31a92ae4-9fdc-4bd8-b9c5-d106a129e0fe"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="31a92ae4-9fdc-4bd8-b9c5-d106a129e0fe" key="textField-282" stretchType="ContainerHeight" x="518" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{COSTREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-292" style="Level3_Line" stretchType="RelativeToBandHeight" x="447" y="0" width="71" height="18" uuid="d25756f5-68ea-4be3-8835-e8da59793fe7"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d25756f5-68ea-4be3-8835-e8da59793fe7" key="textField-292" stretchType="ContainerHeight" x="447" y="0" width="71" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -1808,224 +1598,184 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL4">
-		<groupExpression><![CDATA[$F{NIVEL4}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL4}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-4" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="77f3970e-3959-49e4-938d-b99e76967851"/>
-					<box>
+				<element kind="textField" uuid="77f3970e-3959-49e4-938d-b99e76967851" key="textField-4" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-9" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="dffd0bdc-0fb7-4301-bb47-bf884810fd52"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="dffd0bdc-0fb7-4301-bb47-bf884810fd52" key="textField-9" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-6" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="99a57f8f-79f0-41c3-afeb-7bc2a821f4ef"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="99a57f8f-79f0-41c3-afeb-7bc2a821f4ef" key="textField-6" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="179" height="18" uuid="780abe96-ffd6-42f4-9b0b-05a2307c4058"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="780abe96-ffd6-42f4-9b0b-05a2307c4058" key="textField" stretchType="ContainerHeight" x="45" y="0" width="179" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[$F{NIVEL4}]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL4}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" x="224" y="0" width="71" height="18" uuid="00f0f2c6-a64e-411d-ae01-028ec21b21f5"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="00f0f2c6-a64e-411d-ae01-028ec21b21f5" key="textField" stretchType="ContainerHeight" x="224" y="0" width="71" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" x="832" y="0" width="61" height="18" uuid="ad1ece60-358f-4942-8376-7ffe42f67bee">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ad1ece60-358f-4942-8376-7ffe42f67bee" key="textField" stretchType="ContainerHeight" x="832" y="0" width="61" height="18" evaluationTime="Group" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-164" style="Level4_Line" stretchType="RelativeToBandHeight" x="295" y="0" width="61" height="18" uuid="fd10f506-a8fd-4caf-acc0-2936ec20988a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="fd10f506-a8fd-4caf-acc0-2936ec20988a" key="textField-164" stretchType="ContainerHeight" x="295" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{COST_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COST_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-165" style="Level4_Line" stretchType="RelativeToBandHeight" x="356" y="0" width="61" height="18" uuid="b952f5c2-ffdb-4952-b032-9d1d2fc7a908"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b952f5c2-ffdb-4952-b032-9d1d2fc7a908" key="textField-165" stretchType="ContainerHeight" x="356" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{PROFIT_4}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFIT_4}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-166" style="Level4_Line" stretchType="RelativeToBandHeight" x="417" y="0" width="30" height="18" uuid="c8e0bf08-0c69-40b6-827b-d3c009713b54"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c8e0bf08-0c69-40b6-827b-d3c009713b54" key="textField-166" stretchType="ContainerHeight" x="417" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{MARGIN_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGIN_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-167" style="Level4_Line" stretchType="RelativeToBandHeight" x="740" y="0" width="50" height="18" uuid="012cfc3d-c20a-4577-bf41-d10eec57f667"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="012cfc3d-c20a-4577-bf41-d10eec57f667" key="textField-167" stretchType="ContainerHeight" x="740" y="0" width="50" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-213" style="Level4_Line" stretchType="RelativeToBandHeight" x="942" y="0" width="38" height="18" uuid="80c47aae-2171-4024-8e33-4dd6b3d3008d">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="80c47aae-2171-4024-8e33-4dd6b3d3008d" key="textField-213" stretchType="ContainerHeight" x="942" y="0" width="38" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER4}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_PER4}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" isBlankWhenNull="false">
-					<reportElement key="textField-223" style="Level4_Line" stretchType="RelativeToBandHeight" x="893" y="0" width="49" height="18" uuid="16ba5e18-2807-49ba-8c15-bdd04a688291">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="16ba5e18-2807-49ba-8c15-bdd04a688291" key="textField-223" stretchType="ContainerHeight" x="893" y="0" width="49" height="18" evaluationTime="Group" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-233" style="Level4_Line" stretchType="RelativeToBandHeight" x="790" y="0" width="42" height="18" uuid="7a244ab1-a71f-4042-9e0c-753581d0cb5f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7a244ab1-a71f-4042-9e0c-753581d0cb5f" key="textField-233" stretchType="ContainerHeight" x="790" y="0" width="42" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-243" style="Level4_Line" stretchType="RelativeToBandHeight" x="710" y="0" width="30" height="18" uuid="eaaa364c-d7bb-445d-b77b-9a6c461f8398"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="eaaa364c-d7bb-445d-b77b-9a6c461f8398" key="textField-243" stretchType="ContainerHeight" x="710" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{MARGINDIFF_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-253" style="Level4_Line" stretchType="RelativeToBandHeight" x="670" y="0" width="40" height="18" uuid="640690a5-8214-45ee-a319-1fcb5debc3ea"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="640690a5-8214-45ee-a319-1fcb5debc3ea" key="textField-253" stretchType="ContainerHeight" x="670" y="0" width="40" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{AMOUNT_PER4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-263" style="Level4_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="30" height="18" uuid="1452d57a-2b80-4e7f-8795-d11d0ee58a41"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1452d57a-2b80-4e7f-8795-d11d0ee58a41" key="textField-263" stretchType="ContainerHeight" x="640" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{MARGINREF_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGINREF_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-273" style="Level4_Line" stretchType="RelativeToBandHeight" x="579" y="0" width="61" height="18" uuid="3f7488d8-828b-4e9e-830b-7f6db72ca37f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3f7488d8-828b-4e9e-830b-7f6db72ca37f" key="textField-273" stretchType="ContainerHeight" x="579" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{PROFITREF_4}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFITREF_4}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-283" style="Level4_Line" stretchType="RelativeToBandHeight" x="518" y="0" width="61" height="18" uuid="5e4d8352-c870-43ec-bbb0-6d775e183ac3"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5e4d8352-c870-43ec-bbb0-6d775e183ac3" key="textField-283" stretchType="ContainerHeight" x="518" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{COSTREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-293" style="Level4_Line" stretchType="RelativeToBandHeight" x="447" y="0" width="71" height="18" uuid="ae88e96f-e3b7-4c78-b001-c567aed62f59"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ae88e96f-e3b7-4c78-b001-c567aed62f59" key="textField-293" stretchType="ContainerHeight" x="447" y="0" width="71" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -2035,235 +1785,193 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL5">
-		<groupExpression><![CDATA[$F{NIVEL5}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL5}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-5" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="e9cf0415-10d1-4ab8-a44c-57d82e5e6fba"/>
-					<box>
+				<element kind="textField" uuid="e9cf0415-10d1-4ab8-a44c-57d82e5e6fba" key="textField-5" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-10" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="0ba60106-189b-44bd-89f9-a9961779579b"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="0ba60106-189b-44bd-89f9-a9961779579b" key="textField-10" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-7" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="1fc02cb1-4901-4dbc-a8f8-00b3e59c701c"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="1fc02cb1-4901-4dbc-a8f8-00b3e59c701c" key="textField-7" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-11" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="0e33e7a7-eda3-4b28-a3b0-810c1a1302b1"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="0e33e7a7-eda3-4b28-a3b0-810c1a1302b1" key="textField-11" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="164" height="18" uuid="216f4e98-3e22-4b47-82be-2156ff553ef1"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="216f4e98-3e22-4b47-82be-2156ff553ef1" key="textField" stretchType="ContainerHeight" x="60" y="0" width="164" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[$F{NIVEL5}]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL5}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" x="224" y="0" width="71" height="18" uuid="c282b2b6-cf11-4095-92c9-7ed6a3b943ea"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c282b2b6-cf11-4095-92c9-7ed6a3b943ea" key="textField" stretchType="ContainerHeight" x="224" y="0" width="71" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" x="832" y="0" width="61" height="18" uuid="5fc27a5d-81e8-4933-93a8-04d541f44365">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5fc27a5d-81e8-4933-93a8-04d541f44365" key="textField" stretchType="ContainerHeight" x="832" y="0" width="61" height="18" evaluationTime="Group" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-168" style="Level5_Line" stretchType="RelativeToBandHeight" x="295" y="0" width="61" height="18" uuid="5bcbb677-2834-4d1d-85a6-7305d630fc1e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5bcbb677-2834-4d1d-85a6-7305d630fc1e" key="textField-168" stretchType="ContainerHeight" x="295" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{COST_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COST_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-169" style="Level5_Line" stretchType="RelativeToBandHeight" x="356" y="0" width="61" height="18" uuid="fb70d2f1-fe1b-47ef-a898-415e5e509a53"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="fb70d2f1-fe1b-47ef-a898-415e5e509a53" key="textField-169" stretchType="ContainerHeight" x="356" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{PROFIT_5}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFIT_5}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-170" style="Level5_Line" stretchType="RelativeToBandHeight" x="417" y="0" width="30" height="18" uuid="d7e26407-05cd-40f6-9b17-e8bd38238c25"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d7e26407-05cd-40f6-9b17-e8bd38238c25" key="textField-170" stretchType="ContainerHeight" x="417" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{MARGIN_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGIN_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-171" style="Level5_Line" stretchType="RelativeToBandHeight" x="740" y="0" width="50" height="18" uuid="b29bc968-a576-4709-adda-36278fc731ce"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b29bc968-a576-4709-adda-36278fc731ce" key="textField-171" stretchType="ContainerHeight" x="740" y="0" width="50" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-214" style="Level5_Line" stretchType="RelativeToBandHeight" x="942" y="0" width="38" height="18" uuid="b1007c45-b792-439f-b232-e9f4e4355466">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b1007c45-b792-439f-b232-e9f4e4355466" key="textField-214" stretchType="ContainerHeight" x="942" y="0" width="38" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER5}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_PER5}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" isBlankWhenNull="false">
-					<reportElement key="textField-224" style="Level5_Line" stretchType="RelativeToBandHeight" x="893" y="0" width="49" height="18" uuid="4d07f3d1-f7e6-469d-9f81-e229edda3081">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4d07f3d1-f7e6-469d-9f81-e229edda3081" key="textField-224" stretchType="ContainerHeight" x="893" y="0" width="49" height="18" evaluationTime="Group" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-234" style="Level5_Line" stretchType="RelativeToBandHeight" x="790" y="0" width="42" height="18" uuid="bc176c38-dcbf-4a13-bb30-fad9d66b23cd"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="bc176c38-dcbf-4a13-bb30-fad9d66b23cd" key="textField-234" stretchType="ContainerHeight" x="790" y="0" width="42" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-244" style="Level5_Line" stretchType="RelativeToBandHeight" x="710" y="0" width="30" height="18" uuid="e1c0c5cd-928d-45f3-be9b-31897ba24576"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e1c0c5cd-928d-45f3-be9b-31897ba24576" key="textField-244" stretchType="ContainerHeight" x="710" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{MARGINDIFF_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-254" style="Level5_Line" stretchType="RelativeToBandHeight" x="670" y="0" width="40" height="18" uuid="0d27567a-84fd-4b57-abc0-f6bb2725d5c1"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0d27567a-84fd-4b57-abc0-f6bb2725d5c1" key="textField-254" stretchType="ContainerHeight" x="670" y="0" width="40" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{AMOUNT_PER5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-264" style="Level5_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="30" height="18" uuid="7c707d5f-7104-4308-82f6-6d4d5094d786"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7c707d5f-7104-4308-82f6-6d4d5094d786" key="textField-264" stretchType="ContainerHeight" x="640" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{MARGINREF_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGINREF_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-274" style="Level5_Line" stretchType="RelativeToBandHeight" x="579" y="0" width="61" height="18" uuid="07a4caed-6928-45b4-8c68-d8533db8258e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="07a4caed-6928-45b4-8c68-d8533db8258e" key="textField-274" stretchType="ContainerHeight" x="579" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{PROFITREF_5}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFITREF_5}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-284" style="Level5_Line" stretchType="RelativeToBandHeight" x="518" y="0" width="61" height="18" uuid="0ea145fc-5e9e-4d6a-b5f1-18cff7e96d09"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0ea145fc-5e9e-4d6a-b5f1-18cff7e96d09" key="textField-284" stretchType="ContainerHeight" x="518" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{COSTREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-294" style="Level5_Line" stretchType="RelativeToBandHeight" x="447" y="0" width="71" height="18" uuid="13ec3a90-991d-4604-b729-229545995d22"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="13ec3a90-991d-4604-b729-229545995d22" key="textField-294" stretchType="ContainerHeight" x="447" y="0" width="71" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -2273,246 +1981,202 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL6">
-		<groupExpression><![CDATA[$F{NIVEL6}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL6}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=6)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-70" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="a41749a7-527c-48d0-b655-a6bb95075171"/>
-					<box>
+				<element kind="textField" uuid="a41749a7-527c-48d0-b655-a6bb95075171" key="textField-70" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-72" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="d0652865-c8af-4247-8f64-dad53fb7fafa"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="d0652865-c8af-4247-8f64-dad53fb7fafa" key="textField-72" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-71" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="f75b8500-e27f-49f6-8c84-08964bd7c8f7"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="f75b8500-e27f-49f6-8c84-08964bd7c8f7" key="textField-71" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-73" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="5852eae1-3f43-4da3-a352-0f4182b5b72c"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="5852eae1-3f43-4da3-a352-0f4182b5b72c" key="textField-73" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-74" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="15" height="18" uuid="18bb1036-5b5b-4133-9292-9fee0d0c35bd"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="18bb1036-5b5b-4133-9292-9fee0d0c35bd" key="textField-74" stretchType="ContainerHeight" x="60" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-66" style="Level6_Line" stretchType="RelativeToBandHeight" x="75" y="0" width="149" height="18" uuid="69fcc3ae-f60a-4d4f-926e-d944d7784ebd"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="69fcc3ae-f60a-4d4f-926e-d944d7784ebd" key="textField-66" stretchType="ContainerHeight" x="75" y="0" width="149" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[$F{NIVEL6}]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL6}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-69" style="Level6_Line" stretchType="RelativeToBandHeight" x="224" y="0" width="71" height="18" uuid="d1255c36-436d-4885-9ae9-0444a709e1af"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d1255c36-436d-4885-9ae9-0444a709e1af" key="textField-69" stretchType="ContainerHeight" x="224" y="0" width="71" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" isBlankWhenNull="false">
-					<reportElement key="textField-68" style="Level6_Line" stretchType="RelativeToBandHeight" x="832" y="0" width="61" height="18" uuid="7c65ab57-3a0f-4232-9dc9-b5225f90e0c9">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7c65ab57-3a0f-4232-9dc9-b5225f90e0c9" key="textField-68" stretchType="ContainerHeight" x="832" y="0" width="61" height="18" evaluationTime="Group" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-172" style="Level6_Line" stretchType="RelativeToBandHeight" x="295" y="0" width="61" height="18" uuid="d9ed1a70-c589-4e6a-90c3-9294c1c4cb8a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d9ed1a70-c589-4e6a-90c3-9294c1c4cb8a" key="textField-172" stretchType="ContainerHeight" x="295" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{COST_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COST_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-173" style="Level6_Line" stretchType="RelativeToBandHeight" x="356" y="0" width="61" height="18" uuid="1b3f11d5-c7b6-4129-b4b2-d65a4e51eab3"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1b3f11d5-c7b6-4129-b4b2-d65a4e51eab3" key="textField-173" stretchType="ContainerHeight" x="356" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{PROFIT_6}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFIT_6}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-174" style="Level6_Line" stretchType="RelativeToBandHeight" x="417" y="0" width="30" height="18" uuid="1393b4d6-8fa4-40aa-a022-5fe1109fa5be"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1393b4d6-8fa4-40aa-a022-5fe1109fa5be" key="textField-174" stretchType="ContainerHeight" x="417" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{MARGIN_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGIN_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-175" style="Level6_Line" stretchType="RelativeToBandHeight" x="740" y="0" width="50" height="18" uuid="f923b5b6-e7e4-44b6-a912-668b921b5398"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f923b5b6-e7e4-44b6-a912-668b921b5398" key="textField-175" stretchType="ContainerHeight" x="740" y="0" width="50" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-215" style="Level6_Line" stretchType="RelativeToBandHeight" x="942" y="0" width="38" height="18" uuid="0124b35d-b8d3-45fc-96b2-5d9146c5edd9">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0124b35d-b8d3-45fc-96b2-5d9146c5edd9" key="textField-215" stretchType="ContainerHeight" x="942" y="0" width="38" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER6}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_PER6}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" isBlankWhenNull="false">
-					<reportElement key="textField-225" style="Level6_Line" stretchType="RelativeToBandHeight" x="893" y="0" width="49" height="18" uuid="5f36bf60-92b1-48f5-b3e1-1acaddba16f5">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5f36bf60-92b1-48f5-b3e1-1acaddba16f5" key="textField-225" stretchType="ContainerHeight" x="893" y="0" width="49" height="18" evaluationTime="Group" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-235" style="Level6_Line" stretchType="RelativeToBandHeight" x="790" y="0" width="42" height="18" uuid="68f516ba-adb5-4fd6-8161-de1eb9d318f4"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="68f516ba-adb5-4fd6-8161-de1eb9d318f4" key="textField-235" stretchType="ContainerHeight" x="790" y="0" width="42" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-245" style="Level6_Line" stretchType="RelativeToBandHeight" x="710" y="0" width="30" height="18" uuid="7028d1b3-71c1-4a54-8dd0-0c0b64d3781d"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7028d1b3-71c1-4a54-8dd0-0c0b64d3781d" key="textField-245" stretchType="ContainerHeight" x="710" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{MARGINDIFF_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-255" style="Level6_Line" stretchType="RelativeToBandHeight" x="670" y="0" width="40" height="18" uuid="e8bdf6b5-8d88-4487-8a39-7e83c0992732"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e8bdf6b5-8d88-4487-8a39-7e83c0992732" key="textField-255" stretchType="ContainerHeight" x="670" y="0" width="40" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{AMOUNT_PER6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-265" style="Level6_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="30" height="18" uuid="95a6ceee-0a62-41ab-b4a3-d88b7d475c1a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="95a6ceee-0a62-41ab-b4a3-d88b7d475c1a" key="textField-265" stretchType="ContainerHeight" x="640" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{MARGINREF_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGINREF_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-275" style="Level6_Line" stretchType="RelativeToBandHeight" x="579" y="0" width="61" height="18" uuid="e1a245ab-80d2-456c-9a35-3036bfc8acd6"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e1a245ab-80d2-456c-9a35-3036bfc8acd6" key="textField-275" stretchType="ContainerHeight" x="579" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{PROFITREF_6}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFITREF_6}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-285" style="Level6_Line" stretchType="RelativeToBandHeight" x="518" y="0" width="61" height="18" uuid="30652eee-d682-4437-b0c2-0b65424c8f78"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="30652eee-d682-4437-b0c2-0b65424c8f78" key="textField-285" stretchType="ContainerHeight" x="518" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{COSTREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-295" style="Level6_Line" stretchType="RelativeToBandHeight" x="447" y="0" width="71" height="18" uuid="5332982d-89ec-4410-b89e-adb9987c8407"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5332982d-89ec-4410-b89e-adb9987c8407" key="textField-295" stretchType="ContainerHeight" x="447" y="0" width="71" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -2522,257 +2186,211 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL7">
-		<groupExpression><![CDATA[$F{NIVEL7}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL7}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=7)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-79" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="f4c35d25-9dbf-4d18-b7bb-cdf35b7e8e83"/>
-					<box>
+				<element kind="textField" uuid="f4c35d25-9dbf-4d18-b7bb-cdf35b7e8e83" key="textField-79" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-81" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="4b5d52a3-221a-49a8-8238-b9812dfaee36"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="4b5d52a3-221a-49a8-8238-b9812dfaee36" key="textField-81" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-80" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="17a64bd4-1505-4481-9f03-d0524fe1149d"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="17a64bd4-1505-4481-9f03-d0524fe1149d" key="textField-80" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-82" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="17c32c19-1324-46a0-bcef-2c8dfc63cf42"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="17c32c19-1324-46a0-bcef-2c8dfc63cf42" key="textField-82" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-83" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="15" height="18" uuid="85d11fd2-cde2-4fad-a1c7-2f3c3994bc9c"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="85d11fd2-cde2-4fad-a1c7-2f3c3994bc9c" key="textField-83" stretchType="ContainerHeight" x="60" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-84" style="Level6_Line" stretchType="RelativeToBandHeight" x="75" y="0" width="15" height="18" uuid="ae5d5e7a-a455-4ac9-8ef0-c1d1dd6873fd"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="ae5d5e7a-a455-4ac9-8ef0-c1d1dd6873fd" key="textField-84" stretchType="ContainerHeight" x="75" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-75" style="Level7_Line" stretchType="RelativeToBandHeight" x="90" y="0" width="134" height="18" uuid="8d83ed53-b704-44a5-91b7-4d8a2e8ef5bd"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="8d83ed53-b704-44a5-91b7-4d8a2e8ef5bd" key="textField-75" stretchType="ContainerHeight" x="90" y="0" width="134" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[$F{NIVEL7}]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL7}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-176" style="Level7_Line" stretchType="RelativeToBandHeight" x="224" y="0" width="71" height="18" uuid="d8849f34-657c-4d85-8832-028e6dc194c6"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d8849f34-657c-4d85-8832-028e6dc194c6" key="textField-176" stretchType="ContainerHeight" x="224" y="0" width="71" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" isBlankWhenNull="false">
-					<reportElement key="textField-177" style="Level7_Line" stretchType="RelativeToBandHeight" x="832" y="0" width="61" height="18" uuid="11b31d64-657e-4dfd-a5c0-7ec73efd8cfe">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="11b31d64-657e-4dfd-a5c0-7ec73efd8cfe" key="textField-177" stretchType="ContainerHeight" x="832" y="0" width="61" height="18" evaluationTime="Group" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-179" style="Level7_Line" stretchType="RelativeToBandHeight" x="295" y="0" width="61" height="18" uuid="9631c146-586e-4d53-81a3-b00354a432c1"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9631c146-586e-4d53-81a3-b00354a432c1" key="textField-179" stretchType="ContainerHeight" x="295" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{COST_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COST_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-180" style="Level7_Line" stretchType="RelativeToBandHeight" x="356" y="0" width="61" height="18" uuid="be143c21-a37c-4293-9b51-5270c6d94e29"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="be143c21-a37c-4293-9b51-5270c6d94e29" key="textField-180" stretchType="ContainerHeight" x="356" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{PROFIT_7}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFIT_7}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-181" style="Level7_Line" stretchType="RelativeToBandHeight" x="417" y="0" width="30" height="18" uuid="fd086099-9652-438c-91b8-318195d02f48"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="fd086099-9652-438c-91b8-318195d02f48" key="textField-181" stretchType="ContainerHeight" x="417" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{MARGIN_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGIN_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-182" style="Level7_Line" stretchType="RelativeToBandHeight" x="740" y="0" width="50" height="18" uuid="d51bcec1-5423-454e-8bae-5760a3296006"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d51bcec1-5423-454e-8bae-5760a3296006" key="textField-182" stretchType="ContainerHeight" x="740" y="0" width="50" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-216" style="Level7_Line" stretchType="RelativeToBandHeight" x="942" y="0" width="38" height="18" uuid="b5973d78-1ae1-4c33-9c80-436a700833c2">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b5973d78-1ae1-4c33-9c80-436a700833c2" key="textField-216" stretchType="ContainerHeight" x="942" y="0" width="38" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER7}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_PER7}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" isBlankWhenNull="false">
-					<reportElement key="textField-226" style="Level7_Line" stretchType="RelativeToBandHeight" x="893" y="0" width="49" height="18" uuid="20ddea71-b8f7-4d4d-afed-a2507c60f35c">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="20ddea71-b8f7-4d4d-afed-a2507c60f35c" key="textField-226" stretchType="ContainerHeight" x="893" y="0" width="49" height="18" evaluationTime="Group" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-236" style="Level7_Line" stretchType="RelativeToBandHeight" x="790" y="0" width="42" height="18" uuid="cdacdf2d-c2de-4c2f-89bd-a66941991ea4"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="cdacdf2d-c2de-4c2f-89bd-a66941991ea4" key="textField-236" stretchType="ContainerHeight" x="790" y="0" width="42" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-246" style="Level7_Line" stretchType="RelativeToBandHeight" x="710" y="0" width="30" height="18" uuid="526e7f13-9064-44ce-8d79-5835837e2af8"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="526e7f13-9064-44ce-8d79-5835837e2af8" key="textField-246" stretchType="ContainerHeight" x="710" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{MARGINDIFF_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-256" style="Level7_Line" stretchType="RelativeToBandHeight" x="670" y="0" width="40" height="18" uuid="75f2985f-891e-4fcd-b572-e2ba13967ba5"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="75f2985f-891e-4fcd-b572-e2ba13967ba5" key="textField-256" stretchType="ContainerHeight" x="670" y="0" width="40" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{AMOUNT_PER7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-266" style="Level7_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="30" height="18" uuid="0ca6b479-dba8-4edc-9f32-c5acc05fd2b7"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0ca6b479-dba8-4edc-9f32-c5acc05fd2b7" key="textField-266" stretchType="ContainerHeight" x="640" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{MARGINREF_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGINREF_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-276" style="Level7_Line" stretchType="RelativeToBandHeight" x="579" y="0" width="61" height="18" uuid="43fe06e5-cb44-427e-8b4e-af16466d2e54"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="43fe06e5-cb44-427e-8b4e-af16466d2e54" key="textField-276" stretchType="ContainerHeight" x="579" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{PROFITREF_7}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFITREF_7}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-286" style="Level7_Line" stretchType="RelativeToBandHeight" x="518" y="0" width="61" height="18" uuid="49608270-c548-476a-b0cb-e767f93ea047"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="49608270-c548-476a-b0cb-e767f93ea047" key="textField-286" stretchType="ContainerHeight" x="518" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{COSTREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-296" style="Level7_Line" stretchType="RelativeToBandHeight" x="447" y="0" width="71" height="18" uuid="f23c82ba-286c-45e4-bf5d-654c5b61ebb7"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f23c82ba-286c-45e4-bf5d-654c5b61ebb7" key="textField-296" stretchType="ContainerHeight" x="447" y="0" width="71" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -2782,268 +2400,220 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL8">
-		<groupExpression><![CDATA[$F{NIVEL8}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL8}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=8)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-89" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="117c71e1-934a-4edd-a747-c2b326958673"/>
-					<box>
+				<element kind="textField" uuid="117c71e1-934a-4edd-a747-c2b326958673" key="textField-89" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-91" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="0c7f045c-4eb2-4220-a074-48ee95f9aa8c"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="0c7f045c-4eb2-4220-a074-48ee95f9aa8c" key="textField-91" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-90" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="7ef4e25f-cd47-4b3b-8590-715698ee4d3d"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="7ef4e25f-cd47-4b3b-8590-715698ee4d3d" key="textField-90" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-92" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="924475de-2f16-43df-9570-8fc45e59a0b4"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="924475de-2f16-43df-9570-8fc45e59a0b4" key="textField-92" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-93" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="15" height="18" uuid="cf8f0de4-21d0-4671-bf4c-06310ba46ba9"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="cf8f0de4-21d0-4671-bf4c-06310ba46ba9" key="textField-93" stretchType="ContainerHeight" x="60" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-94" style="Level6_Line" stretchType="RelativeToBandHeight" x="75" y="0" width="15" height="18" uuid="b3931645-8b07-4ccf-9d7c-03df3fbe20b7"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="b3931645-8b07-4ccf-9d7c-03df3fbe20b7" key="textField-94" stretchType="ContainerHeight" x="75" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-95" style="Level7_Line" stretchType="RelativeToBandHeight" x="90" y="0" width="15" height="18" uuid="198243c8-b1ae-44a8-8c8b-b0f001084d6c"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="198243c8-b1ae-44a8-8c8b-b0f001084d6c" key="textField-95" stretchType="ContainerHeight" x="90" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-85" style="Level8_Line" stretchType="RelativeToBandHeight" x="105" y="0" width="119" height="18" uuid="143bceb3-0cea-4c16-92a0-0f75f726ec35"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="143bceb3-0cea-4c16-92a0-0f75f726ec35" key="textField-85" stretchType="ContainerHeight" x="105" y="0" width="119" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level8_Line">
+					<expression><![CDATA[$F{NIVEL8}]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL8}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-183" style="Level8_Line" stretchType="RelativeToBandHeight" x="224" y="0" width="71" height="18" uuid="826724ac-4919-41af-b8c8-6108ee8f5fbf"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="826724ac-4919-41af-b8c8-6108ee8f5fbf" key="textField-183" stretchType="ContainerHeight" x="224" y="0" width="71" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-186" style="Level8_Line" stretchType="RelativeToBandHeight" x="295" y="0" width="61" height="18" uuid="da58adcc-9e6c-4bab-95fa-bfe13aa524d9"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="da58adcc-9e6c-4bab-95fa-bfe13aa524d9" key="textField-186" stretchType="ContainerHeight" x="295" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{COST_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COST_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-187" style="Level8_Line" stretchType="RelativeToBandHeight" x="356" y="0" width="61" height="18" uuid="d0a77a2a-9899-485a-9b90-24765fa12926"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d0a77a2a-9899-485a-9b90-24765fa12926" key="textField-187" stretchType="ContainerHeight" x="356" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{PROFIT_8}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFIT_8}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-188" style="Level8_Line" stretchType="RelativeToBandHeight" x="417" y="0" width="30" height="18" uuid="607348d9-6771-4280-bc15-bef5c858c19e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="607348d9-6771-4280-bc15-bef5c858c19e" key="textField-188" stretchType="ContainerHeight" x="417" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{MARGIN_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGIN_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-189" style="Level8_Line" stretchType="RelativeToBandHeight" x="740" y="0" width="50" height="18" uuid="3739cbeb-57c9-43d7-80d5-e33b8eb238c3"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3739cbeb-57c9-43d7-80d5-e33b8eb238c3" key="textField-189" stretchType="ContainerHeight" x="740" y="0" width="50" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" isBlankWhenNull="false">
-					<reportElement key="textField-184" style="Level8_Line" stretchType="RelativeToBandHeight" x="832" y="0" width="61" height="18" uuid="aa59f414-4305-47e0-9b4e-518e03b7b53b">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="aa59f414-4305-47e0-9b4e-518e03b7b53b" key="textField-184" stretchType="ContainerHeight" x="832" y="0" width="61" height="18" evaluationTime="Group" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-217" style="Level8_Line" stretchType="RelativeToBandHeight" x="942" y="0" width="38" height="18" uuid="feb5d09e-0050-48bc-abb6-d25b407fcb0c">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="feb5d09e-0050-48bc-abb6-d25b407fcb0c" key="textField-217" stretchType="ContainerHeight" x="942" y="0" width="38" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER8}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_PER8}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" isBlankWhenNull="false">
-					<reportElement key="textField-227" style="Level8_Line" stretchType="RelativeToBandHeight" x="893" y="0" width="49" height="18" uuid="ebad45c8-fb1e-490b-8845-92bc37876ced">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ebad45c8-fb1e-490b-8845-92bc37876ced" key="textField-227" stretchType="ContainerHeight" x="893" y="0" width="49" height="18" evaluationTime="Group" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-237" style="Level8_Line" stretchType="RelativeToBandHeight" x="790" y="0" width="42" height="18" uuid="2431b2a7-8573-4297-a5a5-bf0b1e9dac50"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2431b2a7-8573-4297-a5a5-bf0b1e9dac50" key="textField-237" stretchType="ContainerHeight" x="790" y="0" width="42" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-247" style="Level8_Line" stretchType="RelativeToBandHeight" x="710" y="0" width="30" height="18" uuid="a2633545-9c00-4aa8-b2ed-3ea03b7e9653"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a2633545-9c00-4aa8-b2ed-3ea03b7e9653" key="textField-247" stretchType="ContainerHeight" x="710" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{MARGINDIFF_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-257" style="Level8_Line" stretchType="RelativeToBandHeight" x="670" y="0" width="40" height="18" uuid="f6f2d93c-3b1d-4a8b-bf28-0855f900ae6c"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f6f2d93c-3b1d-4a8b-bf28-0855f900ae6c" key="textField-257" stretchType="ContainerHeight" x="670" y="0" width="40" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{AMOUNT_PER8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-267" style="Level8_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="30" height="18" uuid="0656ad9e-333e-46e1-9e5f-8713c06d3300"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0656ad9e-333e-46e1-9e5f-8713c06d3300" key="textField-267" stretchType="ContainerHeight" x="640" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{MARGINREF_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGINREF_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-277" style="Level8_Line" stretchType="RelativeToBandHeight" x="579" y="0" width="61" height="18" uuid="7e8b3877-c356-44bd-a735-870bcd956f89"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7e8b3877-c356-44bd-a735-870bcd956f89" key="textField-277" stretchType="ContainerHeight" x="579" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{PROFITREF_8}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFITREF_8}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-287" style="Level8_Line" stretchType="RelativeToBandHeight" x="518" y="0" width="61" height="18" uuid="1956a743-4e1a-4e5d-8b29-ab0832f71095"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1956a743-4e1a-4e5d-8b29-ab0832f71095" key="textField-287" stretchType="ContainerHeight" x="518" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{COSTREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-297" style="Level8_Line" stretchType="RelativeToBandHeight" x="447" y="0" width="71" height="18" uuid="9212912b-bc13-420c-a3d5-45df4c3aadd1"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9212912b-bc13-420c-a3d5-45df4c3aadd1" key="textField-297" stretchType="ContainerHeight" x="447" y="0" width="71" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -3053,279 +2623,229 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL9">
-		<groupExpression><![CDATA[$F{NIVEL9}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL9}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=9)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-100" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="ef3625c4-ad38-4997-9dab-406f6ccd4d43"/>
-					<box>
+				<element kind="textField" uuid="ef3625c4-ad38-4997-9dab-406f6ccd4d43" key="textField-100" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-102" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="3619b85a-5a80-41ce-b5bd-f8c0901fa1c6"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="3619b85a-5a80-41ce-b5bd-f8c0901fa1c6" key="textField-102" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-101" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="1976193b-5650-4adc-8210-4399045eddd1"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="1976193b-5650-4adc-8210-4399045eddd1" key="textField-101" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-103" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="29cdb783-c97c-4812-b1d3-8a9227c3e3ee"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="29cdb783-c97c-4812-b1d3-8a9227c3e3ee" key="textField-103" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-104" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="15" height="18" uuid="7fa330e3-4c07-4eac-81cc-4325758f025a"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="7fa330e3-4c07-4eac-81cc-4325758f025a" key="textField-104" stretchType="ContainerHeight" x="60" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-105" style="Level6_Line" stretchType="RelativeToBandHeight" x="75" y="0" width="15" height="18" uuid="1adf4459-4ed2-4555-86db-490986e3dfa9"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="1adf4459-4ed2-4555-86db-490986e3dfa9" key="textField-105" stretchType="ContainerHeight" x="75" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-106" style="Level7_Line" stretchType="RelativeToBandHeight" x="90" y="0" width="15" height="18" uuid="b45005ce-8fd7-4a44-8477-49f0e838a734"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="b45005ce-8fd7-4a44-8477-49f0e838a734" key="textField-106" stretchType="ContainerHeight" x="90" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-107" style="Level8_Line" stretchType="RelativeToBandHeight" x="105" y="0" width="15" height="18" uuid="3ece78e7-903d-4704-b7e0-95e43a0f7029"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="3ece78e7-903d-4704-b7e0-95e43a0f7029" key="textField-107" stretchType="ContainerHeight" x="105" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level8_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-96" style="Level9_Line" stretchType="RelativeToBandHeight" x="120" y="0" width="104" height="18" uuid="7a01fb51-cfdc-4e6b-af2d-212d035ad9f3"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7a01fb51-cfdc-4e6b-af2d-212d035ad9f3" key="textField-96" stretchType="ContainerHeight" x="120" y="0" width="104" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level9_Line">
+					<expression><![CDATA[$F{NIVEL9}]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL9}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-190" style="Level9_Line" stretchType="RelativeToBandHeight" x="224" y="0" width="71" height="18" uuid="504eaaf9-abb2-4369-93ff-0a103ec2f064"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="504eaaf9-abb2-4369-93ff-0a103ec2f064" key="textField-190" stretchType="ContainerHeight" x="224" y="0" width="71" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-191" style="Level9_Line" stretchType="RelativeToBandHeight" x="295" y="0" width="61" height="18" uuid="a6b451b2-068c-4c5d-b52b-47e8d66717a8"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a6b451b2-068c-4c5d-b52b-47e8d66717a8" key="textField-191" stretchType="ContainerHeight" x="295" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{COST_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COST_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-192" style="Level9_Line" stretchType="RelativeToBandHeight" x="356" y="0" width="61" height="18" uuid="e2c67f88-69a7-49e1-8b4c-641091905851"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e2c67f88-69a7-49e1-8b4c-641091905851" key="textField-192" stretchType="ContainerHeight" x="356" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{PROFIT_9}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFIT_9}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-193" style="Level9_Line" stretchType="RelativeToBandHeight" x="417" y="0" width="30" height="18" uuid="d1cf93c0-e384-4d71-81b5-b5eb906a90de"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d1cf93c0-e384-4d71-81b5-b5eb906a90de" key="textField-193" stretchType="ContainerHeight" x="417" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{MARGIN_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGIN_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-194" style="Level9_Line" stretchType="RelativeToBandHeight" x="740" y="0" width="50" height="18" uuid="ba179ab6-56ac-49b2-b5de-e0f3b633ac49"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ba179ab6-56ac-49b2-b5de-e0f3b633ac49" key="textField-194" stretchType="ContainerHeight" x="740" y="0" width="50" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" isBlankWhenNull="false">
-					<reportElement key="textField-196" style="Level9_Line" stretchType="RelativeToBandHeight" x="832" y="0" width="61" height="18" uuid="928eb2d3-c929-4bc8-a109-f621830ac44c">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="928eb2d3-c929-4bc8-a109-f621830ac44c" key="textField-196" stretchType="ContainerHeight" x="832" y="0" width="61" height="18" evaluationTime="Group" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-218" style="Level9_Line" stretchType="RelativeToBandHeight" x="942" y="0" width="38" height="18" uuid="5a10519e-e84e-4261-8a94-eba06bfa9876">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5a10519e-e84e-4261-8a94-eba06bfa9876" key="textField-218" stretchType="ContainerHeight" x="942" y="0" width="38" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER9}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_PER9}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" isBlankWhenNull="false">
-					<reportElement key="textField-228" style="Level9_Line" stretchType="RelativeToBandHeight" x="893" y="0" width="49" height="18" uuid="9d968f76-88d3-4e3f-baac-85b39645810a">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9d968f76-88d3-4e3f-baac-85b39645810a" key="textField-228" stretchType="ContainerHeight" x="893" y="0" width="49" height="18" evaluationTime="Group" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-238" style="Level9_Line" stretchType="RelativeToBandHeight" x="790" y="0" width="42" height="18" uuid="ddfbdebb-e3f3-44ba-9490-f31fd4b21203"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ddfbdebb-e3f3-44ba-9490-f31fd4b21203" key="textField-238" stretchType="ContainerHeight" x="790" y="0" width="42" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-248" style="Level9_Line" stretchType="RelativeToBandHeight" x="710" y="0" width="30" height="18" uuid="b8e08ef2-0bef-4c80-9725-ab0a7eea5ba9"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b8e08ef2-0bef-4c80-9725-ab0a7eea5ba9" key="textField-248" stretchType="ContainerHeight" x="710" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{MARGINDIFF_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-258" style="Level9_Line" stretchType="RelativeToBandHeight" x="670" y="0" width="40" height="18" uuid="75fe72cf-20ab-47c3-a193-f5b685aa0d6a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="75fe72cf-20ab-47c3-a193-f5b685aa0d6a" key="textField-258" stretchType="ContainerHeight" x="670" y="0" width="40" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{AMOUNT_PER9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-268" style="Level9_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="30" height="18" uuid="f2fce4e2-3f69-43e7-a218-6749b15199aa"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f2fce4e2-3f69-43e7-a218-6749b15199aa" key="textField-268" stretchType="ContainerHeight" x="640" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{MARGINREF_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGINREF_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-278" style="Level9_Line" stretchType="RelativeToBandHeight" x="579" y="0" width="61" height="18" uuid="556ac84c-3ed4-4fe6-8b2a-1d535ad85287"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="556ac84c-3ed4-4fe6-8b2a-1d535ad85287" key="textField-278" stretchType="ContainerHeight" x="579" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{PROFITREF_9}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFITREF_9}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-288" style="Level9_Line" stretchType="RelativeToBandHeight" x="518" y="0" width="61" height="18" uuid="65f023a2-a018-4a56-9f40-540200c71648"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="65f023a2-a018-4a56-9f40-540200c71648" key="textField-288" stretchType="ContainerHeight" x="518" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{COSTREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-298" style="Level9_Line" stretchType="RelativeToBandHeight" x="447" y="0" width="71" height="18" uuid="b16189cf-8da6-4283-bc3f-598723a87405"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b16189cf-8da6-4283-bc3f-598723a87405" key="textField-298" stretchType="ContainerHeight" x="447" y="0" width="71" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -3335,290 +2855,238 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL10">
-		<groupExpression><![CDATA[$F{NIVEL10}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL10}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=10)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-112" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="1edbb394-dbfe-4235-ad5d-af6c28549a1c"/>
-					<box>
+				<element kind="textField" uuid="1edbb394-dbfe-4235-ad5d-af6c28549a1c" key="textField-112" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-114" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="973f1761-3b90-4ae6-8db0-a0871e797efc"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="973f1761-3b90-4ae6-8db0-a0871e797efc" key="textField-114" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-113" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="ae404ee0-dfb4-413d-96d8-f0b462f55176"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="ae404ee0-dfb4-413d-96d8-f0b462f55176" key="textField-113" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-115" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="b1c6c805-d49f-4d44-9e47-f4bc464e143e"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="b1c6c805-d49f-4d44-9e47-f4bc464e143e" key="textField-115" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-116" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="15" height="18" uuid="577d6416-b705-4c6e-a55c-c8c93b97fd5b"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="577d6416-b705-4c6e-a55c-c8c93b97fd5b" key="textField-116" stretchType="ContainerHeight" x="60" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-117" style="Level6_Line" stretchType="RelativeToBandHeight" x="75" y="0" width="15" height="18" uuid="acd1d7dd-65be-4ddb-be63-a15a71e6176f"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="acd1d7dd-65be-4ddb-be63-a15a71e6176f" key="textField-117" stretchType="ContainerHeight" x="75" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-118" style="Level7_Line" stretchType="RelativeToBandHeight" x="90" y="0" width="15" height="18" uuid="89045fda-9e5a-47bf-9d6e-c845daa724b9"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="89045fda-9e5a-47bf-9d6e-c845daa724b9" key="textField-118" stretchType="ContainerHeight" x="90" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-119" style="Level8_Line" stretchType="RelativeToBandHeight" x="105" y="0" width="15" height="18" uuid="9d1b5703-6050-4aa7-aa8b-429a51abd764"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="9d1b5703-6050-4aa7-aa8b-429a51abd764" key="textField-119" stretchType="ContainerHeight" x="105" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level8_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-120" style="Level9_Line" stretchType="RelativeToBandHeight" x="120" y="0" width="15" height="18" uuid="ec290ecc-b215-42fa-a7ac-f0180747a07c"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="ec290ecc-b215-42fa-a7ac-f0180747a07c" key="textField-120" stretchType="ContainerHeight" x="120" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level9_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-108" style="Level10_Line" stretchType="RelativeToBandHeight" x="135" y="0" width="89" height="18" uuid="15c7fa32-44da-4d7e-a274-64dd35a7131c"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="15c7fa32-44da-4d7e-a274-64dd35a7131c" key="textField-108" stretchType="ContainerHeight" x="135" y="0" width="89" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level10_Line">
+					<expression><![CDATA[$F{NIVEL10}]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL10}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-197" style="Level10_Line" stretchType="RelativeToBandHeight" x="224" y="0" width="71" height="18" uuid="0befd49f-6c0f-49c6-8541-6f5bfbfb482a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0befd49f-6c0f-49c6-8541-6f5bfbfb482a" key="textField-197" stretchType="ContainerHeight" x="224" y="0" width="71" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-198" style="Level10_Line" stretchType="RelativeToBandHeight" x="295" y="0" width="61" height="18" uuid="c396142b-d39b-449a-9a44-c7d74c210494"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c396142b-d39b-449a-9a44-c7d74c210494" key="textField-198" stretchType="ContainerHeight" x="295" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{COST_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COST_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-199" style="Level10_Line" stretchType="RelativeToBandHeight" x="356" y="0" width="61" height="18" uuid="9b722c0f-3764-4e70-bd2c-732863bb6238"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9b722c0f-3764-4e70-bd2c-732863bb6238" key="textField-199" stretchType="ContainerHeight" x="356" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{PROFIT_10}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFIT_10}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-200" style="Level10_Line" stretchType="RelativeToBandHeight" x="417" y="0" width="30" height="18" uuid="24ca0937-cdb7-4da0-9c8c-22cb71ce587e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="24ca0937-cdb7-4da0-9c8c-22cb71ce587e" key="textField-200" stretchType="ContainerHeight" x="417" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{MARGIN_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGIN_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-201" style="Level10_Line" stretchType="RelativeToBandHeight" x="740" y="0" width="50" height="18" uuid="cbe5fb42-a4fe-49d9-86db-8004ffa15130"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="cbe5fb42-a4fe-49d9-86db-8004ffa15130" key="textField-201" stretchType="ContainerHeight" x="740" y="0" width="50" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" isBlankWhenNull="false">
-					<reportElement key="textField-202" style="Level10_Line" stretchType="RelativeToBandHeight" x="832" y="0" width="61" height="18" uuid="6859332e-9ffb-412c-8487-b79fbf2f07c8">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6859332e-9ffb-412c-8487-b79fbf2f07c8" key="textField-202" stretchType="ContainerHeight" x="832" y="0" width="61" height="18" evaluationTime="Group" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-219" style="Level10_Line" stretchType="RelativeToBandHeight" x="942" y="0" width="38" height="18" uuid="4b5357bb-2a5e-402e-8c5b-d475774adcc1">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4b5357bb-2a5e-402e-8c5b-d475774adcc1" key="textField-219" stretchType="ContainerHeight" x="942" y="0" width="38" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER10}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_PER10}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" isBlankWhenNull="false">
-					<reportElement key="textField-229" style="Level10_Line" stretchType="RelativeToBandHeight" x="893" y="0" width="49" height="18" uuid="25882e5e-6ccd-4f6d-816c-a54825454b5f">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="25882e5e-6ccd-4f6d-816c-a54825454b5f" key="textField-229" stretchType="ContainerHeight" x="893" y="0" width="49" height="18" evaluationTime="Group" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-249" style="Level10_Line" stretchType="RelativeToBandHeight" x="710" y="0" width="30" height="18" uuid="a8bc4cee-acc2-4780-91ec-80dabb5cb1a9"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a8bc4cee-acc2-4780-91ec-80dabb5cb1a9" key="textField-249" stretchType="ContainerHeight" x="710" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{MARGINDIFF_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-259" style="Level10_Line" stretchType="RelativeToBandHeight" x="670" y="0" width="40" height="18" uuid="1c390a2a-9772-4d95-bda8-6692012113a4"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1c390a2a-9772-4d95-bda8-6692012113a4" key="textField-259" stretchType="ContainerHeight" x="670" y="0" width="40" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{AMOUNT_PER10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-269" style="Level10_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="30" height="18" uuid="93fe6c1c-0ba2-47cc-85bd-7dc62e3bd778"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="93fe6c1c-0ba2-47cc-85bd-7dc62e3bd778" key="textField-269" stretchType="ContainerHeight" x="640" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{MARGINREF_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGINREF_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-279" style="Level10_Line" stretchType="RelativeToBandHeight" x="579" y="0" width="61" height="18" uuid="bca7c066-8b9b-47c4-a396-ae7d1eac573f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="bca7c066-8b9b-47c4-a396-ae7d1eac573f" key="textField-279" stretchType="ContainerHeight" x="579" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{PROFITREF_10}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFITREF_10}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-289" style="Level10_Line" stretchType="RelativeToBandHeight" x="518" y="0" width="61" height="18" uuid="869d9b2d-6be3-4dbb-a061-b8e58ba1a607"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="869d9b2d-6be3-4dbb-a061-b8e58ba1a607" key="textField-289" stretchType="ContainerHeight" x="518" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{COSTREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-299" style="Level10_Line" stretchType="RelativeToBandHeight" x="447" y="0" width="71" height="18" uuid="a4a06cc1-0574-488f-861f-8b1f54af635b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a4a06cc1-0574-488f-861f-8b1f54af635b" key="textField-299" stretchType="ContainerHeight" x="447" y="0" width="71" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-238" style="Level9_Line" stretchType="RelativeToBandHeight" x="790" y="0" width="42" height="18" uuid="7ae5b729-2a34-49b2-98ad-a6574175324e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7ae5b729-2a34-49b2-98ad-a6574175324e" key="textField-238" stretchType="ContainerHeight" x="790" y="0" width="42" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -3627,576 +3095,413 @@
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="140" splitType="Stretch">
-			<property name="local_mesure_unitheight" value="pixel"/>
-			<property name="com.jaspersoft.studio.unit.height" value="px"/>
-			<frame>
-				<reportElement key="frame-1" positionType="Float" mode="Opaque" x="0" y="122" width="980" height="18" backcolor="#5D5D5D" uuid="fdd5b494-9d67-4d2d-8c0e-c2bf9a4ca57c"/>
-				<box>
+	<background splitType="Stretch"/>
+	<title height="140" splitType="Stretch">
+		<element kind="frame" uuid="fdd5b494-9d67-4d2d-8c0e-c2bf9a4ca57c" key="frame-1" positionType="Float" mode="Opaque" x="0" y="122" width="980" height="18" backcolor="#5D5D5D">
+			<element kind="textField" uuid="cbe2cd26-7f0b-49ee-bb2f-ba08e7913a94" key="textField-61" positionType="Float" x="0" y="0" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-61" style="Detail_Header" positionType="Float" x="0" y="0" width="15" height="18" uuid="cbe2cd26-7f0b-49ee-bb2f-ba08e7913a94">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-62" style="Detail_Header" positionType="Float" x="15" y="0" width="15" height="18" uuid="d9084e40-f9d8-4ba3-b478-eb6094bbe25a">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-63" style="Detail_Header" positionType="Float" x="30" y="0" width="15" height="18" uuid="8ba5affe-3c88-4949-8e09-195fdbfa289f">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-64" style="Detail_Header" positionType="Float" x="45" y="0" width="15" height="18" uuid="288598e4-a69c-4eb0-a415-49e29ae0ba55">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-65" style="Detail_Header" positionType="Float" x="60" y="0" width="15" height="18" uuid="3a0632e7-dfe3-46ea-bdf2-b928f6879e93">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":"")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-9" style="Detail_Header" positionType="Float" mode="Opaque" x="417" y="0" width="30" height="18" uuid="423febcd-a41e-433c-ba50-9ef4d007419a"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[M. %]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-10" style="Detail_Header" positionType="Float" mode="Opaque" x="832" y="0" width="55" height="18" uuid="2281f554-6207-43ee-b24a-97d1908983b6"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-11" style="Detail_Header" positionType="Float" mode="Opaque" x="740" y="0" width="50" height="18" uuid="8b11fde8-98b3-4be9-8bbd-4bcfcd35a868"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Weight]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-12" style="Detail_Header" positionType="Float" mode="Opaque" x="356" y="0" width="61" height="18" uuid="84b70baa-d480-400e-9422-7be3c250399b"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Profit]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-13" style="Detail_Header" positionType="Float" mode="Opaque" x="298" y="0" width="58" height="18" uuid="6d56422a-383e-4b7d-ae16-6c863b73b19f"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Cost]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-14" style="Detail_Header" positionType="Float" mode="Opaque" x="224" y="0" width="71" height="18" uuid="ce20165f-9f74-48b8-a864-6fa1a9537f57"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-205" style="Detail_Header" positionType="Float" x="75" y="0" width="15" height="18" uuid="672891b9-f5ce-4c14-93e6-1417ebea4e1f">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=6)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(6))>=0)?"6":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-206" style="Detail_Header" positionType="Float" x="90" y="0" width="15" height="18" uuid="fd1b0b5c-91dc-4c6a-81d8-de643d69bdf9">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=7)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(7))>=0)?"7":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-207" style="Detail_Header" positionType="Float" x="105" y="0" width="15" height="18" uuid="e06744cc-6fe9-46bb-b59e-ca40c0819199">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=8)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(8))>=0)?"8":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-208" style="Detail_Header" positionType="Float" x="120" y="0" width="15" height="18" uuid="d4bddd64-a0ab-423f-9806-9ac3721e1576">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=9)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(9))>=0)?"9":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-209" style="Detail_Header" positionType="Float" x="135" y="0" width="15" height="18" uuid="8ebde680-0f1a-4b08-87a7-dc7e193a5896">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=10)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(10))>=0)?"10":"")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-15" style="Detail_Header" positionType="Float" mode="Opaque" x="447" y="0" width="71" height="18" uuid="8be82468-0a8f-4187-887a-50597bba82dd"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Amt. ref]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-16" style="Detail_Header" positionType="Float" mode="Opaque" x="518" y="0" width="61" height="18" uuid="eefbd88e-925c-49ae-86e6-d7e90ae8e82d"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Cost ref]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-17" style="Detail_Header" positionType="Float" mode="Opaque" x="579" y="0" width="61" height="18" uuid="685de276-e872-4d46-b7c6-dde536644839"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Pro. ref]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-18" style="Detail_Header" positionType="Float" mode="Opaque" x="640" y="0" width="30" height="18" uuid="cc5d08ec-5196-4671-8359-cd379e01aeac"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[M.r %]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-19" style="Detail_Header" positionType="Float" mode="Opaque" x="670" y="0" width="40" height="18" uuid="0e7409e8-380e-4b92-b938-1a6331742fa6"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[A. %]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-20" style="Detail_Header" positionType="Float" mode="Opaque" x="710" y="0" width="30" height="18" uuid="4514e7c2-b996-4956-829d-c5aa708f2488"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[M.dif]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-21" style="Detail_Header" positionType="Float" mode="Opaque" x="790" y="0" width="42" height="18" uuid="67ae9e79-6da8-4cfd-9a35-03648ea4e39c"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[W. Ref]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-22" style="Detail_Header" positionType="Float" mode="Opaque" x="942" y="0" width="38" height="18" uuid="0181cec1-d27e-4ac6-8ed3-6a23a0896415"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Qty%]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-23" style="Detail_Header" positionType="Float" mode="Opaque" x="893" y="0" width="49" height="18" uuid="286bea30-62f9-4704-a156-325c53f2baf7"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Q. ref]]></text>
-				</staticText>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-308" style="Detail_Header" positionType="Float" x="170" y="0" width="52" height="18" uuid="2b2bd3df-8eae-42a9-bb5c-06320d8515a6"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Center" rotation="None"/>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-			</frame>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Report_Title" x="0" y="0" width="970" height="26" uuid="c65b2f75-c2e7-4370-902b-81f684c8db67"/>
-				<box leftPadding="5">
+			</element>
+			<element kind="textField" uuid="d9084e40-f9d8-4ba3-b478-eb6094bbe25a" key="textField-62" positionType="Float" x="15" y="0" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Subtitle" x="0" y="31" width="970" height="18" uuid="853b20a9-ab43-4f03-a8dd-3e52dc7badd7"/>
-				<box leftPadding="5">
+			</element>
+			<element kind="textField" uuid="8ba5affe-3c88-4949-8e09-195fdbfa289f" key="textField-63" positionType="Float" x="30" y="0" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_SUBTITLE}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-5" style="Report_Data_Label" x="0" y="53" width="114" height="16" uuid="c611a84f-357d-4d1a-b2ea-a2b92f253993"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="288598e4-a69c-4eb0-a415-49e29ae0ba55" key="textField-64" positionType="Float" x="45" y="0" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<text><![CDATA[Grouping Levels:]]></text>
-			</staticText>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="114" y="53" width="818" height="16" uuid="963412f3-3129-4da9-993d-9ee90b64cffc"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="3a0632e7-dfe3-46ea-bdf2-b928f6879e93" key="textField-65" positionType="Float" x="60" y="0" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$P{LEVEL_LABEL}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="26" width="970" height="1" uuid="8685cf48-f749-4d64-a4ab-e85bb5dd9dbe"/>
-			</line>
-			<line>
-				<reportElement key="line-2" x="0" y="49" width="970" height="1" uuid="e3a0791e-43f2-4bb8-8c87-cd1ec1e19719"/>
-			</line>
-			<staticText>
-				<reportElement key="staticText-5" style="Report_Data_Label" x="-1" y="69" width="115" height="16" uuid="d782d4ec-b89f-4ba8-aa4d-2b2904191569"/>
-				<box>
+			</element>
+			<element kind="staticText" uuid="423febcd-a41e-433c-ba50-9ef4d007419a" key="staticText-9" positionType="Float" mode="Opaque" x="417" y="0" width="30" height="18" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[M. %]]></text>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="11" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Secondary Filters:]]></text>
-			</staticText>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="210" y="69" width="760" height="16" uuid="57e7e1e3-7a09-4efe-a793-94be6b4deca7"/>
-				<box>
+			</element>
+			<element kind="staticText" uuid="2281f554-6207-43ee-b24a-97d1908983b6" key="staticText-10" positionType="Float" mode="Opaque" x="832" y="0" width="55" height="18" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Quantity]]></text>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="11"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{ORGANIZATION} + " and any child organization"]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="270" y="85" width="700" height="16" uuid="8ab62721-c379-4ef5-bb9a-8cad601d8564">
-					<printWhenExpression><![CDATA[!$P{BPGROUP}.equals("")]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="staticText" uuid="8b11fde8-98b3-4be9-8bbd-4bcfcd35a868" key="staticText-11" positionType="Float" mode="Opaque" x="740" y="0" width="50" height="18" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Weight]]></text>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="11"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{BPGROUP}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="222" y="101" width="748" height="16" uuid="c3277090-82cf-4454-80e6-e4da8bab374e">
-					<printWhenExpression><![CDATA[!$P{PRODUCTGROUP}.equals("")]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="staticText" uuid="84b70baa-d480-400e-9422-7be3c250399b" key="staticText-12" positionType="Float" mode="Opaque" x="356" y="0" width="61" height="18" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Profit]]></text>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="11"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{PRODUCTGROUP}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="114" y="69" width="96" height="16" uuid="ab0a70ca-656b-43e1-bd6b-69694d1f6b0f"/>
-				<box>
+			</element>
+			<element kind="staticText" uuid="6d56422a-383e-4b7d-ae16-6c863b73b19f" key="staticText-13" positionType="Float" mode="Opaque" x="298" y="0" width="58" height="18" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Cost]]></text>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="11"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Organization- "]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="114" y="85" width="156" height="16" uuid="d90b2e65-7296-49a3-9e46-3863cd6bb9f2">
-					<printWhenExpression><![CDATA[!$P{BPGROUP}.equals("")]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="staticText" uuid="ce20165f-9f74-48b8-a864-6fa1a9537f57" key="staticText-14" positionType="Float" mode="Opaque" x="224" y="0" width="71" height="18" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Amount]]></text>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="11"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Business Partner Group- "]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="114" y="101" width="108" height="16" uuid="de28a4f7-d55a-4ccc-955d-fd9e09963e91">
-					<printWhenExpression><![CDATA[!$P{PRODUCTGROUP}.equals("")]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="textField" uuid="672891b9-f5ce-4c14-93e6-1417ebea4e1f" key="textField-205" positionType="Float" x="75" y="0" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=6)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(6))>=0)?"6":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="11"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Product Group- "]]></textFieldExpression>
-			</textField>
-		</band>
+			</element>
+			<element kind="textField" uuid="fd1b0b5c-91dc-4c6a-81d8-de643d69bdf9" key="textField-206" positionType="Float" x="90" y="0" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=7)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(7))>=0)?"7":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="e06744cc-6fe9-46bb-b59e-ca40c0819199" key="textField-207" positionType="Float" x="105" y="0" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=8)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(8))>=0)?"8":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="d4bddd64-a0ab-423f-9806-9ac3721e1576" key="textField-208" positionType="Float" x="120" y="0" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=9)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(9))>=0)?"9":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="8ebde680-0f1a-4b08-87a7-dc7e193a5896" key="textField-209" positionType="Float" x="135" y="0" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=10)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(10))>=0)?"10":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="8be82468-0a8f-4187-887a-50597bba82dd" key="staticText-15" positionType="Float" mode="Opaque" x="447" y="0" width="71" height="18" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Amt. ref]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="eefbd88e-925c-49ae-86e6-d7e90ae8e82d" key="staticText-16" positionType="Float" mode="Opaque" x="518" y="0" width="61" height="18" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Cost ref]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="685de276-e872-4d46-b7c6-dde536644839" key="staticText-17" positionType="Float" mode="Opaque" x="579" y="0" width="61" height="18" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Pro. ref]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="cc5d08ec-5196-4671-8359-cd379e01aeac" key="staticText-18" positionType="Float" mode="Opaque" x="640" y="0" width="30" height="18" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[M.r %]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="0e7409e8-380e-4b92-b938-1a6331742fa6" key="staticText-19" positionType="Float" mode="Opaque" x="670" y="0" width="40" height="18" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[A. %]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="4514e7c2-b996-4956-829d-c5aa708f2488" key="staticText-20" positionType="Float" mode="Opaque" x="710" y="0" width="30" height="18" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[M.dif]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="67ae9e79-6da8-4cfd-9a35-03648ea4e39c" key="staticText-21" positionType="Float" mode="Opaque" x="790" y="0" width="42" height="18" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[W. Ref]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="0181cec1-d27e-4ac6-8ed3-6a23a0896415" key="staticText-22" positionType="Float" mode="Opaque" x="942" y="0" width="38" height="18" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Qty%]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="286bea30-62f9-4704-a156-325c53f2baf7" key="staticText-23" positionType="Float" mode="Opaque" x="893" y="0" width="49" height="18" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Q. ref]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="2b2bd3df-8eae-42a9-bb5c-06320d8515a6" key="textField-308" positionType="Float" x="170" y="0" width="52" height="18" rotation="None" blankWhenNull="true" hTextAlign="Center" style="Detail_Header">
+				<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="c65b2f75-c2e7-4370-902b-81f684c8db67" key="textField" x="0" y="0" width="970" height="26" textAdjust="StretchHeight" blankWhenNull="true" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="853b20a9-ab43-4f03-a8dd-3e52dc7badd7" key="textField" x="0" y="31" width="970" height="18" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="c611a84f-357d-4d1a-b2ea-a2b92f253993" key="staticText-5" x="0" y="53" width="114" height="16" style="Report_Data_Label">
+			<text><![CDATA[Grouping Levels:]]></text>
+			<box style="Report_Data_Label">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="963412f3-3129-4da9-993d-9ee90b64cffc" key="textField-17" x="114" y="53" width="818" height="16" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Data_Field">
+			<expression><![CDATA[$P{LEVEL_LABEL}]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="8685cf48-f749-4d64-a4ab-e85bb5dd9dbe" key="line-1" x="0" y="26" width="970" height="1"/>
+		<element kind="line" uuid="e3a0791e-43f2-4bb8-8c87-cd1ec1e19719" key="line-2" x="0" y="49" width="970" height="1"/>
+		<element kind="staticText" uuid="d782d4ec-b89f-4ba8-aa4d-2b2904191569" key="staticText-5" x="-1" y="69" width="115" height="16" fontSize="11.0" bold="true" style="Report_Data_Label">
+			<text><![CDATA[Secondary Filters:]]></text>
+			<box style="Report_Data_Label">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="57e7e1e3-7a09-4efe-a793-94be6b4deca7" key="textField-17" x="210" y="69" width="760" height="16" fontSize="11.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<expression><![CDATA[$P{ORGANIZATION} + " and any child organization"]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="8ab62721-c379-4ef5-bb9a-8cad601d8564" key="textField-17" x="270" y="85" width="700" height="16" fontSize="11.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<printWhenExpression><![CDATA[!$P{BPGROUP}.equals("")]]></printWhenExpression>
+			<expression><![CDATA[$P{BPGROUP}]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="c3277090-82cf-4454-80e6-e4da8bab374e" key="textField-17" x="222" y="101" width="748" height="16" fontSize="11.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<printWhenExpression><![CDATA[!$P{PRODUCTGROUP}.equals("")]]></printWhenExpression>
+			<expression><![CDATA[$P{PRODUCTGROUP}]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="ab0a70ca-656b-43e1-bd6b-69694d1f6b0f" key="textField-17" x="114" y="69" width="96" height="16" fontSize="11.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<expression><![CDATA["Organization- "]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="d90b2e65-7296-49a3-9e46-3863cd6bb9f2" key="textField-17" x="114" y="85" width="156" height="16" fontSize="11.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<printWhenExpression><![CDATA[!$P{BPGROUP}.equals("")]]></printWhenExpression>
+			<expression><![CDATA["Business Partner Group- "]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="de28a4f7-d55a-4ccc-955d-fd9e09963e91" key="textField-17" x="114" y="101" width="108" height="16" fontSize="11.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<printWhenExpression><![CDATA[!$P{PRODUCTGROUP}.equals("")]]></printWhenExpression>
+			<expression><![CDATA["Product Group- "]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<property name="local_mesure_unitheight" value="pixel"/>
+		<property name="com.jaspersoft.studio.unit.height" value="px"/>
 	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band splitType="Stretch"/>
 	</detail>
-	<pageFooter>
-		<band height="20" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-7" style="Report_Footer" x="319" y="3" width="78" height="16" uuid="0c0b4c59-573b-456d-8bbf-239db0904b4e"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Generated on ]]></text>
-			</staticText>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-18" style="Report_Footer" x="395" y="3" width="90" height="16" uuid="5ccf0a8c-a161-4ead-988e-2d71918ef885"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-19" style="Report_Footer" x="676" y="3" width="105" height="16" uuid="0ec0263a-443d-407a-9dbd-71957e324c66"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-20" style="Report_Footer" x="773" y="3" width="46" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="e477e192-3983-4c3f-a4ae-7c62ffa84739"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-4" x="0" y="2" width="980" height="1" uuid="b38b9cd9-1ab3-4192-914b-e2904d721a2b"/>
-			</line>
-		</band>
+	<pageFooter height="20" splitType="Stretch">
+		<element kind="staticText" uuid="0c0b4c59-573b-456d-8bbf-239db0904b4e" key="staticText-7" x="319" y="3" width="78" height="16" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Generated on ]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="5ccf0a8c-a161-4ead-988e-2d71918ef885" key="textField-18" x="395" y="3" width="90" height="16" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="0ec0263a-443d-407a-9dbd-71957e324c66" key="textField-19" x="676" y="3" width="105" height="16" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="e477e192-3983-4c3f-a4ae-7c62ffa84739" key="textField-20" x="773" y="3" width="46" height="16" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle" style="Report_Footer">
+			<paragraph lineSpacing="Single" style="Report_Footer"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="b38b9cd9-1ab3-4192-914b-e2904d721a2b" key="line-4" x="0" y="2" width="980" height="1"/>
 	</pageFooter>
-	<lastPageFooter>
-		<band height="58"/>
-	</lastPageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<lastPageFooter height="58"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesMultiComparativeExtendedJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesMultiComparativeExtendedJR.jrxml
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
-<!-- 2017-03-02T13:17:22 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportInvoiceCustomerDimensionalAnalysesMultiComparativeExtendedJR" pageWidth="1650" pageHeight="595" orientation="Landscape" columnWidth="1622" leftMargin="14" rightMargin="14" topMargin="56" bottomMargin="28" uuid="e79411c1-a0fb-4ea2-bb75-304bceb0ccb1">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportInvoiceCustomerDimensionalAnalysesMultiComparativeExtendedJR" language="java" pageWidth="1650" pageHeight="595" orientation="Landscape" columnWidth="1622" leftMargin="14" rightMargin="14" topMargin="56" bottomMargin="28" uuid="e79411c1-a0fb-4ea2-bb75-304bceb0ccb1">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
@@ -9,171 +7,140 @@
 	<property name="ireport.x" value="154"/>
 	<property name="ireport.y" value="0"/>
 	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="true"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8" isBold="true">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Report_Data_Label" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="true"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0" bold="true">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level1_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level1_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==1)&&($V{NIVEL1_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==1)&&($V{NIVEL1_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level2_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level2_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==2)&&($V{NIVEL1_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==2)&&($V{NIVEL1_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level3_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level3_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==3)&&($V{NIVEL2_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==3)&&($V{NIVEL2_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level4_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level4_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==4)&&($V{NIVEL3_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==4)&&($V{NIVEL3_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level5_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level5_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==5)&&($V{NIVEL4_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==5)&&($V{NIVEL4_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level6_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level6_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==6)&&($V{NIVEL5_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==6)&&($V{NIVEL5_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level7_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level7_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==7)&&($V{NIVEL6_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==7)&&($V{NIVEL6_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level8_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level8_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==8)&&($V{NIVEL7_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==8)&&($V{NIVEL7_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level9_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level9_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==9)&&($V{NIVEL8_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==9)&&($V{NIVEL8_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level10_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level10_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==10)&&($V{NIVEL9_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==10)&&($V{NIVEL9_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Report_Footer" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
+	<style name="Report_Footer" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
 	<style name="Detail_Border" forecolor="#8A8A8A"/>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["0,1000000"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["0,1000000"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_client" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_client" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{USER_CLIENT}.equals("") ? " " : " AND C_INVOICE.AD_CLIENT_ID IN(" + $P{USER_CLIENT} + ")"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="ORGANIZATION" class="java.lang.String"/>
@@ -181,97 +148,97 @@
 	<parameter name="PRODUCTGROUP" class="java.lang.String"/>
 	<parameter name="C_CURRENCY_ID" class="java.lang.String"/>
 	<parameter name="AD_ORG_ID" class="java.lang.String"/>
-	<parameter name="aux_org" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_org" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{AD_ORG_ID}.equals("") ? " " : " AND C_INVOICE.AD_ORG_ID IN(" + $P{AD_ORG_ID} + ")"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="DateFrom" class="java.lang.String"/>
 	<parameter name="DateTo" class="java.lang.String"/>
-	<parameter name="aux_DateFrom" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_DateFrom" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{DateFrom} == null || $P{DateFrom}.equals("")) ? "" : "AND C_INVOICE.DATEINVOICED >= TO_DATE('" + $P{DateFrom} + "', 'YYYY-MM-DD')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_DateTo" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_DateTo" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{DateTo} == null || $P{DateTo}.equals("")) ? "" : "AND C_INVOICE.DATEINVOICED <= TO_DATE('" + $P{DateTo} + "', 'YYYY-MM-DD')"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="C_BP_GROUP_ID" class="java.lang.String"/>
-	<parameter name="aux_bpgroup" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_bpgroup" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{C_BP_GROUP_ID}.equals("") ? " " : " AND C_BPARTNER.C_BP_GROUP_ID = '" + $P{C_BP_GROUP_ID} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="C_BPARTNER_ID" class="java.lang.String"/>
-	<parameter name="aux_partner" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_partner" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{C_BPARTNER_ID}.equals("") ? " " : " AND C_BPARTNER.C_BPARTNER_ID IN" + $P{C_BPARTNER_ID}]]></defaultValueExpression>
 	</parameter>
 	<parameter name="M_PRODUCT_CATEGORY_ID" class="java.lang.String"/>
-	<parameter name="aux_productcategory" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_productcategory" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{M_PRODUCT_CATEGORY_ID}.equals("") ? " " : " AND M_PRODUCT_CATEGORY.M_PRODUCT_CATEGORY_ID IN " + $P{M_PRODUCT_CATEGORY_ID}]]></defaultValueExpression>
 	</parameter>
 	<parameter name="M_PRODUCT_ID" class="java.lang.String"/>
-	<parameter name="aux_product" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_product" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{M_PRODUCT_ID}.equals("") ? " " : "  AND M_PRODUCT.M_PRODUCT_ID IN" + $P{M_PRODUCT_ID}]]></defaultValueExpression>
 	</parameter>
 	<parameter name="SALESREP_ID" class="java.lang.String"/>
-	<parameter name="aux_salesrep" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_salesrep" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{SALESREP_ID}.equals("") ? " " : " AND C_INVOICE.SALESREP_ID = '" + $P{SALESREP_ID} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="PARTNER_SALESREP_ID" class="java.lang.String"/>
-	<parameter name="aux_partnersalesrep" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_partnersalesrep" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{PARTNER_SALESREP_ID}.equals("") ? " " : " AND CB.C_BPARTNER_ID = '" + $P{PARTNER_SALESREP_ID} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="C_PROJECT_ID" class="java.lang.String"/>
-	<parameter name="aux_project" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_project" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{C_PROJECT_ID}.equals("") ? " " : " AND C_INVOICE.C_PROJECT_ID = '" + $P{C_PROJECT_ID} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="PRODUCTTYPE" class="java.lang.String"/>
-	<parameter name="aux_producttype" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_producttype" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{PRODUCTTYPE}.equals("") ? " " : " AND M_PRODUCT.PRODUCTTYPE = '" + $P{PRODUCTTYPE} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="C_DOCTYPE_ID" class="java.lang.String"/>
-	<parameter name="aux_doctype" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_doctype" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{C_DOCTYPE_ID}.equals("") ? " " : " AND C_INVOICE.C_DOCTYPE_ID IN" + $P{C_DOCTYPE_ID}]]></defaultValueExpression>
 	</parameter>
 	<parameter name="DOCSTATUS" class="java.lang.String"/>
-	<parameter name="aux_docstatus" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_docstatus" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{DOCSTATUS}.equals("") ? " " : " AND C_INVOICE.DOCSTATUS <> '" + $P{DOCSTATUS} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="LANGUAGE" class="java.lang.String"/>
-	<parameter name="SR_LINES" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="orderBy" class="java.lang.String" isForPrompting="false">
+	<parameter name="SR_LINES" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="orderBy" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[" ORDER BY 1 "]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Purchase Orders Report"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="PRODUCT_LEVEL" class="java.lang.Integer" isForPrompting="false">
+	<parameter name="PRODUCT_LEVEL" forPrompting="false" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[new Integer(3)]]></defaultValueExpression>
 	</parameter>
-	<parameter name="THEME" class="java.lang.String" isForPrompting="false">
+	<parameter name="THEME" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Default"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false">
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/var/lib/tomcat-5.5/webapps/alerts/web"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL1_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL1_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Partner Group"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL2_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL2_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Product Category"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL3_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL3_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Product"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL4_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL4_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Partner"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL5_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL6_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL7_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL8_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL9_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL10_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="DIMENSIONS" class="java.lang.Integer" isForPrompting="false">
+	<parameter name="LEVEL5_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL6_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL7_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL8_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL9_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL10_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="DIMENSIONS" forPrompting="false" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[new Integer(5)]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["1.- "+$P{LEVEL1_LABEL}
 +($P{LEVEL2_LABEL}==""?"":", 2.- "+$P{LEVEL2_LABEL})
 +($P{LEVEL3_LABEL}==""?"":", 3.- "+$P{LEVEL3_LABEL})
@@ -283,12 +250,11 @@
 +($P{LEVEL9_LABEL}==""?"":", 9.- "+$P{LEVEL9_LABEL})
 +($P{LEVEL10_LABEL}==""?"":", 10.- "+$P{LEVEL10_LABEL})]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale">
 		<defaultValueExpression><![CDATA[new Locale("en","US")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10,
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<query language="sql"><![CDATA[SELECT NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10,
       SUM(AMOUNT) AS AMOUNT, SUM(QTY) AS QTY, SUM(WEIGHT) AS WEIGHT, SUM(COST) AS COST,
       SUM(AMOUNTREF) AS AMOUNTREF, SUM(QTYREF) AS QTYREF, SUM(WEIGHTREF) AS WEIGHTREF, SUM(COSTREF) AS COSTREF,
       SUM(AMOUNTREF2) AS AMOUNTREF2, SUM(QTYREF2) AS QTYREF2, SUM(WEIGHTREF2) AS WEIGHTREF2, SUM(COSTREF2) AS COSTREF2,
@@ -519,8 +485,7 @@
       AND 6=6
       ORDER BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10) AA
       GROUP BY  NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10, TRCURRENCYID, TRDATE, TRCLIENTID, TRORGID) ZZ
-      GROUP BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10, 1]]>
-	</queryString>
+      GROUP BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10, 1]]></query>
 	<field name="NIVEL1" class="java.lang.String"/>
 	<field name="NIVEL2" class="java.lang.String"/>
 	<field name="NIVEL3" class="java.lang.String"/>
@@ -560,2081 +525,1769 @@
 	<field name="CONVSYM" class="java.lang.String"/>
 	<field name="CONVISOSYM" class="java.lang.String"/>
 	<field name="COSTCALCULATED" class="java.lang.Integer"/>
-	<variable name="QTY_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF2_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF2}]]></variableExpression>
+	<variable name="QTYREF2_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF2}]]></expression>
 	</variable>
-	<variable name="QTYREF2_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF2}]]></variableExpression>
+	<variable name="QTYREF2_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF2}]]></expression>
 	</variable>
-	<variable name="QTYREF2_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF2}]]></variableExpression>
+	<variable name="QTYREF2_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF2}]]></expression>
 	</variable>
-	<variable name="QTYREF2_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF2}]]></variableExpression>
+	<variable name="QTYREF2_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF2}]]></expression>
 	</variable>
-	<variable name="QTYREF2_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF2}]]></variableExpression>
+	<variable name="QTYREF2_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF2}]]></expression>
 	</variable>
-	<variable name="QTYREF2_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF2}]]></variableExpression>
+	<variable name="QTYREF2_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF2}]]></expression>
 	</variable>
-	<variable name="QTYREF2_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF2}]]></variableExpression>
+	<variable name="QTYREF2_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF2}]]></expression>
 	</variable>
-	<variable name="QTYREF2_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF2}]]></variableExpression>
+	<variable name="QTYREF2_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF2}]]></expression>
 	</variable>
-	<variable name="QTYREF2_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF2}]]></variableExpression>
+	<variable name="QTYREF2_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF2}]]></expression>
 	</variable>
-	<variable name="QTYREF2_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF2}]]></variableExpression>
+	<variable name="QTYREF2_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF2}]]></expression>
 	</variable>
-	<variable name="QTYREF3_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF3}]]></variableExpression>
+	<variable name="QTYREF3_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF3}]]></expression>
 	</variable>
-	<variable name="QTYREF3_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF3}]]></variableExpression>
+	<variable name="QTYREF3_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF3}]]></expression>
 	</variable>
-	<variable name="QTYREF3_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF3}]]></variableExpression>
+	<variable name="QTYREF3_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF3}]]></expression>
 	</variable>
-	<variable name="QTYREF3_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF3}]]></variableExpression>
+	<variable name="QTYREF3_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF3}]]></expression>
 	</variable>
-	<variable name="QTYREF3_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF3}]]></variableExpression>
+	<variable name="QTYREF3_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF3}]]></expression>
 	</variable>
-	<variable name="QTYREF3_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF3}]]></variableExpression>
+	<variable name="QTYREF3_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF3}]]></expression>
 	</variable>
-	<variable name="QTYREF3_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF3}]]></variableExpression>
+	<variable name="QTYREF3_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF3}]]></expression>
 	</variable>
-	<variable name="QTYREF3_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF3}]]></variableExpression>
+	<variable name="QTYREF3_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF3}]]></expression>
 	</variable>
-	<variable name="QTYREF3_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF3}]]></variableExpression>
+	<variable name="QTYREF3_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF3}]]></expression>
 	</variable>
-	<variable name="QTYREF3_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF3}]]></variableExpression>
+	<variable name="QTYREF3_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF3}]]></expression>
 	</variable>
-	<variable name="AMOUNT_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF2_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF2}]]></variableExpression>
+	<variable name="AMOUNTREF2_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF2}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF2_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF2}]]></variableExpression>
+	<variable name="AMOUNTREF2_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF2}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF2_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF2}]]></variableExpression>
+	<variable name="AMOUNTREF2_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF2}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF2_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF2}]]></variableExpression>
+	<variable name="AMOUNTREF2_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF2}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF2_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF2}]]></variableExpression>
+	<variable name="AMOUNTREF2_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF2}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF2_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF2}]]></variableExpression>
+	<variable name="AMOUNTREF2_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF2}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF2_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF2}]]></variableExpression>
+	<variable name="AMOUNTREF2_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF2}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF2_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF2}]]></variableExpression>
+	<variable name="AMOUNTREF2_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF2}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF2_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF2}]]></variableExpression>
+	<variable name="AMOUNTREF2_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF2}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF2_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF2}]]></variableExpression>
+	<variable name="AMOUNTREF2_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF2}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF2_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF2}]]></variableExpression>
+	<variable name="AMOUNTREF2_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF2}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF3_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF3}]]></variableExpression>
+	<variable name="AMOUNTREF3_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF3}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF3_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF3}]]></variableExpression>
+	<variable name="AMOUNTREF3_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF3}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF3_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF3}]]></variableExpression>
+	<variable name="AMOUNTREF3_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF3}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF3_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF3}]]></variableExpression>
+	<variable name="AMOUNTREF3_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF3}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF3_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF3}]]></variableExpression>
+	<variable name="AMOUNTREF3_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF3}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF3_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF3}]]></variableExpression>
+	<variable name="AMOUNTREF3_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF3}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF3_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF3}]]></variableExpression>
+	<variable name="AMOUNTREF3_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF3}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF3_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF3}]]></variableExpression>
+	<variable name="AMOUNTREF3_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF3}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF3_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF3}]]></variableExpression>
+	<variable name="AMOUNTREF3_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF3}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF3_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF3}]]></variableExpression>
+	<variable name="AMOUNTREF3_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF3}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF3_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF2}]]></variableExpression>
+	<variable name="AMOUNTREF3_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF2}]]></expression>
 	</variable>
-	<variable name="COST_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF2_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF2}]]></variableExpression>
+	<variable name="COSTREF2_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF2}]]></expression>
 	</variable>
-	<variable name="COSTREF2_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF2}]]></variableExpression>
+	<variable name="COSTREF2_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF2}]]></expression>
 	</variable>
-	<variable name="COSTREF2_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF2}]]></variableExpression>
+	<variable name="COSTREF2_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF2}]]></expression>
 	</variable>
-	<variable name="COSTREF2_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF2}]]></variableExpression>
+	<variable name="COSTREF2_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF2}]]></expression>
 	</variable>
-	<variable name="COSTREF2_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF2}]]></variableExpression>
+	<variable name="COSTREF2_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF2}]]></expression>
 	</variable>
-	<variable name="COSTREF2_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF2}]]></variableExpression>
+	<variable name="COSTREF2_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF2}]]></expression>
 	</variable>
-	<variable name="COSTREF2_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF2}]]></variableExpression>
+	<variable name="COSTREF2_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF2}]]></expression>
 	</variable>
-	<variable name="COSTREF2_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF2}]]></variableExpression>
+	<variable name="COSTREF2_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF2}]]></expression>
 	</variable>
-	<variable name="COSTREF2_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF2}]]></variableExpression>
+	<variable name="COSTREF2_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF2}]]></expression>
 	</variable>
-	<variable name="COSTREF2_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF2}]]></variableExpression>
+	<variable name="COSTREF2_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF2}]]></expression>
 	</variable>
-	<variable name="COSTREF3_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF3}]]></variableExpression>
+	<variable name="COSTREF3_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF3}]]></expression>
 	</variable>
-	<variable name="COSTREF3_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF3}]]></variableExpression>
+	<variable name="COSTREF3_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF3}]]></expression>
 	</variable>
-	<variable name="COSTREF3_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF3}]]></variableExpression>
+	<variable name="COSTREF3_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF3}]]></expression>
 	</variable>
-	<variable name="COSTREF3_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF3}]]></variableExpression>
+	<variable name="COSTREF3_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF3}]]></expression>
 	</variable>
-	<variable name="COSTREF3_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF3}]]></variableExpression>
+	<variable name="COSTREF3_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF3}]]></expression>
 	</variable>
-	<variable name="COSTREF3_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF3}]]></variableExpression>
+	<variable name="COSTREF3_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF3}]]></expression>
 	</variable>
-	<variable name="COSTREF3_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF3}]]></variableExpression>
+	<variable name="COSTREF3_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF3}]]></expression>
 	</variable>
-	<variable name="COSTREF3_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF3}]]></variableExpression>
+	<variable name="COSTREF3_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF3}]]></expression>
 	</variable>
-	<variable name="COSTREF3_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF3}]]></variableExpression>
+	<variable name="COSTREF3_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF3}]]></expression>
 	</variable>
-	<variable name="COSTREF3_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF3}]]></variableExpression>
+	<variable name="COSTREF3_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF3}]]></expression>
 	</variable>
-	<variable name="PROFIT_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM1}.subtract($V{COST_SUM1})]]></variableExpression>
+	<variable name="PROFIT_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM1}.subtract($V{COST_SUM1})]]></expression>
 	</variable>
-	<variable name="PROFIT_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM2}.subtract($V{COST_SUM2})]]></variableExpression>
+	<variable name="PROFIT_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM2}.subtract($V{COST_SUM2})]]></expression>
 	</variable>
-	<variable name="PROFIT_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM3}.subtract($V{COST_SUM3})]]></variableExpression>
+	<variable name="PROFIT_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM3}.subtract($V{COST_SUM3})]]></expression>
 	</variable>
-	<variable name="PROFIT_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM4}.subtract($V{COST_SUM4})]]></variableExpression>
+	<variable name="PROFIT_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM4}.subtract($V{COST_SUM4})]]></expression>
 	</variable>
-	<variable name="PROFIT_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM5}.subtract($V{COST_SUM5})]]></variableExpression>
+	<variable name="PROFIT_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM5}.subtract($V{COST_SUM5})]]></expression>
 	</variable>
-	<variable name="PROFIT_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM6}.subtract($V{COST_SUM6})]]></variableExpression>
+	<variable name="PROFIT_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM6}.subtract($V{COST_SUM6})]]></expression>
 	</variable>
-	<variable name="PROFIT_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM7}.subtract($V{COST_SUM7})]]></variableExpression>
+	<variable name="PROFIT_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM7}.subtract($V{COST_SUM7})]]></expression>
 	</variable>
-	<variable name="PROFIT_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM8}.subtract($V{COST_SUM8})]]></variableExpression>
+	<variable name="PROFIT_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM8}.subtract($V{COST_SUM8})]]></expression>
 	</variable>
-	<variable name="PROFIT_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM9}.subtract($V{COST_SUM9})]]></variableExpression>
+	<variable name="PROFIT_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM9}.subtract($V{COST_SUM9})]]></expression>
 	</variable>
-	<variable name="PROFIT_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM10}.subtract($V{COST_SUM10})]]></variableExpression>
+	<variable name="PROFIT_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM10}.subtract($V{COST_SUM10})]]></expression>
 	</variable>
-	<variable name="PROFITREF_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM1}.subtract($V{COSTREF_SUM1})]]></variableExpression>
+	<variable name="PROFITREF_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM1}.subtract($V{COSTREF_SUM1})]]></expression>
 	</variable>
-	<variable name="PROFITREF_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM2}.subtract($V{COSTREF_SUM2})]]></variableExpression>
+	<variable name="PROFITREF_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM2}.subtract($V{COSTREF_SUM2})]]></expression>
 	</variable>
-	<variable name="PROFITREF_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM3}.subtract($V{COSTREF_SUM3})]]></variableExpression>
+	<variable name="PROFITREF_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM3}.subtract($V{COSTREF_SUM3})]]></expression>
 	</variable>
-	<variable name="PROFITREF_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM4}.subtract($V{COSTREF_SUM4})]]></variableExpression>
+	<variable name="PROFITREF_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM4}.subtract($V{COSTREF_SUM4})]]></expression>
 	</variable>
-	<variable name="PROFITREF_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM5}.subtract($V{COSTREF_SUM5})]]></variableExpression>
+	<variable name="PROFITREF_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM5}.subtract($V{COSTREF_SUM5})]]></expression>
 	</variable>
-	<variable name="PROFITREF_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM6}.subtract($V{COSTREF_SUM6})]]></variableExpression>
+	<variable name="PROFITREF_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM6}.subtract($V{COSTREF_SUM6})]]></expression>
 	</variable>
-	<variable name="PROFITREF_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM7}.subtract($V{COSTREF_SUM7})]]></variableExpression>
+	<variable name="PROFITREF_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM7}.subtract($V{COSTREF_SUM7})]]></expression>
 	</variable>
-	<variable name="PROFITREF_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM8}.subtract($V{COSTREF_SUM8})]]></variableExpression>
+	<variable name="PROFITREF_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM8}.subtract($V{COSTREF_SUM8})]]></expression>
 	</variable>
-	<variable name="PROFITREF_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM9}.subtract($V{COSTREF_SUM9})]]></variableExpression>
+	<variable name="PROFITREF_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM9}.subtract($V{COSTREF_SUM9})]]></expression>
 	</variable>
-	<variable name="PROFITREF_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM10}.subtract($V{COSTREF_SUM10})]]></variableExpression>
+	<variable name="PROFITREF_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM10}.subtract($V{COSTREF_SUM10})]]></expression>
 	</variable>
-	<variable name="PROFITREF2_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[$V{AMOUNTREF2_SUM1}.subtract($V{COSTREF2_SUM1})]]></variableExpression>
+	<variable name="PROFITREF2_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF2_SUM1}.subtract($V{COSTREF2_SUM1})]]></expression>
 	</variable>
-	<variable name="PROFITREF2_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[$V{AMOUNTREF2_SUM2}.subtract($V{COSTREF2_SUM2})]]></variableExpression>
+	<variable name="PROFITREF2_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF2_SUM2}.subtract($V{COSTREF2_SUM2})]]></expression>
 	</variable>
-	<variable name="PROFITREF2_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[$V{AMOUNTREF2_SUM3}.subtract($V{COSTREF2_SUM3})]]></variableExpression>
+	<variable name="PROFITREF2_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF2_SUM3}.subtract($V{COSTREF2_SUM3})]]></expression>
 	</variable>
-	<variable name="PROFITREF2_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[$V{AMOUNTREF2_SUM4}.subtract($V{COSTREF2_SUM4})]]></variableExpression>
+	<variable name="PROFITREF2_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF2_SUM4}.subtract($V{COSTREF2_SUM4})]]></expression>
 	</variable>
-	<variable name="PROFITREF2_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[$V{AMOUNTREF2_SUM5}.subtract($V{COSTREF2_SUM5})]]></variableExpression>
+	<variable name="PROFITREF2_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF2_SUM5}.subtract($V{COSTREF2_SUM5})]]></expression>
 	</variable>
-	<variable name="PROFITREF2_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[$V{AMOUNTREF2_SUM6}.subtract($V{COSTREF2_SUM6})]]></variableExpression>
+	<variable name="PROFITREF2_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF2_SUM6}.subtract($V{COSTREF2_SUM6})]]></expression>
 	</variable>
-	<variable name="PROFITREF2_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[$V{AMOUNTREF2_SUM7}.subtract($V{COSTREF2_SUM7})]]></variableExpression>
+	<variable name="PROFITREF2_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF2_SUM7}.subtract($V{COSTREF2_SUM7})]]></expression>
 	</variable>
-	<variable name="PROFITREF2_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[$V{AMOUNTREF2_SUM8}.subtract($V{COSTREF2_SUM8})]]></variableExpression>
+	<variable name="PROFITREF2_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF2_SUM8}.subtract($V{COSTREF2_SUM8})]]></expression>
 	</variable>
-	<variable name="PROFITREF2_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[$V{AMOUNTREF2_SUM9}.subtract($V{COSTREF2_SUM9})]]></variableExpression>
+	<variable name="PROFITREF2_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF2_SUM9}.subtract($V{COSTREF2_SUM9})]]></expression>
 	</variable>
-	<variable name="PROFITREF2_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[$V{AMOUNTREF2_SUM10}.subtract($V{COSTREF2_SUM10})]]></variableExpression>
+	<variable name="PROFITREF2_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF2_SUM10}.subtract($V{COSTREF2_SUM10})]]></expression>
 	</variable>
-	<variable name="PROFITREF3_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[$V{AMOUNTREF3_SUM1}.subtract($V{COSTREF3_SUM1})]]></variableExpression>
+	<variable name="PROFITREF3_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF3_SUM1}.subtract($V{COSTREF3_SUM1})]]></expression>
 	</variable>
-	<variable name="PROFITREF3_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[$V{AMOUNTREF3_SUM2}.subtract($V{COSTREF3_SUM2})]]></variableExpression>
+	<variable name="PROFITREF3_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF3_SUM2}.subtract($V{COSTREF3_SUM2})]]></expression>
 	</variable>
-	<variable name="PROFITREF3_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[$V{AMOUNTREF3_SUM3}.subtract($V{COSTREF3_SUM3})]]></variableExpression>
+	<variable name="PROFITREF3_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF3_SUM3}.subtract($V{COSTREF3_SUM3})]]></expression>
 	</variable>
-	<variable name="PROFITREF3_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[$V{AMOUNTREF3_SUM4}.subtract($V{COSTREF3_SUM4})]]></variableExpression>
+	<variable name="PROFITREF3_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF3_SUM4}.subtract($V{COSTREF3_SUM4})]]></expression>
 	</variable>
-	<variable name="PROFITREF3_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[$V{AMOUNTREF3_SUM5}.subtract($V{COSTREF3_SUM5})]]></variableExpression>
+	<variable name="PROFITREF3_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF3_SUM5}.subtract($V{COSTREF3_SUM5})]]></expression>
 	</variable>
-	<variable name="PROFITREF3_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[$V{AMOUNTREF3_SUM6}.subtract($V{COSTREF3_SUM6})]]></variableExpression>
+	<variable name="PROFITREF3_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF3_SUM6}.subtract($V{COSTREF3_SUM6})]]></expression>
 	</variable>
-	<variable name="PROFITREF3_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[$V{AMOUNTREF3_SUM7}.subtract($V{COSTREF3_SUM7})]]></variableExpression>
+	<variable name="PROFITREF3_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF3_SUM7}.subtract($V{COSTREF3_SUM7})]]></expression>
 	</variable>
-	<variable name="PROFITREF3_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[$V{AMOUNTREF3_SUM8}.subtract($V{COSTREF3_SUM8})]]></variableExpression>
+	<variable name="PROFITREF3_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF3_SUM8}.subtract($V{COSTREF3_SUM8})]]></expression>
 	</variable>
-	<variable name="PROFITREF3_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[$V{AMOUNTREF3_SUM9}.subtract($V{COSTREF3_SUM9})]]></variableExpression>
+	<variable name="PROFITREF3_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF3_SUM9}.subtract($V{COSTREF3_SUM9})]]></expression>
 	</variable>
-	<variable name="PROFITREF3_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[$V{AMOUNTREF3_SUM10}.subtract($V{COSTREF3_SUM10})]]></variableExpression>
+	<variable name="PROFITREF3_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF3_SUM10}.subtract($V{COSTREF3_SUM10})]]></expression>
 	</variable>
-	<variable name="MARGIN_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{AMOUNT_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_TOTAL}.divide($V{AMOUNT_TOTAL}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_TOTAL}.signum()))]]></variableExpression>
+	<variable name="MARGIN_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_TOTAL}.divide($V{AMOUNT_TOTAL}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_TOTAL}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_2}.divide( $V{AMOUNT_SUM2}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_2}.signum()))]]></variableExpression>
+	<variable name="MARGIN_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_2}.divide( $V{AMOUNT_SUM2}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_2}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_3}.divide( $V{AMOUNT_SUM3}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_3}.signum()))]]></variableExpression>
+	<variable name="MARGIN_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_3}.divide( $V{AMOUNT_SUM3}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_3}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_4}.divide( $V{AMOUNT_SUM4}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_4}.signum()))]]></variableExpression>
+	<variable name="MARGIN_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_4}.divide( $V{AMOUNT_SUM4}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_4}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_5}.divide( $V{AMOUNT_SUM5}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_5}.signum()))]]></variableExpression>
+	<variable name="MARGIN_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_5}.divide( $V{AMOUNT_SUM5}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_5}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_6}.divide( $V{AMOUNT_SUM6}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_6}.signum()))]]></variableExpression>
+	<variable name="MARGIN_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_6}.divide( $V{AMOUNT_SUM6}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_6}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_7}.divide( $V{AMOUNT_SUM7}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_7}.signum()))]]></variableExpression>
+	<variable name="MARGIN_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_7}.divide( $V{AMOUNT_SUM7}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_7}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_8}.divide( $V{AMOUNT_SUM8}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_8}.signum()))]]></variableExpression>
+	<variable name="MARGIN_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_8}.divide( $V{AMOUNT_SUM8}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_8}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_9}.divide( $V{AMOUNT_SUM9}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_9}.signum()))]]></variableExpression>
+	<variable name="MARGIN_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_9}.divide( $V{AMOUNT_SUM9}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_9}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{PROFIT_10}.divide( $V{AMOUNT_SUM10}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_10}.signum()))]]></variableExpression>
+	<variable name="MARGIN_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{PROFIT_10}.divide( $V{AMOUNT_SUM10}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_10}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM1}.compareTo(BigDecimal.ZERO)==0)?BigDecimal.ZERO: $V{PROFITREF_1}.divide( $V{AMOUNTREF_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_1}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM1}.compareTo(BigDecimal.ZERO)==0)?BigDecimal.ZERO: $V{PROFITREF_1}.divide( $V{AMOUNTREF_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_1}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_2}.divide( $V{AMOUNTREF_SUM2}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_2}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_2}.divide( $V{AMOUNTREF_SUM2}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_2}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_3}.divide( $V{AMOUNTREF_SUM3}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_3}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_3}.divide( $V{AMOUNTREF_SUM3}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_3}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_4}.divide( $V{AMOUNTREF_SUM4}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_4}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_4}.divide( $V{AMOUNTREF_SUM4}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_4}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_5}.divide( $V{AMOUNTREF_SUM5}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_5}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_5}.divide( $V{AMOUNTREF_SUM5}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_5}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_6}.divide( $V{AMOUNTREF_SUM6}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_6}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_6}.divide( $V{AMOUNTREF_SUM6}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_6}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_7}.divide( $V{AMOUNTREF_SUM7}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_7}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_7}.divide( $V{AMOUNTREF_SUM7}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_7}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_8}.divide( $V{AMOUNTREF_SUM8}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_8}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_8}.divide( $V{AMOUNTREF_SUM8}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_8}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_9}.divide( $V{AMOUNTREF_SUM9}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_9}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_9}.divide( $V{AMOUNTREF_SUM9}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_9}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{PROFITREF_10}.divide( $V{AMOUNTREF_SUM10}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_10}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{PROFITREF_10}.divide( $V{AMOUNTREF_SUM10}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_10}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF2_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM1}.compareTo(BigDecimal.ZERO)==0)?BigDecimal.ZERO: $V{PROFITREF2_1}.divide( $V{AMOUNTREF2_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_1}.signum()))]]></variableExpression>
+	<variable name="MARGINREF2_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM1}.compareTo(BigDecimal.ZERO)==0)?BigDecimal.ZERO: $V{PROFITREF2_1}.divide( $V{AMOUNTREF2_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_1}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF2_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_2}.divide( $V{AMOUNTREF2_SUM2}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_2}.signum()))]]></variableExpression>
+	<variable name="MARGINREF2_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_2}.divide( $V{AMOUNTREF2_SUM2}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_2}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF2_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_3}.divide( $V{AMOUNTREF2_SUM3}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_3}.signum()))]]></variableExpression>
+	<variable name="MARGINREF2_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_3}.divide( $V{AMOUNTREF2_SUM3}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_3}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF2_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_4}.divide( $V{AMOUNTREF2_SUM4}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_4}.signum()))]]></variableExpression>
+	<variable name="MARGINREF2_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_4}.divide( $V{AMOUNTREF2_SUM4}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_4}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF2_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_5}.divide( $V{AMOUNTREF2_SUM5}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_5}.signum()))]]></variableExpression>
+	<variable name="MARGINREF2_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_5}.divide( $V{AMOUNTREF2_SUM5}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_5}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF2_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_6}.divide( $V{AMOUNTREF2_SUM6}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_6}.signum()))]]></variableExpression>
+	<variable name="MARGINREF2_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_6}.divide( $V{AMOUNTREF2_SUM6}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_6}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF2_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_7}.divide( $V{AMOUNTREF2_SUM7}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_7}.signum()))]]></variableExpression>
+	<variable name="MARGINREF2_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_7}.divide( $V{AMOUNTREF2_SUM7}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_7}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF2_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_8}.divide( $V{AMOUNTREF2_SUM8}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_8}.signum()))]]></variableExpression>
+	<variable name="MARGINREF2_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_8}.divide( $V{AMOUNTREF2_SUM8}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_8}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF2_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_9}.divide( $V{AMOUNTREF2_SUM9}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_9}.signum()))]]></variableExpression>
+	<variable name="MARGINREF2_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_9}.divide( $V{AMOUNTREF2_SUM9}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_9}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF2_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{PROFITREF2_10}.divide( $V{AMOUNTREF2_SUM10}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_10}.signum()))]]></variableExpression>
+	<variable name="MARGINREF2_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{PROFITREF2_10}.divide( $V{AMOUNTREF2_SUM10}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_10}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF3_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{AMOUNTREF3_SUM1}.compareTo(BigDecimal.ZERO)==0)?BigDecimal.ZERO:$V{PROFITREF3_1}.divide( $V{AMOUNTREF3_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF3_1}.signum()))]]></variableExpression>
+	<variable name="MARGINREF3_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF3_SUM1}.compareTo(BigDecimal.ZERO)==0)?BigDecimal.ZERO:$V{PROFITREF3_1}.divide( $V{AMOUNTREF3_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF3_1}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF3_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{AMOUNTREF3_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF3_2}.divide( $V{AMOUNTREF3_SUM2}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF3_2}.signum()))]]></variableExpression>
+	<variable name="MARGINREF3_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF3_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF3_2}.divide( $V{AMOUNTREF3_SUM2}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF3_2}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF3_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{AMOUNTREF3_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF3_3}.divide( $V{AMOUNTREF3_SUM3}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF3_3}.signum()))]]></variableExpression>
+	<variable name="MARGINREF3_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF3_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF3_3}.divide( $V{AMOUNTREF3_SUM3}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF3_3}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF3_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{AMOUNTREF3_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF3_4}.divide( $V{AMOUNTREF3_SUM4}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF3_4}.signum()))]]></variableExpression>
+	<variable name="MARGINREF3_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF3_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF3_4}.divide( $V{AMOUNTREF3_SUM4}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF3_4}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF3_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{AMOUNTREF3_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF3_5}.divide( $V{AMOUNTREF3_SUM5}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF3_5}.signum()))]]></variableExpression>
+	<variable name="MARGINREF3_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF3_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF3_5}.divide( $V{AMOUNTREF3_SUM5}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF3_5}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF3_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{AMOUNTREF3_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF3_6}.divide( $V{AMOUNTREF3_SUM6}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF3_6}.signum()))]]></variableExpression>
+	<variable name="MARGINREF3_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF3_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF3_6}.divide( $V{AMOUNTREF3_SUM6}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF3_6}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF3_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{AMOUNTREF3_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF3_7}.divide( $V{AMOUNTREF3_SUM7}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF3_7}.signum()))]]></variableExpression>
+	<variable name="MARGINREF3_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF3_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF3_7}.divide( $V{AMOUNTREF3_SUM7}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF3_7}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF3_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{AMOUNTREF3_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF3_8}.divide( $V{AMOUNTREF3_SUM8}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF3_8}.signum()))]]></variableExpression>
+	<variable name="MARGINREF3_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF3_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF3_8}.divide( $V{AMOUNTREF3_SUM8}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF3_8}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF3_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{AMOUNTREF3_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF3_9}.divide( $V{AMOUNTREF3_SUM9}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF3_9}.signum()))]]></variableExpression>
+	<variable name="MARGINREF3_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF3_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF3_9}.divide( $V{AMOUNTREF3_SUM9}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF3_9}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF3_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{AMOUNTREF3_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{PROFITREF3_10}.divide( $V{AMOUNTREF3_SUM10}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF3_10}.signum()))]]></variableExpression>
+	<variable name="MARGINREF3_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF3_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{PROFITREF3_10}.divide( $V{AMOUNTREF3_SUM10}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF3_10}.signum()))]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF2_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF2}]]></variableExpression>
+	<variable name="WEIGHTREF2_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF2}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF2_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF2}]]></variableExpression>
+	<variable name="WEIGHTREF2_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF2}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF2_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF2}]]></variableExpression>
+	<variable name="WEIGHTREF2_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF2}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF2_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF2}]]></variableExpression>
+	<variable name="WEIGHTREF2_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF2}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF2_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF2}]]></variableExpression>
+	<variable name="WEIGHTREF2_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF2}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF2_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF2}]]></variableExpression>
+	<variable name="WEIGHTREF2_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF2}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF2_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF2}]]></variableExpression>
+	<variable name="WEIGHTREF2_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF2}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF2_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF2}]]></variableExpression>
+	<variable name="WEIGHTREF2_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF2}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF2_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF2}]]></variableExpression>
+	<variable name="WEIGHTREF2_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF2}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF2_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF2}]]></variableExpression>
+	<variable name="WEIGHTREF2_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF2}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF2_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF2}]]></variableExpression>
+	<variable name="WEIGHTREF2_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF2}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF3_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF3}]]></variableExpression>
+	<variable name="WEIGHTREF3_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF3}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF3_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF3}]]></variableExpression>
+	<variable name="WEIGHTREF3_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF3}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF3_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF3}]]></variableExpression>
+	<variable name="WEIGHTREF3_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF3}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF3_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF3}]]></variableExpression>
+	<variable name="WEIGHTREF3_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF3}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF3_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF3}]]></variableExpression>
+	<variable name="WEIGHTREF3_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF3}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF3_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF3}]]></variableExpression>
+	<variable name="WEIGHTREF3_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF3}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF3_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF3}]]></variableExpression>
+	<variable name="WEIGHTREF3_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF3}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF3_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF3}]]></variableExpression>
+	<variable name="WEIGHTREF3_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF3}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF3_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF3}]]></variableExpression>
+	<variable name="WEIGHTREF3_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF3}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF3_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF3}]]></variableExpression>
+	<variable name="WEIGHTREF3_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF3}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF3_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF3}]]></variableExpression>
+	<variable name="WEIGHTREF3_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF3}]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM1}.subtract($V{AMOUNTREF_SUM1}).divide( $V{AMOUNTREF_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM1}.subtract($V{AMOUNTREF_SUM1}).divide( $V{AMOUNTREF_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM2}.subtract($V{AMOUNTREF_SUM2}).divide( $V{AMOUNTREF_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM2}.subtract($V{AMOUNTREF_SUM2}).divide( $V{AMOUNTREF_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM3}.subtract($V{AMOUNTREF_SUM3}).divide( $V{AMOUNTREF_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM3}.subtract($V{AMOUNTREF_SUM3}).divide( $V{AMOUNTREF_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM4}.subtract($V{AMOUNTREF_SUM4}).divide( $V{AMOUNTREF_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM4}.subtract($V{AMOUNTREF_SUM4}).divide( $V{AMOUNTREF_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM5}.subtract($V{AMOUNTREF_SUM5}).divide( $V{AMOUNTREF_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM5}.subtract($V{AMOUNTREF_SUM5}).divide( $V{AMOUNTREF_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM6}.subtract($V{AMOUNTREF_SUM6}).divide( $V{AMOUNTREF_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM6}.subtract($V{AMOUNTREF_SUM6}).divide( $V{AMOUNTREF_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM7}.subtract($V{AMOUNTREF_SUM7}).divide( $V{AMOUNTREF_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM7}.subtract($V{AMOUNTREF_SUM7}).divide( $V{AMOUNTREF_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM8}.subtract($V{AMOUNTREF_SUM8}).divide( $V{AMOUNTREF_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM8}.subtract($V{AMOUNTREF_SUM8}).divide( $V{AMOUNTREF_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM9}.subtract($V{AMOUNTREF_SUM9}).divide( $V{AMOUNTREF_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM9}.subtract($V{AMOUNTREF_SUM9}).divide( $V{AMOUNTREF_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM10}.subtract($V{AMOUNTREF_SUM10}).divide( $V{AMOUNTREF_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM10}.subtract($V{AMOUNTREF_SUM10}).divide( $V{AMOUNTREF_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PERTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[($V{AMOUNTREF_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_TOTAL}.subtract($V{AMOUNTREF_TOTAL}).divide( $V{AMOUNTREF_TOTAL}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PERTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_TOTAL}.subtract($V{AMOUNTREF_TOTAL}).divide( $V{AMOUNTREF_TOTAL}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT2_PER1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM1}.subtract($V{AMOUNTREF2_SUM1}).divide( $V{AMOUNTREF2_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT2_PER1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM1}.subtract($V{AMOUNTREF2_SUM1}).divide( $V{AMOUNTREF2_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT2_PER2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM2}.subtract($V{AMOUNTREF2_SUM2}).divide( $V{AMOUNTREF2_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT2_PER2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM2}.subtract($V{AMOUNTREF2_SUM2}).divide( $V{AMOUNTREF2_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT2_PER3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM3}.subtract($V{AMOUNTREF2_SUM3}).divide( $V{AMOUNTREF2_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT2_PER3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM3}.subtract($V{AMOUNTREF2_SUM3}).divide( $V{AMOUNTREF2_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT2_PER4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM4}.subtract($V{AMOUNTREF2_SUM4}).divide( $V{AMOUNTREF2_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT2_PER4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM4}.subtract($V{AMOUNTREF2_SUM4}).divide( $V{AMOUNTREF2_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT2_PER5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM5}.subtract($V{AMOUNTREF2_SUM5}).divide( $V{AMOUNTREF2_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT2_PER5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM5}.subtract($V{AMOUNTREF2_SUM5}).divide( $V{AMOUNTREF2_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT2_PER6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM6}.subtract($V{AMOUNTREF2_SUM6}).divide( $V{AMOUNTREF2_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT2_PER6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM6}.subtract($V{AMOUNTREF2_SUM6}).divide( $V{AMOUNTREF2_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT2_PER7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM7}.subtract($V{AMOUNTREF2_SUM7}).divide( $V{AMOUNTREF2_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT2_PER7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM7}.subtract($V{AMOUNTREF2_SUM7}).divide( $V{AMOUNTREF2_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT2_PER8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM8}.subtract($V{AMOUNTREF2_SUM8}).divide( $V{AMOUNTREF2_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT2_PER8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM8}.subtract($V{AMOUNTREF2_SUM8}).divide( $V{AMOUNTREF2_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT2_PER9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM9}.subtract($V{AMOUNTREF2_SUM9}).divide( $V{AMOUNTREF2_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT2_PER9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM9}.subtract($V{AMOUNTREF2_SUM9}).divide( $V{AMOUNTREF2_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT2_PER10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM10}.subtract($V{AMOUNTREF2_SUM10}).divide( $V{AMOUNTREF2_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT2_PER10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM10}.subtract($V{AMOUNTREF2_SUM10}).divide( $V{AMOUNTREF2_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT2_PERTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_TOTAL}.subtract($V{AMOUNTREF2_TOTAL}).divide( $V{AMOUNTREF2_TOTAL}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT2_PERTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_TOTAL}.subtract($V{AMOUNTREF2_TOTAL}).divide( $V{AMOUNTREF2_TOTAL}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT3_PER1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{AMOUNTREF3_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM1}.subtract($V{AMOUNTREF3_SUM1}).divide( $V{AMOUNTREF3_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT3_PER1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF3_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM1}.subtract($V{AMOUNTREF3_SUM1}).divide( $V{AMOUNTREF3_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT3_PER2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{AMOUNTREF3_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM2}.subtract($V{AMOUNTREF3_SUM2}).divide( $V{AMOUNTREF3_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT3_PER2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF3_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM2}.subtract($V{AMOUNTREF3_SUM2}).divide( $V{AMOUNTREF3_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT3_PER3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{AMOUNTREF3_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM3}.subtract($V{AMOUNTREF3_SUM3}).divide( $V{AMOUNTREF3_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT3_PER3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF3_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM3}.subtract($V{AMOUNTREF3_SUM3}).divide( $V{AMOUNTREF3_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT3_PER4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{AMOUNTREF3_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM4}.subtract($V{AMOUNTREF3_SUM4}).divide( $V{AMOUNTREF3_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT3_PER4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF3_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM4}.subtract($V{AMOUNTREF3_SUM4}).divide( $V{AMOUNTREF3_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT3_PER5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{AMOUNTREF3_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM5}.subtract($V{AMOUNTREF3_SUM5}).divide( $V{AMOUNTREF3_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT3_PER5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF3_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM5}.subtract($V{AMOUNTREF3_SUM5}).divide( $V{AMOUNTREF3_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT3_PER6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{AMOUNTREF3_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM6}.subtract($V{AMOUNTREF3_SUM6}).divide( $V{AMOUNTREF3_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT3_PER6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF3_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM6}.subtract($V{AMOUNTREF3_SUM6}).divide( $V{AMOUNTREF3_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT3_PER7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{AMOUNTREF3_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM7}.subtract($V{AMOUNTREF3_SUM7}).divide( $V{AMOUNTREF3_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT3_PER7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF3_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM7}.subtract($V{AMOUNTREF3_SUM7}).divide( $V{AMOUNTREF3_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT3_PER8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{AMOUNTREF3_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM8}.subtract($V{AMOUNTREF3_SUM8}).divide( $V{AMOUNTREF3_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT3_PER8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF3_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM8}.subtract($V{AMOUNTREF3_SUM8}).divide( $V{AMOUNTREF3_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT3_PER9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{AMOUNTREF3_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM9}.subtract($V{AMOUNTREF3_SUM9}).divide( $V{AMOUNTREF3_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT3_PER9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF3_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM9}.subtract($V{AMOUNTREF3_SUM9}).divide( $V{AMOUNTREF3_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT3_PER10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{AMOUNTREF3_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM10}.subtract($V{AMOUNTREF3_SUM10}).divide( $V{AMOUNTREF3_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT3_PER10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF3_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM10}.subtract($V{AMOUNTREF3_SUM10}).divide( $V{AMOUNTREF3_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT3_PERTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[($V{AMOUNTREF3_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_TOTAL}.subtract($V{AMOUNTREF3_TOTAL}).divide( $V{AMOUNTREF3_TOTAL}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT3_PERTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF3_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_TOTAL}.subtract($V{AMOUNTREF3_TOTAL}).divide( $V{AMOUNTREF3_TOTAL}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{QTYREF_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM1}.subtract($V{QTYREF_SUM1}).divide( $V{QTYREF_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM1}.subtract($V{QTYREF_SUM1}).divide( $V{QTYREF_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{QTYREF_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM2}.subtract($V{QTYREF_SUM2}).divide( $V{QTYREF_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM2}.subtract($V{QTYREF_SUM2}).divide( $V{QTYREF_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{QTYREF_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM3}.subtract($V{QTYREF_SUM3}).divide( $V{QTYREF_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM3}.subtract($V{QTYREF_SUM3}).divide( $V{QTYREF_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{QTYREF_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM4}.subtract($V{QTYREF_SUM4}).divide( $V{QTYREF_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM4}.subtract($V{QTYREF_SUM4}).divide( $V{QTYREF_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{QTYREF_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM5}.subtract($V{QTYREF_SUM5}).divide( $V{QTYREF_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM5}.subtract($V{QTYREF_SUM5}).divide( $V{QTYREF_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{QTYREF_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM6}.subtract($V{QTYREF_SUM6}).divide( $V{QTYREF_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM6}.subtract($V{QTYREF_SUM6}).divide( $V{QTYREF_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{QTYREF_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM7}.subtract($V{QTYREF_SUM7}).divide( $V{QTYREF_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM7}.subtract($V{QTYREF_SUM7}).divide( $V{QTYREF_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{QTYREF_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM8}.subtract($V{QTYREF_SUM8}).divide( $V{QTYREF_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM8}.subtract($V{QTYREF_SUM8}).divide( $V{QTYREF_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{QTYREF_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM9}.subtract($V{QTYREF_SUM9}).divide( $V{QTYREF_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM9}.subtract($V{QTYREF_SUM9}).divide( $V{QTYREF_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{QTYREF_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM10}.subtract($V{QTYREF_SUM10}).divide( $V{QTYREF_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM10}.subtract($V{QTYREF_SUM10}).divide( $V{QTYREF_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY2_PER1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{QTYREF2_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM1}.subtract($V{QTYREF2_SUM1}).divide( $V{QTYREF2_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY2_PER1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF2_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM1}.subtract($V{QTYREF2_SUM1}).divide( $V{QTYREF2_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY2_PER2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{QTYREF2_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM2}.subtract($V{QTYREF2_SUM2}).divide( $V{QTYREF2_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY2_PER2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF2_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM2}.subtract($V{QTYREF2_SUM2}).divide( $V{QTYREF2_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY2_PER3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{QTYREF2_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM3}.subtract($V{QTYREF2_SUM3}).divide( $V{QTYREF2_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY2_PER3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF2_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM3}.subtract($V{QTYREF2_SUM3}).divide( $V{QTYREF2_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY2_PER4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{QTYREF2_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM4}.subtract($V{QTYREF2_SUM4}).divide( $V{QTYREF2_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY2_PER4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF2_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM4}.subtract($V{QTYREF2_SUM4}).divide( $V{QTYREF2_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY2_PER5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{QTYREF2_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM5}.subtract($V{QTYREF2_SUM5}).divide( $V{QTYREF2_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY2_PER5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF2_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM5}.subtract($V{QTYREF2_SUM5}).divide( $V{QTYREF2_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY2_PER6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{QTYREF2_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM6}.subtract($V{QTYREF2_SUM6}).divide( $V{QTYREF2_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY2_PER6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF2_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM6}.subtract($V{QTYREF2_SUM6}).divide( $V{QTYREF2_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY2_PER7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{QTYREF2_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM7}.subtract($V{QTYREF2_SUM7}).divide( $V{QTYREF2_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY2_PER7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF2_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM7}.subtract($V{QTYREF2_SUM7}).divide( $V{QTYREF2_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY2_PER8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{QTYREF2_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM8}.subtract($V{QTYREF2_SUM8}).divide( $V{QTYREF2_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY2_PER8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF2_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM8}.subtract($V{QTYREF2_SUM8}).divide( $V{QTYREF2_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY2_PER9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{QTYREF2_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM9}.subtract($V{QTYREF2_SUM9}).divide( $V{QTYREF2_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY2_PER9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF2_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM9}.subtract($V{QTYREF2_SUM9}).divide( $V{QTYREF2_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY2_PER10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{QTYREF2_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM10}.subtract($V{QTYREF2_SUM10}).divide( $V{QTYREF2_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY2_PER10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF2_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM10}.subtract($V{QTYREF2_SUM10}).divide( $V{QTYREF2_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY3_PER1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{QTYREF3_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM1}.subtract($V{QTYREF3_SUM1}).divide( $V{QTYREF3_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY3_PER1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF3_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM1}.subtract($V{QTYREF3_SUM1}).divide( $V{QTYREF3_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY3_PER2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{QTYREF3_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM2}.subtract($V{QTYREF3_SUM2}).divide( $V{QTYREF3_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY3_PER2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF3_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM2}.subtract($V{QTYREF3_SUM2}).divide( $V{QTYREF3_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY3_PER3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{QTYREF3_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM3}.subtract($V{QTYREF3_SUM3}).divide( $V{QTYREF3_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY3_PER3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF3_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM3}.subtract($V{QTYREF3_SUM3}).divide( $V{QTYREF3_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY3_PER4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{QTYREF3_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM4}.subtract($V{QTYREF3_SUM4}).divide( $V{QTYREF3_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY3_PER4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF3_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM4}.subtract($V{QTYREF3_SUM4}).divide( $V{QTYREF3_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY3_PER5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{QTYREF3_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM5}.subtract($V{QTYREF3_SUM5}).divide( $V{QTYREF3_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY3_PER5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF3_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM5}.subtract($V{QTYREF3_SUM5}).divide( $V{QTYREF3_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY3_PER6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{QTYREF3_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM6}.subtract($V{QTYREF3_SUM6}).divide( $V{QTYREF3_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY3_PER6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF3_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM6}.subtract($V{QTYREF3_SUM6}).divide( $V{QTYREF3_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY3_PER7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{QTYREF3_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM7}.subtract($V{QTYREF3_SUM7}).divide( $V{QTYREF3_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY3_PER7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF3_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM7}.subtract($V{QTYREF3_SUM7}).divide( $V{QTYREF3_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY3_PER8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{QTYREF3_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM8}.subtract($V{QTYREF3_SUM8}).divide( $V{QTYREF3_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY3_PER8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF3_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM8}.subtract($V{QTYREF3_SUM8}).divide( $V{QTYREF3_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY3_PER9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{QTYREF3_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM9}.subtract($V{QTYREF3_SUM9}).divide( $V{QTYREF3_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY3_PER9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF3_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM9}.subtract($V{QTYREF3_SUM9}).divide( $V{QTYREF3_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY3_PER10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{QTYREF3_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM10}.subtract($V{QTYREF3_SUM10}).divide( $V{QTYREF3_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY3_PER10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF3_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM10}.subtract($V{QTYREF3_SUM10}).divide( $V{QTYREF3_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{MARGIN_1}!=null && $V{MARGINREF_1}!=null )?($V{MARGIN_1}.subtract( $V{MARGINREF_1})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_1}!=null && $V{MARGINREF_1}!=null )?($V{MARGIN_1}.subtract( $V{MARGINREF_1})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{MARGIN_2}!=null && $V{MARGINREF_2}!=null )?($V{MARGIN_2}.subtract( $V{MARGINREF_2})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_2}!=null && $V{MARGINREF_2}!=null )?($V{MARGIN_2}.subtract( $V{MARGINREF_2})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{MARGIN_3}!=null && $V{MARGINREF_3}!=null )?($V{MARGIN_3}.subtract( $V{MARGINREF_3})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_3}!=null && $V{MARGINREF_3}!=null )?($V{MARGIN_3}.subtract( $V{MARGINREF_3})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{MARGIN_4}!=null && $V{MARGINREF_4}!=null )?($V{MARGIN_4}.subtract( $V{MARGINREF_4})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_4}!=null && $V{MARGINREF_4}!=null )?($V{MARGIN_4}.subtract( $V{MARGINREF_4})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{MARGIN_5}!=null && $V{MARGINREF_5}!=null )?($V{MARGIN_5}.subtract( $V{MARGINREF_5})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_5}!=null && $V{MARGINREF_5}!=null )?($V{MARGIN_5}.subtract( $V{MARGINREF_5})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{MARGIN_6}!=null && $V{MARGINREF_6}!=null )?($V{MARGIN_6}.subtract( $V{MARGINREF_6})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_6}!=null && $V{MARGINREF_6}!=null )?($V{MARGIN_6}.subtract( $V{MARGINREF_6})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{MARGIN_7}!=null && $V{MARGINREF_7}!=null )?($V{MARGIN_7}.subtract( $V{MARGINREF_7})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_7}!=null && $V{MARGINREF_7}!=null )?($V{MARGIN_7}.subtract( $V{MARGINREF_7})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{MARGIN_8}!=null && $V{MARGINREF_8}!=null )?($V{MARGIN_8}.subtract( $V{MARGINREF_8})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_8}!=null && $V{MARGINREF_8}!=null )?($V{MARGIN_8}.subtract( $V{MARGINREF_8})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{MARGIN_9}!=null && $V{MARGINREF_9}!=null )?($V{MARGIN_9}.subtract( $V{MARGINREF_9})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_9}!=null && $V{MARGINREF_9}!=null )?($V{MARGIN_9}.subtract( $V{MARGINREF_9})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{MARGIN_10}!=null && $V{MARGINREF_10}!=null )?($V{MARGIN_10}.subtract( $V{MARGINREF_10})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_10}!=null && $V{MARGINREF_10}!=null )?($V{MARGIN_10}.subtract( $V{MARGINREF_10})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF2_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{MARGIN_1}!=null && $V{MARGINREF2_1}!=null )?($V{MARGIN_1}.subtract( $V{MARGINREF2_1})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF2_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_1}!=null && $V{MARGINREF2_1}!=null )?($V{MARGIN_1}.subtract( $V{MARGINREF2_1})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF2_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{MARGIN_2}!=null && $V{MARGINREF2_2}!=null )?($V{MARGIN_2}.subtract( $V{MARGINREF2_2})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF2_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_2}!=null && $V{MARGINREF2_2}!=null )?($V{MARGIN_2}.subtract( $V{MARGINREF2_2})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF2_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{MARGIN_3}!=null && $V{MARGINREF2_3}!=null )?($V{MARGIN_3}.subtract( $V{MARGINREF2_3})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF2_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_3}!=null && $V{MARGINREF2_3}!=null )?($V{MARGIN_3}.subtract( $V{MARGINREF2_3})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF2_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{MARGIN_4}!=null && $V{MARGINREF2_4}!=null )?($V{MARGIN_4}.subtract( $V{MARGINREF2_4})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF2_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_4}!=null && $V{MARGINREF2_4}!=null )?($V{MARGIN_4}.subtract( $V{MARGINREF2_4})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF2_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{MARGIN_5}!=null && $V{MARGINREF2_5}!=null )?($V{MARGIN_5}.subtract( $V{MARGINREF2_5})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF2_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_5}!=null && $V{MARGINREF2_5}!=null )?($V{MARGIN_5}.subtract( $V{MARGINREF2_5})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF2_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{MARGIN_6}!=null && $V{MARGINREF2_6}!=null )?($V{MARGIN_6}.subtract( $V{MARGINREF2_6})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF2_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_6}!=null && $V{MARGINREF2_6}!=null )?($V{MARGIN_6}.subtract( $V{MARGINREF2_6})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF2_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{MARGIN_7}!=null && $V{MARGINREF2_7}!=null )?($V{MARGIN_7}.subtract( $V{MARGINREF2_7})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF2_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_7}!=null && $V{MARGINREF2_7}!=null )?($V{MARGIN_7}.subtract( $V{MARGINREF2_7})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF2_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{MARGIN_8}!=null && $V{MARGINREF2_8}!=null )?($V{MARGIN_8}.subtract( $V{MARGINREF2_8})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF2_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_8}!=null && $V{MARGINREF2_8}!=null )?($V{MARGIN_8}.subtract( $V{MARGINREF2_8})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF2_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{MARGIN_9}!=null && $V{MARGINREF2_9}!=null )?($V{MARGIN_9}.subtract( $V{MARGINREF2_9})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF2_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_9}!=null && $V{MARGINREF2_9}!=null )?($V{MARGIN_9}.subtract( $V{MARGINREF2_9})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF2_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{MARGIN_10}!=null && $V{MARGINREF2_10}!=null )?($V{MARGIN_10}.subtract( $V{MARGINREF2_10})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF2_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_10}!=null && $V{MARGINREF2_10}!=null )?($V{MARGIN_10}.subtract( $V{MARGINREF2_10})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF3_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{MARGIN_1}!=null && $V{MARGINREF3_1}!=null )?($V{MARGIN_1}.subtract( $V{MARGINREF3_1})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF3_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_1}!=null && $V{MARGINREF3_1}!=null )?($V{MARGIN_1}.subtract( $V{MARGINREF3_1})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF3_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{MARGIN_2}!=null && $V{MARGINREF3_2}!=null )?($V{MARGIN_2}.subtract( $V{MARGINREF3_2})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF3_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_2}!=null && $V{MARGINREF3_2}!=null )?($V{MARGIN_2}.subtract( $V{MARGINREF3_2})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF3_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{MARGIN_3}!=null && $V{MARGINREF3_3}!=null )?($V{MARGIN_3}.subtract( $V{MARGINREF3_3})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF3_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_3}!=null && $V{MARGINREF3_3}!=null )?($V{MARGIN_3}.subtract( $V{MARGINREF3_3})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF3_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{MARGIN_4}!=null && $V{MARGINREF3_4}!=null )?($V{MARGIN_4}.subtract( $V{MARGINREF3_4})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF3_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_4}!=null && $V{MARGINREF3_4}!=null )?($V{MARGIN_4}.subtract( $V{MARGINREF3_4})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF3_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{MARGIN_5}!=null && $V{MARGINREF3_5}!=null )?($V{MARGIN_5}.subtract( $V{MARGINREF3_5})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF3_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_5}!=null && $V{MARGINREF3_5}!=null )?($V{MARGIN_5}.subtract( $V{MARGINREF3_5})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF3_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{MARGIN_6}!=null && $V{MARGINREF3_6}!=null )?($V{MARGIN_6}.subtract( $V{MARGINREF3_6})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF3_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_6}!=null && $V{MARGINREF3_6}!=null )?($V{MARGIN_6}.subtract( $V{MARGINREF3_6})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF3_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{MARGIN_7}!=null && $V{MARGINREF3_7}!=null )?($V{MARGIN_7}.subtract( $V{MARGINREF3_7})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF3_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_7}!=null && $V{MARGINREF3_7}!=null )?($V{MARGIN_7}.subtract( $V{MARGINREF3_7})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF3_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{MARGIN_8}!=null && $V{MARGINREF3_8}!=null )?($V{MARGIN_8}.subtract( $V{MARGINREF3_8})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF3_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_8}!=null && $V{MARGINREF3_8}!=null )?($V{MARGIN_8}.subtract( $V{MARGINREF3_8})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF3_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{MARGIN_9}!=null && $V{MARGINREF3_9}!=null )?($V{MARGIN_9}.subtract( $V{MARGINREF3_9})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF3_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_9}!=null && $V{MARGINREF3_9}!=null )?($V{MARGIN_9}.subtract( $V{MARGINREF3_9})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF3_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{MARGIN_10}!=null && $V{MARGINREF3_10}!=null )?($V{MARGIN_10}.subtract( $V{MARGINREF3_10})):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF3_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_10}!=null && $V{MARGINREF3_10}!=null )?($V{MARGIN_10}.subtract( $V{MARGINREF3_10})):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="QTY_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="COST_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
 	<variable name="PROFIT_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{AMOUNT_TOTAL}.subtract($V{COST_TOTAL})]]></variableExpression>
+		<expression><![CDATA[$V{AMOUNT_TOTAL}.subtract($V{COST_TOTAL})]]></expression>
 	</variable>
 	<variable name="MARGIN_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[($V{AMOUNT_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{PROFIT_TOTAL}.divide($V{AMOUNT_TOTAL}, 10, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_TOTAL}.signum()))]]></variableExpression>
+		<expression><![CDATA[($V{AMOUNT_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{PROFIT_TOTAL}.divide($V{AMOUNT_TOTAL}, 10, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_TOTAL}.signum()))]]></expression>
 	</variable>
-	<variable name="COSTREF_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
 	<variable name="PROREF_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{AMOUNTREF_TOTAL}.subtract($V{COSTREF_TOTAL})]]></variableExpression>
+		<expression><![CDATA[$V{AMOUNTREF_TOTAL}.subtract($V{COSTREF_TOTAL})]]></expression>
 	</variable>
 	<variable name="MARGINREF_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[($V{AMOUNTREF_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROREF_TOTAL}.divide($V{AMOUNTREF_TOTAL}, 10, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROREF_TOTAL}.signum()))]]></variableExpression>
+		<expression><![CDATA[($V{AMOUNTREF_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROREF_TOTAL}.divide($V{AMOUNTREF_TOTAL}, 10, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROREF_TOTAL}.signum()))]]></expression>
 	</variable>
 	<variable name="MARGINDIFF_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{MARGIN_TOTAL}.subtract($V{MARGINREF_TOTAL})]]></variableExpression>
+		<expression><![CDATA[$V{MARGIN_TOTAL}.subtract($V{MARGINREF_TOTAL})]]></expression>
 	</variable>
-	<variable name="COSTREF2_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF2}]]></variableExpression>
+	<variable name="COSTREF2_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF2}]]></expression>
 	</variable>
 	<variable name="PROREF2_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{AMOUNTREF2_TOTAL}.subtract($V{COSTREF2_TOTAL})]]></variableExpression>
+		<expression><![CDATA[$V{AMOUNTREF2_TOTAL}.subtract($V{COSTREF2_TOTAL})]]></expression>
 	</variable>
 	<variable name="MARGINREF2_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROREF2_TOTAL}.divide($V{AMOUNTREF2_TOTAL}, 10, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROREF2_TOTAL}.signum()))]]></variableExpression>
+		<expression><![CDATA[($V{AMOUNTREF2_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROREF2_TOTAL}.divide($V{AMOUNTREF2_TOTAL}, 10, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROREF2_TOTAL}.signum()))]]></expression>
 	</variable>
 	<variable name="MARGINDIFF2_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{MARGIN_TOTAL}.subtract($V{MARGINREF2_TOTAL})]]></variableExpression>
+		<expression><![CDATA[$V{MARGIN_TOTAL}.subtract($V{MARGINREF2_TOTAL})]]></expression>
 	</variable>
-	<variable name="COSTREF3_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF3}]]></variableExpression>
+	<variable name="COSTREF3_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF3}]]></expression>
 	</variable>
 	<variable name="PROREF3_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{AMOUNTREF3_TOTAL}.subtract($V{COSTREF3_TOTAL})]]></variableExpression>
+		<expression><![CDATA[$V{AMOUNTREF3_TOTAL}.subtract($V{COSTREF3_TOTAL})]]></expression>
 	</variable>
 	<variable name="MARGINREF3_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[($V{AMOUNTREF3_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROREF3_TOTAL}.divide($V{AMOUNTREF3_TOTAL}, 10, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROREF3_TOTAL}.signum()))]]></variableExpression>
+		<expression><![CDATA[($V{AMOUNTREF3_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROREF3_TOTAL}.divide($V{AMOUNTREF3_TOTAL}, 10, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROREF3_TOTAL}.signum()))]]></expression>
 	</variable>
 	<variable name="MARGINDIFF3_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{MARGIN_TOTAL}.subtract($V{MARGINREF3_TOTAL})]]></variableExpression>
+		<expression><![CDATA[$V{MARGIN_TOTAL}.subtract($V{MARGINREF3_TOTAL})]]></expression>
 	</variable>
 	<group name="DocumentType"/>
 	<group name="TOTALIZE">
-		<groupExpression><![CDATA[]]></groupExpression>
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band splitType="Stretch"/>
 		</groupHeader>
 		<groupFooter>
 			<band height="22" splitType="Stretch">
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-21" style="Total_Field" x="190" y="1" width="55" height="16" uuid="2a848c9f-238a-450d-a402-f31cdaf1f90a"/>
-					<box leftPadding="0">
+				<element kind="textField" uuid="2a848c9f-238a-450d-a402-f31cdaf1f90a" key="textField-21" x="190" y="1" width="55" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{AMOUNT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-8" style="Report_Data_Label" x="150" y="1" width="40" height="16" uuid="14c265b1-9d2b-43d7-931c-26609d7ffa14"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="7"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="14c265b1-9d2b-43d7-931c-26609d7ffa14" key="staticText-8" x="150" y="1" width="40" height="16" fontSize="7.0" hTextAlign="Right" vTextAlign="Middle" style="Report_Data_Label">
 					<text><![CDATA[Total:]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-3" x="0" y="0" width="1580" height="1" uuid="f59d0bc7-0f7f-45f2-93b3-041bcc6b3a36"/>
-				</line>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-23" style="Detail_Header" mode="Opaque" x="15" y="1" width="15" height="16" uuid="faf380b4-f84a-423d-a41e-6c365064c977">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+					<box style="Report_Data_Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" evaluationTime="Report" pattern="##0.00" isBlankWhenNull="true">
-					<reportElement key="textField-22" style="Detail_Header" x="0" y="1" width="15" height="16" uuid="4f90face-ef3e-4598-b1a5-114c1c6bdfbb">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="line" uuid="f59d0bc7-0f7f-45f2-93b3-041bcc6b3a36" key="line-3" x="0" y="0" width="1580" height="1"/>
+				<element kind="textField" uuid="faf380b4-f84a-423d-a41e-6c365064c977" key="textField-23" mode="Opaque" x="15" y="1" width="15" height="16" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-24" style="Detail_Header" mode="Opaque" x="30" y="1" width="15" height="16" uuid="ac2cc289-e2dc-4b32-93b6-06fdd2f76c9d">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="4f90face-ef3e-4598-b1a5-114c1c6bdfbb" key="textField-22" x="0" y="1" width="15" height="16" rotation="None" fontSize="7.0" textAdjust="StretchHeight" evaluationTime="Report" pattern="##0.00" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-25" style="Detail_Header" mode="Opaque" x="45" y="1" width="15" height="16" uuid="359679c9-df31-4d7c-bffb-5b2325a03ee5">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="ac2cc289-e2dc-4b32-93b6-06fdd2f76c9d" key="textField-24" mode="Opaque" x="30" y="1" width="15" height="16" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-26" style="Detail_Header" mode="Opaque" x="60" y="1" width="15" height="16" uuid="b5f371cc-0b53-422e-b4a1-d4b99f1c9c7c">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="359679c9-df31-4d7c-bffb-5b2325a03ee5" key="textField-25" mode="Opaque" x="45" y="1" width="15" height="16" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-204" style="Total_Field" x="1150" y="1" width="30" height="16" uuid="c764e460-6964-4d56-a516-b16e8103e48f"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="b5f371cc-0b53-422e-b4a1-d4b99f1c9c7c" key="textField-26" mode="Opaque" x="60" y="1" width="15" height="16" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":" ")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-300" style="Total_Field" x="1180" y="1" width="30" height="16" uuid="2dcc98e7-5733-4e23-8935-52d0c529b832"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="c764e460-6964-4d56-a516-b16e8103e48f" key="textField-204" x="1150" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{WEIGHT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-301" style="Total_Field" x="385" y="1" width="55" height="16" uuid="aecdca63-e792-4619-ba6b-f6d75a3825f6"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="2dcc98e7-5733-4e23-8935-52d0c529b832" key="textField-300" x="1180" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{WEIGHTREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-302" style="Total_Field" x="580" y="1" width="30" height="16" uuid="f1d8df62-9974-440a-ac62-e59621765ec0"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="aecdca63-e792-4619-ba6b-f6d75a3825f6" key="textField-301" x="385" y="1" width="55" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{AMOUNTREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PERTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PERTOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-303" style="Detail_Header" mode="Opaque" x="75" y="1" width="15" height="16" uuid="92488bc4-3b1b-4498-8f57-ceabecd7c950">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=6)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="f1d8df62-9974-440a-ac62-e59621765ec0" key="textField-302" x="580" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{AMOUNT_PERTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PERTOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(6))>=0)?"6":" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-304" style="Detail_Header" mode="Opaque" x="90" y="1" width="15" height="16" uuid="6ccde361-d35a-4855-bba0-b64daa169d54">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=7)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="92488bc4-3b1b-4498-8f57-ceabecd7c950" key="textField-303" mode="Opaque" x="75" y="1" width="15" height="16" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=6)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(6))>=0)?"6":" ")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(7))>=0)?"7":" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-305" style="Detail_Header" mode="Opaque" x="105" y="1" width="15" height="16" uuid="fa04cd14-140a-450a-ad10-247599802e54">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=8)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="6ccde361-d35a-4855-bba0-b64daa169d54" key="textField-304" mode="Opaque" x="90" y="1" width="15" height="16" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=7)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(7))>=0)?"7":" ")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(8))>=0)?"8":" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-306" style="Detail_Header" mode="Opaque" x="120" y="1" width="15" height="16" uuid="d9fb733b-bcf5-4982-a52c-c8f3bcc49094">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=9)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="fa04cd14-140a-450a-ad10-247599802e54" key="textField-305" mode="Opaque" x="105" y="1" width="15" height="16" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=8)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(8))>=0)?"8":" ")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(9))>=0)?"9":" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-307" style="Detail_Header" mode="Opaque" x="135" y="1" width="15" height="16" uuid="02474f57-9d8d-4568-bb9c-696c72372432">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=10)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="d9fb733b-bcf5-4982-a52c-c8f3bcc49094" key="textField-306" mode="Opaque" x="120" y="1" width="15" height="16" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=9)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(9))>=0)?"9":" ")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(10))>=0)?"10":" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-308" style="Total_Field" x="1210" y="1" width="30" height="16" uuid="bca934e6-f1d2-4f10-9cd5-1a167e7f3ed4"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="02474f57-9d8d-4568-bb9c-696c72372432" key="textField-307" mode="Opaque" x="135" y="1" width="15" height="16" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=10)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(10))>=0)?"10":" ")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-310" style="Total_Field" x="835" y="1" width="30" height="16" uuid="67a2de1c-1d5e-4ea9-a89c-d7b9673cd07f"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="bca934e6-f1d2-4f10-9cd5-1a167e7f3ed4" key="textField-308" x="1210" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{WEIGHTREF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT2_PERTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PERTOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-311" style="Total_Field" x="640" y="1" width="55" height="16" uuid="0168e717-45e9-4838-aa94-49d746b9274a"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="67a2de1c-1d5e-4ea9-a89c-d7b9673cd07f" key="textField-310" x="835" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{AMOUNT2_PERTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PERTOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-312" style="Total_Field" x="1240" y="1" width="30" height="16" uuid="ede5cdea-4c20-4e61-adaa-569917c7c806"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="0168e717-45e9-4838-aa94-49d746b9274a" key="textField-311" x="640" y="1" width="55" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{AMOUNTREF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF3_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF3_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-313" style="Total_Field" x="1090" y="1" width="30" height="16" uuid="c57cf82a-85b8-4d6f-b2f6-c187ed583321"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="ede5cdea-4c20-4e61-adaa-569917c7c806" key="textField-312" x="1240" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{WEIGHTREF3_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF3_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT3_PERTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT3_PERTOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-314" style="Total_Field" x="895" y="1" width="55" height="16" uuid="368eaf6c-ca4a-48ef-89df-a99e8c4b11ac"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="c57cf82a-85b8-4d6f-b2f6-c187ed583321" key="textField-313" x="1090" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{AMOUNT3_PERTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT3_PERTOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF3_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF3_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-21" style="Total_Field" x="245" y="1" width="55" height="16" uuid="8c9f8983-a143-4cd4-a22e-23025ab830b1"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="368eaf6c-ca4a-48ef-89df-a99e8c4b11ac" key="textField-314" x="895" y="1" width="55" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{AMOUNTREF3_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF3_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COST_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COST_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-21" style="Total_Field" x="300" y="1" width="55" height="16" uuid="3ef87095-f625-4552-8b97-053000847d51"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="8c9f8983-a143-4cd4-a22e-23025ab830b1" key="textField-21" x="245" y="1" width="55" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{COST_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COST_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFIT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-21" style="Total_Field" x="355" y="1" width="30" height="16" uuid="45856493-0380-4135-92ce-8e2908d17d17"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="3ef87095-f625-4552-8b97-053000847d51" key="textField-21" x="300" y="1" width="55" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{PROFIT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGIN_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-204" style="Total_Field" x="1270" y="1" width="54" height="16" uuid="5ed75fb9-37a4-48e9-b7cb-92ced03b608b">
-						<printWhenExpression><![CDATA[$P{LEVEL1_LABEL}.equals("Product") || $P{LEVEL2_LABEL}.equals("Product") || $P{LEVEL3_LABEL}.equals("Product") || $P{LEVEL4_LABEL}.equals("Product") || $P{LEVEL5_LABEL}.equals("Product") || $P{LEVEL6_LABEL}.equals("Product") || $P{LEVEL7_LABEL}.equals("Product") || $P{LEVEL8_LABEL}.equals("Product") || $P{LEVEL9_LABEL}.equals("Product") || $P{LEVEL10_LABEL}.equals("Product")]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="45856493-0380-4135-92ce-8e2908d17d17" key="textField-21" x="355" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{MARGIN_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{QTY_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-301" style="Total_Field" x="440" y="1" width="55" height="16" uuid="698352ee-35a5-4892-92d8-a4d627474377"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="5ed75fb9-37a4-48e9-b7cb-92ced03b608b" key="textField-204" x="1270" y="1" width="54" height="16" evaluationTime="Report" pattern="" blankWhenNull="false" bold="false" hTextAlign="Right" style="Total_Field">
+					<printWhenExpression><![CDATA[$P{LEVEL1_LABEL}.equals("Product") || $P{LEVEL2_LABEL}.equals("Product") || $P{LEVEL3_LABEL}.equals("Product") || $P{LEVEL4_LABEL}.equals("Product") || $P{LEVEL5_LABEL}.equals("Product") || $P{LEVEL6_LABEL}.equals("Product") || $P{LEVEL7_LABEL}.equals("Product") || $P{LEVEL8_LABEL}.equals("Product") || $P{LEVEL9_LABEL}.equals("Product") || $P{LEVEL10_LABEL}.equals("Product")]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{QTY_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-301" style="Total_Field" x="495" y="1" width="55" height="16" uuid="84ba7624-175d-40fa-a414-25f60e91b9ab"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="698352ee-35a5-4892-92d8-a4d627474377" key="textField-301" x="440" y="1" width="55" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{COSTREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PROREF_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-301" style="Total_Field" x="550" y="1" width="30" height="16" uuid="df095e1e-638b-4c71-8576-393ced48bab1"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="84ba7624-175d-40fa-a414-25f60e91b9ab" key="textField-301" x="495" y="1" width="55" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{PROREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PROREF_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-302" style="Total_Field" x="610" y="1" width="30" height="16" uuid="735f6e6a-ab2c-4343-92e7-602487358d8e"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="df095e1e-638b-4c71-8576-393ced48bab1" key="textField-301" x="550" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{MARGINREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-301" style="Total_Field" x="695" y="1" width="55" height="16" uuid="c8759366-30c2-41cf-abaf-9b8779566f04"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="735f6e6a-ab2c-4343-92e7-602487358d8e" key="textField-302" x="610" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{MARGINDIFF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-301" style="Total_Field" x="750" y="1" width="55" height="16" uuid="07056c12-c679-434f-8b3b-08ec78bd97fb"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="c8759366-30c2-41cf-abaf-9b8779566f04" key="textField-301" x="695" y="1" width="55" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{COSTREF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROREF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PROREF2_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-310" style="Total_Field" x="805" y="1" width="30" height="16" uuid="061f6d37-2bb0-4c77-a190-6a1edde52180"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="07056c12-c679-434f-8b3b-08ec78bd97fb" key="textField-301" x="750" y="1" width="55" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{PROREF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PROREF2_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-310" style="Total_Field" x="865" y="1" width="30" height="16" uuid="8d87e6e2-6e76-4982-a022-e1d77852cf91"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="061f6d37-2bb0-4c77-a190-6a1edde52180" key="textField-310" x="805" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{MARGINREF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-314" style="Total_Field" x="950" y="1" width="55" height="16" uuid="5feffece-96b5-48ea-9eaa-c71e846a1308"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="8d87e6e2-6e76-4982-a022-e1d77852cf91" key="textField-310" x="865" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{MARGINDIFF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF3_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF3_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-314" style="Total_Field" x="1005" y="1" width="55" height="16" uuid="463c1051-2c93-44f8-9c6f-f11a34a7d1f1"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="5feffece-96b5-48ea-9eaa-c71e846a1308" key="textField-314" x="950" y="1" width="55" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{COSTREF3_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF3_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROREF3_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PROREF3_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-313" style="Total_Field" x="1060" y="1" width="30" height="16" uuid="02b7b8df-2f29-4359-ac90-4d0921a82b5a"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="463c1051-2c93-44f8-9c6f-f11a34a7d1f1" key="textField-314" x="1005" y="1" width="55" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{PROREF3_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PROREF3_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF3_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF3_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-313" style="Total_Field" x="1120" y="1" width="30" height="16" uuid="5c17c6bf-252f-4ad9-8fd6-2545ce606369"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="02b7b8df-2f29-4359-ac90-4d0921a82b5a" key="textField-313" x="1060" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{MARGINREF3_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF3_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF3_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF3_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="5c17c6bf-252f-4ad9-8fd6-2545ce606369" key="textField-313" x="1120" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{MARGINDIFF3_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF3_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="NIVEL1">
-		<groupExpression><![CDATA[$F{NIVEL1}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL1}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="150" height="18" uuid="0d5960be-cfaa-4eb3-91b1-65c5aaa9fc7f"/>
-					<box rightPadding="2">
+				<element kind="textField" uuid="0d5960be-cfaa-4eb3-91b1-65c5aaa9fc7f" key="textField" stretchType="ContainerHeight" x="0" y="0" width="150" height="18" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[$F{NIVEL1}]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL1}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-155" style="Level1_Line" stretchType="RelativeToBandHeight" x="190" y="0" width="55" height="18" uuid="781fb5d3-9c81-43e9-b2e5-ed16a99338d4"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="781fb5d3-9c81-43e9-b2e5-ed16a99338d4" key="textField-155" stretchType="ContainerHeight" x="190" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-154" style="Level1_Line" stretchType="RelativeToBandHeight" x="245" y="0" width="55" height="18" uuid="93a3b941-227b-4e84-b800-1074acdd9dad"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="93a3b941-227b-4e84-b800-1074acdd9dad" key="textField-154" stretchType="ContainerHeight" x="245" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{COST_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COST_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-153" style="Level1_Line" stretchType="RelativeToBandHeight" x="300" y="0" width="55" height="18" uuid="5a1116b5-517e-4096-b404-140b8122ad9c"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5a1116b5-517e-4096-b404-140b8122ad9c" key="textField-153" stretchType="ContainerHeight" x="300" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{PROFIT_1}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFIT_1}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" x="355" y="0" width="30" height="18" uuid="7507f0c8-87c0-41ba-9c76-596aef2a380e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7507f0c8-87c0-41ba-9c76-596aef2a380e" key="textField" stretchType="ContainerHeight" x="355" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{MARGIN_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGIN_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-152" style="Level1_Line" stretchType="RelativeToBandHeight" x="1150" y="0" width="30" height="18" uuid="df8574a1-741e-4d15-bfcc-8975057f8710"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="df8574a1-741e-4d15-bfcc-8975057f8710" key="textField-152" stretchType="ContainerHeight" x="1150" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" x="1270" y="0" width="55" height="18" uuid="abe5b7d8-a1ed-4326-a348-5d999491a627">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="abe5b7d8-a1ed-4326-a348-5d999491a627" key="textField" stretchType="ContainerHeight" x="1270" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-210" style="Level1_Line" stretchType="RelativeToBandHeight" x="1380" y="0" width="30" height="18" uuid="6a37bf6c-2755-436b-aab2-3452516cb4fe">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6a37bf6c-2755-436b-aab2-3452516cb4fe" key="textField-210" stretchType="ContainerHeight" x="1380" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER1}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PER1}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" isBlankWhenNull="false">
-					<reportElement key="textField-220" style="Level1_Line" stretchType="RelativeToBandHeight" x="1325" y="0" width="55" height="18" uuid="8d9b13d8-fc01-4556-a704-ab0d34a612df">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="8d9b13d8-fc01-4556-a704-ab0d34a612df" key="textField-220" stretchType="ContainerHeight" x="1325" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-230" style="Level1_Line" stretchType="RelativeToBandHeight" x="1180" y="0" width="30" height="18" uuid="4d33392e-22af-4922-99af-5eea5b199a92"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4d33392e-22af-4922-99af-5eea5b199a92" key="textField-230" stretchType="ContainerHeight" x="1180" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-240" style="Level1_Line" stretchType="RelativeToBandHeight" x="610" y="0" width="30" height="18" uuid="dd842b1a-b27a-4c6e-87d0-ee94cf1358c7"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="dd842b1a-b27a-4c6e-87d0-ee94cf1358c7" key="textField-240" stretchType="ContainerHeight" x="610" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{MARGINDIFF_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-250" style="Level1_Line" stretchType="RelativeToBandHeight" x="580" y="0" width="30" height="18" uuid="7cacc98d-373d-4467-a32d-24aae5e16504"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7cacc98d-373d-4467-a32d-24aae5e16504" key="textField-250" stretchType="ContainerHeight" x="580" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{AMOUNT_PER1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-260" style="Level1_Line" stretchType="RelativeToBandHeight" x="550" y="0" width="30" height="18" uuid="cb7f0943-5d9f-4cae-a125-b1874e89122d"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="cb7f0943-5d9f-4cae-a125-b1874e89122d" key="textField-260" stretchType="ContainerHeight" x="550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{MARGINREF_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-270" style="Level1_Line" stretchType="RelativeToBandHeight" x="495" y="0" width="55" height="18" uuid="28bfc2d9-67eb-40a9-9bec-b5d2b100e75a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="28bfc2d9-67eb-40a9-9bec-b5d2b100e75a" key="textField-270" stretchType="ContainerHeight" x="495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{PROFITREF_1}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF_1}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-280" style="Level1_Line" stretchType="RelativeToBandHeight" x="440" y="0" width="55" height="18" uuid="d6fd434d-de4c-4d9c-ac41-abaf586df616"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d6fd434d-de4c-4d9c-ac41-abaf586df616" key="textField-280" stretchType="ContainerHeight" x="440" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{COSTREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-290" style="Level1_Line" stretchType="RelativeToBandHeight" x="385" y="0" width="55" height="18" uuid="c7d855a6-b312-4549-a2f3-ccf8dd5882a2"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c7d855a6-b312-4549-a2f3-ccf8dd5882a2" key="textField-290" stretchType="ContainerHeight" x="385" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Auto" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-309" style="Level1_Line" stretchType="RelativeToBandHeight" x="150" y="0" width="40" height="18" uuid="5e9367f1-c849-42df-a68e-95c30e8dbb1e"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="5e9367f1-c849-42df-a68e-95c30e8dbb1e" key="textField-309" stretchType="ContainerHeight" x="150" y="0" width="40" height="18" fontSize="7.0" evaluationTime="Auto" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Level1_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM1}!=null && $V{AMOUNT_TOTAL}!=null)?new String("(") + $P{NUMBERFORMAT}.format($V{AMOUNT_SUM1}.doubleValue() / $V{AMOUNT_TOTAL}.doubleValue() * 100.00 ) + new String(" %)"):new String(" ")]]></expression>
+					<box rightPadding="3" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM1}!=null && $V{AMOUNT_TOTAL}!=null)?new String("(") + $P{NUMBERFORMAT}.format($V{AMOUNT_SUM1}.doubleValue() / $V{AMOUNT_TOTAL}.doubleValue() * 100.00 ) + new String(" %)"):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-300" style="Level1_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="55" height="18" uuid="c4dab310-27be-45c1-adad-cbd3b26670d2"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c4dab310-27be-45c1-adad-cbd3b26670d2" key="textField-300" stretchType="ContainerHeight" x="640" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{AMOUNTREF2_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF2_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-310" style="Level1_Line" stretchType="RelativeToBandHeight" x="695" y="0" width="55" height="18" uuid="03981a43-1a2b-4f00-ac0c-c1a98af65bfc"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="03981a43-1a2b-4f00-ac0c-c1a98af65bfc" key="textField-310" stretchType="ContainerHeight" x="695" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{COSTREF2_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF2_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-320" style="Level1_Line" stretchType="RelativeToBandHeight" x="750" y="0" width="55" height="18" uuid="da3bf427-2633-449e-9f5c-d5333be7e389"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="da3bf427-2633-449e-9f5c-d5333be7e389" key="textField-320" stretchType="ContainerHeight" x="750" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{PROFITREF2_1}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF2_1}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-330" style="Level1_Line" stretchType="RelativeToBandHeight" x="805" y="0" width="30" height="18" uuid="eb01d16c-f0b5-4b10-9174-013680b4f8f8"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="eb01d16c-f0b5-4b10-9174-013680b4f8f8" key="textField-330" stretchType="ContainerHeight" x="805" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{MARGINREF2_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF2_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-340" style="Level1_Line" stretchType="RelativeToBandHeight" x="835" y="0" width="30" height="18" uuid="c23c27d8-d892-4f43-b692-3d7ee97f21ad"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c23c27d8-d892-4f43-b692-3d7ee97f21ad" key="textField-340" stretchType="ContainerHeight" x="835" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{AMOUNT2_PER1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT2_PER1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-350" style="Level1_Line" stretchType="RelativeToBandHeight" x="865" y="0" width="30" height="18" uuid="18c046b3-65f4-4134-82e8-5f77e570334e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="18c046b3-65f4-4134-82e8-5f77e570334e" key="textField-350" stretchType="ContainerHeight" x="865" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{MARGINDIFF2_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF2_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-360" style="Level1_Line" stretchType="RelativeToBandHeight" x="1210" y="0" width="30" height="18" uuid="fae9f2b0-4689-4496-84bf-7f6dcdd58c98"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="fae9f2b0-4689-4496-84bf-7f6dcdd58c98" key="textField-360" stretchType="ContainerHeight" x="1210" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{WEIGHTREF2_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF2_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" isBlankWhenNull="false">
-					<reportElement key="textField-370" style="Level1_Line" stretchType="RelativeToBandHeight" x="1410" y="0" width="55" height="18" uuid="5ba5a0a7-7c5b-4296-8499-762e347daa46">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5ba5a0a7-7c5b-4296-8499-762e347daa46" key="textField-370" stretchType="ContainerHeight" x="1410" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF2_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF2_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-380" style="Level1_Line" stretchType="RelativeToBandHeight" x="1465" y="0" width="30" height="18" uuid="16f243ec-0f05-498d-87a9-af238c758af6">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="16f243ec-0f05-498d-87a9-af238c758af6" key="textField-380" stretchType="ContainerHeight" x="1465" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY2_PER1}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY2_PER1}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-390" style="Level1_Line" stretchType="RelativeToBandHeight" x="895" y="0" width="55" height="18" uuid="f5cbc9b5-6f66-4d9e-b825-86d9faed11ed"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f5cbc9b5-6f66-4d9e-b825-86d9faed11ed" key="textField-390" stretchType="ContainerHeight" x="895" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{AMOUNTREF3_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF3_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF3_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF3_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-400" style="Level1_Line" stretchType="RelativeToBandHeight" x="950" y="0" width="55" height="18" uuid="9a3bf385-d10c-407d-9f07-7adb8283851f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9a3bf385-d10c-407d-9f07-7adb8283851f" key="textField-400" stretchType="ContainerHeight" x="950" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{COSTREF3_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF3_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF3_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF3_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-410" style="Level1_Line" stretchType="RelativeToBandHeight" x="1005" y="0" width="55" height="18" uuid="c6477536-c07e-4ce2-b98e-e55588075b64"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c6477536-c07e-4ce2-b98e-e55588075b64" key="textField-410" stretchType="ContainerHeight" x="1005" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{PROFITREF3_1}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF3_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF3_1}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF3_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-420" style="Level1_Line" stretchType="RelativeToBandHeight" x="1060" y="0" width="30" height="18" uuid="17a4df0a-b308-4f09-94c1-b93a5fb4caf2"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="17a4df0a-b308-4f09-94c1-b93a5fb4caf2" key="textField-420" stretchType="ContainerHeight" x="1060" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{MARGINREF3_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF3_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF3_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF3_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-430" style="Level1_Line" stretchType="RelativeToBandHeight" x="1090" y="0" width="30" height="18" uuid="731ec261-3816-4a35-bce7-a6d576abdcf6"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="731ec261-3816-4a35-bce7-a6d576abdcf6" key="textField-430" stretchType="ContainerHeight" x="1090" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{AMOUNT3_PER1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT3_PER1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT3_PER1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT3_PER1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-440" style="Level1_Line" stretchType="RelativeToBandHeight" x="1120" y="0" width="30" height="18" uuid="5331b748-7204-4b68-984f-324ee65e1c82"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5331b748-7204-4b68-984f-324ee65e1c82" key="textField-440" stretchType="ContainerHeight" x="1120" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{MARGINDIFF3_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF3_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF3_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF3_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-450" style="Level1_Line" stretchType="RelativeToBandHeight" x="1240" y="0" width="30" height="18" uuid="0a1f123d-5bf7-4847-9530-9344c56a3789"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0a1f123d-5bf7-4847-9530-9344c56a3789" key="textField-450" stretchType="ContainerHeight" x="1240" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{WEIGHTREF3_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF3_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF3_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF3_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" isBlankWhenNull="false">
-					<reportElement key="textField-460" style="Level1_Line" stretchType="RelativeToBandHeight" x="1495" y="0" width="55" height="18" uuid="95e5b114-c8c5-4809-a997-c30d73cf9378">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="95e5b114-c8c5-4809-a997-c30d73cf9378" key="textField-460" stretchType="ContainerHeight" x="1495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF3_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF3_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF3_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF3_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-470" style="Level1_Line" stretchType="RelativeToBandHeight" x="1550" y="0" width="30" height="18" uuid="14fc9136-d8ad-45d8-b449-c5b908d3fab9">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="14fc9136-d8ad-45d8-b449-c5b908d3fab9" key="textField-470" stretchType="ContainerHeight" x="1550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY3_PER1}!=null)?$P{NUMBERFORMAT}.format($V{QTY3_PER1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY3_PER1}!=null)?$P{NUMBERFORMAT}.format($V{QTY3_PER1}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -2644,479 +2297,332 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL2">
-		<groupExpression><![CDATA[$F{NIVEL2}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL2}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-2" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="680a6e31-cfa9-463f-8767-2c3b6a29a7cc"/>
-					<box>
+				<element kind="textField" uuid="680a6e31-cfa9-463f-8767-2c3b6a29a7cc" key="textField-2" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="175" height="18" uuid="207d0b7a-0182-41a6-b22b-bea0b507d840"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="207d0b7a-0182-41a6-b22b-bea0b507d840" key="textField" stretchType="ContainerHeight" x="15" y="0" width="175" height="18" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[$F{NIVEL2}]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL2}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" x="190" y="0" width="55" height="18" uuid="afdf46cb-7d65-4646-9bc2-db090132b5ca"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="afdf46cb-7d65-4646-9bc2-db090132b5ca" key="textField" stretchType="ContainerHeight" x="190" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" x="1270" y="0" width="55" height="18" uuid="7b4c8d2b-a7c7-4d3c-9bc6-add17fd8c4b6">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7b4c8d2b-a7c7-4d3c-9bc6-add17fd8c4b6" key="textField" stretchType="ContainerHeight" x="1270" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-156" style="Level2_Line" stretchType="RelativeToBandHeight" x="245" y="0" width="55" height="18" uuid="edb7dafb-ca0b-4013-be3c-f03d1d735fbb"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="edb7dafb-ca0b-4013-be3c-f03d1d735fbb" key="textField-156" stretchType="ContainerHeight" x="245" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{COST_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COST_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-157" style="Level2_Line" stretchType="RelativeToBandHeight" x="300" y="0" width="55" height="18" uuid="bfe3462c-0ed1-4ff0-8966-95e1535c560e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="bfe3462c-0ed1-4ff0-8966-95e1535c560e" key="textField-157" stretchType="ContainerHeight" x="300" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{PROFIT_2}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFIT_2}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-158" style="Level2_Line" stretchType="RelativeToBandHeight" x="355" y="0" width="30" height="18" uuid="472b633c-2772-4303-9d33-9cadc33782f7"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="472b633c-2772-4303-9d33-9cadc33782f7" key="textField-158" stretchType="ContainerHeight" x="355" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{MARGIN_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGIN_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-159" style="Level2_Line" stretchType="RelativeToBandHeight" x="1150" y="0" width="30" height="18" uuid="987ebda4-33ad-452e-a0e6-cc24b76f5240"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="987ebda4-33ad-452e-a0e6-cc24b76f5240" key="textField-159" stretchType="ContainerHeight" x="1150" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-211" style="Level2_Line" stretchType="RelativeToBandHeight" x="1380" y="0" width="30" height="18" uuid="9f0b822c-0f86-4bfc-8694-673fa33a583a">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9f0b822c-0f86-4bfc-8694-673fa33a583a" key="textField-211" stretchType="ContainerHeight" x="1380" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER2}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PER2}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" isBlankWhenNull="false">
-					<reportElement key="textField-221" style="Level2_Line" stretchType="RelativeToBandHeight" x="1325" y="0" width="55" height="18" uuid="9032f9e8-7562-4d93-947d-e3246d3517d8">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9032f9e8-7562-4d93-947d-e3246d3517d8" key="textField-221" stretchType="ContainerHeight" x="1325" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-231" style="Level2_Line" stretchType="RelativeToBandHeight" x="1180" y="0" width="30" height="18" uuid="4229c263-ae81-45f9-a526-5bc2c5da0aea"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4229c263-ae81-45f9-a526-5bc2c5da0aea" key="textField-231" stretchType="ContainerHeight" x="1180" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-241" style="Level2_Line" stretchType="RelativeToBandHeight" x="610" y="0" width="30" height="18" uuid="7e06d4d8-cdca-40b4-9613-61115d7961de"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7e06d4d8-cdca-40b4-9613-61115d7961de" key="textField-241" stretchType="ContainerHeight" x="610" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{MARGINDIFF_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-251" style="Level2_Line" stretchType="RelativeToBandHeight" x="580" y="0" width="30" height="18" uuid="11f358b8-7b00-4d26-82bf-729ca1f7e195"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="11f358b8-7b00-4d26-82bf-729ca1f7e195" key="textField-251" stretchType="ContainerHeight" x="580" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{AMOUNT_PER2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-261" style="Level2_Line" stretchType="RelativeToBandHeight" x="550" y="0" width="30" height="18" uuid="9036ecb0-591d-493f-85cc-bb4069ef10bd"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9036ecb0-591d-493f-85cc-bb4069ef10bd" key="textField-261" stretchType="ContainerHeight" x="550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{MARGINREF_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-271" style="Level2_Line" stretchType="RelativeToBandHeight" x="495" y="0" width="55" height="18" uuid="89527575-4759-4858-9739-431b66097aca"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="89527575-4759-4858-9739-431b66097aca" key="textField-271" stretchType="ContainerHeight" x="495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{PROFITREF_2}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF_2}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-281" style="Level2_Line" stretchType="RelativeToBandHeight" x="440" y="0" width="55" height="18" uuid="910f849a-54c7-4b9b-947e-50df599ba5e5"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="910f849a-54c7-4b9b-947e-50df599ba5e5" key="textField-281" stretchType="ContainerHeight" x="440" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{COSTREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-291" style="Level2_Line" stretchType="RelativeToBandHeight" x="385" y="0" width="55" height="18" uuid="c863674a-5a68-4dab-bb9e-e2b6a8993df5"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c863674a-5a68-4dab-bb9e-e2b6a8993df5" key="textField-291" stretchType="ContainerHeight" x="385" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-301" style="Level2_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="55" height="18" uuid="4d22f106-ea61-4ecb-91d1-ef814e62b4a4"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4d22f106-ea61-4ecb-91d1-ef814e62b4a4" key="textField-301" stretchType="ContainerHeight" x="640" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{AMOUNTREF2_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF2_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-311" style="Level2_Line" stretchType="RelativeToBandHeight" x="695" y="0" width="55" height="18" uuid="ba0de1f0-346b-4506-9dee-ba8966679428"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ba0de1f0-346b-4506-9dee-ba8966679428" key="textField-311" stretchType="ContainerHeight" x="695" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{COSTREF2_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF2_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-321" style="Level2_Line" stretchType="RelativeToBandHeight" x="750" y="0" width="55" height="18" uuid="9c64f44b-b3ab-4310-8d0b-70a1de25119e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9c64f44b-b3ab-4310-8d0b-70a1de25119e" key="textField-321" stretchType="ContainerHeight" x="750" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{PROFITREF2_2}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF2_2}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-331" style="Level2_Line" stretchType="RelativeToBandHeight" x="805" y="0" width="30" height="18" uuid="fbb41ade-2e3b-44d4-b784-6073004b53e8"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="fbb41ade-2e3b-44d4-b784-6073004b53e8" key="textField-331" stretchType="ContainerHeight" x="805" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{MARGINREF2_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF2_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-341" style="Level2_Line" stretchType="RelativeToBandHeight" x="835" y="0" width="30" height="18" uuid="c09859a6-acc1-4ec0-9014-9a88150b7e36"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c09859a6-acc1-4ec0-9014-9a88150b7e36" key="textField-341" stretchType="ContainerHeight" x="835" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{AMOUNT2_PER2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT2_PER2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-351" style="Level2_Line" stretchType="RelativeToBandHeight" x="865" y="0" width="30" height="18" uuid="5aca4384-3692-41c4-9647-ed2ca4d7a94c"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5aca4384-3692-41c4-9647-ed2ca4d7a94c" key="textField-351" stretchType="ContainerHeight" x="865" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{MARGINDIFF2_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF2_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" isBlankWhenNull="false">
-					<reportElement key="textField-361" style="Level2_Line" stretchType="RelativeToBandHeight" x="1410" y="0" width="55" height="18" uuid="5736d275-65b4-4e53-82f2-7d565d77cb73">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5736d275-65b4-4e53-82f2-7d565d77cb73" key="textField-361" stretchType="ContainerHeight" x="1410" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF2_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF2_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-371" style="Level2_Line" stretchType="RelativeToBandHeight" x="1210" y="0" width="30" height="18" uuid="59d4358d-f95b-40c4-9abc-b2c6fa884392"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="59d4358d-f95b-40c4-9abc-b2c6fa884392" key="textField-371" stretchType="ContainerHeight" x="1210" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{WEIGHTREF2_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF2_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-381" style="Level2_Line" stretchType="RelativeToBandHeight" x="1465" y="0" width="30" height="18" uuid="9f2aa8df-93b0-4359-80f9-d523bd8dda7d">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9f2aa8df-93b0-4359-80f9-d523bd8dda7d" key="textField-381" stretchType="ContainerHeight" x="1465" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY2_PER2}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY2_PER2}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-391" style="Level2_Line" stretchType="RelativeToBandHeight" x="895" y="0" width="55" height="18" uuid="5bb7dca7-ca2b-4c2b-b47d-baaab31840ec"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5bb7dca7-ca2b-4c2b-b47d-baaab31840ec" key="textField-391" stretchType="ContainerHeight" x="895" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{AMOUNTREF3_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF3_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF3_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF3_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-401" style="Level2_Line" stretchType="RelativeToBandHeight" x="950" y="0" width="55" height="18" uuid="0adf2a89-15ac-4818-91c4-50f0bf45b1e1"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0adf2a89-15ac-4818-91c4-50f0bf45b1e1" key="textField-401" stretchType="ContainerHeight" x="950" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{COSTREF3_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF3_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF3_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF3_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-411" style="Level2_Line" stretchType="RelativeToBandHeight" x="1005" y="0" width="55" height="18" uuid="bd49aa13-e3e2-4ff8-8112-26e9b76f7e54"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="bd49aa13-e3e2-4ff8-8112-26e9b76f7e54" key="textField-411" stretchType="ContainerHeight" x="1005" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{PROFITREF3_2}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF3_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF3_2}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF3_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-421" style="Level2_Line" stretchType="RelativeToBandHeight" x="1060" y="0" width="30" height="18" uuid="7ef29993-9ce6-4198-933f-f9c77f77d4b3"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7ef29993-9ce6-4198-933f-f9c77f77d4b3" key="textField-421" stretchType="ContainerHeight" x="1060" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{MARGINREF3_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF3_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF3_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF3_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-431" style="Level2_Line" stretchType="RelativeToBandHeight" x="1090" y="0" width="30" height="18" uuid="d9a21804-65f3-405a-8d98-66f135b9c5d2"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d9a21804-65f3-405a-8d98-66f135b9c5d2" key="textField-431" stretchType="ContainerHeight" x="1090" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{AMOUNT3_PER2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT3_PER2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT3_PER2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT3_PER2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-441" style="Level2_Line" stretchType="RelativeToBandHeight" x="1120" y="0" width="30" height="18" uuid="3639e133-e9a7-46e6-b22e-6916e6de2b56"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3639e133-e9a7-46e6-b22e-6916e6de2b56" key="textField-441" stretchType="ContainerHeight" x="1120" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{MARGINDIFF3_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF3_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF3_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF3_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-451" style="Level2_Line" stretchType="RelativeToBandHeight" x="1240" y="0" width="30" height="18" uuid="25e6cbef-29ee-4b9f-a358-107cce7f97ad"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="25e6cbef-29ee-4b9f-a358-107cce7f97ad" key="textField-451" stretchType="ContainerHeight" x="1240" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{WEIGHTREF3_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF3_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF3_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF3_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" isBlankWhenNull="false">
-					<reportElement key="textField-461" style="Level2_Line" stretchType="RelativeToBandHeight" x="1495" y="0" width="55" height="18" uuid="42721100-e7d0-4d43-9b55-576b497b4ba8">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="42721100-e7d0-4d43-9b55-576b497b4ba8" key="textField-461" stretchType="ContainerHeight" x="1495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF3_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF3_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF3_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF3_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-471" style="Level2_Line" stretchType="RelativeToBandHeight" x="1550" y="0" width="30" height="18" uuid="ddbe7e90-4b42-4805-9f19-d3b99431235e">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ddbe7e90-4b42-4805-9f19-d3b99431235e" key="textField-471" stretchType="ContainerHeight" x="1550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY3_PER2}!=null)?$P{NUMBERFORMAT}.format($V{QTY3_PER2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY3_PER2}!=null)?$P{NUMBERFORMAT}.format($V{QTY3_PER2}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -3126,492 +2632,341 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL3">
-		<groupExpression><![CDATA[$F{NIVEL3}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL3}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-3" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="d3b8e81e-0bbc-4d5e-9c1d-aca5d1956735"/>
-					<box>
+				<element kind="textField" uuid="d3b8e81e-0bbc-4d5e-9c1d-aca5d1956735" key="textField-3" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-8" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="9ea9dac3-a9fa-4e14-88a1-3bffbf881add"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="9ea9dac3-a9fa-4e14-88a1-3bffbf881add" key="textField-8" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="160" height="18" uuid="3a93892e-d48e-4f92-883d-b97f90db3876"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3a93892e-d48e-4f92-883d-b97f90db3876" key="textField" stretchType="ContainerHeight" x="30" y="0" width="160" height="18" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[$F{NIVEL3}]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL3}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" x="190" y="0" width="55" height="18" uuid="2a7a8dd8-f9df-45ad-87dc-9d748b53dee8"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2a7a8dd8-f9df-45ad-87dc-9d748b53dee8" key="textField" stretchType="ContainerHeight" x="190" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" x="1270" y="0" width="55" height="18" uuid="d613d794-0312-4a2a-9e0a-74642a89add9">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d613d794-0312-4a2a-9e0a-74642a89add9" key="textField" stretchType="ContainerHeight" x="1270" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-160" style="Level3_Line" stretchType="RelativeToBandHeight" x="245" y="0" width="55" height="18" uuid="2f64b0e4-cfd5-4fe9-9140-8fe44b4042f4"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2f64b0e4-cfd5-4fe9-9140-8fe44b4042f4" key="textField-160" stretchType="ContainerHeight" x="245" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{COST_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COST_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-161" style="Level3_Line" stretchType="RelativeToBandHeight" x="300" y="0" width="55" height="18" uuid="ea1d925b-1322-4c07-aec0-a8b31172dbe7"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ea1d925b-1322-4c07-aec0-a8b31172dbe7" key="textField-161" stretchType="ContainerHeight" x="300" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{PROFIT_3}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFIT_3}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-162" style="Level3_Line" stretchType="RelativeToBandHeight" x="355" y="0" width="30" height="18" uuid="2e8e526b-d852-4502-9917-1fb2bed7f129"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2e8e526b-d852-4502-9917-1fb2bed7f129" key="textField-162" stretchType="ContainerHeight" x="355" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{MARGIN_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGIN_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-163" style="Level3_Line" stretchType="RelativeToBandHeight" x="1150" y="0" width="30" height="18" uuid="22e54499-0655-4342-bb80-139075c10559"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="22e54499-0655-4342-bb80-139075c10559" key="textField-163" stretchType="ContainerHeight" x="1150" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-212" style="Level3_Line" stretchType="RelativeToBandHeight" x="1380" y="0" width="30" height="18" uuid="24e0dd73-cd7d-4292-a0e1-2713bf83ecf4">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="24e0dd73-cd7d-4292-a0e1-2713bf83ecf4" key="textField-212" stretchType="ContainerHeight" x="1380" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER3}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PER3}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" isBlankWhenNull="false">
-					<reportElement key="textField-222" style="Level3_Line" stretchType="RelativeToBandHeight" x="1325" y="0" width="55" height="18" uuid="ceb04d76-5f4d-47e8-ba2e-92be52a350f7">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ceb04d76-5f4d-47e8-ba2e-92be52a350f7" key="textField-222" stretchType="ContainerHeight" x="1325" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-232" style="Level3_Line" stretchType="RelativeToBandHeight" x="1180" y="0" width="30" height="18" uuid="d1886372-bad6-4289-b5e9-e9596861b2c6"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d1886372-bad6-4289-b5e9-e9596861b2c6" key="textField-232" stretchType="ContainerHeight" x="1180" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-242" style="Level3_Line" stretchType="RelativeToBandHeight" x="610" y="0" width="30" height="18" uuid="cbbdc7eb-7b0d-47f0-856d-cbb0ad99c399"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="cbbdc7eb-7b0d-47f0-856d-cbb0ad99c399" key="textField-242" stretchType="ContainerHeight" x="610" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{MARGINDIFF_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-252" style="Level3_Line" stretchType="RelativeToBandHeight" x="580" y="0" width="30" height="18" uuid="4ecd06c7-e9ab-4189-95d1-630a96c93bf8"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4ecd06c7-e9ab-4189-95d1-630a96c93bf8" key="textField-252" stretchType="ContainerHeight" x="580" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{AMOUNT_PER3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-262" style="Level3_Line" stretchType="RelativeToBandHeight" x="550" y="0" width="30" height="18" uuid="a705e14c-4862-4035-906e-c49d572b2ec9"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a705e14c-4862-4035-906e-c49d572b2ec9" key="textField-262" stretchType="ContainerHeight" x="550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{MARGINREF_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-272" style="Level3_Line" stretchType="RelativeToBandHeight" x="495" y="0" width="55" height="18" uuid="2ac9ae49-026d-44b9-b550-f96c47e53657"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2ac9ae49-026d-44b9-b550-f96c47e53657" key="textField-272" stretchType="ContainerHeight" x="495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{PROFITREF_3}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF_3}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-282" style="Level3_Line" stretchType="RelativeToBandHeight" x="440" y="0" width="55" height="18" uuid="74189de4-6d97-4e0e-872b-cdf889c6257a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="74189de4-6d97-4e0e-872b-cdf889c6257a" key="textField-282" stretchType="ContainerHeight" x="440" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{COSTREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-292" style="Level3_Line" stretchType="RelativeToBandHeight" x="385" y="0" width="55" height="18" uuid="943b8794-c6fe-41ca-a68c-20b83fe8e38b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="943b8794-c6fe-41ca-a68c-20b83fe8e38b" key="textField-292" stretchType="ContainerHeight" x="385" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-302" style="Level3_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="55" height="18" uuid="4c25a22f-012e-4389-a62b-15a727134ac4"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4c25a22f-012e-4389-a62b-15a727134ac4" key="textField-302" stretchType="ContainerHeight" x="640" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{AMOUNTREF2_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF2_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-312" style="Level3_Line" stretchType="RelativeToBandHeight" x="695" y="0" width="55" height="18" uuid="5ce1e2a3-0a01-4a0b-8d6a-bfa7d0e249b2"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5ce1e2a3-0a01-4a0b-8d6a-bfa7d0e249b2" key="textField-312" stretchType="ContainerHeight" x="695" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{COSTREF2_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF2_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-322" style="Level3_Line" stretchType="RelativeToBandHeight" x="750" y="0" width="55" height="18" uuid="f9f6efad-8d1c-4716-82c0-c33bfb190992"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f9f6efad-8d1c-4716-82c0-c33bfb190992" key="textField-322" stretchType="ContainerHeight" x="750" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{PROFITREF2_3}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF2_3}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-332" style="Level3_Line" stretchType="RelativeToBandHeight" x="805" y="0" width="30" height="18" uuid="858b072a-8186-4e59-b593-b1ebf860a100"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="858b072a-8186-4e59-b593-b1ebf860a100" key="textField-332" stretchType="ContainerHeight" x="805" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{MARGINREF2_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF2_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-342" style="Level3_Line" stretchType="RelativeToBandHeight" x="835" y="0" width="30" height="18" uuid="9fc045d9-60c2-49da-a133-4e8230207505"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9fc045d9-60c2-49da-a133-4e8230207505" key="textField-342" stretchType="ContainerHeight" x="835" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{AMOUNT2_PER3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT2_PER3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-352" style="Level3_Line" stretchType="RelativeToBandHeight" x="865" y="0" width="30" height="18" uuid="6e3125a2-1ed5-4c8b-9af2-52983e83bfab"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6e3125a2-1ed5-4c8b-9af2-52983e83bfab" key="textField-352" stretchType="ContainerHeight" x="865" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{MARGINDIFF2_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF2_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-362" style="Level3_Line" stretchType="RelativeToBandHeight" x="1210" y="0" width="30" height="18" uuid="d45fb7e3-c9ec-4dde-a422-f64da9b3acc2"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d45fb7e3-c9ec-4dde-a422-f64da9b3acc2" key="textField-362" stretchType="ContainerHeight" x="1210" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{WEIGHTREF2_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF2_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" isBlankWhenNull="false">
-					<reportElement key="textField-372" style="Level3_Line" stretchType="RelativeToBandHeight" x="1410" y="0" width="55" height="18" uuid="13ec6c90-48e3-4a9e-a598-c84d071d4257">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="13ec6c90-48e3-4a9e-a598-c84d071d4257" key="textField-372" stretchType="ContainerHeight" x="1410" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF2_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF2_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-382" style="Level3_Line" stretchType="RelativeToBandHeight" x="1465" y="0" width="30" height="18" uuid="11874dc9-ea86-4850-8115-17c455c22d27">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="11874dc9-ea86-4850-8115-17c455c22d27" key="textField-382" stretchType="ContainerHeight" x="1465" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY2_PER3}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY2_PER3}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-392" style="Level3_Line" stretchType="RelativeToBandHeight" x="895" y="0" width="55" height="18" uuid="fd42d1b3-8864-4efd-9011-72ecfd8fdaff"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="fd42d1b3-8864-4efd-9011-72ecfd8fdaff" key="textField-392" stretchType="ContainerHeight" x="895" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{AMOUNTREF3_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF3_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF3_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF3_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-402" style="Level3_Line" stretchType="RelativeToBandHeight" x="950" y="0" width="55" height="18" uuid="1c60c92a-5c47-4fef-b115-d08185cda0d9"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1c60c92a-5c47-4fef-b115-d08185cda0d9" key="textField-402" stretchType="ContainerHeight" x="950" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{COSTREF3_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF3_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF3_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF3_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-412" style="Level3_Line" stretchType="RelativeToBandHeight" x="1005" y="0" width="55" height="18" uuid="3d2627c4-9fdb-4967-81fe-6f121e81a425"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3d2627c4-9fdb-4967-81fe-6f121e81a425" key="textField-412" stretchType="ContainerHeight" x="1005" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{PROFITREF3_3}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF3_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF3_3}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF3_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-422" style="Level3_Line" stretchType="RelativeToBandHeight" x="1060" y="0" width="30" height="18" uuid="e1229028-cc89-4476-8f90-5126fe0885e6"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e1229028-cc89-4476-8f90-5126fe0885e6" key="textField-422" stretchType="ContainerHeight" x="1060" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{MARGINREF3_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF3_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF3_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF3_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-432" style="Level3_Line" stretchType="RelativeToBandHeight" x="1090" y="0" width="30" height="18" uuid="748364d0-ad93-45cc-a798-d69751d801c9"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="748364d0-ad93-45cc-a798-d69751d801c9" key="textField-432" stretchType="ContainerHeight" x="1090" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{AMOUNT3_PER3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT3_PER3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT3_PER3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT3_PER3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-442" style="Level3_Line" stretchType="RelativeToBandHeight" x="1120" y="0" width="30" height="18" uuid="156e6d84-4293-4499-93ff-b13e028b6956"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="156e6d84-4293-4499-93ff-b13e028b6956" key="textField-442" stretchType="ContainerHeight" x="1120" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{MARGINDIFF3_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF3_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF3_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF3_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-452" style="Level3_Line" stretchType="RelativeToBandHeight" x="1240" y="0" width="30" height="18" uuid="c5c094f9-721f-44f7-8c2e-b7d1d0fcb344"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c5c094f9-721f-44f7-8c2e-b7d1d0fcb344" key="textField-452" stretchType="ContainerHeight" x="1240" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{WEIGHTREF3_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF3_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF3_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF3_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" isBlankWhenNull="false">
-					<reportElement key="textField-462" style="Level3_Line" stretchType="RelativeToBandHeight" x="1495" y="0" width="55" height="18" uuid="61ed49af-a35e-410a-9307-1fadc4f31721">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="61ed49af-a35e-410a-9307-1fadc4f31721" key="textField-462" stretchType="ContainerHeight" x="1495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF3_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF3_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF3_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF3_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-472" style="Level3_Line" stretchType="RelativeToBandHeight" x="1550" y="0" width="30" height="18" uuid="91a2aa07-29fd-40ed-ba43-79a6302651f2">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="91a2aa07-29fd-40ed-ba43-79a6302651f2" key="textField-472" stretchType="ContainerHeight" x="1550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY3_PER3}!=null)?$P{NUMBERFORMAT}.format($V{QTY3_PER3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY3_PER3}!=null)?$P{NUMBERFORMAT}.format($V{QTY3_PER3}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -3621,505 +2976,350 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL4">
-		<groupExpression><![CDATA[$F{NIVEL4}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL4}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-4" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="a504e731-1903-40b1-b9f2-988714262bd7"/>
-					<box>
+				<element kind="textField" uuid="a504e731-1903-40b1-b9f2-988714262bd7" key="textField-4" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-9" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="a0d58159-4115-41f6-ad6d-92fe855f031d"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="a0d58159-4115-41f6-ad6d-92fe855f031d" key="textField-9" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-6" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="2df8baa4-b59f-4b6d-a2b5-3661d6f54acf"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="2df8baa4-b59f-4b6d-a2b5-3661d6f54acf" key="textField-6" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="145" height="18" uuid="6f7dbb56-0584-4061-bbf1-26a43bd7c362"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6f7dbb56-0584-4061-bbf1-26a43bd7c362" key="textField" stretchType="ContainerHeight" x="45" y="0" width="145" height="18" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[$F{NIVEL4}]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL4}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" x="190" y="0" width="55" height="18" uuid="2e7b61f6-8a99-4ed1-9482-330622a75f31"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2e7b61f6-8a99-4ed1-9482-330622a75f31" key="textField" stretchType="ContainerHeight" x="190" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" x="1270" y="0" width="55" height="18" uuid="77078ab9-a815-4d03-a2e5-b111e7576b5c">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="77078ab9-a815-4d03-a2e5-b111e7576b5c" key="textField" stretchType="ContainerHeight" x="1270" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-164" style="Level4_Line" stretchType="RelativeToBandHeight" x="245" y="0" width="55" height="18" uuid="02faba48-f7b7-4994-8cbe-1ddb73af10b9"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="02faba48-f7b7-4994-8cbe-1ddb73af10b9" key="textField-164" stretchType="ContainerHeight" x="245" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{COST_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COST_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-165" style="Level4_Line" stretchType="RelativeToBandHeight" x="300" y="0" width="55" height="18" uuid="653980ca-f80c-48e5-a89f-564c4837a168"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="653980ca-f80c-48e5-a89f-564c4837a168" key="textField-165" stretchType="ContainerHeight" x="300" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{PROFIT_4}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFIT_4}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-166" style="Level4_Line" stretchType="RelativeToBandHeight" x="355" y="0" width="30" height="18" uuid="73e9d416-b59f-403f-94da-f30b27ecab50"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="73e9d416-b59f-403f-94da-f30b27ecab50" key="textField-166" stretchType="ContainerHeight" x="355" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{MARGIN_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGIN_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-167" style="Level4_Line" stretchType="RelativeToBandHeight" x="1150" y="0" width="30" height="18" uuid="06fc2b4f-c345-47fa-a66a-c04b3c0b4123"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="06fc2b4f-c345-47fa-a66a-c04b3c0b4123" key="textField-167" stretchType="ContainerHeight" x="1150" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-213" style="Level4_Line" stretchType="RelativeToBandHeight" x="1380" y="0" width="30" height="18" uuid="21464b04-6bce-449d-9e11-f225803c12cd">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="21464b04-6bce-449d-9e11-f225803c12cd" key="textField-213" stretchType="ContainerHeight" x="1380" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER4}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PER4}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" isBlankWhenNull="false">
-					<reportElement key="textField-223" style="Level4_Line" stretchType="RelativeToBandHeight" x="1325" y="0" width="55" height="18" uuid="fdf7681c-2e95-4c2b-8468-7e0066b77bdf">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="fdf7681c-2e95-4c2b-8468-7e0066b77bdf" key="textField-223" stretchType="ContainerHeight" x="1325" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-233" style="Level4_Line" stretchType="RelativeToBandHeight" x="1180" y="0" width="30" height="18" uuid="a27e2778-f6f3-4ddb-ae51-8ed9e5724a2c"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a27e2778-f6f3-4ddb-ae51-8ed9e5724a2c" key="textField-233" stretchType="ContainerHeight" x="1180" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-243" style="Level4_Line" stretchType="RelativeToBandHeight" x="610" y="0" width="30" height="18" uuid="d6544ecb-7a7c-4edb-b1ce-abf8082a7e2d"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d6544ecb-7a7c-4edb-b1ce-abf8082a7e2d" key="textField-243" stretchType="ContainerHeight" x="610" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{MARGINDIFF_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-253" style="Level4_Line" stretchType="RelativeToBandHeight" x="580" y="0" width="30" height="18" uuid="e34fb428-40b9-4441-80f4-bc64329e0056"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e34fb428-40b9-4441-80f4-bc64329e0056" key="textField-253" stretchType="ContainerHeight" x="580" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{AMOUNT_PER4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-263" style="Level4_Line" stretchType="RelativeToBandHeight" x="550" y="0" width="30" height="18" uuid="4372e284-102e-48c0-8d92-9702c308f6b0"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4372e284-102e-48c0-8d92-9702c308f6b0" key="textField-263" stretchType="ContainerHeight" x="550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{MARGINREF_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-273" style="Level4_Line" stretchType="RelativeToBandHeight" x="495" y="0" width="55" height="18" uuid="3564d831-eaf6-423e-83ca-7c71419188ef"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3564d831-eaf6-423e-83ca-7c71419188ef" key="textField-273" stretchType="ContainerHeight" x="495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{PROFITREF_4}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF_4}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-283" style="Level4_Line" stretchType="RelativeToBandHeight" x="440" y="0" width="55" height="18" uuid="e9dfcd06-50d6-4643-8a3d-50735a84286a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e9dfcd06-50d6-4643-8a3d-50735a84286a" key="textField-283" stretchType="ContainerHeight" x="440" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{COSTREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-293" style="Level4_Line" stretchType="RelativeToBandHeight" x="385" y="0" width="55" height="18" uuid="7c97a4a1-231e-41fd-9fe6-066a0ed9a0f2"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7c97a4a1-231e-41fd-9fe6-066a0ed9a0f2" key="textField-293" stretchType="ContainerHeight" x="385" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-303" style="Level4_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="55" height="18" uuid="c12f4606-068e-4740-8d93-8e967eef093c"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c12f4606-068e-4740-8d93-8e967eef093c" key="textField-303" stretchType="ContainerHeight" x="640" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{AMOUNTREF2_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF2_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-313" style="Level4_Line" stretchType="RelativeToBandHeight" x="695" y="0" width="55" height="18" uuid="989cacb2-3c77-4e73-afa8-85c3e16fac9d"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="989cacb2-3c77-4e73-afa8-85c3e16fac9d" key="textField-313" stretchType="ContainerHeight" x="695" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{COSTREF2_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF2_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-323" style="Level4_Line" stretchType="RelativeToBandHeight" x="750" y="0" width="55" height="18" uuid="866476a8-a9de-437e-b928-5f583130a171"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="866476a8-a9de-437e-b928-5f583130a171" key="textField-323" stretchType="ContainerHeight" x="750" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{PROFITREF2_4}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF2_4}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-333" style="Level4_Line" stretchType="RelativeToBandHeight" x="805" y="0" width="30" height="18" uuid="e0881294-3c10-4776-9648-1d3645edd847"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e0881294-3c10-4776-9648-1d3645edd847" key="textField-333" stretchType="ContainerHeight" x="805" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{MARGINREF2_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF2_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-343" style="Level4_Line" stretchType="RelativeToBandHeight" x="835" y="0" width="30" height="18" uuid="9452b605-1cf5-4701-ba60-d61afc6e51d6"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9452b605-1cf5-4701-ba60-d61afc6e51d6" key="textField-343" stretchType="ContainerHeight" x="835" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{AMOUNT2_PER4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT2_PER4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-353" style="Level4_Line" stretchType="RelativeToBandHeight" x="865" y="0" width="30" height="18" uuid="187a60a2-35b1-4012-8b98-85cd090c5a67"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="187a60a2-35b1-4012-8b98-85cd090c5a67" key="textField-353" stretchType="ContainerHeight" x="865" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{MARGINDIFF2_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF2_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-363" style="Level4_Line" stretchType="RelativeToBandHeight" x="1210" y="0" width="30" height="18" uuid="106c90a8-8dc0-4ec6-9ffe-bf22f2edd98b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="106c90a8-8dc0-4ec6-9ffe-bf22f2edd98b" key="textField-363" stretchType="ContainerHeight" x="1210" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{WEIGHTREF2_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF2_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" isBlankWhenNull="false">
-					<reportElement key="textField-373" style="Level4_Line" stretchType="RelativeToBandHeight" x="1410" y="0" width="55" height="18" uuid="7719e99b-75b2-4bf6-833a-182bf4d31c28">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7719e99b-75b2-4bf6-833a-182bf4d31c28" key="textField-373" stretchType="ContainerHeight" x="1410" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF2_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF2_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-383" style="Level4_Line" stretchType="RelativeToBandHeight" x="1465" y="0" width="30" height="18" uuid="075d2447-a116-4cd2-8e07-53fbde2ac60c">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="075d2447-a116-4cd2-8e07-53fbde2ac60c" key="textField-383" stretchType="ContainerHeight" x="1465" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY2_PER4}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY2_PER4}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-393" style="Level4_Line" stretchType="RelativeToBandHeight" x="895" y="0" width="55" height="18" uuid="f8a8aa08-1d4d-4299-af67-560c73b4da24"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f8a8aa08-1d4d-4299-af67-560c73b4da24" key="textField-393" stretchType="ContainerHeight" x="895" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{AMOUNTREF3_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF3_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF3_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF3_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-403" style="Level4_Line" stretchType="RelativeToBandHeight" x="950" y="0" width="55" height="18" uuid="32c627f2-4f7b-4424-9841-754cf5aa4566"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="32c627f2-4f7b-4424-9841-754cf5aa4566" key="textField-403" stretchType="ContainerHeight" x="950" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{COSTREF3_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF3_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF3_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF3_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-413" style="Level4_Line" stretchType="RelativeToBandHeight" x="1005" y="0" width="55" height="18" uuid="f8b3a02c-3435-42cf-b157-4e459669d2d3"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f8b3a02c-3435-42cf-b157-4e459669d2d3" key="textField-413" stretchType="ContainerHeight" x="1005" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{PROFITREF3_4}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF3_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF3_4}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF3_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-423" style="Level4_Line" stretchType="RelativeToBandHeight" x="1060" y="0" width="30" height="18" uuid="675bb063-534c-441b-9fee-470fd516a065"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="675bb063-534c-441b-9fee-470fd516a065" key="textField-423" stretchType="ContainerHeight" x="1060" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{MARGINREF3_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF3_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF3_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF3_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-433" style="Level4_Line" stretchType="RelativeToBandHeight" x="1090" y="0" width="30" height="18" uuid="dfe0be77-bb4d-4459-936c-45db6fcf1df5"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="dfe0be77-bb4d-4459-936c-45db6fcf1df5" key="textField-433" stretchType="ContainerHeight" x="1090" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{AMOUNT3_PER4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT3_PER4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT3_PER4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT3_PER4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-443" style="Level4_Line" stretchType="RelativeToBandHeight" x="1120" y="0" width="30" height="18" uuid="6a2ae9ce-8fcf-4916-85ef-7e564b1cbcb9"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6a2ae9ce-8fcf-4916-85ef-7e564b1cbcb9" key="textField-443" stretchType="ContainerHeight" x="1120" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{MARGINDIFF3_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF3_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF3_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF3_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-453" style="Level4_Line" stretchType="RelativeToBandHeight" x="1240" y="0" width="30" height="18" uuid="34046d47-8750-45ef-b71b-1cd8559e550c"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="34046d47-8750-45ef-b71b-1cd8559e550c" key="textField-453" stretchType="ContainerHeight" x="1240" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{WEIGHTREF3_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF3_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF3_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF3_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" isBlankWhenNull="false">
-					<reportElement key="textField-463" style="Level4_Line" stretchType="RelativeToBandHeight" x="1495" y="0" width="55" height="18" uuid="a5fe20b7-adf3-450f-a9ad-2c47695a0a99">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a5fe20b7-adf3-450f-a9ad-2c47695a0a99" key="textField-463" stretchType="ContainerHeight" x="1495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF3_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF3_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF3_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF3_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-473" style="Level4_Line" stretchType="RelativeToBandHeight" x="1550" y="0" width="30" height="18" uuid="4be426b9-9723-4765-b538-c0cdc62c4e5e">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4be426b9-9723-4765-b538-c0cdc62c4e5e" key="textField-473" stretchType="ContainerHeight" x="1550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY3_PER4}!=null)?$P{NUMBERFORMAT}.format($V{QTY3_PER4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY3_PER4}!=null)?$P{NUMBERFORMAT}.format($V{QTY3_PER4}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -4129,518 +3329,359 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL5">
-		<groupExpression><![CDATA[$F{NIVEL5}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL5}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-5" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="c11cd92f-a964-444f-b00c-a334493703e2"/>
-					<box>
+				<element kind="textField" uuid="c11cd92f-a964-444f-b00c-a334493703e2" key="textField-5" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-10" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="40f9e1fd-e049-45e8-81a4-1d96a018fc70"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="40f9e1fd-e049-45e8-81a4-1d96a018fc70" key="textField-10" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-7" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="b0133a8b-245a-4290-a6a4-b8d982d388ec"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="b0133a8b-245a-4290-a6a4-b8d982d388ec" key="textField-7" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-11" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="7cea8658-c868-4503-a32a-3392f0e5f5ab"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="7cea8658-c868-4503-a32a-3392f0e5f5ab" key="textField-11" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="130" height="18" uuid="32a6ab26-b346-4517-ad3e-70a67dcdc23f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="32a6ab26-b346-4517-ad3e-70a67dcdc23f" key="textField" stretchType="ContainerHeight" x="60" y="0" width="130" height="18" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[$F{NIVEL5}]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL5}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" x="190" y="0" width="55" height="18" uuid="3d3db475-6e06-406f-82ee-b67226fe4d5c"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3d3db475-6e06-406f-82ee-b67226fe4d5c" key="textField" stretchType="ContainerHeight" x="190" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" x="1270" y="0" width="55" height="18" uuid="4991e118-fa8e-4d0b-85e0-82e9246317ff">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4991e118-fa8e-4d0b-85e0-82e9246317ff" key="textField" stretchType="ContainerHeight" x="1270" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-168" style="Level5_Line" stretchType="RelativeToBandHeight" x="245" y="0" width="55" height="18" uuid="9fcb8734-9a67-4c2b-a425-933b8093102d"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9fcb8734-9a67-4c2b-a425-933b8093102d" key="textField-168" stretchType="ContainerHeight" x="245" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{COST_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COST_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-169" style="Level5_Line" stretchType="RelativeToBandHeight" x="300" y="0" width="55" height="18" uuid="d88c1065-31b2-4ab7-a233-6b42e960681b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d88c1065-31b2-4ab7-a233-6b42e960681b" key="textField-169" stretchType="ContainerHeight" x="300" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{PROFIT_5}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFIT_5}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-170" style="Level5_Line" stretchType="RelativeToBandHeight" x="355" y="0" width="30" height="18" uuid="698f85f9-528a-4682-9def-ee4829f4b146"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="698f85f9-528a-4682-9def-ee4829f4b146" key="textField-170" stretchType="ContainerHeight" x="355" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{MARGIN_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGIN_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-171" style="Level5_Line" stretchType="RelativeToBandHeight" x="1150" y="0" width="30" height="18" uuid="7a375278-04c3-4272-91c8-324be677c5a4"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7a375278-04c3-4272-91c8-324be677c5a4" key="textField-171" stretchType="ContainerHeight" x="1150" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-214" style="Level5_Line" stretchType="RelativeToBandHeight" x="1380" y="0" width="30" height="18" uuid="f41351d3-d33d-4619-a4da-8925c70e1c6b">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f41351d3-d33d-4619-a4da-8925c70e1c6b" key="textField-214" stretchType="ContainerHeight" x="1380" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER5}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PER5}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" isBlankWhenNull="false">
-					<reportElement key="textField-224" style="Level5_Line" stretchType="RelativeToBandHeight" x="1325" y="0" width="55" height="18" uuid="a2e507b0-710d-4fb6-bd33-fd12761c5fd6">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a2e507b0-710d-4fb6-bd33-fd12761c5fd6" key="textField-224" stretchType="ContainerHeight" x="1325" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-234" style="Level5_Line" stretchType="RelativeToBandHeight" x="1180" y="0" width="30" height="18" uuid="b78a2a24-02d9-435d-bc26-df71ec319898"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b78a2a24-02d9-435d-bc26-df71ec319898" key="textField-234" stretchType="ContainerHeight" x="1180" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-244" style="Level5_Line" stretchType="RelativeToBandHeight" x="610" y="0" width="30" height="18" uuid="603d1960-96dd-4c1e-ba08-ba9d5299a242"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="603d1960-96dd-4c1e-ba08-ba9d5299a242" key="textField-244" stretchType="ContainerHeight" x="610" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{MARGINDIFF_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-254" style="Level5_Line" stretchType="RelativeToBandHeight" x="580" y="0" width="30" height="18" uuid="96fb8adb-6d69-4845-bfd8-f55f92059b13"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="96fb8adb-6d69-4845-bfd8-f55f92059b13" key="textField-254" stretchType="ContainerHeight" x="580" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{AMOUNT_PER5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-264" style="Level5_Line" stretchType="RelativeToBandHeight" x="550" y="0" width="30" height="18" uuid="4d1849f2-1628-494e-9d04-2ea9e4f2c41b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4d1849f2-1628-494e-9d04-2ea9e4f2c41b" key="textField-264" stretchType="ContainerHeight" x="550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{MARGINREF_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-274" style="Level5_Line" stretchType="RelativeToBandHeight" x="495" y="0" width="55" height="18" uuid="eb1588fa-545c-4bc6-ac74-e1101ffecef6"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="eb1588fa-545c-4bc6-ac74-e1101ffecef6" key="textField-274" stretchType="ContainerHeight" x="495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{PROFITREF_5}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF_5}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-284" style="Level5_Line" stretchType="RelativeToBandHeight" x="440" y="0" width="55" height="18" uuid="0a601546-b72b-4952-a41b-bf193bb35d02"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0a601546-b72b-4952-a41b-bf193bb35d02" key="textField-284" stretchType="ContainerHeight" x="440" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{COSTREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-294" style="Level5_Line" stretchType="RelativeToBandHeight" x="385" y="0" width="55" height="18" uuid="7142f176-bc72-4e78-be1f-358bf1823752"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7142f176-bc72-4e78-be1f-358bf1823752" key="textField-294" stretchType="ContainerHeight" x="385" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-304" style="Level5_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="55" height="18" uuid="1be475a9-6432-4642-b612-1511d0b38593"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1be475a9-6432-4642-b612-1511d0b38593" key="textField-304" stretchType="ContainerHeight" x="640" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{AMOUNTREF2_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF2_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-314" style="Level5_Line" stretchType="RelativeToBandHeight" x="695" y="0" width="55" height="18" uuid="d199c285-174a-48f1-9192-4eea2eacd857"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d199c285-174a-48f1-9192-4eea2eacd857" key="textField-314" stretchType="ContainerHeight" x="695" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{COSTREF2_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF2_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-324" style="Level5_Line" stretchType="RelativeToBandHeight" x="750" y="0" width="55" height="18" uuid="dc7c642d-987a-4517-8307-0606db226919"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="dc7c642d-987a-4517-8307-0606db226919" key="textField-324" stretchType="ContainerHeight" x="750" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{PROFITREF2_5}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF2_5}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-334" style="Level5_Line" stretchType="RelativeToBandHeight" x="805" y="0" width="30" height="18" uuid="6f6f7c21-acd1-4ff8-8032-b7a2b00d492f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6f6f7c21-acd1-4ff8-8032-b7a2b00d492f" key="textField-334" stretchType="ContainerHeight" x="805" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{MARGINREF2_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF2_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-344" style="Level5_Line" stretchType="RelativeToBandHeight" x="835" y="0" width="30" height="18" uuid="0140cfbb-c920-4957-a390-ceab9c81cb67"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0140cfbb-c920-4957-a390-ceab9c81cb67" key="textField-344" stretchType="ContainerHeight" x="835" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{AMOUNT2_PER5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT2_PER5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-354" style="Level5_Line" stretchType="RelativeToBandHeight" x="865" y="0" width="30" height="18" uuid="607ec318-4fee-42a1-908f-41201dd75c0d"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="607ec318-4fee-42a1-908f-41201dd75c0d" key="textField-354" stretchType="ContainerHeight" x="865" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{MARGINDIFF2_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF2_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-364" style="Level5_Line" stretchType="RelativeToBandHeight" x="1210" y="0" width="30" height="18" uuid="d71c2e35-2dc6-4a92-a647-128af44ca4b5"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d71c2e35-2dc6-4a92-a647-128af44ca4b5" key="textField-364" stretchType="ContainerHeight" x="1210" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{WEIGHTREF2_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF2_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" isBlankWhenNull="false">
-					<reportElement key="textField-374" style="Level5_Line" stretchType="RelativeToBandHeight" x="1410" y="0" width="55" height="18" uuid="9c2bf839-d1a3-4705-95b5-b854da5bee4f">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9c2bf839-d1a3-4705-95b5-b854da5bee4f" key="textField-374" stretchType="ContainerHeight" x="1410" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF2_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF2_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-384" style="Level5_Line" stretchType="RelativeToBandHeight" x="1465" y="0" width="30" height="18" uuid="f6be8905-6d0b-4219-999a-80be6bda73ee">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f6be8905-6d0b-4219-999a-80be6bda73ee" key="textField-384" stretchType="ContainerHeight" x="1465" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY2_PER5}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY2_PER5}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-394" style="Level5_Line" stretchType="RelativeToBandHeight" x="895" y="0" width="55" height="18" uuid="06388ea2-d3db-499c-8baa-144dfe325801"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="06388ea2-d3db-499c-8baa-144dfe325801" key="textField-394" stretchType="ContainerHeight" x="895" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{AMOUNTREF3_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF3_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF3_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF3_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-404" style="Level5_Line" stretchType="RelativeToBandHeight" x="950" y="0" width="55" height="18" uuid="82b445d7-cbbe-4507-9be1-59f1485a638b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="82b445d7-cbbe-4507-9be1-59f1485a638b" key="textField-404" stretchType="ContainerHeight" x="950" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{COSTREF3_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF3_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF3_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF3_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-414" style="Level5_Line" stretchType="RelativeToBandHeight" x="1005" y="0" width="55" height="18" uuid="885e9689-7eba-48ee-adc7-4200943ac125"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="885e9689-7eba-48ee-adc7-4200943ac125" key="textField-414" stretchType="ContainerHeight" x="1005" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{PROFITREF3_5}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF3_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF3_5}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF3_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-424" style="Level5_Line" stretchType="RelativeToBandHeight" x="1060" y="0" width="30" height="18" uuid="d95e72cb-8839-411c-a0c8-0b1d59a2b23c"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d95e72cb-8839-411c-a0c8-0b1d59a2b23c" key="textField-424" stretchType="ContainerHeight" x="1060" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{MARGINREF3_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF3_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF3_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF3_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-434" style="Level5_Line" stretchType="RelativeToBandHeight" x="1090" y="0" width="30" height="18" uuid="653a0430-2783-41de-84a5-446eb6fd1b30"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="653a0430-2783-41de-84a5-446eb6fd1b30" key="textField-434" stretchType="ContainerHeight" x="1090" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{AMOUNT3_PER5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT3_PER5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT3_PER5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT3_PER5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-444" style="Level5_Line" stretchType="RelativeToBandHeight" x="1120" y="0" width="30" height="18" uuid="660fbe9f-5afa-486e-9de0-01f019238dc3"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="660fbe9f-5afa-486e-9de0-01f019238dc3" key="textField-444" stretchType="ContainerHeight" x="1120" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{MARGINDIFF3_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF3_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF3_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF3_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-454" style="Level5_Line" stretchType="RelativeToBandHeight" x="1240" y="0" width="30" height="18" uuid="21b1f92e-9eb7-4250-896f-6e9c34af0a8b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="21b1f92e-9eb7-4250-896f-6e9c34af0a8b" key="textField-454" stretchType="ContainerHeight" x="1240" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{WEIGHTREF3_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF3_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF3_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF3_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" isBlankWhenNull="false">
-					<reportElement key="textField-464" style="Level5_Line" stretchType="RelativeToBandHeight" x="1495" y="0" width="55" height="18" uuid="8aa4e17f-7781-49e7-b3be-de4291348573">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="8aa4e17f-7781-49e7-b3be-de4291348573" key="textField-464" stretchType="ContainerHeight" x="1495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF3_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF3_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF3_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF3_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-474" style="Level5_Line" stretchType="RelativeToBandHeight" x="1550" y="0" width="30" height="18" uuid="386dd6e0-c4d8-4ff2-9ae1-158309ad7f3b">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="386dd6e0-c4d8-4ff2-9ae1-158309ad7f3b" key="textField-474" stretchType="ContainerHeight" x="1550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY3_PER5}!=null)?$P{NUMBERFORMAT}.format($V{QTY3_PER5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY3_PER5}!=null)?$P{NUMBERFORMAT}.format($V{QTY3_PER5}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -4650,531 +3691,368 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL6">
-		<groupExpression><![CDATA[$F{NIVEL6}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL6}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=6)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-70" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="a07b2f96-481b-49bd-8fd1-a5087d431ebe"/>
-					<box>
+				<element kind="textField" uuid="a07b2f96-481b-49bd-8fd1-a5087d431ebe" key="textField-70" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-72" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="0edf7772-4863-4418-989c-69d226030c97"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="0edf7772-4863-4418-989c-69d226030c97" key="textField-72" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-71" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="13b95377-d136-438c-be5a-a9150a681646"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="13b95377-d136-438c-be5a-a9150a681646" key="textField-71" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-73" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="fabfb9b3-4a23-4ce0-9c01-cc2cb0e401b3"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="fabfb9b3-4a23-4ce0-9c01-cc2cb0e401b3" key="textField-73" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-74" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="15" height="18" uuid="6fc8e283-0901-4e04-adbc-94423b0e7f69"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="6fc8e283-0901-4e04-adbc-94423b0e7f69" key="textField-74" stretchType="ContainerHeight" x="60" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-66" style="Level6_Line" stretchType="RelativeToBandHeight" x="75" y="0" width="115" height="18" uuid="d01ddd4a-14b9-4d39-a1c9-3a56c3efdb5b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d01ddd4a-14b9-4d39-a1c9-3a56c3efdb5b" key="textField-66" stretchType="ContainerHeight" x="75" y="0" width="115" height="18" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[$F{NIVEL6}]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL6}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-69" style="Level6_Line" stretchType="RelativeToBandHeight" x="190" y="0" width="55" height="18" uuid="41677605-7447-46a1-bbd0-85215b491ffe"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="41677605-7447-46a1-bbd0-85215b491ffe" key="textField-69" stretchType="ContainerHeight" x="190" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" isBlankWhenNull="false">
-					<reportElement key="textField-68" style="Level6_Line" stretchType="RelativeToBandHeight" x="1270" y="0" width="55" height="18" uuid="f5503676-ffa5-40e8-96a9-8c8ec5a57445">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f5503676-ffa5-40e8-96a9-8c8ec5a57445" key="textField-68" stretchType="ContainerHeight" x="1270" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-172" style="Level6_Line" stretchType="RelativeToBandHeight" x="245" y="0" width="55" height="18" uuid="75a9a36b-4f62-41b9-9a71-2fbdd2cda669"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="75a9a36b-4f62-41b9-9a71-2fbdd2cda669" key="textField-172" stretchType="ContainerHeight" x="245" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{COST_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COST_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-173" style="Level6_Line" stretchType="RelativeToBandHeight" x="300" y="0" width="55" height="18" uuid="f4b55ae2-f12a-4c56-906c-3b63c4ce415e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f4b55ae2-f12a-4c56-906c-3b63c4ce415e" key="textField-173" stretchType="ContainerHeight" x="300" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{PROFIT_6}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFIT_6}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-174" style="Level6_Line" stretchType="RelativeToBandHeight" x="355" y="0" width="30" height="18" uuid="755c4d0a-bb9f-41e3-8333-bbfb65576644"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="755c4d0a-bb9f-41e3-8333-bbfb65576644" key="textField-174" stretchType="ContainerHeight" x="355" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{MARGIN_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGIN_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-175" style="Level6_Line" stretchType="RelativeToBandHeight" x="1150" y="0" width="30" height="18" uuid="2a8d587f-2701-4520-9f2f-a5f51d31ecbc"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2a8d587f-2701-4520-9f2f-a5f51d31ecbc" key="textField-175" stretchType="ContainerHeight" x="1150" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-215" style="Level6_Line" stretchType="RelativeToBandHeight" x="1380" y="0" width="30" height="18" uuid="3912bc28-5f39-4e4c-be72-af8d91b474ea">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3912bc28-5f39-4e4c-be72-af8d91b474ea" key="textField-215" stretchType="ContainerHeight" x="1380" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER6}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PER6}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" isBlankWhenNull="false">
-					<reportElement key="textField-225" style="Level6_Line" stretchType="RelativeToBandHeight" x="1325" y="0" width="55" height="18" uuid="118e21a5-77c1-4c61-8f12-1c1b4efcb707">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="118e21a5-77c1-4c61-8f12-1c1b4efcb707" key="textField-225" stretchType="ContainerHeight" x="1325" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-235" style="Level6_Line" stretchType="RelativeToBandHeight" x="1180" y="0" width="30" height="18" uuid="0c0a5cc5-b8fc-443c-9304-fe35b4727de1"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0c0a5cc5-b8fc-443c-9304-fe35b4727de1" key="textField-235" stretchType="ContainerHeight" x="1180" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-245" style="Level6_Line" stretchType="RelativeToBandHeight" x="610" y="0" width="30" height="18" uuid="8ee9566b-c8f9-4641-8a84-c2eb72d63d67"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="8ee9566b-c8f9-4641-8a84-c2eb72d63d67" key="textField-245" stretchType="ContainerHeight" x="610" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{MARGINDIFF_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-255" style="Level6_Line" stretchType="RelativeToBandHeight" x="580" y="0" width="30" height="18" uuid="1b937824-fb1e-441b-affa-f24f9a63a0f5"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1b937824-fb1e-441b-affa-f24f9a63a0f5" key="textField-255" stretchType="ContainerHeight" x="580" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{AMOUNT_PER6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-265" style="Level6_Line" stretchType="RelativeToBandHeight" x="550" y="0" width="30" height="18" uuid="2310cdc4-d856-43af-8c56-f050b3414c57"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2310cdc4-d856-43af-8c56-f050b3414c57" key="textField-265" stretchType="ContainerHeight" x="550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{MARGINREF_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-275" style="Level6_Line" stretchType="RelativeToBandHeight" x="495" y="0" width="55" height="18" uuid="8171f0b4-c27f-498f-80c2-76e8c661941b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="8171f0b4-c27f-498f-80c2-76e8c661941b" key="textField-275" stretchType="ContainerHeight" x="495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{PROFITREF_6}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF_6}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-285" style="Level6_Line" stretchType="RelativeToBandHeight" x="440" y="0" width="55" height="18" uuid="5f24514f-6c9b-4203-b181-70564f117296"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5f24514f-6c9b-4203-b181-70564f117296" key="textField-285" stretchType="ContainerHeight" x="440" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{COSTREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-295" style="Level6_Line" stretchType="RelativeToBandHeight" x="385" y="0" width="55" height="18" uuid="cce80c90-5dd8-4477-81ce-1780e16802d3"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="cce80c90-5dd8-4477-81ce-1780e16802d3" key="textField-295" stretchType="ContainerHeight" x="385" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-305" style="Level6_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="55" height="18" uuid="56081a35-2f3e-4056-95dc-48321a4959b4"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="56081a35-2f3e-4056-95dc-48321a4959b4" key="textField-305" stretchType="ContainerHeight" x="640" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{AMOUNTREF2_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF2_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-315" style="Level6_Line" stretchType="RelativeToBandHeight" x="695" y="0" width="55" height="18" uuid="ef59c88a-0b27-4fa0-956c-fbad3ce6eec6"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ef59c88a-0b27-4fa0-956c-fbad3ce6eec6" key="textField-315" stretchType="ContainerHeight" x="695" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{COSTREF2_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF2_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-325" style="Level6_Line" stretchType="RelativeToBandHeight" x="750" y="0" width="55" height="18" uuid="7af69fd7-30c0-4e5c-b407-f6b573189fcb"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7af69fd7-30c0-4e5c-b407-f6b573189fcb" key="textField-325" stretchType="ContainerHeight" x="750" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{PROFITREF2_6}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF2_6}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-335" style="Level6_Line" stretchType="RelativeToBandHeight" x="805" y="0" width="30" height="18" uuid="f8067f81-1b23-4a64-b486-485f1aa35257"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f8067f81-1b23-4a64-b486-485f1aa35257" key="textField-335" stretchType="ContainerHeight" x="805" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{MARGINREF2_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF2_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-345" style="Level6_Line" stretchType="RelativeToBandHeight" x="835" y="0" width="30" height="18" uuid="821a8925-39bf-4926-aa56-cce15969d1fa"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="821a8925-39bf-4926-aa56-cce15969d1fa" key="textField-345" stretchType="ContainerHeight" x="835" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{AMOUNT2_PER6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT2_PER6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-355" style="Level6_Line" stretchType="RelativeToBandHeight" x="865" y="0" width="30" height="18" uuid="52d4df53-a4fd-455b-a74c-41376ffc26b9"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="52d4df53-a4fd-455b-a74c-41376ffc26b9" key="textField-355" stretchType="ContainerHeight" x="865" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{MARGINDIFF2_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF2_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-365" style="Level6_Line" stretchType="RelativeToBandHeight" x="1210" y="0" width="30" height="18" uuid="24031b14-ed2c-4a4d-9a54-2835dfb6f269"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="24031b14-ed2c-4a4d-9a54-2835dfb6f269" key="textField-365" stretchType="ContainerHeight" x="1210" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{WEIGHTREF2_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF2_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" isBlankWhenNull="false">
-					<reportElement key="textField-375" style="Level6_Line" stretchType="RelativeToBandHeight" x="1410" y="0" width="55" height="18" uuid="00530083-1d95-40ee-841a-d40935908e00">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="00530083-1d95-40ee-841a-d40935908e00" key="textField-375" stretchType="ContainerHeight" x="1410" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF2_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF2_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-385" style="Level6_Line" stretchType="RelativeToBandHeight" x="1465" y="0" width="30" height="18" uuid="638a58a1-5b3b-4bbb-8090-9308abab8513">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="638a58a1-5b3b-4bbb-8090-9308abab8513" key="textField-385" stretchType="ContainerHeight" x="1465" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY2_PER6}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY2_PER6}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-395" style="Level6_Line" stretchType="RelativeToBandHeight" x="895" y="0" width="55" height="18" uuid="a4eeb0e0-a141-4728-85a0-689c722ef07d"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a4eeb0e0-a141-4728-85a0-689c722ef07d" key="textField-395" stretchType="ContainerHeight" x="895" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{AMOUNTREF3_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF3_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF3_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF3_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-405" style="Level6_Line" stretchType="RelativeToBandHeight" x="950" y="0" width="55" height="18" uuid="a866edd9-e50e-4175-80e1-60851a2d79be"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a866edd9-e50e-4175-80e1-60851a2d79be" key="textField-405" stretchType="ContainerHeight" x="950" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{COSTREF3_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF3_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF3_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF3_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-415" style="Level6_Line" stretchType="RelativeToBandHeight" x="1005" y="0" width="55" height="18" uuid="46afe442-1ec5-43d4-91cd-3c3102ab7aea"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="46afe442-1ec5-43d4-91cd-3c3102ab7aea" key="textField-415" stretchType="ContainerHeight" x="1005" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{PROFITREF3_6}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF3_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF3_6}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF3_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-425" style="Level6_Line" stretchType="RelativeToBandHeight" x="1060" y="0" width="30" height="18" uuid="246b4dec-05ae-4c24-8883-86bea4fb553c"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="246b4dec-05ae-4c24-8883-86bea4fb553c" key="textField-425" stretchType="ContainerHeight" x="1060" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{MARGINREF3_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF3_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF3_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF3_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-435" style="Level6_Line" stretchType="RelativeToBandHeight" x="1090" y="0" width="30" height="18" uuid="fb2d5165-621c-431e-8366-4889fe3feccb"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="fb2d5165-621c-431e-8366-4889fe3feccb" key="textField-435" stretchType="ContainerHeight" x="1090" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{AMOUNT3_PER6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT3_PER6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT3_PER6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT3_PER6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-445" style="Level6_Line" stretchType="RelativeToBandHeight" x="1120" y="0" width="30" height="18" uuid="3f535ba0-3cdc-4e86-83a7-3f2fa6cad7de"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3f535ba0-3cdc-4e86-83a7-3f2fa6cad7de" key="textField-445" stretchType="ContainerHeight" x="1120" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{MARGINDIFF3_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF3_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF3_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF3_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-455" style="Level6_Line" stretchType="RelativeToBandHeight" x="1240" y="0" width="30" height="18" uuid="58d72dd8-048d-4b21-8a2a-e5bf3c76f572"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="58d72dd8-048d-4b21-8a2a-e5bf3c76f572" key="textField-455" stretchType="ContainerHeight" x="1240" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{WEIGHTREF3_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF3_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF3_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF3_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" isBlankWhenNull="false">
-					<reportElement key="textField-465" style="Level6_Line" stretchType="RelativeToBandHeight" x="1495" y="0" width="55" height="18" uuid="bdcfcd72-2a4b-45bf-89ab-1bc0f2f61898">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="bdcfcd72-2a4b-45bf-89ab-1bc0f2f61898" key="textField-465" stretchType="ContainerHeight" x="1495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF3_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF3_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF3_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF3_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-475" style="Level6_Line" stretchType="RelativeToBandHeight" x="1550" y="0" width="30" height="18" uuid="05c0b9c5-2a4c-4c1c-a03c-82346826a0f7">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="05c0b9c5-2a4c-4c1c-a03c-82346826a0f7" key="textField-475" stretchType="ContainerHeight" x="1550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY3_PER6}!=null)?$P{NUMBERFORMAT}.format($V{QTY3_PER6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY3_PER6}!=null)?$P{NUMBERFORMAT}.format($V{QTY3_PER6}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -5184,544 +4062,377 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL7">
-		<groupExpression><![CDATA[$F{NIVEL7}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL7}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=7)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-79" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="2ab7730d-bac9-4d8d-b849-e9ff7b96d29f"/>
-					<box>
+				<element kind="textField" uuid="2ab7730d-bac9-4d8d-b849-e9ff7b96d29f" key="textField-79" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-81" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="3750a67e-a0aa-407a-88b4-6e11899e9c10"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="3750a67e-a0aa-407a-88b4-6e11899e9c10" key="textField-81" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-80" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="2f61ac07-aee9-4c72-a98b-75afbf2ad697"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="2f61ac07-aee9-4c72-a98b-75afbf2ad697" key="textField-80" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-82" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="2dca668c-e906-49cb-b43f-c7bf26683c0a"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="2dca668c-e906-49cb-b43f-c7bf26683c0a" key="textField-82" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-83" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="15" height="18" uuid="19a1b373-dfeb-4375-b661-02c6658cf9f1"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="19a1b373-dfeb-4375-b661-02c6658cf9f1" key="textField-83" stretchType="ContainerHeight" x="60" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-84" style="Level6_Line" stretchType="RelativeToBandHeight" x="75" y="0" width="15" height="18" uuid="0ebc0343-6a87-4dd1-ab68-c1ed306b904f"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="0ebc0343-6a87-4dd1-ab68-c1ed306b904f" key="textField-84" stretchType="ContainerHeight" x="75" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-75" style="Level7_Line" stretchType="RelativeToBandHeight" x="90" y="0" width="100" height="18" uuid="aafffce9-674c-42ca-bb68-292e28b1c6f4"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="aafffce9-674c-42ca-bb68-292e28b1c6f4" key="textField-75" stretchType="ContainerHeight" x="90" y="0" width="100" height="18" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[$F{NIVEL7}]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL7}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-176" style="Level7_Line" stretchType="RelativeToBandHeight" x="190" y="0" width="55" height="18" uuid="20af01b3-4bee-450e-bca3-82c7810b7441"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="20af01b3-4bee-450e-bca3-82c7810b7441" key="textField-176" stretchType="ContainerHeight" x="190" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" isBlankWhenNull="false">
-					<reportElement key="textField-177" style="Level7_Line" stretchType="RelativeToBandHeight" x="1270" y="0" width="55" height="18" uuid="8807e610-5bda-41f9-8bf6-7816985b6a35">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="8807e610-5bda-41f9-8bf6-7816985b6a35" key="textField-177" stretchType="ContainerHeight" x="1270" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-179" style="Level7_Line" stretchType="RelativeToBandHeight" x="245" y="0" width="55" height="18" uuid="b228319d-db3b-4e62-b254-4656863b6439"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b228319d-db3b-4e62-b254-4656863b6439" key="textField-179" stretchType="ContainerHeight" x="245" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{COST_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COST_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-180" style="Level7_Line" stretchType="RelativeToBandHeight" x="300" y="0" width="55" height="18" uuid="937bb3d6-eb04-4332-b909-91ab71b68dca"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="937bb3d6-eb04-4332-b909-91ab71b68dca" key="textField-180" stretchType="ContainerHeight" x="300" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{PROFIT_7}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFIT_7}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-181" style="Level7_Line" stretchType="RelativeToBandHeight" x="355" y="0" width="30" height="18" uuid="25aa9170-b7bf-48b5-b01f-37acfda30bc1"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="25aa9170-b7bf-48b5-b01f-37acfda30bc1" key="textField-181" stretchType="ContainerHeight" x="355" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{MARGIN_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGIN_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-182" style="Level7_Line" stretchType="RelativeToBandHeight" x="1150" y="0" width="30" height="18" uuid="f746ac6c-41c3-419a-ab95-aed4c5668494"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f746ac6c-41c3-419a-ab95-aed4c5668494" key="textField-182" stretchType="ContainerHeight" x="1150" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-216" style="Level7_Line" stretchType="RelativeToBandHeight" x="1380" y="0" width="30" height="18" uuid="6f91cd90-66e4-4d5f-9b31-0641dd9583a5">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6f91cd90-66e4-4d5f-9b31-0641dd9583a5" key="textField-216" stretchType="ContainerHeight" x="1380" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER7}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PER7}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" isBlankWhenNull="false">
-					<reportElement key="textField-226" style="Level7_Line" stretchType="RelativeToBandHeight" x="1325" y="0" width="55" height="18" uuid="ee8f707f-5e3d-4a33-bb25-c9052b02cf62">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ee8f707f-5e3d-4a33-bb25-c9052b02cf62" key="textField-226" stretchType="ContainerHeight" x="1325" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-236" style="Level7_Line" stretchType="RelativeToBandHeight" x="1180" y="0" width="30" height="18" uuid="d46a63ba-6f39-4e58-9600-59cc02f90d2f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d46a63ba-6f39-4e58-9600-59cc02f90d2f" key="textField-236" stretchType="ContainerHeight" x="1180" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-246" style="Level7_Line" stretchType="RelativeToBandHeight" x="610" y="0" width="30" height="18" uuid="fdc4eaa2-45bd-4c34-99eb-04f78b2a698d"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="fdc4eaa2-45bd-4c34-99eb-04f78b2a698d" key="textField-246" stretchType="ContainerHeight" x="610" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{MARGINDIFF_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-256" style="Level7_Line" stretchType="RelativeToBandHeight" x="580" y="0" width="30" height="18" uuid="bbc92847-66c2-437d-8fba-3239b53155c1"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="bbc92847-66c2-437d-8fba-3239b53155c1" key="textField-256" stretchType="ContainerHeight" x="580" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{AMOUNT_PER7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-266" style="Level7_Line" stretchType="RelativeToBandHeight" x="550" y="0" width="30" height="18" uuid="cc267d55-96bb-49fb-82e2-7aca31a17e6f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="cc267d55-96bb-49fb-82e2-7aca31a17e6f" key="textField-266" stretchType="ContainerHeight" x="550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{MARGINREF_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-276" style="Level7_Line" stretchType="RelativeToBandHeight" x="495" y="0" width="55" height="18" uuid="1cdb9ddc-0b71-4d09-9bc2-e4b52002086f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1cdb9ddc-0b71-4d09-9bc2-e4b52002086f" key="textField-276" stretchType="ContainerHeight" x="495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{PROFITREF_7}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF_7}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-286" style="Level7_Line" stretchType="RelativeToBandHeight" x="440" y="0" width="55" height="18" uuid="bcfe8e34-8d1b-4f2b-a85d-1d3b86bedbbf"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="bcfe8e34-8d1b-4f2b-a85d-1d3b86bedbbf" key="textField-286" stretchType="ContainerHeight" x="440" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{COSTREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-296" style="Level7_Line" stretchType="RelativeToBandHeight" x="385" y="0" width="55" height="18" uuid="d9a3f2a8-4e0a-4d5e-b8f6-20d2a2948891"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d9a3f2a8-4e0a-4d5e-b8f6-20d2a2948891" key="textField-296" stretchType="ContainerHeight" x="385" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-306" style="Level7_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="55" height="18" uuid="7566bb9a-9ec1-4483-9577-4d356898a087"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7566bb9a-9ec1-4483-9577-4d356898a087" key="textField-306" stretchType="ContainerHeight" x="640" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{AMOUNTREF2_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF2_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-316" style="Level7_Line" stretchType="RelativeToBandHeight" x="695" y="0" width="55" height="18" uuid="157a464b-8b2d-414e-8d1b-23f2291c1e13"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="157a464b-8b2d-414e-8d1b-23f2291c1e13" key="textField-316" stretchType="ContainerHeight" x="695" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{COSTREF2_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF2_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-326" style="Level7_Line" stretchType="RelativeToBandHeight" x="750" y="0" width="55" height="18" uuid="7a8f1457-4567-4956-a5cd-c0ad0e1a64d8"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7a8f1457-4567-4956-a5cd-c0ad0e1a64d8" key="textField-326" stretchType="ContainerHeight" x="750" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{PROFITREF2_7}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF2_7}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-336" style="Level7_Line" stretchType="RelativeToBandHeight" x="805" y="0" width="30" height="18" uuid="ecd9bb38-d0a0-4874-8b2e-a35fc6f7b6d3"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ecd9bb38-d0a0-4874-8b2e-a35fc6f7b6d3" key="textField-336" stretchType="ContainerHeight" x="805" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{MARGINREF2_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF2_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-346" style="Level7_Line" stretchType="RelativeToBandHeight" x="835" y="0" width="30" height="18" uuid="8c2fb6c2-315f-4218-bda2-2f634b316cd9"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="8c2fb6c2-315f-4218-bda2-2f634b316cd9" key="textField-346" stretchType="ContainerHeight" x="835" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{AMOUNT2_PER7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT2_PER7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-356" style="Level7_Line" stretchType="RelativeToBandHeight" x="865" y="0" width="30" height="18" uuid="0950f2d1-423a-4a28-b4bb-2c935d2cc6bf"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0950f2d1-423a-4a28-b4bb-2c935d2cc6bf" key="textField-356" stretchType="ContainerHeight" x="865" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{MARGINDIFF2_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF2_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-366" style="Level7_Line" stretchType="RelativeToBandHeight" x="1210" y="0" width="30" height="18" uuid="5c668a4a-83bf-458f-bcce-324ef7cf434b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5c668a4a-83bf-458f-bcce-324ef7cf434b" key="textField-366" stretchType="ContainerHeight" x="1210" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{WEIGHTREF2_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF2_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" isBlankWhenNull="false">
-					<reportElement key="textField-376" style="Level7_Line" stretchType="RelativeToBandHeight" x="1410" y="0" width="55" height="18" uuid="094f6c6b-aa6c-4264-b57e-0b8ef3aacb07">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="094f6c6b-aa6c-4264-b57e-0b8ef3aacb07" key="textField-376" stretchType="ContainerHeight" x="1410" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF2_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF2_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-386" style="Level7_Line" stretchType="RelativeToBandHeight" x="1465" y="0" width="30" height="18" uuid="952bd018-fc05-4627-bbda-9cb5b23fea54">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="952bd018-fc05-4627-bbda-9cb5b23fea54" key="textField-386" stretchType="ContainerHeight" x="1465" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY2_PER7}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY2_PER7}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-396" style="Level7_Line" stretchType="RelativeToBandHeight" x="895" y="0" width="55" height="18" uuid="529de9f7-c79c-46b0-af37-bfc6559b9a29"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="529de9f7-c79c-46b0-af37-bfc6559b9a29" key="textField-396" stretchType="ContainerHeight" x="895" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{AMOUNTREF3_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF3_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF3_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF3_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-406" style="Level7_Line" stretchType="RelativeToBandHeight" x="950" y="0" width="55" height="18" uuid="b282737b-95f3-4cd8-a21c-b115d76109ed"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b282737b-95f3-4cd8-a21c-b115d76109ed" key="textField-406" stretchType="ContainerHeight" x="950" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{COSTREF3_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF3_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF3_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF3_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-416" style="Level7_Line" stretchType="RelativeToBandHeight" x="1005" y="0" width="55" height="18" uuid="bf5ad21e-96d7-4dba-b642-5c851c98c1fe"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="bf5ad21e-96d7-4dba-b642-5c851c98c1fe" key="textField-416" stretchType="ContainerHeight" x="1005" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{PROFITREF3_7}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF3_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF3_7}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF3_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-426" style="Level7_Line" stretchType="RelativeToBandHeight" x="1060" y="0" width="30" height="18" uuid="d7e7e9dc-5ef1-4f2d-b3f2-d3cf8e9f5692"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d7e7e9dc-5ef1-4f2d-b3f2-d3cf8e9f5692" key="textField-426" stretchType="ContainerHeight" x="1060" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{MARGINREF3_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF3_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF3_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF3_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-436" style="Level7_Line" stretchType="RelativeToBandHeight" x="1090" y="0" width="30" height="18" uuid="1e3ea184-eb02-4b7e-8466-c2eb9d4f5d53"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1e3ea184-eb02-4b7e-8466-c2eb9d4f5d53" key="textField-436" stretchType="ContainerHeight" x="1090" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{AMOUNT3_PER7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT3_PER7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT3_PER7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT3_PER7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-446" style="Level7_Line" stretchType="RelativeToBandHeight" x="1120" y="0" width="30" height="18" uuid="d9e52b46-a3fd-4045-b9e2-b6b7b7e62124"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d9e52b46-a3fd-4045-b9e2-b6b7b7e62124" key="textField-446" stretchType="ContainerHeight" x="1120" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{MARGINDIFF3_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF3_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF3_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF3_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-456" style="Level7_Line" stretchType="RelativeToBandHeight" x="1240" y="0" width="30" height="18" uuid="02a8f240-07a3-45b0-b8de-7f9bbd7c3a1b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="02a8f240-07a3-45b0-b8de-7f9bbd7c3a1b" key="textField-456" stretchType="ContainerHeight" x="1240" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{WEIGHTREF3_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF3_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF3_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF3_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" isBlankWhenNull="false">
-					<reportElement key="textField-466" style="Level7_Line" stretchType="RelativeToBandHeight" x="1495" y="0" width="55" height="18" uuid="c1741c41-7515-4f4e-86da-3cbaa3d7228a">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c1741c41-7515-4f4e-86da-3cbaa3d7228a" key="textField-466" stretchType="ContainerHeight" x="1495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF3_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF3_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF3_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF3_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-476" style="Level7_Line" stretchType="RelativeToBandHeight" x="1550" y="0" width="30" height="18" uuid="58308eef-7cc1-4fc7-a6e7-4291cb044371">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="58308eef-7cc1-4fc7-a6e7-4291cb044371" key="textField-476" stretchType="ContainerHeight" x="1550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY3_PER7}!=null)?$P{NUMBERFORMAT}.format($V{QTY3_PER7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY3_PER7}!=null)?$P{NUMBERFORMAT}.format($V{QTY3_PER7}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -5731,557 +4442,386 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL8">
-		<groupExpression><![CDATA[$F{NIVEL8}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL8}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=8)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-89" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="03f075f3-b8cc-47d5-9853-e2206d0932d3"/>
-					<box>
+				<element kind="textField" uuid="03f075f3-b8cc-47d5-9853-e2206d0932d3" key="textField-89" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-91" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="84a2060a-6aae-4097-9b60-8a3f0f906de6"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="84a2060a-6aae-4097-9b60-8a3f0f906de6" key="textField-91" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-90" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="685e9995-7afc-4f13-b996-2bc059ae02fc"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="685e9995-7afc-4f13-b996-2bc059ae02fc" key="textField-90" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-92" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="1f0b2915-e369-46b8-9ee7-1123a3eda443"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="1f0b2915-e369-46b8-9ee7-1123a3eda443" key="textField-92" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-93" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="15" height="18" uuid="15068bf0-4733-4fdc-b64b-e19f762b418c"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="15068bf0-4733-4fdc-b64b-e19f762b418c" key="textField-93" stretchType="ContainerHeight" x="60" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-94" style="Level6_Line" stretchType="RelativeToBandHeight" x="75" y="0" width="15" height="18" uuid="982b76be-118e-42f0-8b02-bb03541bab66"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="982b76be-118e-42f0-8b02-bb03541bab66" key="textField-94" stretchType="ContainerHeight" x="75" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-95" style="Level7_Line" stretchType="RelativeToBandHeight" x="90" y="0" width="15" height="18" uuid="e8dcf82d-92af-4a2a-962c-521399cca268"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="e8dcf82d-92af-4a2a-962c-521399cca268" key="textField-95" stretchType="ContainerHeight" x="90" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-85" style="Level8_Line" stretchType="RelativeToBandHeight" x="105" y="0" width="85" height="18" uuid="5fe1468a-7b94-4c7f-9206-0594c58b485d"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5fe1468a-7b94-4c7f-9206-0594c58b485d" key="textField-85" stretchType="ContainerHeight" x="105" y="0" width="85" height="18" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level8_Line">
+					<expression><![CDATA[$F{NIVEL8}]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL8}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-183" style="Level8_Line" stretchType="RelativeToBandHeight" x="190" y="0" width="55" height="18" uuid="5481b721-ba3c-47fe-b065-ff3c66629c78"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5481b721-ba3c-47fe-b065-ff3c66629c78" key="textField-183" stretchType="ContainerHeight" x="190" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-186" style="Level8_Line" stretchType="RelativeToBandHeight" x="245" y="0" width="55" height="18" uuid="350e681e-fc79-46f4-a822-7c923e5a6c04"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="350e681e-fc79-46f4-a822-7c923e5a6c04" key="textField-186" stretchType="ContainerHeight" x="245" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{COST_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COST_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-187" style="Level8_Line" stretchType="RelativeToBandHeight" x="300" y="0" width="55" height="18" uuid="d5f888ca-ed00-4c67-8d40-7efda760e5fe"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d5f888ca-ed00-4c67-8d40-7efda760e5fe" key="textField-187" stretchType="ContainerHeight" x="300" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{PROFIT_8}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFIT_8}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-188" style="Level8_Line" stretchType="RelativeToBandHeight" x="355" y="0" width="30" height="18" uuid="3ab8173b-25bc-400e-bbc7-6b4a5dca31f6"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3ab8173b-25bc-400e-bbc7-6b4a5dca31f6" key="textField-188" stretchType="ContainerHeight" x="355" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{MARGIN_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGIN_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-189" style="Level8_Line" stretchType="RelativeToBandHeight" x="1150" y="0" width="30" height="18" uuid="a3f449e6-fad3-49c3-9305-05d31b9b25d4"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a3f449e6-fad3-49c3-9305-05d31b9b25d4" key="textField-189" stretchType="ContainerHeight" x="1150" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" isBlankWhenNull="false">
-					<reportElement key="textField-184" style="Level8_Line" stretchType="RelativeToBandHeight" x="1270" y="0" width="55" height="18" uuid="7e8191dd-14e8-41c0-a64d-23dcb1518b38">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7e8191dd-14e8-41c0-a64d-23dcb1518b38" key="textField-184" stretchType="ContainerHeight" x="1270" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-217" style="Level8_Line" stretchType="RelativeToBandHeight" x="1380" y="0" width="30" height="18" uuid="ee6c4664-06ad-4ebe-bfcd-0950a04f2f09">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ee6c4664-06ad-4ebe-bfcd-0950a04f2f09" key="textField-217" stretchType="ContainerHeight" x="1380" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER8}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PER8}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" isBlankWhenNull="false">
-					<reportElement key="textField-227" style="Level8_Line" stretchType="RelativeToBandHeight" x="1325" y="0" width="55" height="18" uuid="9edf204f-a635-47ae-8a59-ab94e56c0eae">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9edf204f-a635-47ae-8a59-ab94e56c0eae" key="textField-227" stretchType="ContainerHeight" x="1325" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-237" style="Level8_Line" stretchType="RelativeToBandHeight" x="1180" y="0" width="30" height="18" uuid="a321be40-4eeb-426a-8e46-f26c2d376d4b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a321be40-4eeb-426a-8e46-f26c2d376d4b" key="textField-237" stretchType="ContainerHeight" x="1180" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-247" style="Level8_Line" stretchType="RelativeToBandHeight" x="610" y="0" width="30" height="18" uuid="cfe3fbee-a16a-4245-814b-f54b360386e5"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="cfe3fbee-a16a-4245-814b-f54b360386e5" key="textField-247" stretchType="ContainerHeight" x="610" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{MARGINDIFF_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-257" style="Level8_Line" stretchType="RelativeToBandHeight" x="580" y="0" width="30" height="18" uuid="bbd0f141-eadc-4061-90b0-c6d06052e171"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="bbd0f141-eadc-4061-90b0-c6d06052e171" key="textField-257" stretchType="ContainerHeight" x="580" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{AMOUNT_PER8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-267" style="Level8_Line" stretchType="RelativeToBandHeight" x="550" y="0" width="30" height="18" uuid="6e44fe53-ea36-47ed-9b51-76fee96e3ca5"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6e44fe53-ea36-47ed-9b51-76fee96e3ca5" key="textField-267" stretchType="ContainerHeight" x="550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{MARGINREF_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-277" style="Level8_Line" stretchType="RelativeToBandHeight" x="495" y="0" width="55" height="18" uuid="26598235-dd15-46ba-aaeb-e4a6c847be53"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="26598235-dd15-46ba-aaeb-e4a6c847be53" key="textField-277" stretchType="ContainerHeight" x="495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{PROFITREF_8}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF_8}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-287" style="Level8_Line" stretchType="RelativeToBandHeight" x="440" y="0" width="55" height="18" uuid="a7f2ac41-bf18-4ddc-91be-48e924261399"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a7f2ac41-bf18-4ddc-91be-48e924261399" key="textField-287" stretchType="ContainerHeight" x="440" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{COSTREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-297" style="Level8_Line" stretchType="RelativeToBandHeight" x="385" y="0" width="55" height="18" uuid="b4598c06-9e2a-484f-a94a-e598ae23af29"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b4598c06-9e2a-484f-a94a-e598ae23af29" key="textField-297" stretchType="ContainerHeight" x="385" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-307" style="Level8_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="55" height="18" uuid="bc1275d3-b4cc-4c41-bafd-ce66216177f6"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="bc1275d3-b4cc-4c41-bafd-ce66216177f6" key="textField-307" stretchType="ContainerHeight" x="640" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{AMOUNTREF2_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF2_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-317" style="Level8_Line" stretchType="RelativeToBandHeight" x="695" y="0" width="55" height="18" uuid="2fcbf0bb-ea7c-4539-99f4-330ed8d4eb54"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2fcbf0bb-ea7c-4539-99f4-330ed8d4eb54" key="textField-317" stretchType="ContainerHeight" x="695" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{COSTREF2_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF2_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-327" style="Level8_Line" stretchType="RelativeToBandHeight" x="750" y="0" width="55" height="18" uuid="89b8aa56-0a2d-47fc-af4d-73a3e5f77ca9"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="89b8aa56-0a2d-47fc-af4d-73a3e5f77ca9" key="textField-327" stretchType="ContainerHeight" x="750" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{PROFITREF2_8}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF2_8}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-337" style="Level8_Line" stretchType="RelativeToBandHeight" x="805" y="0" width="30" height="18" uuid="78366432-c68f-4579-b357-b5e2a9ee1d1d"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="78366432-c68f-4579-b357-b5e2a9ee1d1d" key="textField-337" stretchType="ContainerHeight" x="805" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{MARGINREF2_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF2_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-347" style="Level8_Line" stretchType="RelativeToBandHeight" x="835" y="0" width="30" height="18" uuid="a23568b8-9933-4a7e-9c78-55dc561bfd16"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a23568b8-9933-4a7e-9c78-55dc561bfd16" key="textField-347" stretchType="ContainerHeight" x="835" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{AMOUNT2_PER8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT2_PER8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-357" style="Level8_Line" stretchType="RelativeToBandHeight" x="865" y="0" width="30" height="18" uuid="0ddea337-bcf1-45fb-9800-fabb171dc8b2"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0ddea337-bcf1-45fb-9800-fabb171dc8b2" key="textField-357" stretchType="ContainerHeight" x="865" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{MARGINDIFF2_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF2_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-367" style="Level8_Line" stretchType="RelativeToBandHeight" x="1210" y="0" width="30" height="18" uuid="6ecfc193-207b-446a-88fc-0ac91d456f1e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6ecfc193-207b-446a-88fc-0ac91d456f1e" key="textField-367" stretchType="ContainerHeight" x="1210" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{WEIGHTREF2_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF2_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" isBlankWhenNull="false">
-					<reportElement key="textField-377" style="Level8_Line" stretchType="RelativeToBandHeight" x="1410" y="0" width="55" height="18" uuid="3a88a5f2-4057-4fcf-9f44-7d66865ae28f">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3a88a5f2-4057-4fcf-9f44-7d66865ae28f" key="textField-377" stretchType="ContainerHeight" x="1410" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF2_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF2_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-387" style="Level8_Line" stretchType="RelativeToBandHeight" x="1465" y="0" width="30" height="18" uuid="da893c7d-db60-4aa5-b5a1-e5ea1920f01a">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="da893c7d-db60-4aa5-b5a1-e5ea1920f01a" key="textField-387" stretchType="ContainerHeight" x="1465" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY2_PER8}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY2_PER8}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-397" style="Level8_Line" stretchType="RelativeToBandHeight" x="895" y="0" width="55" height="18" uuid="c4aff096-03a0-4183-93c2-c428d5af0e6b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c4aff096-03a0-4183-93c2-c428d5af0e6b" key="textField-397" stretchType="ContainerHeight" x="895" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{AMOUNTREF3_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF3_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF3_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF3_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-407" style="Level8_Line" stretchType="RelativeToBandHeight" x="950" y="0" width="55" height="18" uuid="eddfbe2f-754b-4cdc-8aa0-33dd23876dd4"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="eddfbe2f-754b-4cdc-8aa0-33dd23876dd4" key="textField-407" stretchType="ContainerHeight" x="950" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{COSTREF3_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF3_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF3_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF3_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-417" style="Level8_Line" stretchType="RelativeToBandHeight" x="1005" y="0" width="55" height="18" uuid="6ed1e580-6628-4802-b233-2e9d26ba3678"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6ed1e580-6628-4802-b233-2e9d26ba3678" key="textField-417" stretchType="ContainerHeight" x="1005" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{PROFITREF3_8}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF3_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF3_8}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF3_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-427" style="Level8_Line" stretchType="RelativeToBandHeight" x="1060" y="0" width="30" height="18" uuid="e05cf0e4-e94c-4419-9edc-bf4ad2a07519"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e05cf0e4-e94c-4419-9edc-bf4ad2a07519" key="textField-427" stretchType="ContainerHeight" x="1060" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{MARGINREF3_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF3_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF3_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF3_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-437" style="Level8_Line" stretchType="RelativeToBandHeight" x="1090" y="0" width="30" height="18" uuid="f7c50d62-47f4-4da7-9f4d-1a826f043b0f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f7c50d62-47f4-4da7-9f4d-1a826f043b0f" key="textField-437" stretchType="ContainerHeight" x="1090" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{AMOUNT3_PER8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT3_PER8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT3_PER8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT3_PER8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-447" style="Level8_Line" stretchType="RelativeToBandHeight" x="1120" y="0" width="30" height="18" uuid="b18d1ede-c7ff-40c7-86ed-dbe8c9e61654"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b18d1ede-c7ff-40c7-86ed-dbe8c9e61654" key="textField-447" stretchType="ContainerHeight" x="1120" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{MARGINDIFF3_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF3_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF3_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF3_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-457" style="Level8_Line" stretchType="RelativeToBandHeight" x="1240" y="0" width="30" height="18" uuid="1857db1e-db0b-40e2-8a1a-7621fc80881a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1857db1e-db0b-40e2-8a1a-7621fc80881a" key="textField-457" stretchType="ContainerHeight" x="1240" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{WEIGHTREF3_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF3_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF3_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF3_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" isBlankWhenNull="false">
-					<reportElement key="textField-467" style="Level8_Line" stretchType="RelativeToBandHeight" x="1495" y="0" width="55" height="18" uuid="36febfef-041d-49b1-bbc7-5d997bd4924f">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="36febfef-041d-49b1-bbc7-5d997bd4924f" key="textField-467" stretchType="ContainerHeight" x="1495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF3_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF3_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF3_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF3_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-477" style="Level8_Line" stretchType="RelativeToBandHeight" x="1550" y="0" width="30" height="18" uuid="6d28518d-20b3-4e66-a2f5-e9b4dd2c9caa">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6d28518d-20b3-4e66-a2f5-e9b4dd2c9caa" key="textField-477" stretchType="ContainerHeight" x="1550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY3_PER8}!=null)?$P{NUMBERFORMAT}.format($V{QTY3_PER8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY3_PER8}!=null)?$P{NUMBERFORMAT}.format($V{QTY3_PER8}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -6291,570 +4831,395 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL9">
-		<groupExpression><![CDATA[$F{NIVEL9}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL9}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=9)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-100" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="005608e3-75ee-4751-ab92-e50ed6e777bd"/>
-					<box>
+				<element kind="textField" uuid="005608e3-75ee-4751-ab92-e50ed6e777bd" key="textField-100" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-102" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="30b92441-1ed2-45e5-95a8-c08f64c3d236"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="30b92441-1ed2-45e5-95a8-c08f64c3d236" key="textField-102" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-101" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="35fe75f8-5fd0-416e-aad6-1e5570401632"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="35fe75f8-5fd0-416e-aad6-1e5570401632" key="textField-101" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-103" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="394217e2-3cd7-48a4-8d37-86be03d5427e"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="394217e2-3cd7-48a4-8d37-86be03d5427e" key="textField-103" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-104" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="15" height="18" uuid="8394589b-1341-4fc3-85df-cb40268e7bd5"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="8394589b-1341-4fc3-85df-cb40268e7bd5" key="textField-104" stretchType="ContainerHeight" x="60" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-105" style="Level6_Line" stretchType="RelativeToBandHeight" x="75" y="0" width="15" height="18" uuid="ac6233a3-74f0-4810-943b-be6e663e130e"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="ac6233a3-74f0-4810-943b-be6e663e130e" key="textField-105" stretchType="ContainerHeight" x="75" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-106" style="Level7_Line" stretchType="RelativeToBandHeight" x="90" y="0" width="15" height="18" uuid="b2f8d88a-9742-42c5-b510-af2a9ef1e805"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="b2f8d88a-9742-42c5-b510-af2a9ef1e805" key="textField-106" stretchType="ContainerHeight" x="90" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-107" style="Level8_Line" stretchType="RelativeToBandHeight" x="105" y="0" width="15" height="18" uuid="4489dfdf-67ba-4f8c-bc57-dfa8c489ff60"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="4489dfdf-67ba-4f8c-bc57-dfa8c489ff60" key="textField-107" stretchType="ContainerHeight" x="105" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level8_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-96" style="Level9_Line" stretchType="RelativeToBandHeight" x="120" y="0" width="70" height="18" uuid="7dd61395-a528-4cbb-98e2-fc0bb8088865"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7dd61395-a528-4cbb-98e2-fc0bb8088865" key="textField-96" stretchType="ContainerHeight" x="120" y="0" width="70" height="18" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level9_Line">
+					<expression><![CDATA[$F{NIVEL9}]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL9}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-190" style="Level9_Line" stretchType="RelativeToBandHeight" x="190" y="0" width="55" height="18" uuid="08dff57f-1f88-430f-a383-81b8d9cf577e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="08dff57f-1f88-430f-a383-81b8d9cf577e" key="textField-190" stretchType="ContainerHeight" x="190" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-191" style="Level9_Line" stretchType="RelativeToBandHeight" x="245" y="0" width="55" height="18" uuid="6b07ed74-f752-41e8-bd4b-114f71846ef2"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6b07ed74-f752-41e8-bd4b-114f71846ef2" key="textField-191" stretchType="ContainerHeight" x="245" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{COST_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COST_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-192" style="Level9_Line" stretchType="RelativeToBandHeight" x="300" y="0" width="55" height="18" uuid="4fe544fc-ef04-4245-9d22-4f6de860fa86"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4fe544fc-ef04-4245-9d22-4f6de860fa86" key="textField-192" stretchType="ContainerHeight" x="300" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{PROFIT_9}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFIT_9}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-193" style="Level9_Line" stretchType="RelativeToBandHeight" x="355" y="0" width="30" height="18" uuid="a905e2a6-faba-4e4f-be92-2e22c76d1d84"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a905e2a6-faba-4e4f-be92-2e22c76d1d84" key="textField-193" stretchType="ContainerHeight" x="355" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{MARGIN_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGIN_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-194" style="Level9_Line" stretchType="RelativeToBandHeight" x="1150" y="0" width="30" height="18" uuid="4b36d683-cd34-48b4-83ee-32191759400f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4b36d683-cd34-48b4-83ee-32191759400f" key="textField-194" stretchType="ContainerHeight" x="1150" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" isBlankWhenNull="false">
-					<reportElement key="textField-196" style="Level9_Line" stretchType="RelativeToBandHeight" x="1270" y="0" width="55" height="18" uuid="87a61581-eb02-4fb4-b4f8-bf4787d99df3">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="87a61581-eb02-4fb4-b4f8-bf4787d99df3" key="textField-196" stretchType="ContainerHeight" x="1270" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-218" style="Level9_Line" stretchType="RelativeToBandHeight" x="1380" y="0" width="30" height="18" uuid="7a0a85fe-d94b-4945-be63-f69733aef340">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7a0a85fe-d94b-4945-be63-f69733aef340" key="textField-218" stretchType="ContainerHeight" x="1380" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER9}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PER9}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" isBlankWhenNull="false">
-					<reportElement key="textField-228" style="Level9_Line" stretchType="RelativeToBandHeight" x="1325" y="0" width="55" height="18" uuid="0a986275-5a2f-430a-8565-dc8880708578">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0a986275-5a2f-430a-8565-dc8880708578" key="textField-228" stretchType="ContainerHeight" x="1325" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-238" style="Level9_Line" stretchType="RelativeToBandHeight" x="1180" y="0" width="30" height="18" uuid="11fdab7c-86a8-4f4a-be22-a8b3534ddcd6"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="11fdab7c-86a8-4f4a-be22-a8b3534ddcd6" key="textField-238" stretchType="ContainerHeight" x="1180" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-248" style="Level9_Line" stretchType="RelativeToBandHeight" x="610" y="0" width="30" height="18" uuid="9c0fa861-1ff1-4565-bb04-c1ed0f9657cf"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9c0fa861-1ff1-4565-bb04-c1ed0f9657cf" key="textField-248" stretchType="ContainerHeight" x="610" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{MARGINDIFF_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-258" style="Level9_Line" stretchType="RelativeToBandHeight" x="580" y="0" width="30" height="18" uuid="f0b99e65-2b5c-4fd0-9320-5ce80e41dd6e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f0b99e65-2b5c-4fd0-9320-5ce80e41dd6e" key="textField-258" stretchType="ContainerHeight" x="580" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{AMOUNT_PER9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-268" style="Level9_Line" stretchType="RelativeToBandHeight" x="550" y="0" width="30" height="18" uuid="72f2bc6d-049b-4046-96f5-99d6266aa092"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="72f2bc6d-049b-4046-96f5-99d6266aa092" key="textField-268" stretchType="ContainerHeight" x="550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{MARGINREF_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-278" style="Level9_Line" stretchType="RelativeToBandHeight" x="495" y="0" width="55" height="18" uuid="7c62377a-4bd9-4c02-aed4-91958df0c2f1"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7c62377a-4bd9-4c02-aed4-91958df0c2f1" key="textField-278" stretchType="ContainerHeight" x="495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{PROFITREF_9}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF_9}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-288" style="Level9_Line" stretchType="RelativeToBandHeight" x="440" y="0" width="55" height="18" uuid="aa07f9a7-a50c-40ba-842a-3aa6e7981688"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="aa07f9a7-a50c-40ba-842a-3aa6e7981688" key="textField-288" stretchType="ContainerHeight" x="440" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{COSTREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-298" style="Level9_Line" stretchType="RelativeToBandHeight" x="385" y="0" width="55" height="18" uuid="f56fe3bf-e1d2-4936-81c4-4d3d0f9ce72e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f56fe3bf-e1d2-4936-81c4-4d3d0f9ce72e" key="textField-298" stretchType="ContainerHeight" x="385" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-308" style="Level9_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="55" height="18" uuid="c3ef4657-34d5-49f1-98de-11ad4c5857b5"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c3ef4657-34d5-49f1-98de-11ad4c5857b5" key="textField-308" stretchType="ContainerHeight" x="640" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{AMOUNTREF2_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF2_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-318" style="Level9_Line" stretchType="RelativeToBandHeight" x="695" y="0" width="55" height="18" uuid="3eadec46-eeba-46a2-bb1b-6ee8806879f5"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3eadec46-eeba-46a2-bb1b-6ee8806879f5" key="textField-318" stretchType="ContainerHeight" x="695" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{COSTREF2_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF2_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-328" style="Level9_Line" stretchType="RelativeToBandHeight" x="750" y="0" width="55" height="18" uuid="3aa3002f-5f9d-4306-9b57-316096545d9c"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3aa3002f-5f9d-4306-9b57-316096545d9c" key="textField-328" stretchType="ContainerHeight" x="750" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{PROFITREF2_9}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF2_9}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-338" style="Level9_Line" stretchType="RelativeToBandHeight" x="805" y="0" width="30" height="18" uuid="dd116dfb-2fb1-4356-8cb0-014e577e12d5"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="dd116dfb-2fb1-4356-8cb0-014e577e12d5" key="textField-338" stretchType="ContainerHeight" x="805" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{MARGINREF2_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF2_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-348" style="Level9_Line" stretchType="RelativeToBandHeight" x="835" y="0" width="30" height="18" uuid="8370a9f2-8a32-4f80-8f2e-2cceb7d2ea56"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="8370a9f2-8a32-4f80-8f2e-2cceb7d2ea56" key="textField-348" stretchType="ContainerHeight" x="835" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{AMOUNT2_PER9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT2_PER9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-358" style="Level9_Line" stretchType="RelativeToBandHeight" x="865" y="0" width="30" height="18" uuid="75395053-d3ca-49bf-97d8-cfcb34f460a9"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="75395053-d3ca-49bf-97d8-cfcb34f460a9" key="textField-358" stretchType="ContainerHeight" x="865" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{MARGINDIFF2_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF2_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-368" style="Level9_Line" stretchType="RelativeToBandHeight" x="1210" y="0" width="30" height="18" uuid="b3839bea-5abc-40c7-b6c8-b050de6dd3b7"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b3839bea-5abc-40c7-b6c8-b050de6dd3b7" key="textField-368" stretchType="ContainerHeight" x="1210" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{WEIGHTREF2_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF2_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" isBlankWhenNull="false">
-					<reportElement key="textField-378" style="Level9_Line" stretchType="RelativeToBandHeight" x="1410" y="0" width="55" height="18" uuid="803d4753-688b-49e0-8945-9b4f06681ff5">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="803d4753-688b-49e0-8945-9b4f06681ff5" key="textField-378" stretchType="ContainerHeight" x="1410" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF2_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF2_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-388" style="Level9_Line" stretchType="RelativeToBandHeight" x="1465" y="0" width="30" height="18" uuid="b363d244-5313-434c-9989-a0aa532fe318">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b363d244-5313-434c-9989-a0aa532fe318" key="textField-388" stretchType="ContainerHeight" x="1465" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY2_PER9}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY2_PER9}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-398" style="Level9_Line" stretchType="RelativeToBandHeight" x="895" y="0" width="55" height="18" uuid="1e894642-edc7-48d3-a0bb-38ac6ad8d6c3"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1e894642-edc7-48d3-a0bb-38ac6ad8d6c3" key="textField-398" stretchType="ContainerHeight" x="895" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{AMOUNTREF3_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF3_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF3_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF3_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-408" style="Level9_Line" stretchType="RelativeToBandHeight" x="950" y="0" width="55" height="18" uuid="8e9e005d-9085-4aa0-af24-c2d3f4cd9a9c"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="8e9e005d-9085-4aa0-af24-c2d3f4cd9a9c" key="textField-408" stretchType="ContainerHeight" x="950" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{COSTREF3_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF3_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF3_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF3_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-418" style="Level9_Line" stretchType="RelativeToBandHeight" x="1005" y="0" width="55" height="18" uuid="3f1794b7-2f85-4405-9341-56faf1022b17"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3f1794b7-2f85-4405-9341-56faf1022b17" key="textField-418" stretchType="ContainerHeight" x="1005" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{PROFITREF3_9}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF3_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF3_9}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF3_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-428" style="Level9_Line" stretchType="RelativeToBandHeight" x="1060" y="0" width="30" height="18" uuid="b0931e7e-76fa-45a5-9113-dff7cb74aa2a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b0931e7e-76fa-45a5-9113-dff7cb74aa2a" key="textField-428" stretchType="ContainerHeight" x="1060" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{MARGINREF3_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF3_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF3_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF3_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-438" style="Level9_Line" stretchType="RelativeToBandHeight" x="1090" y="0" width="30" height="18" uuid="cab7bca2-981c-442c-a8a6-3ca27b297421"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="cab7bca2-981c-442c-a8a6-3ca27b297421" key="textField-438" stretchType="ContainerHeight" x="1090" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{AMOUNT3_PER9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT3_PER9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT3_PER9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT3_PER9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-448" style="Level9_Line" stretchType="RelativeToBandHeight" x="1120" y="0" width="30" height="18" uuid="9cd8b961-2b23-4c81-9277-e38a5ce4b5b8"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9cd8b961-2b23-4c81-9277-e38a5ce4b5b8" key="textField-448" stretchType="ContainerHeight" x="1120" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{MARGINDIFF3_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF3_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF3_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF3_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-458" style="Level9_Line" stretchType="RelativeToBandHeight" x="1240" y="0" width="30" height="18" uuid="8ab52a00-bc38-4716-a5b8-615314e11cfc"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="8ab52a00-bc38-4716-a5b8-615314e11cfc" key="textField-458" stretchType="ContainerHeight" x="1240" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{WEIGHTREF3_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF3_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF3_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF3_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" isBlankWhenNull="false">
-					<reportElement key="textField-468" style="Level9_Line" stretchType="RelativeToBandHeight" x="1495" y="0" width="55" height="18" uuid="a3c5fe5f-d03d-4010-bbe4-5a3fa86a2b67">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a3c5fe5f-d03d-4010-bbe4-5a3fa86a2b67" key="textField-468" stretchType="ContainerHeight" x="1495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF3_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF3_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF3_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF3_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-478" style="Level9_Line" stretchType="RelativeToBandHeight" x="1550" y="0" width="30" height="18" uuid="c4f7a48d-6a6d-417e-9903-34dae0483a4f">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c4f7a48d-6a6d-417e-9903-34dae0483a4f" key="textField-478" stretchType="ContainerHeight" x="1550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY3_PER9}!=null)?$P{NUMBERFORMAT}.format($V{QTY3_PER9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY3_PER9}!=null)?$P{NUMBERFORMAT}.format($V{QTY3_PER9}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -6864,583 +5229,404 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL10">
-		<groupExpression><![CDATA[$F{NIVEL10}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL10}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=10)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-112" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="24e6ab61-4703-4895-b3a9-704d37804a2a"/>
-					<box>
+				<element kind="textField" uuid="24e6ab61-4703-4895-b3a9-704d37804a2a" key="textField-112" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-114" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="f5335bfd-e8db-443d-a2ae-d6b6a332f120"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="f5335bfd-e8db-443d-a2ae-d6b6a332f120" key="textField-114" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-113" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="b9ec8a0a-9f66-42d4-bd4c-827fb23849be"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="b9ec8a0a-9f66-42d4-bd4c-827fb23849be" key="textField-113" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-115" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="b3a35694-0b04-4fe2-b24a-8cfbd2b020bf"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="b3a35694-0b04-4fe2-b24a-8cfbd2b020bf" key="textField-115" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-116" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="15" height="18" uuid="1ce7fc6c-ed3f-4213-82cf-0a675a9f121c"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="1ce7fc6c-ed3f-4213-82cf-0a675a9f121c" key="textField-116" stretchType="ContainerHeight" x="60" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-117" style="Level6_Line" stretchType="RelativeToBandHeight" x="75" y="0" width="15" height="18" uuid="6e1fa608-435d-4d7a-9b29-084e8b3407c5"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="6e1fa608-435d-4d7a-9b29-084e8b3407c5" key="textField-117" stretchType="ContainerHeight" x="75" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-118" style="Level7_Line" stretchType="RelativeToBandHeight" x="90" y="0" width="15" height="18" uuid="fe309000-0ce8-40a6-9345-c3a4d04b3982"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="fe309000-0ce8-40a6-9345-c3a4d04b3982" key="textField-118" stretchType="ContainerHeight" x="90" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-119" style="Level8_Line" stretchType="RelativeToBandHeight" x="105" y="0" width="15" height="18" uuid="7042f617-f16a-4c81-bb8a-9e7bde575ba6"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="7042f617-f16a-4c81-bb8a-9e7bde575ba6" key="textField-119" stretchType="ContainerHeight" x="105" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level8_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-120" style="Level9_Line" stretchType="RelativeToBandHeight" x="120" y="0" width="15" height="18" uuid="cf329866-35b3-4c3c-ad9f-3cba57e7e781"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="cf329866-35b3-4c3c-ad9f-3cba57e7e781" key="textField-120" stretchType="ContainerHeight" x="120" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level9_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-108" style="Level10_Line" stretchType="RelativeToBandHeight" x="135" y="0" width="55" height="18" uuid="da6c7825-35ee-449c-b1ce-37a2b517c449"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="da6c7825-35ee-449c-b1ce-37a2b517c449" key="textField-108" stretchType="ContainerHeight" x="135" y="0" width="55" height="18" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level10_Line">
+					<expression><![CDATA[$F{NIVEL10}]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL10}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-197" style="Level10_Line" stretchType="RelativeToBandHeight" x="190" y="0" width="55" height="18" uuid="a642146f-a413-4cff-b67b-a0af71dda6df"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a642146f-a413-4cff-b67b-a0af71dda6df" key="textField-197" stretchType="ContainerHeight" x="190" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-198" style="Level10_Line" stretchType="RelativeToBandHeight" x="245" y="0" width="55" height="18" uuid="49e64e3e-d96d-4288-973c-bdd3b4af2237"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="49e64e3e-d96d-4288-973c-bdd3b4af2237" key="textField-198" stretchType="ContainerHeight" x="245" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{COST_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COST_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-199" style="Level10_Line" stretchType="RelativeToBandHeight" x="300" y="0" width="55" height="18" uuid="acafecff-197e-4918-8ba8-fdf8df651416"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="acafecff-197e-4918-8ba8-fdf8df651416" key="textField-199" stretchType="ContainerHeight" x="300" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{PROFIT_10}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFIT_10}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-200" style="Level10_Line" stretchType="RelativeToBandHeight" x="355" y="0" width="30" height="18" uuid="bbc663d5-956d-441e-b273-84f58066ab8e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="bbc663d5-956d-441e-b273-84f58066ab8e" key="textField-200" stretchType="ContainerHeight" x="355" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{MARGIN_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGIN_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-201" style="Level10_Line" stretchType="RelativeToBandHeight" x="1150" y="0" width="30" height="18" uuid="3013d0ba-551f-4ff0-bbb7-360a21d818fa"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3013d0ba-551f-4ff0-bbb7-360a21d818fa" key="textField-201" stretchType="ContainerHeight" x="1150" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" isBlankWhenNull="false">
-					<reportElement key="textField-202" style="Level10_Line" stretchType="RelativeToBandHeight" x="1270" y="0" width="55" height="18" uuid="80429e1f-7bc6-4d88-b1bb-231ec6684dbd">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="80429e1f-7bc6-4d88-b1bb-231ec6684dbd" key="textField-202" stretchType="ContainerHeight" x="1270" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-219" style="Level10_Line" stretchType="RelativeToBandHeight" x="1380" y="0" width="30" height="18" uuid="42b6b52e-3374-4cf4-9848-aab8aaf1f822">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="42b6b52e-3374-4cf4-9848-aab8aaf1f822" key="textField-219" stretchType="ContainerHeight" x="1380" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER10}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PER10}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" isBlankWhenNull="false">
-					<reportElement key="textField-229" style="Level10_Line" stretchType="RelativeToBandHeight" x="1325" y="0" width="55" height="18" uuid="ee1fb55e-17d4-491f-af92-3043ffa348c8">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ee1fb55e-17d4-491f-af92-3043ffa348c8" key="textField-229" stretchType="ContainerHeight" x="1325" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-239" style="Level10_Line" stretchType="RelativeToBandHeight" x="1180" y="0" width="30" height="18" uuid="81d9fc43-6b21-42ec-8a71-90e4917aef99"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="81d9fc43-6b21-42ec-8a71-90e4917aef99" key="textField-239" stretchType="ContainerHeight" x="1180" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-249" style="Level10_Line" stretchType="RelativeToBandHeight" x="610" y="0" width="30" height="18" uuid="c7632290-6de6-4aea-adb5-63a96e50bcb0"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c7632290-6de6-4aea-adb5-63a96e50bcb0" key="textField-249" stretchType="ContainerHeight" x="610" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{MARGINDIFF_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-259" style="Level10_Line" stretchType="RelativeToBandHeight" x="580" y="0" width="30" height="18" uuid="5a27c3ac-a8ec-4f7d-94cd-64873c86f201"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5a27c3ac-a8ec-4f7d-94cd-64873c86f201" key="textField-259" stretchType="ContainerHeight" x="580" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{AMOUNT_PER10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-269" style="Level10_Line" stretchType="RelativeToBandHeight" x="550" y="0" width="30" height="18" uuid="13b4f08b-a14a-4ff5-92eb-f3581b42bf26"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="13b4f08b-a14a-4ff5-92eb-f3581b42bf26" key="textField-269" stretchType="ContainerHeight" x="550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{MARGINREF_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-279" style="Level10_Line" stretchType="RelativeToBandHeight" x="495" y="0" width="55" height="18" uuid="0705ef37-1cbb-440f-a0ac-33597d6fd2e2"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0705ef37-1cbb-440f-a0ac-33597d6fd2e2" key="textField-279" stretchType="ContainerHeight" x="495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{PROFITREF_10}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF_10}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-289" style="Level10_Line" stretchType="RelativeToBandHeight" x="440" y="0" width="55" height="18" uuid="85c1302b-f95b-4f4d-a6c1-406de2d2e14d"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="85c1302b-f95b-4f4d-a6c1-406de2d2e14d" key="textField-289" stretchType="ContainerHeight" x="440" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{COSTREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-299" style="Level10_Line" stretchType="RelativeToBandHeight" x="385" y="0" width="55" height="18" uuid="c29dfb63-9b7b-4428-a03b-a5d20f1fbfb3"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c29dfb63-9b7b-4428-a03b-a5d20f1fbfb3" key="textField-299" stretchType="ContainerHeight" x="385" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-309" style="Level10_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="55" height="18" uuid="6676bc51-7aa9-4fb3-af18-c624ccd37dd6"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6676bc51-7aa9-4fb3-af18-c624ccd37dd6" key="textField-309" stretchType="ContainerHeight" x="640" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{AMOUNTREF2_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF2_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-319" style="Level10_Line" stretchType="RelativeToBandHeight" x="695" y="0" width="55" height="18" uuid="20c1321d-2ea5-4ffe-af4e-3576b33c034f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="20c1321d-2ea5-4ffe-af4e-3576b33c034f" key="textField-319" stretchType="ContainerHeight" x="695" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{COSTREF2_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF2_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-329" style="Level10_Line" stretchType="RelativeToBandHeight" x="750" y="0" width="55" height="18" uuid="18077b20-1158-4e8d-af70-2f8cd1ea85eb"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="18077b20-1158-4e8d-af70-2f8cd1ea85eb" key="textField-329" stretchType="ContainerHeight" x="750" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{PROFITREF2_10}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF2_10}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-339" style="Level10_Line" stretchType="RelativeToBandHeight" x="805" y="0" width="30" height="18" uuid="57537548-433b-4b38-a885-f802b0e6f0b7"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="57537548-433b-4b38-a885-f802b0e6f0b7" key="textField-339" stretchType="ContainerHeight" x="805" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{MARGINREF2_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF2_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-349" style="Level10_Line" stretchType="RelativeToBandHeight" x="835" y="0" width="30" height="18" uuid="b953bb8c-daad-4d48-b41b-ca9a811f1d16"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b953bb8c-daad-4d48-b41b-ca9a811f1d16" key="textField-349" stretchType="ContainerHeight" x="835" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{AMOUNT2_PER10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT2_PER10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-359" style="Level10_Line" stretchType="RelativeToBandHeight" x="865" y="0" width="30" height="18" uuid="57f6e44b-3c02-4048-a658-da2f6cce39be"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="57f6e44b-3c02-4048-a658-da2f6cce39be" key="textField-359" stretchType="ContainerHeight" x="865" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{MARGINDIFF2_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF2_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-369" style="Level10_Line" stretchType="RelativeToBandHeight" x="1210" y="0" width="30" height="18" uuid="a7229a91-fe25-4926-a311-dc50605b957e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a7229a91-fe25-4926-a311-dc50605b957e" key="textField-369" stretchType="ContainerHeight" x="1210" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{WEIGHTREF2_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF2_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" isBlankWhenNull="false">
-					<reportElement key="textField-379" style="Level10_Line" stretchType="RelativeToBandHeight" x="1410" y="0" width="55" height="18" uuid="f2b2d456-a55f-4ad6-8a76-2a6f119ca057">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f2b2d456-a55f-4ad6-8a76-2a6f119ca057" key="textField-379" stretchType="ContainerHeight" x="1410" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF2_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF2_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-389" style="Level10_Line" stretchType="RelativeToBandHeight" x="1465" y="0" width="30" height="18" uuid="0129527d-411d-486b-98ee-9512084f8849">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0129527d-411d-486b-98ee-9512084f8849" key="textField-389" stretchType="ContainerHeight" x="1465" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY2_PER10}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY2_PER10}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-399" style="Level10_Line" stretchType="RelativeToBandHeight" x="895" y="0" width="55" height="18" uuid="8dcd8e41-4c0a-44bb-ad79-9b67bc491fdf"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="8dcd8e41-4c0a-44bb-ad79-9b67bc491fdf" key="textField-399" stretchType="ContainerHeight" x="895" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{AMOUNTREF3_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF3_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF3_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF3_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-409" style="Level10_Line" stretchType="RelativeToBandHeight" x="950" y="0" width="55" height="18" uuid="05dabe6b-401b-48b3-9915-4fae5f8fd3be"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="05dabe6b-401b-48b3-9915-4fae5f8fd3be" key="textField-409" stretchType="ContainerHeight" x="950" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{COSTREF3_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF3_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF3_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF3_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-419" style="Level10_Line" stretchType="RelativeToBandHeight" x="1005" y="0" width="55" height="18" uuid="9ad241e9-23e9-4aab-829c-213514d5fa29"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9ad241e9-23e9-4aab-829c-213514d5fa29" key="textField-419" stretchType="ContainerHeight" x="1005" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{PROFITREF3_10}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF3_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF3_10}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF3_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-429" style="Level10_Line" stretchType="RelativeToBandHeight" x="1060" y="0" width="30" height="18" uuid="d4dbc919-308b-4756-96bd-d286c2fcbced"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d4dbc919-308b-4756-96bd-d286c2fcbced" key="textField-429" stretchType="ContainerHeight" x="1060" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{MARGINREF3_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF3_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF3_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF3_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-439" style="Level10_Line" stretchType="RelativeToBandHeight" x="1090" y="0" width="30" height="18" uuid="571d3a10-0543-47fe-a4c1-9b0eff934af2"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="571d3a10-0543-47fe-a4c1-9b0eff934af2" key="textField-439" stretchType="ContainerHeight" x="1090" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{AMOUNT3_PER10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT3_PER10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT3_PER10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT3_PER10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-449" style="Level10_Line" stretchType="RelativeToBandHeight" x="1120" y="0" width="30" height="18" uuid="d2951b9a-51af-4b27-91b3-f1a345acc15a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d2951b9a-51af-4b27-91b3-f1a345acc15a" key="textField-449" stretchType="ContainerHeight" x="1120" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{MARGINDIFF3_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF3_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF3_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF3_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-459" style="Level10_Line" stretchType="RelativeToBandHeight" x="1240" y="0" width="30" height="18" uuid="08ca1e31-93fa-4671-b178-6573cb5d93dc"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="08ca1e31-93fa-4671-b178-6573cb5d93dc" key="textField-459" stretchType="ContainerHeight" x="1240" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{WEIGHTREF3_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF3_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF3_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF3_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" isBlankWhenNull="false">
-					<reportElement key="textField-469" style="Level10_Line" stretchType="RelativeToBandHeight" x="1495" y="0" width="55" height="18" uuid="304ae3ae-3ad3-430d-8279-95e2774734ae">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="304ae3ae-3ad3-430d-8279-95e2774734ae" key="textField-469" stretchType="ContainerHeight" x="1495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF3_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF3_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF3_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF3_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-479" style="Level10_Line" stretchType="RelativeToBandHeight" x="1550" y="0" width="30" height="18" uuid="cfd78b4d-3b9a-4740-b4a9-e0536e5fab8e">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="cfd78b4d-3b9a-4740-b4a9-e0536e5fab8e" key="textField-479" stretchType="ContainerHeight" x="1550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY3_PER10}!=null)?$P{NUMBERFORMAT}.format($V{QTY3_PER10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY3_PER10}!=null)?$P{NUMBERFORMAT}.format($V{QTY3_PER10}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -7449,838 +5635,575 @@
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="140" splitType="Stretch">
-			<property name="local_mesure_unitheight" value="pixel"/>
-			<property name="com.jaspersoft.studio.unit.height" value="px"/>
-			<frame>
-				<reportElement key="frame-1" positionType="Float" mode="Opaque" x="0" y="122" width="1580" height="18" backcolor="#5D5D5D" uuid="801cc352-be73-444c-83c6-f49e6285cbea"/>
-				<box>
+	<background splitType="Stretch"/>
+	<title height="140" splitType="Stretch">
+		<element kind="frame" uuid="801cc352-be73-444c-83c6-f49e6285cbea" key="frame-1" positionType="Float" mode="Opaque" x="0" y="122" width="1580" height="18" backcolor="#5D5D5D">
+			<element kind="textField" uuid="1e273022-6348-4c6c-8093-ad2d6b62d94c" key="textField-61" positionType="Float" x="0" y="0" width="15" height="18" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-61" style="Detail_Header" positionType="Float" x="0" y="0" width="15" height="18" uuid="1e273022-6348-4c6c-8093-ad2d6b62d94c">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-62" style="Detail_Header" positionType="Float" x="15" y="0" width="15" height="18" uuid="9069e145-efb2-421a-9508-14c74d20d930">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-63" style="Detail_Header" positionType="Float" x="30" y="0" width="15" height="18" uuid="b1b40ed5-93ec-4037-b404-4dfea937eb7f">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-64" style="Detail_Header" positionType="Float" x="45" y="0" width="15" height="18" uuid="0858b441-ac62-4825-9aff-0921b1793e0b">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-65" style="Detail_Header" positionType="Float" x="60" y="0" width="15" height="18" uuid="18655c56-4020-4e9c-bb70-810602664dc1">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-205" style="Detail_Header" positionType="Float" x="75" y="0" width="15" height="18" uuid="ba3d9bd5-0acc-47d0-a294-d5be013e844b">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=6)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(6))>=0)?"6":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-206" style="Detail_Header" positionType="Float" x="90" y="0" width="15" height="18" uuid="be12a55e-5ec9-4a6b-accf-0971673fed80">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=7)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(7))>=0)?"7":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-207" style="Detail_Header" positionType="Float" x="105" y="0" width="15" height="18" uuid="0673bb3b-ea50-4f97-a42e-b244c74b2e01">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=8)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(8))>=0)?"8":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-208" style="Detail_Header" positionType="Float" x="120" y="0" width="15" height="18" uuid="1a908e9e-a2df-4d6e-b452-227f4ccbf20a">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=9)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(9))>=0)?"9":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-209" style="Detail_Header" positionType="Float" x="135" y="0" width="15" height="18" uuid="b46d08e4-b7bd-43d0-9d04-2f29287f2ebb">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=10)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(10))>=0)?"10":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-308" style="Detail_Header" positionType="Float" x="150" y="0" width="40" height="18" uuid="d22f4807-2ba6-4848-86d2-a10de5d1f248"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Center" rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-14" style="Detail_Header" positionType="Float" mode="Opaque" x="190" y="0" width="55" height="18" uuid="9d086033-3cb6-4331-afee-a48906c5f68a"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-13" style="Detail_Header" positionType="Float" mode="Opaque" x="245" y="0" width="55" height="18" uuid="ce5dfd0c-3f15-4638-ae17-7cbef5483978"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Cost]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-12" style="Detail_Header" positionType="Float" mode="Opaque" x="300" y="0" width="55" height="18" uuid="43399fb4-7dfd-46b5-ac92-94051c5f6992"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Profit]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-9" style="Detail_Header" positionType="Float" mode="Opaque" x="355" y="0" width="30" height="18" uuid="5fa3944d-6a6f-4fd0-ae2d-66a546e570a3"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[M. %]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-15" style="Detail_Header" positionType="Float" mode="Opaque" x="385" y="0" width="55" height="18" uuid="1af30ded-750c-4dbc-8317-498534973e4e"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Amt. ref]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-16" style="Detail_Header" positionType="Float" mode="Opaque" x="440" y="0" width="55" height="18" uuid="e332de49-4d79-4f54-bb88-4864629243e4"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Cost ref]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-17" style="Detail_Header" positionType="Float" mode="Opaque" x="495" y="0" width="55" height="18" uuid="777f3668-b72a-41ce-8f19-189f6387ed3c"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Pro. ref]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-18" style="Detail_Header" positionType="Float" mode="Opaque" x="550" y="0" width="30" height="18" uuid="f72ff07f-7233-49fb-b70c-d22ce270c6eb"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[M.r %]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-19" style="Detail_Header" positionType="Float" mode="Opaque" x="580" y="0" width="30" height="18" uuid="86715671-ccc3-4c47-a95b-cded2e753dfe"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[A. %]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-20" style="Detail_Header" positionType="Float" mode="Opaque" x="610" y="0" width="30" height="18" uuid="d542a8f8-b627-495d-bf94-54b9368d18db"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[M.dif]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-24" style="Detail_Header" positionType="Float" mode="Opaque" x="640" y="0" width="55" height="18" uuid="3c14c07d-d81b-45dc-8921-db00463838a6"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Amt. ref2]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-25" style="Detail_Header" positionType="Float" mode="Opaque" x="695" y="0" width="55" height="18" uuid="2bee6c7d-4a4e-4002-92c0-67093d3e0a30"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Cost ref2]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-26" style="Detail_Header" positionType="Float" mode="Opaque" x="750" y="0" width="55" height="18" uuid="12869949-5ff5-483e-8236-6e3609415e04"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Pro. ref2]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-27" style="Detail_Header" positionType="Float" mode="Opaque" x="805" y="0" width="30" height="18" uuid="ad6c2eb4-129b-4560-9ea1-729999a83325"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[M.r2 %]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-28" style="Detail_Header" positionType="Float" mode="Opaque" x="835" y="0" width="30" height="18" uuid="5835a21b-da93-4ffd-8669-1360013529ae"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[A.2 %]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-29" style="Detail_Header" positionType="Float" mode="Opaque" x="865" y="0" width="30" height="18" uuid="166c9b75-e05f-4348-b9b8-5c9049085451"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[M.dif2]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-11" style="Detail_Header" positionType="Float" mode="Opaque" x="1150" y="0" width="30" height="18" uuid="4fe9da23-6e79-4894-99e9-8348a74b2bf6"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Weight]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-21" style="Detail_Header" positionType="Float" mode="Opaque" x="1180" y="0" width="30" height="18" uuid="ab9f7afc-f016-4da4-83ba-2d371ff5b61b"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[W. Ref]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-30" style="Detail_Header" positionType="Float" mode="Opaque" x="1210" y="0" width="30" height="18" uuid="298f1504-d54a-4bd0-807b-04dfe6031e79"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[W.Ref2]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-10" style="Detail_Header" positionType="Float" mode="Opaque" x="1270" y="0" width="55" height="18" uuid="b5fa9183-7bb9-4fb9-af3a-ac23cd60bbb6"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-23" style="Detail_Header" positionType="Float" mode="Opaque" x="1325" y="0" width="55" height="18" uuid="528295ff-ffbd-4475-a43b-aa3ac4e77e4c"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Q. ref]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-22" style="Detail_Header" positionType="Float" mode="Opaque" x="1380" y="0" width="30" height="18" uuid="ea1653ed-9054-48a6-9e5c-09d5d0f07ff0"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Qty%]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-31" style="Detail_Header" positionType="Float" mode="Opaque" x="1410" y="0" width="55" height="18" uuid="56ef8037-ca2d-471f-a7ad-6cd76a837f64"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Q. ref2]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-32" style="Detail_Header" positionType="Float" mode="Opaque" x="1465" y="0" width="30" height="18" uuid="f1d3b992-eece-4c88-88f7-925c22665d5e"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Qty2%]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-33" style="Detail_Header" positionType="Float" mode="Opaque" x="895" y="0" width="55" height="18" uuid="0a8620bc-c2ae-43ab-a617-f0355f6c204f"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Amt. ref3]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-34" style="Detail_Header" positionType="Float" mode="Opaque" x="950" y="0" width="55" height="18" uuid="a1c2a119-bf30-4c62-9e48-bafb96be9f05"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Cost ref3]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-35" style="Detail_Header" positionType="Float" mode="Opaque" x="1005" y="0" width="55" height="18" uuid="f28a4d84-0e3a-4fd7-ae97-f8bd92103e6d"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Pro. ref3]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-36" style="Detail_Header" positionType="Float" mode="Opaque" x="1060" y="0" width="30" height="18" uuid="b7529d46-d27b-463e-aa0d-a7ede6b08253"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[M.r3 %]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-37" style="Detail_Header" positionType="Float" mode="Opaque" x="1090" y="0" width="30" height="18" uuid="a3f7a1cc-9a5c-49f6-a99a-e38b621b5f27"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[A.3 %]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-38" style="Detail_Header" positionType="Float" mode="Opaque" x="1120" y="0" width="30" height="18" uuid="107595c4-132e-440a-9a78-8c2558c9a2db"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[M.dif3]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-39" style="Detail_Header" positionType="Float" mode="Opaque" x="1240" y="0" width="30" height="18" uuid="8202d348-90d5-4cb7-9830-06dd7956c49d"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[W.Ref3]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-40" style="Detail_Header" positionType="Float" mode="Opaque" x="1495" y="0" width="55" height="18" uuid="6de9628a-4dbc-4c27-8ee8-420023300124"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Q. ref3]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-41" style="Detail_Header" positionType="Float" mode="Opaque" x="1550" y="0" width="30" height="18" uuid="6bfa3bf5-1ce4-4152-bb11-2dd356bfa20f"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Qty3%]]></text>
-				</staticText>
-			</frame>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Report_Title" x="0" y="0" width="1580" height="26" uuid="f97e3d7f-d719-4fbc-b7c3-8388a1cf5dc5"/>
-				<box leftPadding="5">
+			</element>
+			<element kind="textField" uuid="9069e145-efb2-421a-9508-14c74d20d930" key="textField-62" positionType="Float" x="15" y="0" width="15" height="18" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Subtitle" x="0" y="31" width="1580" height="18" uuid="9d562ed1-4c4f-44a1-a1e2-e905501a9c33"/>
-				<box leftPadding="5">
+			</element>
+			<element kind="textField" uuid="b1b40ed5-93ec-4037-b404-4dfea937eb7f" key="textField-63" positionType="Float" x="30" y="0" width="15" height="18" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_SUBTITLE}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-5" style="Report_Data_Label" x="0" y="52" width="102" height="16" uuid="73f3f231-eff0-4c2b-a32f-d771f8aa1263"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="0858b441-ac62-4825-9aff-0921b1793e0b" key="textField-64" positionType="Float" x="45" y="0" width="15" height="18" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="9"/>
-				</textElement>
-				<text><![CDATA[Grouping Levels:]]></text>
-			</staticText>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="102" y="52" width="1592" height="16" uuid="2b528e62-24b6-41ee-a207-86cfd9451306"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="18655c56-4020-4e9c-bb70-810602664dc1" key="textField-65" positionType="Float" x="60" y="0" width="15" height="18" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{LEVEL_LABEL}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="26" width="1580" height="1" uuid="d81481f5-a670-4664-8d8d-3419cb5774b5"/>
-			</line>
-			<line>
-				<reportElement key="line-2" x="0" y="49" width="1580" height="1" uuid="75196ed7-0c2a-480d-b641-aa3b2a9b0a26"/>
-			</line>
-			<staticText>
-				<reportElement key="staticText-5" style="Report_Data_Label" x="1" y="68" width="101" height="16" uuid="4908fc8f-71c2-41b9-b8f4-870bdb43a24b"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="ba3d9bd5-0acc-47d0-a294-d5be013e844b" key="textField-205" positionType="Float" x="75" y="0" width="15" height="18" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=6)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(6))>=0)?"6":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="9" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Secondary Filters:]]></text>
-			</staticText>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="180" y="68" width="1400" height="16" uuid="d9be9d8e-e59a-405a-a6f9-7daf0f033d58"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="be12a55e-5ec9-4a6b-accf-0971673fed80" key="textField-206" positionType="Float" x="90" y="0" width="15" height="18" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=7)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(7))>=0)?"7":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{ORGANIZATION} + " and any child organization"]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="229" y="84" width="1351" height="16" printWhenGroupChanges="DocumentType" uuid="4b256a99-9cf8-4b0b-bf6d-df50adc49d95">
-					<printWhenExpression><![CDATA[!$P{BPGROUP}.equals("")]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="textField" uuid="0673bb3b-ea50-4f97-a42e-b244c74b2e01" key="textField-207" positionType="Float" x="105" y="0" width="15" height="18" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=8)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(8))>=0)?"8":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{BPGROUP}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="190" y="100" width="1388" height="16" printWhenGroupChanges="DocumentType" uuid="917ae2e9-9dfa-44e0-a482-4fdd8518a270">
-					<printWhenExpression><![CDATA[!$P{PRODUCTGROUP}.equals("")]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="textField" uuid="1a908e9e-a2df-4d6e-b452-227f4ccbf20a" key="textField-208" positionType="Float" x="120" y="0" width="15" height="18" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=9)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(9))>=0)?"9":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{PRODUCTGROUP}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="102" y="84" width="127" height="16" printWhenGroupChanges="DocumentType" uuid="a38e13bb-2c4b-44bb-ad03-faf2808dca7c">
-					<printWhenExpression><![CDATA[!$P{BPGROUP}.equals("")]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="textField" uuid="b46d08e4-b7bd-43d0-9d04-2f29287f2ebb" key="textField-209" positionType="Float" x="135" y="0" width="15" height="18" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=10)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(10))>=0)?"10":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Business Partner Group- "]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="102" y="100" width="88" height="16" printWhenGroupChanges="DocumentType" uuid="a6471908-c435-486c-8464-5bb77eeaa8da">
-					<printWhenExpression><![CDATA[!$P{PRODUCTGROUP}.equals("")]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="textField" uuid="d22f4807-2ba6-4848-86d2-a10de5d1f248" key="textField-308" positionType="Float" x="150" y="0" width="40" height="18" rotation="None" fontSize="7.0" blankWhenNull="true" hTextAlign="Center" style="Detail_Header">
+				<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Product Group- "]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="102" y="68" width="78" height="16" uuid="75a5133f-fcbb-41dd-a613-f7a71271153b"/>
-				<box>
+			</element>
+			<element kind="staticText" uuid="9d086033-3cb6-4331-afee-a48906c5f68a" key="staticText-14" positionType="Float" mode="Opaque" x="190" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Amount]]></text>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Organization- "]]></textFieldExpression>
-			</textField>
-		</band>
+			</element>
+			<element kind="staticText" uuid="ce5dfd0c-3f15-4638-ae17-7cbef5483978" key="staticText-13" positionType="Float" mode="Opaque" x="245" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Cost]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="43399fb4-7dfd-46b5-ac92-94051c5f6992" key="staticText-12" positionType="Float" mode="Opaque" x="300" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Profit]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="5fa3944d-6a6f-4fd0-ae2d-66a546e570a3" key="staticText-9" positionType="Float" mode="Opaque" x="355" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[M. %]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="1af30ded-750c-4dbc-8317-498534973e4e" key="staticText-15" positionType="Float" mode="Opaque" x="385" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Amt. ref]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="e332de49-4d79-4f54-bb88-4864629243e4" key="staticText-16" positionType="Float" mode="Opaque" x="440" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Cost ref]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="777f3668-b72a-41ce-8f19-189f6387ed3c" key="staticText-17" positionType="Float" mode="Opaque" x="495" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Pro. ref]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="f72ff07f-7233-49fb-b70c-d22ce270c6eb" key="staticText-18" positionType="Float" mode="Opaque" x="550" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[M.r %]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="86715671-ccc3-4c47-a95b-cded2e753dfe" key="staticText-19" positionType="Float" mode="Opaque" x="580" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[A. %]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="d542a8f8-b627-495d-bf94-54b9368d18db" key="staticText-20" positionType="Float" mode="Opaque" x="610" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[M.dif]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="3c14c07d-d81b-45dc-8921-db00463838a6" key="staticText-24" positionType="Float" mode="Opaque" x="640" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Amt. ref2]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="2bee6c7d-4a4e-4002-92c0-67093d3e0a30" key="staticText-25" positionType="Float" mode="Opaque" x="695" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Cost ref2]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="12869949-5ff5-483e-8236-6e3609415e04" key="staticText-26" positionType="Float" mode="Opaque" x="750" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Pro. ref2]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="ad6c2eb4-129b-4560-9ea1-729999a83325" key="staticText-27" positionType="Float" mode="Opaque" x="805" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[M.r2 %]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="5835a21b-da93-4ffd-8669-1360013529ae" key="staticText-28" positionType="Float" mode="Opaque" x="835" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[A.2 %]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="166c9b75-e05f-4348-b9b8-5c9049085451" key="staticText-29" positionType="Float" mode="Opaque" x="865" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[M.dif2]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="4fe9da23-6e79-4894-99e9-8348a74b2bf6" key="staticText-11" positionType="Float" mode="Opaque" x="1150" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Weight]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="ab9f7afc-f016-4da4-83ba-2d371ff5b61b" key="staticText-21" positionType="Float" mode="Opaque" x="1180" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[W. Ref]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="298f1504-d54a-4bd0-807b-04dfe6031e79" key="staticText-30" positionType="Float" mode="Opaque" x="1210" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[W.Ref2]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="b5fa9183-7bb9-4fb9-af3a-ac23cd60bbb6" key="staticText-10" positionType="Float" mode="Opaque" x="1270" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Quantity]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="528295ff-ffbd-4475-a43b-aa3ac4e77e4c" key="staticText-23" positionType="Float" mode="Opaque" x="1325" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Q. ref]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="ea1653ed-9054-48a6-9e5c-09d5d0f07ff0" key="staticText-22" positionType="Float" mode="Opaque" x="1380" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Qty%]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="56ef8037-ca2d-471f-a7ad-6cd76a837f64" key="staticText-31" positionType="Float" mode="Opaque" x="1410" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Q. ref2]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="f1d3b992-eece-4c88-88f7-925c22665d5e" key="staticText-32" positionType="Float" mode="Opaque" x="1465" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Qty2%]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="0a8620bc-c2ae-43ab-a617-f0355f6c204f" key="staticText-33" positionType="Float" mode="Opaque" x="895" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Amt. ref3]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="a1c2a119-bf30-4c62-9e48-bafb96be9f05" key="staticText-34" positionType="Float" mode="Opaque" x="950" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Cost ref3]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="f28a4d84-0e3a-4fd7-ae97-f8bd92103e6d" key="staticText-35" positionType="Float" mode="Opaque" x="1005" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Pro. ref3]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="b7529d46-d27b-463e-aa0d-a7ede6b08253" key="staticText-36" positionType="Float" mode="Opaque" x="1060" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[M.r3 %]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="a3f7a1cc-9a5c-49f6-a99a-e38b621b5f27" key="staticText-37" positionType="Float" mode="Opaque" x="1090" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[A.3 %]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="107595c4-132e-440a-9a78-8c2558c9a2db" key="staticText-38" positionType="Float" mode="Opaque" x="1120" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[M.dif3]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="8202d348-90d5-4cb7-9830-06dd7956c49d" key="staticText-39" positionType="Float" mode="Opaque" x="1240" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[W.Ref3]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="6de9628a-4dbc-4c27-8ee8-420023300124" key="staticText-40" positionType="Float" mode="Opaque" x="1495" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Q. ref3]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="6bfa3bf5-1ce4-4152-bb11-2dd356bfa20f" key="staticText-41" positionType="Float" mode="Opaque" x="1550" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Qty3%]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="f97e3d7f-d719-4fbc-b7c3-8388a1cf5dc5" key="textField" x="0" y="0" width="1580" height="26" textAdjust="StretchHeight" blankWhenNull="true" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="9d562ed1-4c4f-44a1-a1e2-e905501a9c33" key="textField" x="0" y="31" width="1580" height="18" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="73f3f231-eff0-4c2b-a32f-d771f8aa1263" key="staticText-5" x="0" y="52" width="102" height="16" fontSize="9.0" style="Report_Data_Label">
+			<text><![CDATA[Grouping Levels:]]></text>
+			<box style="Report_Data_Label">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="2b528e62-24b6-41ee-a207-86cfd9451306" key="textField-17" x="102" y="52" width="1592" height="16" fontSize="9.0" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Data_Field">
+			<expression><![CDATA[$P{LEVEL_LABEL}]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="d81481f5-a670-4664-8d8d-3419cb5774b5" key="line-1" x="0" y="26" width="1580" height="1"/>
+		<element kind="line" uuid="75196ed7-0c2a-480d-b641-aa3b2a9b0a26" key="line-2" x="0" y="49" width="1580" height="1"/>
+		<element kind="staticText" uuid="4908fc8f-71c2-41b9-b8f4-870bdb43a24b" key="staticText-5" x="1" y="68" width="101" height="16" fontSize="9.0" bold="true" style="Report_Data_Label">
+			<text><![CDATA[Secondary Filters:]]></text>
+			<box style="Report_Data_Label">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="d9be9d8e-e59a-405a-a6f9-7daf0f033d58" key="textField-17" x="180" y="68" width="1400" height="16" fontSize="9.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<expression><![CDATA[$P{ORGANIZATION} + " and any child organization"]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="4b256a99-9cf8-4b0b-bf6d-df50adc49d95" key="textField-17" x="229" y="84" width="1351" height="16" printWhenGroupChanges="DocumentType" fontSize="9.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<printWhenExpression><![CDATA[!$P{BPGROUP}.equals("")]]></printWhenExpression>
+			<expression><![CDATA[$P{BPGROUP}]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="917ae2e9-9dfa-44e0-a482-4fdd8518a270" key="textField-17" x="190" y="100" width="1388" height="16" printWhenGroupChanges="DocumentType" fontSize="9.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<printWhenExpression><![CDATA[!$P{PRODUCTGROUP}.equals("")]]></printWhenExpression>
+			<expression><![CDATA[$P{PRODUCTGROUP}]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="a38e13bb-2c4b-44bb-ad03-faf2808dca7c" key="textField-17" x="102" y="84" width="127" height="16" printWhenGroupChanges="DocumentType" fontSize="9.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<printWhenExpression><![CDATA[!$P{BPGROUP}.equals("")]]></printWhenExpression>
+			<expression><![CDATA["Business Partner Group- "]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="a6471908-c435-486c-8464-5bb77eeaa8da" key="textField-17" x="102" y="100" width="88" height="16" printWhenGroupChanges="DocumentType" fontSize="9.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<printWhenExpression><![CDATA[!$P{PRODUCTGROUP}.equals("")]]></printWhenExpression>
+			<expression><![CDATA["Product Group- "]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="75a5133f-fcbb-41dd-a613-f7a71271153b" key="textField-17" x="102" y="68" width="78" height="16" fontSize="9.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<expression><![CDATA["Organization- "]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<property name="local_mesure_unitheight" value="pixel"/>
+		<property name="com.jaspersoft.studio.unit.height" value="px"/>
 	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band splitType="Stretch"/>
 	</detail>
-	<pageFooter>
-		<band height="20" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-7" style="Report_Footer" x="582" y="3" width="78" height="16" uuid="3c11af95-6455-4edd-a8d1-5fbede6df264"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Generated on ]]></text>
-			</staticText>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-18" style="Report_Footer" x="660" y="3" width="90" height="16" uuid="bc21191d-4986-4162-9531-ea1ceaf4a2aa"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-19" style="Report_Footer" x="939" y="3" width="95" height="16" uuid="7e965f7e-fdd9-460d-91c9-f1102bae55ae"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-20" style="Report_Footer" x="1036" y="3" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="1e7a1d1d-e864-40dd-b4c1-bb3c93c0cad5"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-4" x="0" y="2" width="1580" height="1" uuid="3e4f21ce-353f-4323-962e-493dd5ca6c4e"/>
-			</line>
-		</band>
+	<pageFooter height="20" splitType="Stretch">
+		<element kind="staticText" uuid="3c11af95-6455-4edd-a8d1-5fbede6df264" key="staticText-7" x="582" y="3" width="78" height="16" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Generated on ]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="bc21191d-4986-4162-9531-ea1ceaf4a2aa" key="textField-18" x="660" y="3" width="90" height="16" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="7e965f7e-fdd9-460d-91c9-f1102bae55ae" key="textField-19" x="939" y="3" width="95" height="16" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="1e7a1d1d-e864-40dd-b4c1-bb3c93c0cad5" key="textField-20" x="1036" y="3" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle" style="Report_Footer">
+			<paragraph lineSpacing="Single" style="Report_Footer"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="3e4f21ce-353f-4323-962e-493dd5ca6c4e" key="line-4" x="0" y="2" width="1580" height="1"/>
 	</pageFooter>
-	<lastPageFooter>
-		<band height="58"/>
-	</lastPageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<lastPageFooter height="58"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesMultiComparativeJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesMultiComparativeJR.jrxml
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
-<!-- 2017-03-02T13:17:04 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportInvoiceCustomerDimensionalAnalysesMultiComparativeJR" pageWidth="1300" pageHeight="595" orientation="Landscape" columnWidth="1272" leftMargin="14" rightMargin="14" topMargin="56" bottomMargin="28" uuid="3f1d7732-64a5-4b19-b4dd-5f06efe61a6b">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportInvoiceCustomerDimensionalAnalysesMultiComparativeJR" language="java" pageWidth="1300" pageHeight="595" orientation="Landscape" columnWidth="1272" leftMargin="14" rightMargin="14" topMargin="56" bottomMargin="28" uuid="3f1d7732-64a5-4b19-b4dd-5f06efe61a6b">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
@@ -9,171 +7,140 @@
 	<property name="ireport.x" value="685"/>
 	<property name="ireport.y" value="516"/>
 	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="true"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8" isBold="true">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Report_Data_Label" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="true"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0" bold="true">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level1_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level1_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==1)&&($V{NIVEL1_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==1)&&($V{NIVEL1_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level2_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level2_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==2)&&($V{NIVEL1_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==2)&&($V{NIVEL1_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level3_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level3_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==3)&&($V{NIVEL2_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==3)&&($V{NIVEL2_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level4_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level4_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==4)&&($V{NIVEL3_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==4)&&($V{NIVEL3_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level5_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level5_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==5)&&($V{NIVEL4_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==5)&&($V{NIVEL4_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level6_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level6_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==6)&&($V{NIVEL5_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==6)&&($V{NIVEL5_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level7_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level7_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==7)&&($V{NIVEL6_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==7)&&($V{NIVEL6_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level8_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level8_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==8)&&($V{NIVEL7_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==8)&&($V{NIVEL7_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level9_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level9_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==9)&&($V{NIVEL8_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==9)&&($V{NIVEL8_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level10_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level10_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==10)&&($V{NIVEL9_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==10)&&($V{NIVEL9_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Report_Footer" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
+	<style name="Report_Footer" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
 	<style name="Detail_Border" forecolor="#8A8A8A"/>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["0,1000000"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["0,1000000"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_client" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_client" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{USER_CLIENT}.equals("") ? " " : " AND C_INVOICE.AD_CLIENT_ID IN(" + $P{USER_CLIENT} + ")"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="ORGANIZATION" class="java.lang.String"/>
@@ -181,97 +148,97 @@
 	<parameter name="PRODUCTGROUP" class="java.lang.String"/>
 	<parameter name="C_CURRENCY_ID" class="java.lang.String"/>
 	<parameter name="AD_ORG_ID" class="java.lang.String"/>
-	<parameter name="aux_org" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_org" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{AD_ORG_ID}.equals("") ? " " : " AND C_INVOICE.AD_ORG_ID IN(" + $P{AD_ORG_ID} + ")"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="DateFrom" class="java.lang.String"/>
 	<parameter name="DateTo" class="java.lang.String"/>
-	<parameter name="aux_DateFrom" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_DateFrom" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{DateFrom} == null || $P{DateFrom}.equals("")) ? "" : "AND C_INVOICE.DATEINVOICED >= TO_DATE('" + $P{DateFrom} + "', 'YYYY-MM-DD')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_DateTo" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_DateTo" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{DateTo} == null || $P{DateTo}.equals("")) ? "" : "AND C_INVOICE.DATEINVOICED <= TO_DATE('" + $P{DateTo} + "', 'YYYY-MM-DD')"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="C_BP_GROUP_ID" class="java.lang.String"/>
-	<parameter name="aux_bpgroup" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_bpgroup" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{C_BP_GROUP_ID}.equals("") ? " " : " AND C_BPARTNER.C_BP_GROUP_ID = '" + $P{C_BP_GROUP_ID} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="C_BPARTNER_ID" class="java.lang.String"/>
-	<parameter name="aux_partner" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_partner" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{C_BPARTNER_ID}.equals("") ? " " : " AND C_BPARTNER.C_BPARTNER_ID IN" + $P{C_BPARTNER_ID}]]></defaultValueExpression>
 	</parameter>
 	<parameter name="M_PRODUCT_CATEGORY_ID" class="java.lang.String"/>
-	<parameter name="aux_productcategory" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_productcategory" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{M_PRODUCT_CATEGORY_ID}.equals("") ? " " : " AND M_PRODUCT_CATEGORY.M_PRODUCT_CATEGORY_ID IN " + $P{M_PRODUCT_CATEGORY_ID}]]></defaultValueExpression>
 	</parameter>
 	<parameter name="M_PRODUCT_ID" class="java.lang.String"/>
-	<parameter name="aux_product" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_product" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{M_PRODUCT_ID}.equals("") ? " " : "  AND M_PRODUCT.M_PRODUCT_ID IN" + $P{M_PRODUCT_ID}]]></defaultValueExpression>
 	</parameter>
 	<parameter name="SALESREP_ID" class="java.lang.String"/>
-	<parameter name="aux_salesrep" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_salesrep" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{SALESREP_ID}.equals("") ? " " : " AND C_INVOICE.SALESREP_ID = '" + $P{SALESREP_ID} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="PARTNER_SALESREP_ID" class="java.lang.String"/>
-	<parameter name="aux_partnersalesrep" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_partnersalesrep" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{PARTNER_SALESREP_ID}.equals("") ? " " : " AND CB.C_BPARTNER_ID = '" + $P{PARTNER_SALESREP_ID} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="C_PROJECT_ID" class="java.lang.String"/>
-	<parameter name="aux_project" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_project" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{C_PROJECT_ID}.equals("") ? " " : " AND C_INVOICE.C_PROJECT_ID = '" + $P{C_PROJECT_ID} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="PRODUCTTYPE" class="java.lang.String"/>
-	<parameter name="aux_producttype" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_producttype" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{PRODUCTTYPE}.equals("") ? " " : " AND M_PRODUCT.PRODUCTTYPE = '" + $P{PRODUCTTYPE} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="C_DOCTYPE_ID" class="java.lang.String"/>
-	<parameter name="aux_doctype" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_doctype" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{C_DOCTYPE_ID}.equals("") ? " " : " AND C_INVOICE.C_DOCTYPE_ID IN" + $P{C_DOCTYPE_ID}]]></defaultValueExpression>
 	</parameter>
 	<parameter name="DOCSTATUS" class="java.lang.String"/>
-	<parameter name="aux_docstatus" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_docstatus" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{DOCSTATUS}.equals("") ? " " : " AND C_INVOICE.DOCSTATUS <> '" + $P{DOCSTATUS} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="LANGUAGE" class="java.lang.String"/>
-	<parameter name="SR_LINES" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="orderBy" class="java.lang.String" isForPrompting="false">
+	<parameter name="SR_LINES" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="orderBy" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[" ORDER BY 1 "]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Purchase Orders Report"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="PRODUCT_LEVEL" class="java.lang.Integer" isForPrompting="false">
+	<parameter name="PRODUCT_LEVEL" forPrompting="false" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[new Integer(3)]]></defaultValueExpression>
 	</parameter>
-	<parameter name="THEME" class="java.lang.String" isForPrompting="false">
+	<parameter name="THEME" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Default"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false">
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/var/lib/tomcat-5.5/webapps/alerts/web"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL1_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL1_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Partner Group"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL2_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL2_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Product Category"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL3_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL3_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Product"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL4_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL4_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Partner"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL5_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL6_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL7_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL8_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL9_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL10_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="DIMENSIONS" class="java.lang.Integer" isForPrompting="false">
+	<parameter name="LEVEL5_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL6_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL7_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL8_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL9_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL10_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="DIMENSIONS" forPrompting="false" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[new Integer(5)]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["1.- "+$P{LEVEL1_LABEL}
 +($P{LEVEL2_LABEL}==""?"":", 2.- "+$P{LEVEL2_LABEL})
 +($P{LEVEL3_LABEL}==""?"":", 3.- "+$P{LEVEL3_LABEL})
@@ -283,12 +250,11 @@
 +($P{LEVEL9_LABEL}==""?"":", 9.- "+$P{LEVEL9_LABEL})
 +($P{LEVEL10_LABEL}==""?"":", 10.- "+$P{LEVEL10_LABEL})]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale">
 		<defaultValueExpression><![CDATA[new Locale("en","US")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10,
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<query language="sql"><![CDATA[SELECT NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10,
       SUM(AMOUNT) AS AMOUNT, SUM(QTY) AS QTY, SUM(WEIGHT) AS WEIGHT, SUM(COST) AS COST,
       SUM(AMOUNTREF) AS AMOUNTREF, SUM(QTYREF) AS QTYREF, SUM(WEIGHTREF) AS WEIGHTREF, SUM(COSTREF) AS COSTREF,
       SUM(AMOUNTREF2) AS AMOUNTREF2, SUM(QTYREF2) AS QTYREF2, SUM(WEIGHTREF2) AS WEIGHTREF2, SUM(COSTREF2) AS COSTREF2,
@@ -455,8 +421,7 @@
       AND 4=4
       ORDER BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10) AA
       GROUP BY  NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10, TRCURRENCYID, TRDATE, TRCLIENTID, TRORGID) ZZ
-      GROUP BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10, 1]]>
-	</queryString>
+      GROUP BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10, 1]]></query>
 	<field name="NIVEL1" class="java.lang.String"/>
 	<field name="NIVEL2" class="java.lang.String"/>
 	<field name="NIVEL3" class="java.lang.String"/>
@@ -490,1578 +455,1332 @@
 	<field name="CONVSYM" class="java.lang.String"/>
 	<field name="CONVISOSYM" class="java.lang.String"/>
 	<field name="COSTCALCULATED" class="java.lang.Integer"/>
-	<variable name="QTY_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF2_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF2}]]></variableExpression>
+	<variable name="QTYREF2_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF2}]]></expression>
 	</variable>
-	<variable name="QTYREF2_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF2}]]></variableExpression>
+	<variable name="QTYREF2_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF2}]]></expression>
 	</variable>
-	<variable name="QTYREF2_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF2}]]></variableExpression>
+	<variable name="QTYREF2_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF2}]]></expression>
 	</variable>
-	<variable name="QTYREF2_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF2}]]></variableExpression>
+	<variable name="QTYREF2_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF2}]]></expression>
 	</variable>
-	<variable name="QTYREF2_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF2}]]></variableExpression>
+	<variable name="QTYREF2_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF2}]]></expression>
 	</variable>
-	<variable name="QTYREF2_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF2}]]></variableExpression>
+	<variable name="QTYREF2_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF2}]]></expression>
 	</variable>
-	<variable name="QTYREF2_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF2}]]></variableExpression>
+	<variable name="QTYREF2_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF2}]]></expression>
 	</variable>
-	<variable name="QTYREF2_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF2}]]></variableExpression>
+	<variable name="QTYREF2_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF2}]]></expression>
 	</variable>
-	<variable name="QTYREF2_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF2}]]></variableExpression>
+	<variable name="QTYREF2_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF2}]]></expression>
 	</variable>
-	<variable name="QTYREF2_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF2}]]></variableExpression>
+	<variable name="QTYREF2_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF2}]]></expression>
 	</variable>
-	<variable name="AMOUNT_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF2_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF2}]]></variableExpression>
+	<variable name="AMOUNTREF2_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF2}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF2_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF2}]]></variableExpression>
+	<variable name="AMOUNTREF2_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF2}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF2_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF2}]]></variableExpression>
+	<variable name="AMOUNTREF2_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF2}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF2_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF2}]]></variableExpression>
+	<variable name="AMOUNTREF2_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF2}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF2_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF2}]]></variableExpression>
+	<variable name="AMOUNTREF2_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF2}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF2_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF2}]]></variableExpression>
+	<variable name="AMOUNTREF2_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF2}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF2_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF2}]]></variableExpression>
+	<variable name="AMOUNTREF2_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF2}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF2_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF2}]]></variableExpression>
+	<variable name="AMOUNTREF2_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF2}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF2_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF2}]]></variableExpression>
+	<variable name="AMOUNTREF2_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF2}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF2_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF2}]]></variableExpression>
+	<variable name="AMOUNTREF2_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF2}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF2_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF2}]]></variableExpression>
+	<variable name="AMOUNTREF2_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF2}]]></expression>
 	</variable>
-	<variable name="COST_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
-	<variable name="COSTREF2_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF2}]]></variableExpression>
+	<variable name="COSTREF2_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF2}]]></expression>
 	</variable>
-	<variable name="COSTREF2_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF2}]]></variableExpression>
+	<variable name="COSTREF2_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF2}]]></expression>
 	</variable>
-	<variable name="COSTREF2_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF2}]]></variableExpression>
+	<variable name="COSTREF2_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF2}]]></expression>
 	</variable>
-	<variable name="COSTREF2_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF2}]]></variableExpression>
+	<variable name="COSTREF2_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF2}]]></expression>
 	</variable>
-	<variable name="COSTREF2_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF2}]]></variableExpression>
+	<variable name="COSTREF2_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF2}]]></expression>
 	</variable>
-	<variable name="COSTREF2_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF2}]]></variableExpression>
+	<variable name="COSTREF2_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF2}]]></expression>
 	</variable>
-	<variable name="COSTREF2_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF2}]]></variableExpression>
+	<variable name="COSTREF2_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF2}]]></expression>
 	</variable>
-	<variable name="COSTREF2_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF2}]]></variableExpression>
+	<variable name="COSTREF2_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF2}]]></expression>
 	</variable>
-	<variable name="COSTREF2_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF2}]]></variableExpression>
+	<variable name="COSTREF2_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF2}]]></expression>
 	</variable>
-	<variable name="COSTREF2_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF2}]]></variableExpression>
+	<variable name="COSTREF2_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF2}]]></expression>
 	</variable>
-	<variable name="PROFIT_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM1}.subtract($V{COST_SUM1})]]></variableExpression>
+	<variable name="PROFIT_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM1}.subtract($V{COST_SUM1})]]></expression>
 	</variable>
-	<variable name="PROFIT_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM2}.subtract($V{COST_SUM2})]]></variableExpression>
+	<variable name="PROFIT_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM2}.subtract($V{COST_SUM2})]]></expression>
 	</variable>
-	<variable name="PROFIT_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM3}.subtract($V{COST_SUM3})]]></variableExpression>
+	<variable name="PROFIT_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM3}.subtract($V{COST_SUM3})]]></expression>
 	</variable>
-	<variable name="PROFIT_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM4}.subtract($V{COST_SUM4})]]></variableExpression>
+	<variable name="PROFIT_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM4}.subtract($V{COST_SUM4})]]></expression>
 	</variable>
-	<variable name="PROFIT_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM5}.subtract($V{COST_SUM5})]]></variableExpression>
+	<variable name="PROFIT_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM5}.subtract($V{COST_SUM5})]]></expression>
 	</variable>
-	<variable name="PROFIT_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM6}.subtract($V{COST_SUM6})]]></variableExpression>
+	<variable name="PROFIT_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM6}.subtract($V{COST_SUM6})]]></expression>
 	</variable>
-	<variable name="PROFIT_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM7}.subtract($V{COST_SUM7})]]></variableExpression>
+	<variable name="PROFIT_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM7}.subtract($V{COST_SUM7})]]></expression>
 	</variable>
-	<variable name="PROFIT_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM8}.subtract($V{COST_SUM8})]]></variableExpression>
+	<variable name="PROFIT_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM8}.subtract($V{COST_SUM8})]]></expression>
 	</variable>
-	<variable name="PROFIT_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM9}.subtract($V{COST_SUM9})]]></variableExpression>
+	<variable name="PROFIT_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM9}.subtract($V{COST_SUM9})]]></expression>
 	</variable>
-	<variable name="PROFIT_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM10}.subtract($V{COST_SUM10})]]></variableExpression>
+	<variable name="PROFIT_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM10}.subtract($V{COST_SUM10})]]></expression>
 	</variable>
-	<variable name="PROFITREF_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM1}.subtract($V{COSTREF_SUM1})]]></variableExpression>
+	<variable name="PROFITREF_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM1}.subtract($V{COSTREF_SUM1})]]></expression>
 	</variable>
-	<variable name="PROFITREF_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM2}.subtract($V{COSTREF_SUM2})]]></variableExpression>
+	<variable name="PROFITREF_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM2}.subtract($V{COSTREF_SUM2})]]></expression>
 	</variable>
-	<variable name="PROFITREF_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM3}.subtract($V{COSTREF_SUM3})]]></variableExpression>
+	<variable name="PROFITREF_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM3}.subtract($V{COSTREF_SUM3})]]></expression>
 	</variable>
-	<variable name="PROFITREF_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM4}.subtract($V{COSTREF_SUM4})]]></variableExpression>
+	<variable name="PROFITREF_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM4}.subtract($V{COSTREF_SUM4})]]></expression>
 	</variable>
-	<variable name="PROFITREF_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM5}.subtract($V{COSTREF_SUM5})]]></variableExpression>
+	<variable name="PROFITREF_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM5}.subtract($V{COSTREF_SUM5})]]></expression>
 	</variable>
-	<variable name="PROFITREF_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM6}.subtract($V{COSTREF_SUM6})]]></variableExpression>
+	<variable name="PROFITREF_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM6}.subtract($V{COSTREF_SUM6})]]></expression>
 	</variable>
-	<variable name="PROFITREF_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM7}.subtract($V{COSTREF_SUM7})]]></variableExpression>
+	<variable name="PROFITREF_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM7}.subtract($V{COSTREF_SUM7})]]></expression>
 	</variable>
-	<variable name="PROFITREF_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM8}.subtract($V{COSTREF_SUM8})]]></variableExpression>
+	<variable name="PROFITREF_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM8}.subtract($V{COSTREF_SUM8})]]></expression>
 	</variable>
-	<variable name="PROFITREF_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM9}.subtract($V{COSTREF_SUM9})]]></variableExpression>
+	<variable name="PROFITREF_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM9}.subtract($V{COSTREF_SUM9})]]></expression>
 	</variable>
-	<variable name="PROFITREF_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[$V{AMOUNTREF_SUM10}.subtract($V{COSTREF_SUM10})]]></variableExpression>
+	<variable name="PROFITREF_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF_SUM10}.subtract($V{COSTREF_SUM10})]]></expression>
 	</variable>
-	<variable name="PROFITREF2_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[$V{AMOUNTREF2_SUM1}.subtract($V{COSTREF2_SUM1})]]></variableExpression>
+	<variable name="PROFITREF2_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF2_SUM1}.subtract($V{COSTREF2_SUM1})]]></expression>
 	</variable>
-	<variable name="PROFITREF2_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[$V{AMOUNTREF2_SUM2}.subtract($V{COSTREF2_SUM2})]]></variableExpression>
+	<variable name="PROFITREF2_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF2_SUM2}.subtract($V{COSTREF2_SUM2})]]></expression>
 	</variable>
-	<variable name="PROFITREF2_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[$V{AMOUNTREF2_SUM3}.subtract($V{COSTREF2_SUM3})]]></variableExpression>
+	<variable name="PROFITREF2_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF2_SUM3}.subtract($V{COSTREF2_SUM3})]]></expression>
 	</variable>
-	<variable name="PROFITREF2_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[$V{AMOUNTREF2_SUM4}.subtract($V{COSTREF2_SUM4})]]></variableExpression>
+	<variable name="PROFITREF2_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF2_SUM4}.subtract($V{COSTREF2_SUM4})]]></expression>
 	</variable>
-	<variable name="PROFITREF2_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[$V{AMOUNTREF2_SUM5}.subtract($V{COSTREF2_SUM5})]]></variableExpression>
+	<variable name="PROFITREF2_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF2_SUM5}.subtract($V{COSTREF2_SUM5})]]></expression>
 	</variable>
-	<variable name="PROFITREF2_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[$V{AMOUNTREF2_SUM6}.subtract($V{COSTREF2_SUM6})]]></variableExpression>
+	<variable name="PROFITREF2_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF2_SUM6}.subtract($V{COSTREF2_SUM6})]]></expression>
 	</variable>
-	<variable name="PROFITREF2_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[$V{AMOUNTREF2_SUM7}.subtract($V{COSTREF2_SUM7})]]></variableExpression>
+	<variable name="PROFITREF2_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF2_SUM7}.subtract($V{COSTREF2_SUM7})]]></expression>
 	</variable>
-	<variable name="PROFITREF2_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[$V{AMOUNTREF2_SUM8}.subtract($V{COSTREF2_SUM8})]]></variableExpression>
+	<variable name="PROFITREF2_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF2_SUM8}.subtract($V{COSTREF2_SUM8})]]></expression>
 	</variable>
-	<variable name="PROFITREF2_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[$V{AMOUNTREF2_SUM9}.subtract($V{COSTREF2_SUM9})]]></variableExpression>
+	<variable name="PROFITREF2_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF2_SUM9}.subtract($V{COSTREF2_SUM9})]]></expression>
 	</variable>
-	<variable name="PROFITREF2_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[$V{AMOUNTREF2_SUM10}.subtract($V{COSTREF2_SUM10})]]></variableExpression>
+	<variable name="PROFITREF2_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNTREF2_SUM10}.subtract($V{COSTREF2_SUM10})]]></expression>
 	</variable>
-	<variable name="MARGIN_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_1}.divide( $V{AMOUNT_SUM1}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_1}.signum()))]]></variableExpression>
+	<variable name="MARGIN_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_1}.divide( $V{AMOUNT_SUM1}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_1}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_2}.divide( $V{AMOUNT_SUM2}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_2}.signum()))]]></variableExpression>
+	<variable name="MARGIN_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_2}.divide( $V{AMOUNT_SUM2}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_2}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_3}.divide( $V{AMOUNT_SUM3}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_3}.signum()))]]></variableExpression>
+	<variable name="MARGIN_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_3}.divide( $V{AMOUNT_SUM3}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_3}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_4}.divide( $V{AMOUNT_SUM4}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_4}.signum()))]]></variableExpression>
+	<variable name="MARGIN_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_4}.divide( $V{AMOUNT_SUM4}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_4}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_5}.divide( $V{AMOUNT_SUM5}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_5}.signum()))]]></variableExpression>
+	<variable name="MARGIN_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_5}.divide( $V{AMOUNT_SUM5}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_5}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_6}.divide( $V{AMOUNT_SUM6}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_6}.signum()))]]></variableExpression>
+	<variable name="MARGIN_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_6}.divide( $V{AMOUNT_SUM6}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_6}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_7}.divide( $V{AMOUNT_SUM7}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_7}.signum()))]]></variableExpression>
+	<variable name="MARGIN_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_7}.divide( $V{AMOUNT_SUM7}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_7}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_8}.divide( $V{AMOUNT_SUM8}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_8}.signum()))]]></variableExpression>
+	<variable name="MARGIN_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_8}.divide( $V{AMOUNT_SUM8}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_8}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_9}.divide( $V{AMOUNT_SUM9}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_9}.signum()))]]></variableExpression>
+	<variable name="MARGIN_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_9}.divide( $V{AMOUNT_SUM9}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_9}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{PROFIT_10}.divide( $V{AMOUNT_SUM10}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_10}.signum()))]]></variableExpression>
+	<variable name="MARGIN_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{PROFIT_10}.divide( $V{AMOUNT_SUM10}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_10}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_1}.divide( $V{AMOUNTREF_SUM1}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_1}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_1}.divide( $V{AMOUNTREF_SUM1}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_1}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_2}.divide( $V{AMOUNTREF_SUM2}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_2}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_2}.divide( $V{AMOUNTREF_SUM2}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_2}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_3}.divide( $V{AMOUNTREF_SUM3}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_3}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_3}.divide( $V{AMOUNTREF_SUM3}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_3}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_4}.divide( $V{AMOUNTREF_SUM4}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_4}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_4}.divide( $V{AMOUNTREF_SUM4}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_4}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_5}.divide( $V{AMOUNTREF_SUM5}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_5}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_5}.divide( $V{AMOUNTREF_SUM5}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_5}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_6}.divide( $V{AMOUNTREF_SUM6}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_6}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_6}.divide( $V{AMOUNTREF_SUM6}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_6}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_7}.divide( $V{AMOUNTREF_SUM7}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_7}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_7}.divide( $V{AMOUNTREF_SUM7}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_7}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_8}.divide( $V{AMOUNTREF_SUM8}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_8}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_8}.divide( $V{AMOUNTREF_SUM8}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_8}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_9}.divide( $V{AMOUNTREF_SUM9}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_9}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF_9}.divide( $V{AMOUNTREF_SUM9}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_9}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{PROFITREF_10}.divide( $V{AMOUNTREF_SUM10}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_10}.signum()))]]></variableExpression>
+	<variable name="MARGINREF_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{PROFITREF_10}.divide( $V{AMOUNTREF_SUM10}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF_10}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF2_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM1}.compareTo(BigDecimal.ZERO)==0)?BigDecimal.ZERO: $V{PROFITREF2_1}.divide( $V{AMOUNTREF2_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_1}.signum()))]]></variableExpression>
+	<variable name="MARGINREF2_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM1}.compareTo(BigDecimal.ZERO)==0)?BigDecimal.ZERO: $V{PROFITREF2_1}.divide( $V{AMOUNTREF2_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_1}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF2_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_2}.divide( $V{AMOUNTREF2_SUM2}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_2}.signum()))]]></variableExpression>
+	<variable name="MARGINREF2_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_2}.divide( $V{AMOUNTREF2_SUM2}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_2}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF2_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_3}.divide( $V{AMOUNTREF2_SUM3}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_3}.signum()))]]></variableExpression>
+	<variable name="MARGINREF2_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_3}.divide( $V{AMOUNTREF2_SUM3}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_3}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF2_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_4}.divide( $V{AMOUNTREF2_SUM4}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_4}.signum()))]]></variableExpression>
+	<variable name="MARGINREF2_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_4}.divide( $V{AMOUNTREF2_SUM4}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_4}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF2_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_5}.divide( $V{AMOUNTREF2_SUM5}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_5}.signum()))]]></variableExpression>
+	<variable name="MARGINREF2_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_5}.divide( $V{AMOUNTREF2_SUM5}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_5}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF2_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_6}.divide( $V{AMOUNTREF2_SUM6}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_6}.signum()))]]></variableExpression>
+	<variable name="MARGINREF2_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_6}.divide( $V{AMOUNTREF2_SUM6}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_6}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF2_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_7}.divide( $V{AMOUNTREF2_SUM7}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_7}.signum()))]]></variableExpression>
+	<variable name="MARGINREF2_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_7}.divide( $V{AMOUNTREF2_SUM7}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_7}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF2_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_8}.divide( $V{AMOUNTREF2_SUM8}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_8}.signum()))]]></variableExpression>
+	<variable name="MARGINREF2_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_8}.divide( $V{AMOUNTREF2_SUM8}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_8}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF2_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_9}.divide( $V{AMOUNTREF2_SUM9}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_9}.signum()))]]></variableExpression>
+	<variable name="MARGINREF2_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFITREF2_9}.divide( $V{AMOUNTREF2_SUM9}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_9}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGINREF2_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{PROFITREF2_10}.divide( $V{AMOUNTREF2_SUM10}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_10}.signum()))]]></variableExpression>
+	<variable name="MARGINREF2_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{PROFITREF2_10}.divide( $V{AMOUNTREF2_SUM10}, 4, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFITREF2_10}.signum()))]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF2_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF2}]]></variableExpression>
+	<variable name="WEIGHTREF2_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF2}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF2_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF2}]]></variableExpression>
+	<variable name="WEIGHTREF2_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF2}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF2_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF2}]]></variableExpression>
+	<variable name="WEIGHTREF2_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF2}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF2_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF2}]]></variableExpression>
+	<variable name="WEIGHTREF2_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF2}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF2_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF2}]]></variableExpression>
+	<variable name="WEIGHTREF2_SUM5" resetType="Group" calculation="Sum" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF2}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF2_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF2}]]></variableExpression>
+	<variable name="WEIGHTREF2_SUM6" resetType="Group" calculation="Sum" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF2}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF2_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF2}]]></variableExpression>
+	<variable name="WEIGHTREF2_SUM7" resetType="Group" calculation="Sum" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF2}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF2_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF2}]]></variableExpression>
+	<variable name="WEIGHTREF2_SUM8" resetType="Group" calculation="Sum" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF2}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF2_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF2}]]></variableExpression>
+	<variable name="WEIGHTREF2_SUM9" resetType="Group" calculation="Sum" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF2}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF2_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF2}]]></variableExpression>
+	<variable name="WEIGHTREF2_SUM10" resetType="Group" calculation="Sum" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF2}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF2_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF2}]]></variableExpression>
+	<variable name="WEIGHTREF2_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF2}]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM1}.subtract($V{AMOUNTREF_SUM1}).divide( $V{AMOUNTREF_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM1}.subtract($V{AMOUNTREF_SUM1}).divide( $V{AMOUNTREF_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM2}.subtract($V{AMOUNTREF_SUM2}).divide( $V{AMOUNTREF_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM2}.subtract($V{AMOUNTREF_SUM2}).divide( $V{AMOUNTREF_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM3}.subtract($V{AMOUNTREF_SUM3}).divide( $V{AMOUNTREF_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM3}.subtract($V{AMOUNTREF_SUM3}).divide( $V{AMOUNTREF_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM4}.subtract($V{AMOUNTREF_SUM4}).divide( $V{AMOUNTREF_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM4}.subtract($V{AMOUNTREF_SUM4}).divide( $V{AMOUNTREF_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM5}.subtract($V{AMOUNTREF_SUM5}).divide( $V{AMOUNTREF_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM5}.subtract($V{AMOUNTREF_SUM5}).divide( $V{AMOUNTREF_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM6}.subtract($V{AMOUNTREF_SUM6}).divide( $V{AMOUNTREF_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM6}.subtract($V{AMOUNTREF_SUM6}).divide( $V{AMOUNTREF_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM7}.subtract($V{AMOUNTREF_SUM7}).divide( $V{AMOUNTREF_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM7}.subtract($V{AMOUNTREF_SUM7}).divide( $V{AMOUNTREF_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM8}.subtract($V{AMOUNTREF_SUM8}).divide( $V{AMOUNTREF_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM8}.subtract($V{AMOUNTREF_SUM8}).divide( $V{AMOUNTREF_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM9}.subtract($V{AMOUNTREF_SUM9}).divide( $V{AMOUNTREF_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM9}.subtract($V{AMOUNTREF_SUM9}).divide( $V{AMOUNTREF_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PER10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM10}.subtract($V{AMOUNTREF_SUM10}).divide( $V{AMOUNTREF_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PER10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM10}.subtract($V{AMOUNTREF_SUM10}).divide( $V{AMOUNTREF_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT_PERTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[($V{AMOUNTREF_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_TOTAL}.subtract($V{AMOUNTREF_TOTAL}).divide( $V{AMOUNTREF_TOTAL}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT_PERTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_TOTAL}.subtract($V{AMOUNTREF_TOTAL}).divide( $V{AMOUNTREF_TOTAL}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT2_PER1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM1}.subtract($V{AMOUNTREF2_SUM1}).divide( $V{AMOUNTREF2_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT2_PER1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM1}.subtract($V{AMOUNTREF2_SUM1}).divide( $V{AMOUNTREF2_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT2_PER2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM2}.subtract($V{AMOUNTREF2_SUM2}).divide( $V{AMOUNTREF2_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT2_PER2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM2}.subtract($V{AMOUNTREF2_SUM2}).divide( $V{AMOUNTREF2_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT2_PER3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM3}.subtract($V{AMOUNTREF2_SUM3}).divide( $V{AMOUNTREF2_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT2_PER3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM3}.subtract($V{AMOUNTREF2_SUM3}).divide( $V{AMOUNTREF2_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT2_PER4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM4}.subtract($V{AMOUNTREF2_SUM4}).divide( $V{AMOUNTREF2_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT2_PER4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM4}.subtract($V{AMOUNTREF2_SUM4}).divide( $V{AMOUNTREF2_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT2_PER5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM5}.subtract($V{AMOUNTREF2_SUM5}).divide( $V{AMOUNTREF2_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT2_PER5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM5}.subtract($V{AMOUNTREF2_SUM5}).divide( $V{AMOUNTREF2_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT2_PER6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM6}.subtract($V{AMOUNTREF2_SUM6}).divide( $V{AMOUNTREF2_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT2_PER6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM6}.subtract($V{AMOUNTREF2_SUM6}).divide( $V{AMOUNTREF2_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT2_PER7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM7}.subtract($V{AMOUNTREF2_SUM7}).divide( $V{AMOUNTREF2_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT2_PER7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM7}.subtract($V{AMOUNTREF2_SUM7}).divide( $V{AMOUNTREF2_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT2_PER8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM8}.subtract($V{AMOUNTREF2_SUM8}).divide( $V{AMOUNTREF2_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT2_PER8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM8}.subtract($V{AMOUNTREF2_SUM8}).divide( $V{AMOUNTREF2_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT2_PER9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM9}.subtract($V{AMOUNTREF2_SUM9}).divide( $V{AMOUNTREF2_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT2_PER9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM9}.subtract($V{AMOUNTREF2_SUM9}).divide( $V{AMOUNTREF2_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT2_PER10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM10}.subtract($V{AMOUNTREF2_SUM10}).divide( $V{AMOUNTREF2_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT2_PER10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_SUM10}.subtract($V{AMOUNTREF2_SUM10}).divide( $V{AMOUNTREF2_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="AMOUNT2_PERTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_TOTAL}.subtract($V{AMOUNTREF2_TOTAL}).divide( $V{AMOUNTREF2_TOTAL}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="AMOUNT2_PERTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF2_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{AMOUNT_TOTAL}.subtract($V{AMOUNTREF2_TOTAL}).divide( $V{AMOUNTREF2_TOTAL}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{QTYREF_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM1}.subtract($V{QTYREF_SUM1}).divide( $V{QTYREF_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM1}.subtract($V{QTYREF_SUM1}).divide( $V{QTYREF_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{QTYREF_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM2}.subtract($V{QTYREF_SUM2}).divide( $V{QTYREF_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM2}.subtract($V{QTYREF_SUM2}).divide( $V{QTYREF_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{QTYREF_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM3}.subtract($V{QTYREF_SUM3}).divide( $V{QTYREF_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM3}.subtract($V{QTYREF_SUM3}).divide( $V{QTYREF_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{QTYREF_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM4}.subtract($V{QTYREF_SUM4}).divide( $V{QTYREF_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM4}.subtract($V{QTYREF_SUM4}).divide( $V{QTYREF_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{QTYREF_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM5}.subtract($V{QTYREF_SUM5}).divide( $V{QTYREF_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM5}.subtract($V{QTYREF_SUM5}).divide( $V{QTYREF_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{QTYREF_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM6}.subtract($V{QTYREF_SUM6}).divide( $V{QTYREF_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM6}.subtract($V{QTYREF_SUM6}).divide( $V{QTYREF_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{QTYREF_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM7}.subtract($V{QTYREF_SUM7}).divide( $V{QTYREF_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM7}.subtract($V{QTYREF_SUM7}).divide( $V{QTYREF_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{QTYREF_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM8}.subtract($V{QTYREF_SUM8}).divide( $V{QTYREF_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM8}.subtract($V{QTYREF_SUM8}).divide( $V{QTYREF_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{QTYREF_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM9}.subtract($V{QTYREF_SUM9}).divide( $V{QTYREF_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM9}.subtract($V{QTYREF_SUM9}).divide( $V{QTYREF_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY_PER10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{QTYREF_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM10}.subtract($V{QTYREF_SUM10}).divide( $V{QTYREF_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY_PER10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM10}.subtract($V{QTYREF_SUM10}).divide( $V{QTYREF_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY2_PER1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{QTYREF2_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM1}.subtract($V{QTYREF2_SUM1}).divide( $V{QTYREF2_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY2_PER1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF2_SUM1}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM1}.subtract($V{QTYREF2_SUM1}).divide( $V{QTYREF2_SUM1}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY2_PER2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{QTYREF2_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM2}.subtract($V{QTYREF2_SUM2}).divide( $V{QTYREF2_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY2_PER2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF2_SUM2}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM2}.subtract($V{QTYREF2_SUM2}).divide( $V{QTYREF2_SUM2}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY2_PER3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{QTYREF2_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM3}.subtract($V{QTYREF2_SUM3}).divide( $V{QTYREF2_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY2_PER3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF2_SUM3}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM3}.subtract($V{QTYREF2_SUM3}).divide( $V{QTYREF2_SUM3}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY2_PER4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{QTYREF2_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM4}.subtract($V{QTYREF2_SUM4}).divide( $V{QTYREF2_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY2_PER4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF2_SUM4}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM4}.subtract($V{QTYREF2_SUM4}).divide( $V{QTYREF2_SUM4}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY2_PER5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{QTYREF2_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM5}.subtract($V{QTYREF2_SUM5}).divide( $V{QTYREF2_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY2_PER5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF2_SUM5}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM5}.subtract($V{QTYREF2_SUM5}).divide( $V{QTYREF2_SUM5}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY2_PER6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{QTYREF2_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM6}.subtract($V{QTYREF2_SUM6}).divide( $V{QTYREF2_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY2_PER6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF2_SUM6}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM6}.subtract($V{QTYREF2_SUM6}).divide( $V{QTYREF2_SUM6}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY2_PER7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{QTYREF2_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM7}.subtract($V{QTYREF2_SUM7}).divide( $V{QTYREF2_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY2_PER7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF2_SUM7}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM7}.subtract($V{QTYREF2_SUM7}).divide( $V{QTYREF2_SUM7}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY2_PER8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{QTYREF2_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM8}.subtract($V{QTYREF2_SUM8}).divide( $V{QTYREF2_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY2_PER8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF2_SUM8}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM8}.subtract($V{QTYREF2_SUM8}).divide( $V{QTYREF2_SUM8}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY2_PER9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{QTYREF2_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM9}.subtract($V{QTYREF2_SUM9}).divide( $V{QTYREF2_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY2_PER9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF2_SUM9}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM9}.subtract($V{QTYREF2_SUM9}).divide( $V{QTYREF2_SUM9}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="QTY2_PER10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{QTYREF2_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM10}.subtract($V{QTYREF2_SUM10}).divide( $V{QTYREF2_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></variableExpression>
+	<variable name="QTY2_PER10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF2_SUM10}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO:$V{QTY_SUM10}.subtract($V{QTYREF2_SUM10}).divide( $V{QTYREF2_SUM10}, 2, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100"))]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{MARGIN_1}!=null && $V{MARGINREF_1}!=null )?$V{MARGIN_1}.subtract( $V{MARGINREF_1}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_1}!=null && $V{MARGINREF_1}!=null )?$V{MARGIN_1}.subtract( $V{MARGINREF_1}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{MARGIN_2}!=null && $V{MARGINREF_2}!=null )?$V{MARGIN_2}.subtract( $V{MARGINREF_2}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_2}!=null && $V{MARGINREF_2}!=null )?$V{MARGIN_2}.subtract( $V{MARGINREF_2}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{MARGIN_3}!=null && $V{MARGINREF_3}!=null )?$V{MARGIN_3}.subtract( $V{MARGINREF_3}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_3}!=null && $V{MARGINREF_3}!=null )?$V{MARGIN_3}.subtract( $V{MARGINREF_3}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{MARGIN_4}!=null && $V{MARGINREF_4}!=null )?$V{MARGIN_4}.subtract( $V{MARGINREF_4}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_4}!=null && $V{MARGINREF_4}!=null )?$V{MARGIN_4}.subtract( $V{MARGINREF_4}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{MARGIN_5}!=null && $V{MARGINREF_5}!=null )?$V{MARGIN_5}.subtract( $V{MARGINREF_5}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_5}!=null && $V{MARGINREF_5}!=null )?$V{MARGIN_5}.subtract( $V{MARGINREF_5}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{MARGIN_6}!=null && $V{MARGINREF_6}!=null )?$V{MARGIN_6}.subtract( $V{MARGINREF_6}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_6}!=null && $V{MARGINREF_6}!=null )?$V{MARGIN_6}.subtract( $V{MARGINREF_6}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{MARGIN_7}!=null && $V{MARGINREF_7}!=null )?$V{MARGIN_7}.subtract( $V{MARGINREF_7}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_7}!=null && $V{MARGINREF_7}!=null )?$V{MARGIN_7}.subtract( $V{MARGINREF_7}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{MARGIN_8}!=null && $V{MARGINREF_8}!=null )?$V{MARGIN_8}.subtract( $V{MARGINREF_8}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_8}!=null && $V{MARGINREF_8}!=null )?$V{MARGIN_8}.subtract( $V{MARGINREF_8}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{MARGIN_9}!=null && $V{MARGINREF_9}!=null )?$V{MARGIN_9}.subtract( $V{MARGINREF_9}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_9}!=null && $V{MARGINREF_9}!=null )?$V{MARGIN_9}.subtract( $V{MARGINREF_9}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{MARGIN_10}!=null && $V{MARGINREF_10}!=null )?$V{MARGIN_10}.subtract( $V{MARGINREF_10}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_10}!=null && $V{MARGINREF_10}!=null )?$V{MARGIN_10}.subtract( $V{MARGINREF_10}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF2_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{MARGIN_1}!=null && $V{MARGINREF2_1}!=null )?$V{MARGIN_1}.subtract( $V{MARGINREF2_1}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF2_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_1}!=null && $V{MARGINREF2_1}!=null )?$V{MARGIN_1}.subtract( $V{MARGINREF2_1}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF2_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{MARGIN_2}!=null && $V{MARGINREF2_2}!=null )?$V{MARGIN_2}.subtract( $V{MARGINREF2_2}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF2_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_2}!=null && $V{MARGINREF2_2}!=null )?$V{MARGIN_2}.subtract( $V{MARGINREF2_2}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF2_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{MARGIN_3}!=null && $V{MARGINREF2_3}!=null )?$V{MARGIN_3}.subtract( $V{MARGINREF2_3}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF2_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_3}!=null && $V{MARGINREF2_3}!=null )?$V{MARGIN_3}.subtract( $V{MARGINREF2_3}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF2_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{MARGIN_4}!=null && $V{MARGINREF2_4}!=null )?$V{MARGIN_4}.subtract( $V{MARGINREF2_4}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF2_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_4}!=null && $V{MARGINREF2_4}!=null )?$V{MARGIN_4}.subtract( $V{MARGINREF2_4}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF2_5" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL5">
-		<variableExpression><![CDATA[($V{MARGIN_5}!=null && $V{MARGINREF2_5}!=null )?$V{MARGIN_5}.subtract( $V{MARGINREF2_5}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF2_5" resetType="Group" resetGroup="NIVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_5}!=null && $V{MARGINREF2_5}!=null )?$V{MARGIN_5}.subtract( $V{MARGINREF2_5}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF2_6" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL6">
-		<variableExpression><![CDATA[($V{MARGIN_6}!=null && $V{MARGINREF2_6}!=null )?$V{MARGIN_6}.subtract( $V{MARGINREF2_6}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF2_6" resetType="Group" resetGroup="NIVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_6}!=null && $V{MARGINREF2_6}!=null )?$V{MARGIN_6}.subtract( $V{MARGINREF2_6}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF2_7" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL7">
-		<variableExpression><![CDATA[($V{MARGIN_7}!=null && $V{MARGINREF2_7}!=null )?$V{MARGIN_7}.subtract( $V{MARGINREF2_7}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF2_7" resetType="Group" resetGroup="NIVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_7}!=null && $V{MARGINREF2_7}!=null )?$V{MARGIN_7}.subtract( $V{MARGINREF2_7}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF2_8" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL8">
-		<variableExpression><![CDATA[($V{MARGIN_8}!=null && $V{MARGINREF2_8}!=null )?$V{MARGIN_8}.subtract( $V{MARGINREF2_8}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF2_8" resetType="Group" resetGroup="NIVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_8}!=null && $V{MARGINREF2_8}!=null )?$V{MARGIN_8}.subtract( $V{MARGINREF2_8}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF2_9" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL9">
-		<variableExpression><![CDATA[($V{MARGIN_9}!=null && $V{MARGINREF2_9}!=null )?$V{MARGIN_9}.subtract( $V{MARGINREF2_9}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF2_9" resetType="Group" resetGroup="NIVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_9}!=null && $V{MARGINREF2_9}!=null )?$V{MARGIN_9}.subtract( $V{MARGINREF2_9}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="MARGINDIFF2_10" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL10">
-		<variableExpression><![CDATA[($V{MARGIN_10}!=null && $V{MARGINREF2_10}!=null )?$V{MARGIN_10}.subtract( $V{MARGINREF2_10}):BigDecimal.ZERO]]></variableExpression>
+	<variable name="MARGINDIFF2_10" resetType="Group" resetGroup="NIVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{MARGIN_10}!=null && $V{MARGINREF2_10}!=null )?$V{MARGIN_10}.subtract( $V{MARGINREF2_10}):BigDecimal.ZERO]]></expression>
 	</variable>
-	<variable name="QTY_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="COST_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
 	<variable name="PROFIT_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{AMOUNT_TOTAL}.subtract($V{COST_TOTAL})]]></variableExpression>
+		<expression><![CDATA[$V{AMOUNT_TOTAL}.subtract($V{COST_TOTAL})]]></expression>
 	</variable>
 	<variable name="MARGIN_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[($V{AMOUNT_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_TOTAL}.divide($V{AMOUNT_TOTAL}, 10, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_TOTAL}.signum()))]]></variableExpression>
+		<expression><![CDATA[($V{AMOUNT_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_TOTAL}.divide($V{AMOUNT_TOTAL}, 10, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_TOTAL}.signum()))]]></expression>
 	</variable>
-	<variable name="COSTREF_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF}]]></variableExpression>
+	<variable name="COSTREF_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF}]]></expression>
 	</variable>
 	<variable name="PROREF_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{AMOUNTREF_TOTAL}.subtract($V{COSTREF_TOTAL})]]></variableExpression>
+		<expression><![CDATA[$V{AMOUNTREF_TOTAL}.subtract($V{COSTREF_TOTAL})]]></expression>
 	</variable>
 	<variable name="MARGINREF_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[($V{AMOUNTREF_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROREF_TOTAL}.divide($V{AMOUNTREF_TOTAL}, 10, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROREF_TOTAL}.signum()))]]></variableExpression>
+		<expression><![CDATA[($V{AMOUNTREF_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROREF_TOTAL}.divide($V{AMOUNTREF_TOTAL}, 10, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROREF_TOTAL}.signum()))]]></expression>
 	</variable>
 	<variable name="MARGINDIFF_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{MARGIN_TOTAL}.subtract($V{MARGINREF_TOTAL})]]></variableExpression>
+		<expression><![CDATA[$V{MARGIN_TOTAL}.subtract($V{MARGINREF_TOTAL})]]></expression>
 	</variable>
-	<variable name="COSTREF2_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOSTREF2}]]></variableExpression>
+	<variable name="COSTREF2_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOSTREF2}]]></expression>
 	</variable>
 	<variable name="PROREF2_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{AMOUNTREF2_TOTAL}.subtract($V{COSTREF2_TOTAL})]]></variableExpression>
+		<expression><![CDATA[$V{AMOUNTREF2_TOTAL}.subtract($V{COSTREF2_TOTAL})]]></expression>
 	</variable>
 	<variable name="MARGINREF2_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[($V{AMOUNTREF2_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROREF2_TOTAL}.divide($V{AMOUNTREF2_TOTAL}, 10, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROREF2_TOTAL}.signum()))]]></variableExpression>
+		<expression><![CDATA[($V{AMOUNTREF2_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROREF2_TOTAL}.divide($V{AMOUNTREF2_TOTAL}, 10, BigDecimal.ROUND_HALF_UP).multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROREF2_TOTAL}.signum()))]]></expression>
 	</variable>
 	<variable name="MARGINDIFF2_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{MARGIN_TOTAL}.subtract($V{MARGINREF2_TOTAL})]]></variableExpression>
+		<expression><![CDATA[$V{MARGIN_TOTAL}.subtract($V{MARGINREF2_TOTAL})]]></expression>
 	</variable>
 	<group name="DocumentType"/>
 	<group name="TOTALIZE">
-		<groupExpression><![CDATA[]]></groupExpression>
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band splitType="Stretch"/>
 		</groupHeader>
 		<groupFooter>
 			<band height="23" splitType="Stretch">
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-21" style="Total_Field" x="190" y="1" width="55" height="16" uuid="9fb2a908-910a-4b65-8cb4-164f8d9a345e"/>
-					<box leftPadding="0">
+				<element kind="textField" uuid="9fb2a908-910a-4b65-8cb4-164f8d9a345e" key="textField-21" x="190" y="1" width="55" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{AMOUNT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-8" style="Report_Data_Label" x="150" y="1" width="40" height="16" uuid="06d9422b-4326-4f92-94ad-5497205a69d9"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="7"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="06d9422b-4326-4f92-94ad-5497205a69d9" key="staticText-8" x="150" y="1" width="40" height="16" fontSize="7.0" hTextAlign="Right" vTextAlign="Middle" style="Report_Data_Label">
 					<text><![CDATA[Total:]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-3" x="0" y="0" width="1210" height="1" uuid="452513fe-92eb-440a-a262-2d4486fe8570"/>
-				</line>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-23" style="Detail_Header" mode="Opaque" x="15" y="1" width="15" height="16" uuid="fe568cdf-35aa-42d9-9166-b84e950ebe97">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+					<box style="Report_Data_Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" evaluationTime="Report" pattern="##0.00" isBlankWhenNull="true">
-					<reportElement key="textField-22" style="Detail_Header" x="0" y="1" width="15" height="16" uuid="7ee0eb8d-0409-4e5b-9e55-697d7fe00ab1">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="line" uuid="452513fe-92eb-440a-a262-2d4486fe8570" key="line-3" x="0" y="0" width="1210" height="1"/>
+				<element kind="textField" uuid="fe568cdf-35aa-42d9-9166-b84e950ebe97" key="textField-23" mode="Opaque" x="15" y="1" width="15" height="16" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-24" style="Detail_Header" mode="Opaque" x="30" y="1" width="15" height="16" uuid="fe630179-a202-4f5f-9a28-18269984a089">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="7ee0eb8d-0409-4e5b-9e55-697d7fe00ab1" key="textField-22" x="0" y="1" width="15" height="16" rotation="None" fontSize="7.0" textAdjust="StretchHeight" evaluationTime="Report" pattern="##0.00" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-25" style="Detail_Header" mode="Opaque" x="45" y="1" width="15" height="16" uuid="50d25f06-235d-4add-a0ab-92a1b5a175ff">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="fe630179-a202-4f5f-9a28-18269984a089" key="textField-24" mode="Opaque" x="30" y="1" width="15" height="16" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-26" style="Detail_Header" mode="Opaque" x="60" y="1" width="15" height="16" uuid="3bc831c1-77b1-4964-8c19-8bb2997aa7ec">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="50d25f06-235d-4add-a0ab-92a1b5a175ff" key="textField-25" mode="Opaque" x="45" y="1" width="15" height="16" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-204" style="Total_Field" x="895" y="1" width="30" height="16" uuid="45a9e7d3-bd3e-4670-8a8d-5a1982a03b19"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="3bc831c1-77b1-4964-8c19-8bb2997aa7ec" key="textField-26" mode="Opaque" x="60" y="1" width="15" height="16" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":" ")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-300" style="Total_Field" x="925" y="1" width="30" height="16" uuid="bd676a01-044c-409e-8717-a2da2d89c518"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="45a9e7d3-bd3e-4670-8a8d-5a1982a03b19" key="textField-204" x="895" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{WEIGHT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-301" style="Total_Field" x="385" y="1" width="55" height="16" uuid="a9e26228-93f3-46fb-a5cb-41613f6e5a53"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="bd676a01-044c-409e-8717-a2da2d89c518" key="textField-300" x="925" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{WEIGHTREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-302" style="Total_Field" x="580" y="1" width="30" height="16" uuid="5ee3aeae-91c9-4533-a398-c7326057c92d"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="a9e26228-93f3-46fb-a5cb-41613f6e5a53" key="textField-301" x="385" y="1" width="55" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{AMOUNTREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PERTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PERTOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-303" style="Detail_Header" mode="Opaque" x="75" y="1" width="15" height="16" uuid="a727507b-346e-4764-bc0a-9af839ea5541">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=6)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="5ee3aeae-91c9-4533-a398-c7326057c92d" key="textField-302" x="580" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{AMOUNT_PERTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PERTOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(6))>=0)?"6":" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-304" style="Detail_Header" mode="Opaque" x="90" y="1" width="15" height="16" uuid="b0b61e9c-9e82-4caf-a321-f5b3a59db6a9">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=7)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="a727507b-346e-4764-bc0a-9af839ea5541" key="textField-303" mode="Opaque" x="75" y="1" width="15" height="16" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=6)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(6))>=0)?"6":" ")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(7))>=0)?"7":" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-305" style="Detail_Header" mode="Opaque" x="105" y="1" width="15" height="16" uuid="c4d316e3-86cd-4ea1-8480-acf51ff033f9">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=8)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="b0b61e9c-9e82-4caf-a321-f5b3a59db6a9" key="textField-304" mode="Opaque" x="90" y="1" width="15" height="16" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=7)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(7))>=0)?"7":" ")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(8))>=0)?"8":" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-306" style="Detail_Header" mode="Opaque" x="120" y="1" width="15" height="16" uuid="eb4d560e-dacc-46b3-b7cd-75b1f96fbecf">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=9)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="c4d316e3-86cd-4ea1-8480-acf51ff033f9" key="textField-305" mode="Opaque" x="105" y="1" width="15" height="16" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=8)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(8))>=0)?"8":" ")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(9))>=0)?"9":" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-307" style="Detail_Header" mode="Opaque" x="135" y="1" width="15" height="16" uuid="0c4c537a-89d7-4adb-8b1c-28d60a1680a3">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=10)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="eb4d560e-dacc-46b3-b7cd-75b1f96fbecf" key="textField-306" mode="Opaque" x="120" y="1" width="15" height="16" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=9)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(9))>=0)?"9":" ")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(10))>=0)?"10":" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-308" style="Total_Field" x="955" y="1" width="30" height="16" uuid="f0cc2218-66f6-4d1d-abba-7d958041a2cf"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="0c4c537a-89d7-4adb-8b1c-28d60a1680a3" key="textField-307" mode="Opaque" x="135" y="1" width="15" height="16" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=10)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(10))>=0)?"10":" ")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-310" style="Total_Field" x="835" y="1" width="30" height="16" uuid="7d5229c6-f334-4599-bdd0-31c24131e24c"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="f0cc2218-66f6-4d1d-abba-7d958041a2cf" key="textField-308" x="955" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{WEIGHTREF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT2_PERTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PERTOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-311" style="Total_Field" x="640" y="1" width="55" height="16" uuid="d2272432-890f-4993-be7b-d8ae56aef621"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="7d5229c6-f334-4599-bdd0-31c24131e24c" key="textField-310" x="835" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{AMOUNT2_PERTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PERTOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-21" style="Total_Field" x="245" y="1" width="55" height="16" uuid="53b8074b-7fb5-4c37-b36d-ce9901583e61"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="d2272432-890f-4993-be7b-d8ae56aef621" key="textField-311" x="640" y="1" width="55" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{AMOUNTREF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COST_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COST_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-21" style="Total_Field" x="300" y="1" width="55" height="16" uuid="24926af2-d2f8-4f47-84c8-92aa04ee8e84"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="53b8074b-7fb5-4c37-b36d-ce9901583e61" key="textField-21" x="245" y="1" width="55" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{COST_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COST_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFIT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-21" style="Total_Field" x="355" y="1" width="30" height="16" uuid="84c46484-9aa7-4166-a385-b37a68e2fbf2"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="24926af2-d2f8-4f47-84c8-92aa04ee8e84" key="textField-21" x="300" y="1" width="55" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{PROFIT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGIN_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-204" style="Total_Field" x="985" y="1" width="55" height="16" uuid="0d392591-7182-4974-a1fa-cff8e5bd28d8">
-						<printWhenExpression><![CDATA[$P{LEVEL1_LABEL}.equals("Product") || $P{LEVEL2_LABEL}.equals("Product") || $P{LEVEL3_LABEL}.equals("Product") || $P{LEVEL4_LABEL}.equals("Product") || $P{LEVEL5_LABEL}.equals("Product") || $P{LEVEL6_LABEL}.equals("Product") || $P{LEVEL7_LABEL}.equals("Product") || $P{LEVEL8_LABEL}.equals("Product") || $P{LEVEL9_LABEL}.equals("Product") || $P{LEVEL10_LABEL}.equals("Product")]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="84c46484-9aa7-4166-a385-b37a68e2fbf2" key="textField-21" x="355" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{MARGIN_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{QTY_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-301" style="Total_Field" x="440" y="1" width="55" height="16" uuid="2272fc63-700b-40d0-8a4c-cc55133e6a6c"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="0d392591-7182-4974-a1fa-cff8e5bd28d8" key="textField-204" x="985" y="1" width="55" height="16" evaluationTime="Report" pattern="" blankWhenNull="false" bold="false" hTextAlign="Right" style="Total_Field">
+					<printWhenExpression><![CDATA[$P{LEVEL1_LABEL}.equals("Product") || $P{LEVEL2_LABEL}.equals("Product") || $P{LEVEL3_LABEL}.equals("Product") || $P{LEVEL4_LABEL}.equals("Product") || $P{LEVEL5_LABEL}.equals("Product") || $P{LEVEL6_LABEL}.equals("Product") || $P{LEVEL7_LABEL}.equals("Product") || $P{LEVEL8_LABEL}.equals("Product") || $P{LEVEL9_LABEL}.equals("Product") || $P{LEVEL10_LABEL}.equals("Product")]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{QTY_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-301" style="Total_Field" x="495" y="1" width="55" height="16" uuid="cdc41b26-840e-4c81-91ab-2275e6bdafe6"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="2272fc63-700b-40d0-8a4c-cc55133e6a6c" key="textField-301" x="440" y="1" width="55" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{COSTREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PROREF_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-301" style="Total_Field" x="695" y="1" width="55" height="16" uuid="2df96f7a-c1a5-4cf1-83e9-27d368db16bd"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="cdc41b26-840e-4c81-91ab-2275e6bdafe6" key="textField-301" x="495" y="1" width="55" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{PROREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PROREF_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-301" style="Total_Field" x="750" y="1" width="55" height="16" uuid="d68573a3-7cf0-4f20-96c9-7650b4d40e81"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="2df96f7a-c1a5-4cf1-83e9-27d368db16bd" key="textField-301" x="695" y="1" width="55" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{COSTREF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROREF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PROREF2_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-302" style="Total_Field" x="550" y="1" width="30" height="16" uuid="93ccc7e4-31d6-49f6-a2b9-d1f385168b5c"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="d68573a3-7cf0-4f20-96c9-7650b4d40e81" key="textField-301" x="750" y="1" width="55" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{PROREF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PROREF2_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-302" style="Total_Field" x="610" y="1" width="30" height="16" uuid="eaed9c3a-bb2c-43a9-b715-130dc6829f95"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="93ccc7e4-31d6-49f6-a2b9-d1f385168b5c" key="textField-302" x="550" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{MARGINREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-302" style="Total_Field" x="805" y="1" width="30" height="16" uuid="e1951452-d0b9-4ada-94c6-942e8436ae28"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="eaed9c3a-bb2c-43a9-b715-130dc6829f95" key="textField-302" x="610" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{MARGINDIFF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-302" style="Total_Field" x="865" y="1" width="30" height="16" uuid="3d09de74-e0eb-4d28-b6f3-f55e36762726"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="e1951452-d0b9-4ada-94c6-942e8436ae28" key="textField-302" x="805" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{MARGINREF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="3d09de74-e0eb-4d28-b6f3-f55e36762726" key="textField-302" x="865" y="1" width="30" height="16" fontSize="7.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{MARGINDIFF2_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="NIVEL1">
-		<groupExpression><![CDATA[$F{NIVEL1}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL1}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="150" height="18" uuid="e6bf8381-b02d-4792-a429-1b45fad1fcb9"/>
-					<box rightPadding="2">
+				<element kind="textField" uuid="e6bf8381-b02d-4792-a429-1b45fad1fcb9" key="textField" stretchType="ContainerHeight" x="0" y="0" width="150" height="18" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[$F{NIVEL1}]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL1}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-155" style="Level1_Line" stretchType="RelativeToBandHeight" x="190" y="0" width="55" height="18" uuid="4fa54048-5a01-4a92-895c-6374d1b6f2d9"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4fa54048-5a01-4a92-895c-6374d1b6f2d9" key="textField-155" stretchType="ContainerHeight" x="190" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-154" style="Level1_Line" stretchType="RelativeToBandHeight" x="245" y="0" width="55" height="18" uuid="3db88354-6147-4fce-97b7-e59615c0de31"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3db88354-6147-4fce-97b7-e59615c0de31" key="textField-154" stretchType="ContainerHeight" x="245" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{COST_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COST_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-153" style="Level1_Line" stretchType="RelativeToBandHeight" x="300" y="0" width="55" height="18" uuid="ae60a323-dd5c-4b5b-9f3a-62cc91f3ed97"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ae60a323-dd5c-4b5b-9f3a-62cc91f3ed97" key="textField-153" stretchType="ContainerHeight" x="300" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{PROFIT_1}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFIT_1}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" x="355" y="0" width="30" height="18" uuid="2f77cb2b-5447-414e-9ad7-e5326d8d457f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2f77cb2b-5447-414e-9ad7-e5326d8d457f" key="textField" stretchType="ContainerHeight" x="355" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{MARGIN_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGIN_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-152" style="Level1_Line" stretchType="RelativeToBandHeight" x="895" y="0" width="30" height="18" uuid="3938ba7f-b4f9-4c25-9397-2791b86ab474"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3938ba7f-b4f9-4c25-9397-2791b86ab474" key="textField-152" stretchType="ContainerHeight" x="895" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" x="985" y="0" width="55" height="18" uuid="5fb7a645-8584-4076-812f-342bfe624a9c">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5fb7a645-8584-4076-812f-342bfe624a9c" key="textField" stretchType="ContainerHeight" x="985" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-210" style="Level1_Line" stretchType="RelativeToBandHeight" x="1095" y="0" width="30" height="18" uuid="e613e201-8b33-4908-a080-d7b3d8deca81">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e613e201-8b33-4908-a080-d7b3d8deca81" key="textField-210" stretchType="ContainerHeight" x="1095" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER1}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PER1}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" isBlankWhenNull="false">
-					<reportElement key="textField-220" style="Level1_Line" stretchType="RelativeToBandHeight" x="1040" y="0" width="55" height="18" uuid="63ed7077-409d-4cd6-9fea-8c940bab03ff">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="63ed7077-409d-4cd6-9fea-8c940bab03ff" key="textField-220" stretchType="ContainerHeight" x="1040" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-230" style="Level1_Line" stretchType="RelativeToBandHeight" x="925" y="0" width="30" height="18" uuid="07eb0765-7ea8-431c-a1de-2e7c642c73c9"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="07eb0765-7ea8-431c-a1de-2e7c642c73c9" key="textField-230" stretchType="ContainerHeight" x="925" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-240" style="Level1_Line" stretchType="RelativeToBandHeight" x="610" y="0" width="30" height="18" uuid="57f3745a-1f26-4852-b1a1-48cfae53c042"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="57f3745a-1f26-4852-b1a1-48cfae53c042" key="textField-240" stretchType="ContainerHeight" x="610" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{MARGINDIFF_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-250" style="Level1_Line" stretchType="RelativeToBandHeight" x="580" y="0" width="30" height="18" uuid="f9a4d004-cd0e-4c23-be9a-c50c84a2b7bb"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f9a4d004-cd0e-4c23-be9a-c50c84a2b7bb" key="textField-250" stretchType="ContainerHeight" x="580" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{AMOUNT_PER1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-260" style="Level1_Line" stretchType="RelativeToBandHeight" x="550" y="0" width="30" height="18" uuid="2857d57c-82c4-41d0-beb6-798f69eae465"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2857d57c-82c4-41d0-beb6-798f69eae465" key="textField-260" stretchType="ContainerHeight" x="550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{MARGINREF_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-270" style="Level1_Line" stretchType="RelativeToBandHeight" x="495" y="0" width="55" height="18" uuid="72b7d847-e30f-41a3-a336-91e59d5ae192"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="72b7d847-e30f-41a3-a336-91e59d5ae192" key="textField-270" stretchType="ContainerHeight" x="495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{PROFITREF_1}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF_1}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-280" style="Level1_Line" stretchType="RelativeToBandHeight" x="440" y="0" width="55" height="18" uuid="3b7af5b4-57d4-49da-a403-3e980e806c7a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3b7af5b4-57d4-49da-a403-3e980e806c7a" key="textField-280" stretchType="ContainerHeight" x="440" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{COSTREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-290" style="Level1_Line" stretchType="RelativeToBandHeight" x="385" y="0" width="55" height="18" uuid="b4664325-c342-4997-b711-93b7a5173022"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b4664325-c342-4997-b711-93b7a5173022" key="textField-290" stretchType="ContainerHeight" x="385" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Auto" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-309" style="Level1_Line" stretchType="RelativeToBandHeight" x="150" y="0" width="40" height="18" uuid="3cefd6b4-56cc-4a03-809d-40370bddc619"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="3cefd6b4-56cc-4a03-809d-40370bddc619" key="textField-309" stretchType="ContainerHeight" x="150" y="0" width="40" height="18" fontSize="7.0" evaluationTime="Auto" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Level1_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM1}!=null && $V{AMOUNT_TOTAL}!=null)?new String("(") + $P{NUMBERFORMAT}.format($V{AMOUNT_SUM1}.doubleValue() / $V{AMOUNT_TOTAL}.doubleValue() * 100.00 ) + new String(" %)"):new String(" ")]]></expression>
+					<box rightPadding="3" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM1}!=null && $V{AMOUNT_TOTAL}!=null)?new String("(") + $P{NUMBERFORMAT}.format($V{AMOUNT_SUM1}.doubleValue() / $V{AMOUNT_TOTAL}.doubleValue() * 100.00 ) + new String(" %)"):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-300" style="Level1_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="55" height="18" uuid="dc283db4-a347-49d7-9d7d-8b058aa68c82"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="dc283db4-a347-49d7-9d7d-8b058aa68c82" key="textField-300" stretchType="ContainerHeight" x="640" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{AMOUNTREF2_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF2_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-310" style="Level1_Line" stretchType="RelativeToBandHeight" x="695" y="0" width="55" height="18" uuid="87131295-c57b-4895-bce5-0b082366c2c4"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="87131295-c57b-4895-bce5-0b082366c2c4" key="textField-310" stretchType="ContainerHeight" x="695" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{COSTREF2_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF2_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-320" style="Level1_Line" stretchType="RelativeToBandHeight" x="750" y="0" width="55" height="18" uuid="e442e342-d41e-4148-a52b-edddc9c9d22b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e442e342-d41e-4148-a52b-edddc9c9d22b" key="textField-320" stretchType="ContainerHeight" x="750" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{PROFITREF2_1}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF2_1}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-330" style="Level1_Line" stretchType="RelativeToBandHeight" x="805" y="0" width="30" height="18" uuid="16762514-2ad8-480c-99d8-aef96ba79cdc"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="16762514-2ad8-480c-99d8-aef96ba79cdc" key="textField-330" stretchType="ContainerHeight" x="805" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{MARGINREF2_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF2_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-340" style="Level1_Line" stretchType="RelativeToBandHeight" x="835" y="0" width="30" height="18" uuid="6de3c680-f9ce-4db1-a3de-bf47af142686"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6de3c680-f9ce-4db1-a3de-bf47af142686" key="textField-340" stretchType="ContainerHeight" x="835" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{AMOUNT2_PER1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT2_PER1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-350" style="Level1_Line" stretchType="RelativeToBandHeight" x="865" y="0" width="30" height="18" uuid="d1d4de62-6aa7-4df2-82d2-cf886ad5543b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d1d4de62-6aa7-4df2-82d2-cf886ad5543b" key="textField-350" stretchType="ContainerHeight" x="865" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{MARGINDIFF2_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF2_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-360" style="Level1_Line" stretchType="RelativeToBandHeight" x="955" y="0" width="30" height="18" uuid="58bb0954-7c95-4db8-a2bb-732d0bcb76d2"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="58bb0954-7c95-4db8-a2bb-732d0bcb76d2" key="textField-360" stretchType="ContainerHeight" x="955" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{WEIGHTREF2_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF2_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" isBlankWhenNull="false">
-					<reportElement key="textField-370" style="Level1_Line" stretchType="RelativeToBandHeight" x="1125" y="0" width="55" height="18" uuid="0d968b13-0a88-4d0f-9634-fca78b08c221">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0d968b13-0a88-4d0f-9634-fca78b08c221" key="textField-370" stretchType="ContainerHeight" x="1125" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF2_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF2_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-380" style="Level1_Line" stretchType="RelativeToBandHeight" x="1180" y="0" width="30" height="18" uuid="ad6c6531-0c50-45a5-b0ca-9c350d82916a">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ad6c6531-0c50-45a5-b0ca-9c350d82916a" key="textField-380" stretchType="ContainerHeight" x="1180" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY2_PER1}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY2_PER1}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER1}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -2071,358 +1790,249 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL2">
-		<groupExpression><![CDATA[$F{NIVEL2}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL2}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-2" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="f64fed27-d501-493f-bfe1-8cdfc2a2db74"/>
-					<box>
+				<element kind="textField" uuid="f64fed27-d501-493f-bfe1-8cdfc2a2db74" key="textField-2" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="175" height="18" uuid="1906af41-82cc-4472-b71d-240888b3e2c8"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1906af41-82cc-4472-b71d-240888b3e2c8" key="textField" stretchType="ContainerHeight" x="15" y="0" width="175" height="18" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[$F{NIVEL2}]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL2}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" x="190" y="0" width="55" height="18" uuid="a9fda08e-526a-4044-8df7-2f3efee0351c"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a9fda08e-526a-4044-8df7-2f3efee0351c" key="textField" stretchType="ContainerHeight" x="190" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" x="985" y="0" width="55" height="18" uuid="713a26a5-5d44-4901-97b9-307d1f6aad5b">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="713a26a5-5d44-4901-97b9-307d1f6aad5b" key="textField" stretchType="ContainerHeight" x="985" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-156" style="Level2_Line" stretchType="RelativeToBandHeight" x="245" y="0" width="55" height="18" uuid="4d82b55c-ba18-4e71-8ef1-cf31298a34f8"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4d82b55c-ba18-4e71-8ef1-cf31298a34f8" key="textField-156" stretchType="ContainerHeight" x="245" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{COST_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COST_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-157" style="Level2_Line" stretchType="RelativeToBandHeight" x="300" y="0" width="55" height="18" uuid="0496751b-bc0c-41c3-aa2d-391ec305150e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0496751b-bc0c-41c3-aa2d-391ec305150e" key="textField-157" stretchType="ContainerHeight" x="300" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{PROFIT_2}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFIT_2}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-158" style="Level2_Line" stretchType="RelativeToBandHeight" x="355" y="0" width="30" height="18" uuid="f336abe0-0df4-4fd6-8b3f-547da972576a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f336abe0-0df4-4fd6-8b3f-547da972576a" key="textField-158" stretchType="ContainerHeight" x="355" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{MARGIN_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGIN_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-159" style="Level2_Line" stretchType="RelativeToBandHeight" x="895" y="0" width="30" height="18" uuid="a93e0a4b-e364-4160-b4cf-efdf52385433"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a93e0a4b-e364-4160-b4cf-efdf52385433" key="textField-159" stretchType="ContainerHeight" x="895" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-211" style="Level2_Line" stretchType="RelativeToBandHeight" x="1095" y="0" width="30" height="18" uuid="cbd7388d-01ed-4d99-b084-c2205f335400">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="cbd7388d-01ed-4d99-b084-c2205f335400" key="textField-211" stretchType="ContainerHeight" x="1095" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER2}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PER2}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" isBlankWhenNull="false">
-					<reportElement key="textField-221" style="Level2_Line" stretchType="RelativeToBandHeight" x="1040" y="0" width="55" height="18" uuid="74d04e52-602e-464a-a411-eede7c1b0552">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="74d04e52-602e-464a-a411-eede7c1b0552" key="textField-221" stretchType="ContainerHeight" x="1040" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-231" style="Level2_Line" stretchType="RelativeToBandHeight" x="925" y="0" width="30" height="18" uuid="4e9cfa3f-43cf-4c6f-acf1-128677c7a043"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4e9cfa3f-43cf-4c6f-acf1-128677c7a043" key="textField-231" stretchType="ContainerHeight" x="925" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-241" style="Level2_Line" stretchType="RelativeToBandHeight" x="610" y="0" width="30" height="18" uuid="75a4e0cc-e30a-4a13-a677-0ba6a8e8d998"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="75a4e0cc-e30a-4a13-a677-0ba6a8e8d998" key="textField-241" stretchType="ContainerHeight" x="610" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{MARGINDIFF_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-251" style="Level2_Line" stretchType="RelativeToBandHeight" x="580" y="0" width="30" height="18" uuid="1614b2ca-a60b-4945-8c29-1931e4a70441"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1614b2ca-a60b-4945-8c29-1931e4a70441" key="textField-251" stretchType="ContainerHeight" x="580" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{AMOUNT_PER2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-261" style="Level2_Line" stretchType="RelativeToBandHeight" x="550" y="0" width="30" height="18" uuid="ae34f94a-6ce8-4448-ba26-8e00db4fb2ec"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ae34f94a-6ce8-4448-ba26-8e00db4fb2ec" key="textField-261" stretchType="ContainerHeight" x="550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{MARGINREF_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-271" style="Level2_Line" stretchType="RelativeToBandHeight" x="495" y="0" width="55" height="18" uuid="c24c42df-878d-4c0a-bbef-90047e793aa4"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c24c42df-878d-4c0a-bbef-90047e793aa4" key="textField-271" stretchType="ContainerHeight" x="495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{PROFITREF_2}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF_2}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-281" style="Level2_Line" stretchType="RelativeToBandHeight" x="440" y="0" width="55" height="18" uuid="317d4179-d1ae-4767-957c-974a96962165"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="317d4179-d1ae-4767-957c-974a96962165" key="textField-281" stretchType="ContainerHeight" x="440" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{COSTREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-291" style="Level2_Line" stretchType="RelativeToBandHeight" x="385" y="0" width="55" height="18" uuid="9879e0e9-2095-47e4-a5da-f96bbbfedb83"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9879e0e9-2095-47e4-a5da-f96bbbfedb83" key="textField-291" stretchType="ContainerHeight" x="385" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-301" style="Level2_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="55" height="18" uuid="bd7b17a8-d9a1-4948-8b8a-9b163637fdc5"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="bd7b17a8-d9a1-4948-8b8a-9b163637fdc5" key="textField-301" stretchType="ContainerHeight" x="640" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{AMOUNTREF2_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF2_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-311" style="Level2_Line" stretchType="RelativeToBandHeight" x="695" y="0" width="55" height="18" uuid="350fbc3f-0cdc-45eb-93e2-9f87f5bdab23"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="350fbc3f-0cdc-45eb-93e2-9f87f5bdab23" key="textField-311" stretchType="ContainerHeight" x="695" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{COSTREF2_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF2_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-321" style="Level2_Line" stretchType="RelativeToBandHeight" x="750" y="0" width="55" height="18" uuid="a14acb85-00f8-4979-aad5-15df58b1c934"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a14acb85-00f8-4979-aad5-15df58b1c934" key="textField-321" stretchType="ContainerHeight" x="750" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{PROFITREF2_2}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF2_2}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-331" style="Level2_Line" stretchType="RelativeToBandHeight" x="805" y="0" width="30" height="18" uuid="7de8ca31-2b29-41dc-bdf1-2f2dce05d027"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7de8ca31-2b29-41dc-bdf1-2f2dce05d027" key="textField-331" stretchType="ContainerHeight" x="805" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{MARGINREF2_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF2_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-341" style="Level2_Line" stretchType="RelativeToBandHeight" x="835" y="0" width="30" height="18" uuid="1b7c0065-ceb3-4e36-b4cf-bbb5215ca6d2"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1b7c0065-ceb3-4e36-b4cf-bbb5215ca6d2" key="textField-341" stretchType="ContainerHeight" x="835" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{AMOUNT2_PER2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT2_PER2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-351" style="Level2_Line" stretchType="RelativeToBandHeight" x="865" y="0" width="30" height="18" uuid="c79c0d4e-052d-4655-ba70-57a6482424e9"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c79c0d4e-052d-4655-ba70-57a6482424e9" key="textField-351" stretchType="ContainerHeight" x="865" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{MARGINDIFF2_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF2_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" isBlankWhenNull="false">
-					<reportElement key="textField-361" style="Level2_Line" stretchType="RelativeToBandHeight" x="1125" y="0" width="55" height="18" uuid="0d6e2ae1-4bb6-4ff3-8d15-e839f420e3a3">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0d6e2ae1-4bb6-4ff3-8d15-e839f420e3a3" key="textField-361" stretchType="ContainerHeight" x="1125" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF2_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF2_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-371" style="Level2_Line" stretchType="RelativeToBandHeight" x="955" y="0" width="30" height="18" uuid="888215fe-7c64-433b-a14d-8b8f127b30a8"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="888215fe-7c64-433b-a14d-8b8f127b30a8" key="textField-371" stretchType="ContainerHeight" x="955" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{WEIGHTREF2_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF2_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-381" style="Level2_Line" stretchType="RelativeToBandHeight" x="1180" y="0" width="30" height="18" uuid="ffe92066-802e-4874-85f6-e3f0b69c2a9f">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ffe92066-802e-4874-85f6-e3f0b69c2a9f" key="textField-381" stretchType="ContainerHeight" x="1180" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY2_PER2}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY2_PER2}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER2}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -2432,371 +2042,258 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL3">
-		<groupExpression><![CDATA[$F{NIVEL3}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL3}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-3" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="cdad79c7-196c-4646-b74e-1e60a91166f9"/>
-					<box>
+				<element kind="textField" uuid="cdad79c7-196c-4646-b74e-1e60a91166f9" key="textField-3" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-8" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="75a9b111-d692-4496-bafc-e25d6c06f0e8"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="75a9b111-d692-4496-bafc-e25d6c06f0e8" key="textField-8" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="160" height="18" uuid="784539b9-f5c8-438c-b642-8f021ab52211"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="784539b9-f5c8-438c-b642-8f021ab52211" key="textField" stretchType="ContainerHeight" x="30" y="0" width="160" height="18" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[$F{NIVEL3}]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL3}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" x="190" y="0" width="55" height="18" uuid="35c7eb38-103e-4269-8b91-f86bdc8ebeb2"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="35c7eb38-103e-4269-8b91-f86bdc8ebeb2" key="textField" stretchType="ContainerHeight" x="190" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" x="985" y="0" width="55" height="18" uuid="5f316202-f0db-4fc0-8acc-fde636cb2ce4">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5f316202-f0db-4fc0-8acc-fde636cb2ce4" key="textField" stretchType="ContainerHeight" x="985" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-160" style="Level3_Line" stretchType="RelativeToBandHeight" x="245" y="0" width="55" height="18" uuid="fec9cbef-1175-4977-b419-0b6905c37399"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="fec9cbef-1175-4977-b419-0b6905c37399" key="textField-160" stretchType="ContainerHeight" x="245" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{COST_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COST_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-161" style="Level3_Line" stretchType="RelativeToBandHeight" x="300" y="0" width="55" height="18" uuid="b134af56-1b61-4e1e-86d9-c9ff80a6a95b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b134af56-1b61-4e1e-86d9-c9ff80a6a95b" key="textField-161" stretchType="ContainerHeight" x="300" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{PROFIT_3}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFIT_3}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-162" style="Level3_Line" stretchType="RelativeToBandHeight" x="355" y="0" width="30" height="18" uuid="675c83cf-4d83-4cf3-ad18-034ead665a86"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="675c83cf-4d83-4cf3-ad18-034ead665a86" key="textField-162" stretchType="ContainerHeight" x="355" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{MARGIN_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGIN_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-163" style="Level3_Line" stretchType="RelativeToBandHeight" x="895" y="0" width="30" height="18" uuid="4aa0eafa-03c2-4525-9abb-d51cc66adc84"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4aa0eafa-03c2-4525-9abb-d51cc66adc84" key="textField-163" stretchType="ContainerHeight" x="895" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-212" style="Level3_Line" stretchType="RelativeToBandHeight" x="1095" y="0" width="30" height="18" uuid="41bcf7f9-bfc8-44c4-9d58-06ee2c2d246c">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="41bcf7f9-bfc8-44c4-9d58-06ee2c2d246c" key="textField-212" stretchType="ContainerHeight" x="1095" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER3}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PER3}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" isBlankWhenNull="false">
-					<reportElement key="textField-222" style="Level3_Line" stretchType="RelativeToBandHeight" x="1040" y="0" width="55" height="18" uuid="c44b9451-6633-4508-96bb-a97978e6ced1">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c44b9451-6633-4508-96bb-a97978e6ced1" key="textField-222" stretchType="ContainerHeight" x="1040" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-232" style="Level3_Line" stretchType="RelativeToBandHeight" x="925" y="0" width="30" height="18" uuid="a7c0bbb9-9262-473e-a606-bb446547daa0"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a7c0bbb9-9262-473e-a606-bb446547daa0" key="textField-232" stretchType="ContainerHeight" x="925" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-242" style="Level3_Line" stretchType="RelativeToBandHeight" x="610" y="0" width="30" height="18" uuid="1a7fc5e3-afe5-4370-8775-eb6743692554"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1a7fc5e3-afe5-4370-8775-eb6743692554" key="textField-242" stretchType="ContainerHeight" x="610" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{MARGINDIFF_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-252" style="Level3_Line" stretchType="RelativeToBandHeight" x="580" y="0" width="30" height="18" uuid="a4895d17-bad9-4950-abbe-4f9e34d1863e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a4895d17-bad9-4950-abbe-4f9e34d1863e" key="textField-252" stretchType="ContainerHeight" x="580" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{AMOUNT_PER3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-262" style="Level3_Line" stretchType="RelativeToBandHeight" x="550" y="0" width="30" height="18" uuid="d7dae8b9-6898-4b55-a412-6151ca4babb1"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d7dae8b9-6898-4b55-a412-6151ca4babb1" key="textField-262" stretchType="ContainerHeight" x="550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{MARGINREF_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-272" style="Level3_Line" stretchType="RelativeToBandHeight" x="495" y="0" width="55" height="18" uuid="a8477b7d-1659-4ff5-a880-e5671ae181be"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a8477b7d-1659-4ff5-a880-e5671ae181be" key="textField-272" stretchType="ContainerHeight" x="495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{PROFITREF_3}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF_3}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-282" style="Level3_Line" stretchType="RelativeToBandHeight" x="440" y="0" width="55" height="18" uuid="29b41fde-1772-41c2-8259-46994094d13b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="29b41fde-1772-41c2-8259-46994094d13b" key="textField-282" stretchType="ContainerHeight" x="440" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{COSTREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-292" style="Level3_Line" stretchType="RelativeToBandHeight" x="385" y="0" width="55" height="18" uuid="874ea256-4a79-4e7f-88c5-84afd0a106d1"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="874ea256-4a79-4e7f-88c5-84afd0a106d1" key="textField-292" stretchType="ContainerHeight" x="385" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-302" style="Level3_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="55" height="18" uuid="16c41eb0-ba71-4a41-a51f-b6942e29f858"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="16c41eb0-ba71-4a41-a51f-b6942e29f858" key="textField-302" stretchType="ContainerHeight" x="640" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{AMOUNTREF2_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF2_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-312" style="Level3_Line" stretchType="RelativeToBandHeight" x="695" y="0" width="55" height="18" uuid="f39c5c9f-1a56-4381-b412-787046c56c11"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f39c5c9f-1a56-4381-b412-787046c56c11" key="textField-312" stretchType="ContainerHeight" x="695" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{COSTREF2_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF2_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-322" style="Level3_Line" stretchType="RelativeToBandHeight" x="750" y="0" width="55" height="18" uuid="dc14760d-783e-468c-9e4b-e07771c70d40"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="dc14760d-783e-468c-9e4b-e07771c70d40" key="textField-322" stretchType="ContainerHeight" x="750" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{PROFITREF2_3}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF2_3}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-332" style="Level3_Line" stretchType="RelativeToBandHeight" x="805" y="0" width="30" height="18" uuid="c7767592-5759-4c5c-b999-45c3e4f28c82"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c7767592-5759-4c5c-b999-45c3e4f28c82" key="textField-332" stretchType="ContainerHeight" x="805" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{MARGINREF2_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF2_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-342" style="Level3_Line" stretchType="RelativeToBandHeight" x="835" y="0" width="30" height="18" uuid="6a27aad3-1c35-4b9d-9965-9db171c77f28"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6a27aad3-1c35-4b9d-9965-9db171c77f28" key="textField-342" stretchType="ContainerHeight" x="835" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{AMOUNT2_PER3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT2_PER3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-352" style="Level3_Line" stretchType="RelativeToBandHeight" x="865" y="0" width="30" height="18" uuid="2a429a55-669c-460f-a9e4-5b2247b34d64"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2a429a55-669c-460f-a9e4-5b2247b34d64" key="textField-352" stretchType="ContainerHeight" x="865" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{MARGINDIFF2_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF2_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-362" style="Level3_Line" stretchType="RelativeToBandHeight" x="955" y="0" width="30" height="18" uuid="9c9152c4-bf7b-4ff5-9275-95a4e3c307e4"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9c9152c4-bf7b-4ff5-9275-95a4e3c307e4" key="textField-362" stretchType="ContainerHeight" x="955" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{WEIGHTREF2_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF2_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" isBlankWhenNull="false">
-					<reportElement key="textField-372" style="Level3_Line" stretchType="RelativeToBandHeight" x="1125" y="0" width="55" height="18" uuid="eafafb2b-041a-4be5-8acb-7342523fb7a8">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="eafafb2b-041a-4be5-8acb-7342523fb7a8" key="textField-372" stretchType="ContainerHeight" x="1125" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF2_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF2_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-382" style="Level3_Line" stretchType="RelativeToBandHeight" x="1180" y="0" width="30" height="18" uuid="e50f0147-af12-42af-a42d-495c2025fb3c">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e50f0147-af12-42af-a42d-495c2025fb3c" key="textField-382" stretchType="ContainerHeight" x="1180" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY2_PER3}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY2_PER3}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER3}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -2806,384 +2303,267 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL4">
-		<groupExpression><![CDATA[$F{NIVEL4}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL4}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-4" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="550e605a-034e-42f9-9c64-589921bbf18b"/>
-					<box>
+				<element kind="textField" uuid="550e605a-034e-42f9-9c64-589921bbf18b" key="textField-4" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-9" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="24e445b7-cf81-4e51-82e7-a8cf838e27aa"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="24e445b7-cf81-4e51-82e7-a8cf838e27aa" key="textField-9" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-6" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="f72abe23-0076-4b8e-a2c2-90bef194d6d7"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="f72abe23-0076-4b8e-a2c2-90bef194d6d7" key="textField-6" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="145" height="18" uuid="f626811a-dd3d-4ee1-a33c-f7b09ab0368b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f626811a-dd3d-4ee1-a33c-f7b09ab0368b" key="textField" stretchType="ContainerHeight" x="45" y="0" width="145" height="18" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[$F{NIVEL4}]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL4}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" x="190" y="0" width="55" height="18" uuid="ba5c85ae-3cef-4ca1-ba64-b0527a13dbcd"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ba5c85ae-3cef-4ca1-ba64-b0527a13dbcd" key="textField" stretchType="ContainerHeight" x="190" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" x="985" y="0" width="55" height="18" uuid="ff35563c-1bc8-475e-a0a5-c82f58eba691">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ff35563c-1bc8-475e-a0a5-c82f58eba691" key="textField" stretchType="ContainerHeight" x="985" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-164" style="Level4_Line" stretchType="RelativeToBandHeight" x="245" y="0" width="55" height="18" uuid="42bc981a-86b4-45b1-b29f-d6502b34ff0b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="42bc981a-86b4-45b1-b29f-d6502b34ff0b" key="textField-164" stretchType="ContainerHeight" x="245" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{COST_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COST_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-165" style="Level4_Line" stretchType="RelativeToBandHeight" x="300" y="0" width="55" height="18" uuid="f3b665e2-b3db-4b13-862c-f024dc528d5c"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f3b665e2-b3db-4b13-862c-f024dc528d5c" key="textField-165" stretchType="ContainerHeight" x="300" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{PROFIT_4}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFIT_4}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-166" style="Level4_Line" stretchType="RelativeToBandHeight" x="355" y="0" width="30" height="18" uuid="57183089-b611-460a-ad12-b572b86b5eb7"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="57183089-b611-460a-ad12-b572b86b5eb7" key="textField-166" stretchType="ContainerHeight" x="355" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{MARGIN_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGIN_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-167" style="Level4_Line" stretchType="RelativeToBandHeight" x="895" y="0" width="30" height="18" uuid="c892d90a-e45d-4459-82c8-7b2c32dee97d"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c892d90a-e45d-4459-82c8-7b2c32dee97d" key="textField-167" stretchType="ContainerHeight" x="895" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-213" style="Level4_Line" stretchType="RelativeToBandHeight" x="1095" y="0" width="30" height="18" uuid="7b301664-dcd4-44cc-90d5-6d34d53ecf9c">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7b301664-dcd4-44cc-90d5-6d34d53ecf9c" key="textField-213" stretchType="ContainerHeight" x="1095" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER4}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PER4}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" isBlankWhenNull="false">
-					<reportElement key="textField-223" style="Level4_Line" stretchType="RelativeToBandHeight" x="1040" y="0" width="55" height="18" uuid="1fd25459-0d16-49ae-90a1-4309e6e16839">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1fd25459-0d16-49ae-90a1-4309e6e16839" key="textField-223" stretchType="ContainerHeight" x="1040" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-233" style="Level4_Line" stretchType="RelativeToBandHeight" x="925" y="0" width="30" height="18" uuid="90132d67-8135-40a5-9d1c-e417d47c315c"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="90132d67-8135-40a5-9d1c-e417d47c315c" key="textField-233" stretchType="ContainerHeight" x="925" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-243" style="Level4_Line" stretchType="RelativeToBandHeight" x="610" y="0" width="30" height="18" uuid="7b04b56c-eb12-4f98-a3b0-968dd3b10028"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7b04b56c-eb12-4f98-a3b0-968dd3b10028" key="textField-243" stretchType="ContainerHeight" x="610" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{MARGINDIFF_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-253" style="Level4_Line" stretchType="RelativeToBandHeight" x="580" y="0" width="30" height="18" uuid="2dbb55de-ce57-45d6-850c-6a15d4f242fc"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2dbb55de-ce57-45d6-850c-6a15d4f242fc" key="textField-253" stretchType="ContainerHeight" x="580" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{AMOUNT_PER4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-263" style="Level4_Line" stretchType="RelativeToBandHeight" x="550" y="0" width="30" height="18" uuid="d159dd0c-98f9-4a34-923a-458d05e81464"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d159dd0c-98f9-4a34-923a-458d05e81464" key="textField-263" stretchType="ContainerHeight" x="550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{MARGINREF_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-273" style="Level4_Line" stretchType="RelativeToBandHeight" x="495" y="0" width="55" height="18" uuid="1d6a2514-99c1-40ec-bc82-e5fe77941173"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1d6a2514-99c1-40ec-bc82-e5fe77941173" key="textField-273" stretchType="ContainerHeight" x="495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{PROFITREF_4}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF_4}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-283" style="Level4_Line" stretchType="RelativeToBandHeight" x="440" y="0" width="55" height="18" uuid="6fe7da74-cac4-443f-8c93-b82ab967643d"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6fe7da74-cac4-443f-8c93-b82ab967643d" key="textField-283" stretchType="ContainerHeight" x="440" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{COSTREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-293" style="Level4_Line" stretchType="RelativeToBandHeight" x="385" y="0" width="55" height="18" uuid="32828165-cbb0-408e-b0e0-5cbb6f0d0fc0"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="32828165-cbb0-408e-b0e0-5cbb6f0d0fc0" key="textField-293" stretchType="ContainerHeight" x="385" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-303" style="Level4_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="55" height="18" uuid="18695b87-cd10-471d-9953-57738cdd8b26"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="18695b87-cd10-471d-9953-57738cdd8b26" key="textField-303" stretchType="ContainerHeight" x="640" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{AMOUNTREF2_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF2_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-313" style="Level4_Line" stretchType="RelativeToBandHeight" x="695" y="0" width="55" height="18" uuid="885c38d1-5eea-4baf-91ea-75ec99c91c51"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="885c38d1-5eea-4baf-91ea-75ec99c91c51" key="textField-313" stretchType="ContainerHeight" x="695" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{COSTREF2_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF2_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-323" style="Level4_Line" stretchType="RelativeToBandHeight" x="750" y="0" width="55" height="18" uuid="c25fb77c-6afe-4fed-9f54-a7f9f79c5ac4"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c25fb77c-6afe-4fed-9f54-a7f9f79c5ac4" key="textField-323" stretchType="ContainerHeight" x="750" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{PROFITREF2_4}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF2_4}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-333" style="Level4_Line" stretchType="RelativeToBandHeight" x="805" y="0" width="30" height="18" uuid="fba467d6-47b8-432d-aa0d-cceb906c4fc4"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="fba467d6-47b8-432d-aa0d-cceb906c4fc4" key="textField-333" stretchType="ContainerHeight" x="805" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{MARGINREF2_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF2_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-343" style="Level4_Line" stretchType="RelativeToBandHeight" x="835" y="0" width="30" height="18" uuid="503024ce-9278-4bbd-9c1d-b33a3732cbdf"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="503024ce-9278-4bbd-9c1d-b33a3732cbdf" key="textField-343" stretchType="ContainerHeight" x="835" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{AMOUNT2_PER4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT2_PER4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-353" style="Level4_Line" stretchType="RelativeToBandHeight" x="865" y="0" width="30" height="18" uuid="400845f1-09b3-4630-b63c-70e0ecc2087e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="400845f1-09b3-4630-b63c-70e0ecc2087e" key="textField-353" stretchType="ContainerHeight" x="865" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{MARGINDIFF2_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF2_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-363" style="Level4_Line" stretchType="RelativeToBandHeight" x="955" y="0" width="30" height="18" uuid="c7e7a6ab-fbab-48f3-a699-884cbbc90f9a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c7e7a6ab-fbab-48f3-a699-884cbbc90f9a" key="textField-363" stretchType="ContainerHeight" x="955" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{WEIGHTREF2_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF2_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" isBlankWhenNull="false">
-					<reportElement key="textField-373" style="Level4_Line" stretchType="RelativeToBandHeight" x="1125" y="0" width="55" height="18" uuid="c344db57-a1a2-44ec-bbd1-798b0dd1c5f5">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c344db57-a1a2-44ec-bbd1-798b0dd1c5f5" key="textField-373" stretchType="ContainerHeight" x="1125" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF2_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF2_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-383" style="Level4_Line" stretchType="RelativeToBandHeight" x="1180" y="0" width="30" height="18" uuid="6e8cbc7a-481b-4692-99dc-4b175e260f09">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6e8cbc7a-481b-4692-99dc-4b175e260f09" key="textField-383" stretchType="ContainerHeight" x="1180" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY2_PER4}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY2_PER4}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER4}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -3193,397 +2573,276 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL5">
-		<groupExpression><![CDATA[$F{NIVEL5}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL5}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-5" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="2ed926ee-d1bd-43b5-969b-ba0e46a81432"/>
-					<box>
+				<element kind="textField" uuid="2ed926ee-d1bd-43b5-969b-ba0e46a81432" key="textField-5" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-10" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="3c3ddda6-6d63-419e-a069-8aea3e4588e5"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="3c3ddda6-6d63-419e-a069-8aea3e4588e5" key="textField-10" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-7" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="27117c90-d0f2-44c0-81f9-0fc89ace5792"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="27117c90-d0f2-44c0-81f9-0fc89ace5792" key="textField-7" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-11" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="e6cb34ba-fc5b-4a14-bc5f-753ee3101d0b"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="e6cb34ba-fc5b-4a14-bc5f-753ee3101d0b" key="textField-11" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="130" height="18" uuid="55ee30af-7a1a-45f4-92c2-7fd96e3c6db7"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="55ee30af-7a1a-45f4-92c2-7fd96e3c6db7" key="textField" stretchType="ContainerHeight" x="60" y="0" width="130" height="18" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[$F{NIVEL5}]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL5}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" x="190" y="0" width="55" height="18" uuid="3bbb71d8-568f-48cf-b617-bc78f4de140f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3bbb71d8-568f-48cf-b617-bc78f4de140f" key="textField" stretchType="ContainerHeight" x="190" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" x="985" y="0" width="55" height="18" uuid="9e16a4fa-0f85-4442-9572-13341797fa1b">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9e16a4fa-0f85-4442-9572-13341797fa1b" key="textField" stretchType="ContainerHeight" x="985" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-168" style="Level5_Line" stretchType="RelativeToBandHeight" x="245" y="0" width="55" height="18" uuid="e384687a-0558-4f65-90fe-ffccd7229e16"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e384687a-0558-4f65-90fe-ffccd7229e16" key="textField-168" stretchType="ContainerHeight" x="245" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{COST_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COST_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-169" style="Level5_Line" stretchType="RelativeToBandHeight" x="300" y="0" width="55" height="18" uuid="eed9d96c-21f1-4531-a8b6-79fd246fee5d"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="eed9d96c-21f1-4531-a8b6-79fd246fee5d" key="textField-169" stretchType="ContainerHeight" x="300" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{PROFIT_5}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFIT_5}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-170" style="Level5_Line" stretchType="RelativeToBandHeight" x="355" y="0" width="30" height="18" uuid="864c8200-3ad8-4d29-970c-193656573a83"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="864c8200-3ad8-4d29-970c-193656573a83" key="textField-170" stretchType="ContainerHeight" x="355" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{MARGIN_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGIN_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-171" style="Level5_Line" stretchType="RelativeToBandHeight" x="895" y="0" width="30" height="18" uuid="5b538036-2324-40e8-8694-e60b53b72312"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5b538036-2324-40e8-8694-e60b53b72312" key="textField-171" stretchType="ContainerHeight" x="895" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-214" style="Level5_Line" stretchType="RelativeToBandHeight" x="1095" y="0" width="30" height="18" uuid="8e44e3c0-7a20-40fc-9585-adc0ba2df945">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="8e44e3c0-7a20-40fc-9585-adc0ba2df945" key="textField-214" stretchType="ContainerHeight" x="1095" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER5}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PER5}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" isBlankWhenNull="false">
-					<reportElement key="textField-224" style="Level5_Line" stretchType="RelativeToBandHeight" x="1040" y="0" width="55" height="18" uuid="802911b9-a5b3-48a7-8847-d4a2893f5ef8">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="802911b9-a5b3-48a7-8847-d4a2893f5ef8" key="textField-224" stretchType="ContainerHeight" x="1040" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-234" style="Level5_Line" stretchType="RelativeToBandHeight" x="925" y="0" width="30" height="18" uuid="373b3135-8ff7-4587-b6c2-15e8de8980ee"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="373b3135-8ff7-4587-b6c2-15e8de8980ee" key="textField-234" stretchType="ContainerHeight" x="925" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-244" style="Level5_Line" stretchType="RelativeToBandHeight" x="610" y="0" width="30" height="18" uuid="cb34f9d4-5c56-4353-b4ab-35978580d81a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="cb34f9d4-5c56-4353-b4ab-35978580d81a" key="textField-244" stretchType="ContainerHeight" x="610" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{MARGINDIFF_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-254" style="Level5_Line" stretchType="RelativeToBandHeight" x="580" y="0" width="30" height="18" uuid="3e110287-6c0e-4aa0-a6ad-52d88877a65f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3e110287-6c0e-4aa0-a6ad-52d88877a65f" key="textField-254" stretchType="ContainerHeight" x="580" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{AMOUNT_PER5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-264" style="Level5_Line" stretchType="RelativeToBandHeight" x="550" y="0" width="30" height="18" uuid="b1487a75-7f19-46ab-a7be-9080e15626a5"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b1487a75-7f19-46ab-a7be-9080e15626a5" key="textField-264" stretchType="ContainerHeight" x="550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{MARGINREF_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-274" style="Level5_Line" stretchType="RelativeToBandHeight" x="495" y="0" width="55" height="18" uuid="a6f1a456-dea9-4d74-a9a6-1e05bfac9980"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a6f1a456-dea9-4d74-a9a6-1e05bfac9980" key="textField-274" stretchType="ContainerHeight" x="495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{PROFITREF_5}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF_5}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-284" style="Level5_Line" stretchType="RelativeToBandHeight" x="440" y="0" width="55" height="18" uuid="2aca0d2a-7b27-407d-bad9-defc657a8d88"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2aca0d2a-7b27-407d-bad9-defc657a8d88" key="textField-284" stretchType="ContainerHeight" x="440" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{COSTREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-294" style="Level5_Line" stretchType="RelativeToBandHeight" x="385" y="0" width="55" height="18" uuid="ea71f1eb-6ae6-4b95-899b-2177a42ad540"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ea71f1eb-6ae6-4b95-899b-2177a42ad540" key="textField-294" stretchType="ContainerHeight" x="385" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-304" style="Level5_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="55" height="18" uuid="bd16f996-32fc-4ee0-bb00-b8e553b7d39b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="bd16f996-32fc-4ee0-bb00-b8e553b7d39b" key="textField-304" stretchType="ContainerHeight" x="640" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{AMOUNTREF2_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF2_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-314" style="Level5_Line" stretchType="RelativeToBandHeight" x="695" y="0" width="55" height="18" uuid="a214f9ea-f187-4b32-9244-58b7f8df3352"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a214f9ea-f187-4b32-9244-58b7f8df3352" key="textField-314" stretchType="ContainerHeight" x="695" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{COSTREF2_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF2_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-324" style="Level5_Line" stretchType="RelativeToBandHeight" x="750" y="0" width="55" height="18" uuid="580762a3-1075-4536-90ae-9f6a0fd129e8"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="580762a3-1075-4536-90ae-9f6a0fd129e8" key="textField-324" stretchType="ContainerHeight" x="750" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{PROFITREF2_5}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF2_5}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-334" style="Level5_Line" stretchType="RelativeToBandHeight" x="805" y="0" width="30" height="18" uuid="34f3dfce-6c38-43e5-a78d-7f4fe0689d6b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="34f3dfce-6c38-43e5-a78d-7f4fe0689d6b" key="textField-334" stretchType="ContainerHeight" x="805" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{MARGINREF2_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF2_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-344" style="Level5_Line" stretchType="RelativeToBandHeight" x="835" y="0" width="30" height="18" uuid="90a1a5b9-611d-4c69-894e-2c2fb1b9bdca"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="90a1a5b9-611d-4c69-894e-2c2fb1b9bdca" key="textField-344" stretchType="ContainerHeight" x="835" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{AMOUNT2_PER5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT2_PER5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-354" style="Level5_Line" stretchType="RelativeToBandHeight" x="865" y="0" width="30" height="18" uuid="6901cfa4-6dfd-448c-837a-37b4104ffc9b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6901cfa4-6dfd-448c-837a-37b4104ffc9b" key="textField-354" stretchType="ContainerHeight" x="865" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{MARGINDIFF2_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF2_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-364" style="Level5_Line" stretchType="RelativeToBandHeight" x="955" y="0" width="30" height="18" uuid="13d4ccfb-a534-4ad1-b610-5dd61c26ad11"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="13d4ccfb-a534-4ad1-b610-5dd61c26ad11" key="textField-364" stretchType="ContainerHeight" x="955" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{WEIGHTREF2_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF2_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" isBlankWhenNull="false">
-					<reportElement key="textField-374" style="Level5_Line" stretchType="RelativeToBandHeight" x="1125" y="0" width="55" height="18" uuid="27e0ecc0-f241-4efb-9b83-0cf8ca0eb8b1">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="27e0ecc0-f241-4efb-9b83-0cf8ca0eb8b1" key="textField-374" stretchType="ContainerHeight" x="1125" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF2_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF2_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-384" style="Level5_Line" stretchType="RelativeToBandHeight" x="1180" y="0" width="30" height="18" uuid="1f686685-60c1-425e-8bc9-ce696d370efb">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1f686685-60c1-425e-8bc9-ce696d370efb" key="textField-384" stretchType="ContainerHeight" x="1180" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY2_PER5}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY2_PER5}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER5}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -3593,410 +2852,285 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL6">
-		<groupExpression><![CDATA[$F{NIVEL6}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL6}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=6)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-70" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="2ad676be-91c9-42e6-92cd-d40377d94db4"/>
-					<box>
+				<element kind="textField" uuid="2ad676be-91c9-42e6-92cd-d40377d94db4" key="textField-70" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-72" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="ed0a3ac2-978a-4931-93a5-45b2116c509f"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="ed0a3ac2-978a-4931-93a5-45b2116c509f" key="textField-72" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-71" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="6bebb81f-3274-4533-9c14-50faedb97d0c"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="6bebb81f-3274-4533-9c14-50faedb97d0c" key="textField-71" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-73" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="9273bec7-2e30-4ed8-b1c8-9138d7d0c21d"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="9273bec7-2e30-4ed8-b1c8-9138d7d0c21d" key="textField-73" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-74" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="15" height="18" uuid="5dbcc4b1-b1e5-4120-a0aa-607e5d888b73"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="5dbcc4b1-b1e5-4120-a0aa-607e5d888b73" key="textField-74" stretchType="ContainerHeight" x="60" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-66" style="Level6_Line" stretchType="RelativeToBandHeight" x="75" y="0" width="115" height="18" uuid="a17e8e56-85d3-4fee-a173-e1277576c5ea"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a17e8e56-85d3-4fee-a173-e1277576c5ea" key="textField-66" stretchType="ContainerHeight" x="75" y="0" width="115" height="18" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[$F{NIVEL6}]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL6}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-69" style="Level6_Line" stretchType="RelativeToBandHeight" x="190" y="0" width="55" height="18" uuid="566ead43-28bf-41e9-9ab9-a90a6ed56656"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="566ead43-28bf-41e9-9ab9-a90a6ed56656" key="textField-69" stretchType="ContainerHeight" x="190" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" isBlankWhenNull="false">
-					<reportElement key="textField-68" style="Level6_Line" stretchType="RelativeToBandHeight" x="985" y="0" width="55" height="18" uuid="265ce143-edfa-4ca6-940a-f112d38e6ba7">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="265ce143-edfa-4ca6-940a-f112d38e6ba7" key="textField-68" stretchType="ContainerHeight" x="985" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-172" style="Level6_Line" stretchType="RelativeToBandHeight" x="245" y="0" width="55" height="18" uuid="da73d70f-3d0a-455a-ab28-02b3857f6e52"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="da73d70f-3d0a-455a-ab28-02b3857f6e52" key="textField-172" stretchType="ContainerHeight" x="245" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{COST_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COST_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-173" style="Level6_Line" stretchType="RelativeToBandHeight" x="300" y="0" width="55" height="18" uuid="4e8ea291-1150-430b-a6a8-f65cd3aa8629"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4e8ea291-1150-430b-a6a8-f65cd3aa8629" key="textField-173" stretchType="ContainerHeight" x="300" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{PROFIT_6}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFIT_6}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-174" style="Level6_Line" stretchType="RelativeToBandHeight" x="355" y="0" width="30" height="18" uuid="4587382d-c16e-438c-8a45-42d3fccba17f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4587382d-c16e-438c-8a45-42d3fccba17f" key="textField-174" stretchType="ContainerHeight" x="355" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{MARGIN_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGIN_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-175" style="Level6_Line" stretchType="RelativeToBandHeight" x="895" y="0" width="30" height="18" uuid="b2a3e2b6-1f8a-48cf-8f3b-6ff835220e45"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b2a3e2b6-1f8a-48cf-8f3b-6ff835220e45" key="textField-175" stretchType="ContainerHeight" x="895" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-215" style="Level6_Line" stretchType="RelativeToBandHeight" x="1095" y="0" width="30" height="18" uuid="92138d61-599d-4def-b7be-73413287f83f">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="92138d61-599d-4def-b7be-73413287f83f" key="textField-215" stretchType="ContainerHeight" x="1095" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER6}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PER6}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" isBlankWhenNull="false">
-					<reportElement key="textField-225" style="Level6_Line" stretchType="RelativeToBandHeight" x="1040" y="0" width="55" height="18" uuid="1fff8f85-f583-4727-84ac-a616c1d31723">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1fff8f85-f583-4727-84ac-a616c1d31723" key="textField-225" stretchType="ContainerHeight" x="1040" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-235" style="Level6_Line" stretchType="RelativeToBandHeight" x="925" y="0" width="30" height="18" uuid="fa19d349-87e9-4d77-a94e-e11060f35c58"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="fa19d349-87e9-4d77-a94e-e11060f35c58" key="textField-235" stretchType="ContainerHeight" x="925" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-245" style="Level6_Line" stretchType="RelativeToBandHeight" x="610" y="0" width="30" height="18" uuid="a063d550-f74e-47ba-8d95-2c730a9101cb"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a063d550-f74e-47ba-8d95-2c730a9101cb" key="textField-245" stretchType="ContainerHeight" x="610" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{MARGINDIFF_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-255" style="Level6_Line" stretchType="RelativeToBandHeight" x="580" y="0" width="30" height="18" uuid="3ff87d96-00ce-4d7f-bf06-bf4123bf2047"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3ff87d96-00ce-4d7f-bf06-bf4123bf2047" key="textField-255" stretchType="ContainerHeight" x="580" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{AMOUNT_PER6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-265" style="Level6_Line" stretchType="RelativeToBandHeight" x="550" y="0" width="30" height="18" uuid="2429a0c2-1409-49e6-a74c-176cfa96bdfb"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2429a0c2-1409-49e6-a74c-176cfa96bdfb" key="textField-265" stretchType="ContainerHeight" x="550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{MARGINREF_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-275" style="Level6_Line" stretchType="RelativeToBandHeight" x="495" y="0" width="55" height="18" uuid="6fa40c4c-c0f2-48ec-94e5-eb045c47cf73"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6fa40c4c-c0f2-48ec-94e5-eb045c47cf73" key="textField-275" stretchType="ContainerHeight" x="495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{PROFITREF_6}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF_6}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-285" style="Level6_Line" stretchType="RelativeToBandHeight" x="440" y="0" width="55" height="18" uuid="848d8122-7c6b-4fb3-8a50-242584154afa"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="848d8122-7c6b-4fb3-8a50-242584154afa" key="textField-285" stretchType="ContainerHeight" x="440" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{COSTREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-295" style="Level6_Line" stretchType="RelativeToBandHeight" x="385" y="0" width="55" height="18" uuid="728245be-8894-4529-b8fb-36b9db3b831d"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="728245be-8894-4529-b8fb-36b9db3b831d" key="textField-295" stretchType="ContainerHeight" x="385" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-305" style="Level6_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="55" height="18" uuid="f7f6d73b-5502-4bd6-9034-1eb9b4ed8cb1"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f7f6d73b-5502-4bd6-9034-1eb9b4ed8cb1" key="textField-305" stretchType="ContainerHeight" x="640" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{AMOUNTREF2_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF2_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-315" style="Level6_Line" stretchType="RelativeToBandHeight" x="695" y="0" width="55" height="18" uuid="ebc16755-363f-4351-bf9f-81017dfb940f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ebc16755-363f-4351-bf9f-81017dfb940f" key="textField-315" stretchType="ContainerHeight" x="695" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{COSTREF2_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF2_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-325" style="Level6_Line" stretchType="RelativeToBandHeight" x="750" y="0" width="55" height="18" uuid="e9a573a3-e708-4ef9-ba12-7568cd845d59"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e9a573a3-e708-4ef9-ba12-7568cd845d59" key="textField-325" stretchType="ContainerHeight" x="750" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{PROFITREF2_6}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF2_6}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-335" style="Level6_Line" stretchType="RelativeToBandHeight" x="805" y="0" width="30" height="18" uuid="485653d8-307e-4392-893b-d2f9b46aba07"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="485653d8-307e-4392-893b-d2f9b46aba07" key="textField-335" stretchType="ContainerHeight" x="805" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{MARGINREF2_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF2_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-345" style="Level6_Line" stretchType="RelativeToBandHeight" x="835" y="0" width="30" height="18" uuid="eb9d81c6-64b1-48bf-b672-2c66b6264ed9"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="eb9d81c6-64b1-48bf-b672-2c66b6264ed9" key="textField-345" stretchType="ContainerHeight" x="835" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{AMOUNT2_PER6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT2_PER6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-355" style="Level6_Line" stretchType="RelativeToBandHeight" x="865" y="0" width="30" height="18" uuid="59f2a6cd-a761-4a48-861d-fe63febccf1f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="59f2a6cd-a761-4a48-861d-fe63febccf1f" key="textField-355" stretchType="ContainerHeight" x="865" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{MARGINDIFF2_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF2_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-365" style="Level6_Line" stretchType="RelativeToBandHeight" x="955" y="0" width="30" height="18" uuid="b21bb954-8811-4e7b-b348-9c9180331174"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b21bb954-8811-4e7b-b348-9c9180331174" key="textField-365" stretchType="ContainerHeight" x="955" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{WEIGHTREF2_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF2_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" isBlankWhenNull="false">
-					<reportElement key="textField-375" style="Level6_Line" stretchType="RelativeToBandHeight" x="1125" y="0" width="55" height="18" uuid="65bf8884-bff8-477c-8279-5964a6386090">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="65bf8884-bff8-477c-8279-5964a6386090" key="textField-375" stretchType="ContainerHeight" x="1125" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF2_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF2_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-385" style="Level6_Line" stretchType="RelativeToBandHeight" x="1180" y="0" width="30" height="18" uuid="2992b8b8-9c4f-4eec-9902-e8f2108cbf7e">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2992b8b8-9c4f-4eec-9902-e8f2108cbf7e" key="textField-385" stretchType="ContainerHeight" x="1180" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY2_PER6}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY2_PER6}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER6}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -4006,423 +3140,294 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL7">
-		<groupExpression><![CDATA[$F{NIVEL7}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL7}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=7)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-79" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="1176cd31-dc9c-4518-89d4-34d4b83a6a31"/>
-					<box>
+				<element kind="textField" uuid="1176cd31-dc9c-4518-89d4-34d4b83a6a31" key="textField-79" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-81" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="c7eb30bc-c5af-41f4-805d-c7d70839e31c"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="c7eb30bc-c5af-41f4-805d-c7d70839e31c" key="textField-81" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-80" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="06aeb6ff-83ba-476b-bf69-d92a11209c0e"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="06aeb6ff-83ba-476b-bf69-d92a11209c0e" key="textField-80" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-82" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="a29df056-8cda-4a35-990f-6000860c0b2f"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="a29df056-8cda-4a35-990f-6000860c0b2f" key="textField-82" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-83" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="15" height="18" uuid="0184746b-8b56-4f66-b8ba-35580fcd6373"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="0184746b-8b56-4f66-b8ba-35580fcd6373" key="textField-83" stretchType="ContainerHeight" x="60" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-84" style="Level6_Line" stretchType="RelativeToBandHeight" x="75" y="0" width="15" height="18" uuid="31c4d993-9480-4d15-9262-445c15b1dc49"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="31c4d993-9480-4d15-9262-445c15b1dc49" key="textField-84" stretchType="ContainerHeight" x="75" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-75" style="Level7_Line" stretchType="RelativeToBandHeight" x="90" y="0" width="100" height="18" uuid="c3cbb0c8-6921-4453-ad09-2a9d495cd261"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c3cbb0c8-6921-4453-ad09-2a9d495cd261" key="textField-75" stretchType="ContainerHeight" x="90" y="0" width="100" height="18" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[$F{NIVEL7}]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL7}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-176" style="Level7_Line" stretchType="RelativeToBandHeight" x="190" y="0" width="55" height="18" uuid="892bc564-7b50-415d-87d5-c60442f77d82"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="892bc564-7b50-415d-87d5-c60442f77d82" key="textField-176" stretchType="ContainerHeight" x="190" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" isBlankWhenNull="false">
-					<reportElement key="textField-177" style="Level7_Line" stretchType="RelativeToBandHeight" x="985" y="0" width="55" height="18" uuid="078edc68-c402-4973-a32d-79aebcb0f714">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="078edc68-c402-4973-a32d-79aebcb0f714" key="textField-177" stretchType="ContainerHeight" x="985" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-179" style="Level7_Line" stretchType="RelativeToBandHeight" x="245" y="0" width="55" height="18" uuid="de3f2cc9-e275-4fe3-bfed-ca18aba4c988"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="de3f2cc9-e275-4fe3-bfed-ca18aba4c988" key="textField-179" stretchType="ContainerHeight" x="245" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{COST_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COST_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-180" style="Level7_Line" stretchType="RelativeToBandHeight" x="300" y="0" width="55" height="18" uuid="4f595fc6-5989-49fc-867e-c25231ce850e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4f595fc6-5989-49fc-867e-c25231ce850e" key="textField-180" stretchType="ContainerHeight" x="300" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{PROFIT_7}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFIT_7}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-181" style="Level7_Line" stretchType="RelativeToBandHeight" x="355" y="0" width="30" height="18" uuid="1fb47451-23f9-4a9e-b0ef-650723d9d378"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1fb47451-23f9-4a9e-b0ef-650723d9d378" key="textField-181" stretchType="ContainerHeight" x="355" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{MARGIN_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGIN_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-182" style="Level7_Line" stretchType="RelativeToBandHeight" x="895" y="0" width="30" height="18" uuid="de20b69e-9ee2-41f3-b004-dc5ee21ee681"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="de20b69e-9ee2-41f3-b004-dc5ee21ee681" key="textField-182" stretchType="ContainerHeight" x="895" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-216" style="Level7_Line" stretchType="RelativeToBandHeight" x="1095" y="0" width="30" height="18" uuid="1201ed1c-31ff-4589-9caa-3cd83c276a13">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1201ed1c-31ff-4589-9caa-3cd83c276a13" key="textField-216" stretchType="ContainerHeight" x="1095" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER7}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PER7}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" isBlankWhenNull="false">
-					<reportElement key="textField-226" style="Level7_Line" stretchType="RelativeToBandHeight" x="1040" y="0" width="55" height="18" uuid="79d430f1-9ce1-4c21-a934-2911188eb7af">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="79d430f1-9ce1-4c21-a934-2911188eb7af" key="textField-226" stretchType="ContainerHeight" x="1040" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-236" style="Level7_Line" stretchType="RelativeToBandHeight" x="925" y="0" width="30" height="18" uuid="25b0caaa-8634-45c7-b667-55b486b96df1"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="25b0caaa-8634-45c7-b667-55b486b96df1" key="textField-236" stretchType="ContainerHeight" x="925" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-246" style="Level7_Line" stretchType="RelativeToBandHeight" x="610" y="0" width="30" height="18" uuid="dedec825-3500-453f-a052-5f53a1465d52"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="dedec825-3500-453f-a052-5f53a1465d52" key="textField-246" stretchType="ContainerHeight" x="610" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{MARGINDIFF_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-256" style="Level7_Line" stretchType="RelativeToBandHeight" x="580" y="0" width="30" height="18" uuid="04e8c25a-bc47-4b46-8ed1-fb3b981ea4aa"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="04e8c25a-bc47-4b46-8ed1-fb3b981ea4aa" key="textField-256" stretchType="ContainerHeight" x="580" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{AMOUNT_PER7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-266" style="Level7_Line" stretchType="RelativeToBandHeight" x="550" y="0" width="30" height="18" uuid="d7ce19cc-0c8a-4f0f-b423-98994ae90a7b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d7ce19cc-0c8a-4f0f-b423-98994ae90a7b" key="textField-266" stretchType="ContainerHeight" x="550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{MARGINREF_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-276" style="Level7_Line" stretchType="RelativeToBandHeight" x="495" y="0" width="55" height="18" uuid="688e036f-7950-43ce-a4ac-8a28d992633b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="688e036f-7950-43ce-a4ac-8a28d992633b" key="textField-276" stretchType="ContainerHeight" x="495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{PROFITREF_7}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF_7}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-286" style="Level7_Line" stretchType="RelativeToBandHeight" x="440" y="0" width="55" height="18" uuid="b7a23395-5ca9-4a54-8c29-d241a3b1f532"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b7a23395-5ca9-4a54-8c29-d241a3b1f532" key="textField-286" stretchType="ContainerHeight" x="440" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{COSTREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-296" style="Level7_Line" stretchType="RelativeToBandHeight" x="385" y="0" width="55" height="18" uuid="9b8a2cc5-574e-4e5d-a54c-436ecc5e072a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9b8a2cc5-574e-4e5d-a54c-436ecc5e072a" key="textField-296" stretchType="ContainerHeight" x="385" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-306" style="Level7_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="55" height="18" uuid="da966d04-ade2-4cb6-a6cf-2b40c61fdca1"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="da966d04-ade2-4cb6-a6cf-2b40c61fdca1" key="textField-306" stretchType="ContainerHeight" x="640" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{AMOUNTREF2_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF2_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-316" style="Level7_Line" stretchType="RelativeToBandHeight" x="695" y="0" width="55" height="18" uuid="a45e400c-2400-41c2-a1d4-443a73a5d6e9"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a45e400c-2400-41c2-a1d4-443a73a5d6e9" key="textField-316" stretchType="ContainerHeight" x="695" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{COSTREF2_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF2_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-326" style="Level7_Line" stretchType="RelativeToBandHeight" x="750" y="0" width="55" height="18" uuid="77c452cb-e5a9-4af8-9e4d-aed56c013906"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="77c452cb-e5a9-4af8-9e4d-aed56c013906" key="textField-326" stretchType="ContainerHeight" x="750" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{PROFITREF2_7}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF2_7}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-336" style="Level7_Line" stretchType="RelativeToBandHeight" x="805" y="0" width="30" height="18" uuid="22631b15-f759-4220-8137-b71238623cff"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="22631b15-f759-4220-8137-b71238623cff" key="textField-336" stretchType="ContainerHeight" x="805" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{MARGINREF2_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF2_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-346" style="Level7_Line" stretchType="RelativeToBandHeight" x="835" y="0" width="30" height="18" uuid="543beca4-b1ae-4be2-9035-8256d67edfb0"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="543beca4-b1ae-4be2-9035-8256d67edfb0" key="textField-346" stretchType="ContainerHeight" x="835" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{AMOUNT2_PER7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT2_PER7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-356" style="Level7_Line" stretchType="RelativeToBandHeight" x="865" y="0" width="30" height="18" uuid="d3bbad18-a7fb-4869-a4e7-c5cef6dca296"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d3bbad18-a7fb-4869-a4e7-c5cef6dca296" key="textField-356" stretchType="ContainerHeight" x="865" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{MARGINDIFF2_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF2_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-366" style="Level7_Line" stretchType="RelativeToBandHeight" x="955" y="0" width="30" height="18" uuid="adec09f9-b413-4d08-a55a-0efde1882ae7"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="adec09f9-b413-4d08-a55a-0efde1882ae7" key="textField-366" stretchType="ContainerHeight" x="955" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{WEIGHTREF2_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF2_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" isBlankWhenNull="false">
-					<reportElement key="textField-376" style="Level7_Line" stretchType="RelativeToBandHeight" x="1125" y="0" width="55" height="18" uuid="86f7182a-c34a-4ed8-a371-9609500a8f86">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="86f7182a-c34a-4ed8-a371-9609500a8f86" key="textField-376" stretchType="ContainerHeight" x="1125" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF2_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF2_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-386" style="Level7_Line" stretchType="RelativeToBandHeight" x="1180" y="0" width="30" height="18" uuid="095c0da9-0a55-4325-b618-5b686cc87b97">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="095c0da9-0a55-4325-b618-5b686cc87b97" key="textField-386" stretchType="ContainerHeight" x="1180" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY2_PER7}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY2_PER7}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER7}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -4432,436 +3437,303 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL8">
-		<groupExpression><![CDATA[$F{NIVEL8}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL8}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=8)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-89" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="ebcfa79d-1feb-4146-bc5b-19d70719f731"/>
-					<box>
+				<element kind="textField" uuid="ebcfa79d-1feb-4146-bc5b-19d70719f731" key="textField-89" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-91" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="f8d806f7-170e-4dab-b356-5f2061eb7ba5"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="f8d806f7-170e-4dab-b356-5f2061eb7ba5" key="textField-91" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-90" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="d1c0ea49-4d9f-46f3-9400-7aef4dd6140e"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="d1c0ea49-4d9f-46f3-9400-7aef4dd6140e" key="textField-90" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-92" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="4b134c37-460b-499f-b7eb-fe4b42b79be9"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="4b134c37-460b-499f-b7eb-fe4b42b79be9" key="textField-92" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-93" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="15" height="18" uuid="b5f31535-668f-4f33-aa86-8bbbd297f122"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="b5f31535-668f-4f33-aa86-8bbbd297f122" key="textField-93" stretchType="ContainerHeight" x="60" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-94" style="Level6_Line" stretchType="RelativeToBandHeight" x="75" y="0" width="15" height="18" uuid="e907a7e7-cbba-4697-b3ef-327d85ebd0ff"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="e907a7e7-cbba-4697-b3ef-327d85ebd0ff" key="textField-94" stretchType="ContainerHeight" x="75" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-95" style="Level7_Line" stretchType="RelativeToBandHeight" x="90" y="0" width="15" height="18" uuid="062fd077-e665-4ccf-ae3c-1223e6909de6"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="062fd077-e665-4ccf-ae3c-1223e6909de6" key="textField-95" stretchType="ContainerHeight" x="90" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-85" style="Level8_Line" stretchType="RelativeToBandHeight" x="105" y="0" width="85" height="18" uuid="a503048b-7150-41c7-9841-c2d00619c8f5"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a503048b-7150-41c7-9841-c2d00619c8f5" key="textField-85" stretchType="ContainerHeight" x="105" y="0" width="85" height="18" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level8_Line">
+					<expression><![CDATA[$F{NIVEL8}]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL8}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-183" style="Level8_Line" stretchType="RelativeToBandHeight" x="190" y="0" width="55" height="18" uuid="cc9b923e-924d-428b-88b7-5e43bdcad4d9"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="cc9b923e-924d-428b-88b7-5e43bdcad4d9" key="textField-183" stretchType="ContainerHeight" x="190" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-186" style="Level8_Line" stretchType="RelativeToBandHeight" x="245" y="0" width="55" height="18" uuid="c3d39813-4ae0-4358-a9a4-ed390fefdf03"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c3d39813-4ae0-4358-a9a4-ed390fefdf03" key="textField-186" stretchType="ContainerHeight" x="245" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{COST_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COST_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-187" style="Level8_Line" stretchType="RelativeToBandHeight" x="300" y="0" width="55" height="18" uuid="704c3ded-f696-4283-b695-4bd0fd056324"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="704c3ded-f696-4283-b695-4bd0fd056324" key="textField-187" stretchType="ContainerHeight" x="300" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{PROFIT_8}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFIT_8}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-188" style="Level8_Line" stretchType="RelativeToBandHeight" x="355" y="0" width="30" height="18" uuid="e4d7731b-62b6-47fa-a2eb-5a68277e511b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e4d7731b-62b6-47fa-a2eb-5a68277e511b" key="textField-188" stretchType="ContainerHeight" x="355" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{MARGIN_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGIN_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-189" style="Level8_Line" stretchType="RelativeToBandHeight" x="895" y="0" width="30" height="18" uuid="29ea882f-adf1-4bed-b9e7-ad3ef9f662b8"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="29ea882f-adf1-4bed-b9e7-ad3ef9f662b8" key="textField-189" stretchType="ContainerHeight" x="895" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" isBlankWhenNull="false">
-					<reportElement key="textField-184" style="Level8_Line" stretchType="RelativeToBandHeight" x="985" y="0" width="55" height="18" uuid="f096221e-3fcb-41bd-a70e-4fb2565229f6">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f096221e-3fcb-41bd-a70e-4fb2565229f6" key="textField-184" stretchType="ContainerHeight" x="985" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-217" style="Level8_Line" stretchType="RelativeToBandHeight" x="1095" y="0" width="30" height="18" uuid="b77f7d4d-da21-4b52-9bec-b562be792033">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b77f7d4d-da21-4b52-9bec-b562be792033" key="textField-217" stretchType="ContainerHeight" x="1095" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER8}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PER8}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" isBlankWhenNull="false">
-					<reportElement key="textField-227" style="Level8_Line" stretchType="RelativeToBandHeight" x="1040" y="0" width="55" height="18" uuid="a0f86c04-ec00-4c50-93c0-f94ec3efe3cc">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a0f86c04-ec00-4c50-93c0-f94ec3efe3cc" key="textField-227" stretchType="ContainerHeight" x="1040" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-237" style="Level8_Line" stretchType="RelativeToBandHeight" x="925" y="0" width="30" height="18" uuid="5b1d6379-b5fc-408a-b7ab-808648329565"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5b1d6379-b5fc-408a-b7ab-808648329565" key="textField-237" stretchType="ContainerHeight" x="925" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-247" style="Level8_Line" stretchType="RelativeToBandHeight" x="610" y="0" width="30" height="18" uuid="bf1771b2-754f-4268-8273-766a6b7d8ff5"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="bf1771b2-754f-4268-8273-766a6b7d8ff5" key="textField-247" stretchType="ContainerHeight" x="610" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{MARGINDIFF_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-257" style="Level8_Line" stretchType="RelativeToBandHeight" x="580" y="0" width="30" height="18" uuid="12a47d58-23f6-462a-997a-6de102f4362d"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="12a47d58-23f6-462a-997a-6de102f4362d" key="textField-257" stretchType="ContainerHeight" x="580" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{AMOUNT_PER8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-267" style="Level8_Line" stretchType="RelativeToBandHeight" x="550" y="0" width="30" height="18" uuid="03c6308b-0cc9-46bd-8f8e-476543ff4bd5"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="03c6308b-0cc9-46bd-8f8e-476543ff4bd5" key="textField-267" stretchType="ContainerHeight" x="550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{MARGINREF_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-277" style="Level8_Line" stretchType="RelativeToBandHeight" x="495" y="0" width="55" height="18" uuid="5aeb5ba7-18de-4559-bfc0-60e87ef4111e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5aeb5ba7-18de-4559-bfc0-60e87ef4111e" key="textField-277" stretchType="ContainerHeight" x="495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{PROFITREF_8}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF_8}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-287" style="Level8_Line" stretchType="RelativeToBandHeight" x="440" y="0" width="55" height="18" uuid="045eff55-3876-42e1-9210-4edf4ea80f1b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="045eff55-3876-42e1-9210-4edf4ea80f1b" key="textField-287" stretchType="ContainerHeight" x="440" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{COSTREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-297" style="Level8_Line" stretchType="RelativeToBandHeight" x="385" y="0" width="55" height="18" uuid="e02cf4c9-7588-49b7-baf5-d580e15b7a4d"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e02cf4c9-7588-49b7-baf5-d580e15b7a4d" key="textField-297" stretchType="ContainerHeight" x="385" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-307" style="Level8_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="55" height="18" uuid="b55bb5f1-0aa6-4534-b364-f4d066c3d1d2"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b55bb5f1-0aa6-4534-b364-f4d066c3d1d2" key="textField-307" stretchType="ContainerHeight" x="640" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{AMOUNTREF2_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF2_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-317" style="Level8_Line" stretchType="RelativeToBandHeight" x="695" y="0" width="55" height="18" uuid="e7ae0c11-67da-423c-8017-bd02c47cfa14"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e7ae0c11-67da-423c-8017-bd02c47cfa14" key="textField-317" stretchType="ContainerHeight" x="695" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{COSTREF2_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF2_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-327" style="Level8_Line" stretchType="RelativeToBandHeight" x="750" y="0" width="55" height="18" uuid="5330e956-c1e1-4ffc-b045-dc8dde76668c"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5330e956-c1e1-4ffc-b045-dc8dde76668c" key="textField-327" stretchType="ContainerHeight" x="750" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{PROFITREF2_8}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF2_8}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-337" style="Level8_Line" stretchType="RelativeToBandHeight" x="805" y="0" width="30" height="18" uuid="eafab551-e4ff-40ec-97f9-6771eb21e0a7"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="eafab551-e4ff-40ec-97f9-6771eb21e0a7" key="textField-337" stretchType="ContainerHeight" x="805" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{MARGINREF2_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF2_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-347" style="Level8_Line" stretchType="RelativeToBandHeight" x="835" y="0" width="30" height="18" uuid="e649edb2-6318-4789-a6d0-229b3c0617cf"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e649edb2-6318-4789-a6d0-229b3c0617cf" key="textField-347" stretchType="ContainerHeight" x="835" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{AMOUNT2_PER8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT2_PER8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-357" style="Level8_Line" stretchType="RelativeToBandHeight" x="865" y="0" width="30" height="18" uuid="028c294e-5592-4307-a7e5-f212f5fda4e4"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="028c294e-5592-4307-a7e5-f212f5fda4e4" key="textField-357" stretchType="ContainerHeight" x="865" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{MARGINDIFF2_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF2_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-367" style="Level8_Line" stretchType="RelativeToBandHeight" x="955" y="0" width="30" height="18" uuid="56708364-9c7f-4a40-ac8e-0ddf71971a04"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="56708364-9c7f-4a40-ac8e-0ddf71971a04" key="textField-367" stretchType="ContainerHeight" x="955" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{WEIGHTREF2_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF2_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" isBlankWhenNull="false">
-					<reportElement key="textField-377" style="Level8_Line" stretchType="RelativeToBandHeight" x="1125" y="0" width="55" height="18" uuid="532d1008-3484-4573-b3a7-4482ea3fded5">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="532d1008-3484-4573-b3a7-4482ea3fded5" key="textField-377" stretchType="ContainerHeight" x="1125" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF2_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF2_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-387" style="Level8_Line" stretchType="RelativeToBandHeight" x="1180" y="0" width="30" height="18" uuid="67b25e69-7add-4f85-b4e5-4c8a5d9c8aa4">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="67b25e69-7add-4f85-b4e5-4c8a5d9c8aa4" key="textField-387" stretchType="ContainerHeight" x="1180" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY2_PER8}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY2_PER8}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER8}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -4871,449 +3743,312 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL9">
-		<groupExpression><![CDATA[$F{NIVEL9}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL9}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=9)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-100" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="97e5580b-1575-4619-b97c-b467fdbb3ce6"/>
-					<box>
+				<element kind="textField" uuid="97e5580b-1575-4619-b97c-b467fdbb3ce6" key="textField-100" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-102" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="78f98ed3-d486-4007-94f1-0a70ffbc2ec9"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="78f98ed3-d486-4007-94f1-0a70ffbc2ec9" key="textField-102" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-101" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="8ba5288e-59b7-4005-b59b-bf78cff37730"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="8ba5288e-59b7-4005-b59b-bf78cff37730" key="textField-101" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-103" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="6776f74b-c5a9-4d6b-b57c-f94341c7e897"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="6776f74b-c5a9-4d6b-b57c-f94341c7e897" key="textField-103" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-104" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="15" height="18" uuid="cc2e425c-806a-444c-9976-b4a6483ea5c5"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="cc2e425c-806a-444c-9976-b4a6483ea5c5" key="textField-104" stretchType="ContainerHeight" x="60" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-105" style="Level6_Line" stretchType="RelativeToBandHeight" x="75" y="0" width="15" height="18" uuid="7d083a0b-935c-47fe-ac82-071f37ebdeed"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="7d083a0b-935c-47fe-ac82-071f37ebdeed" key="textField-105" stretchType="ContainerHeight" x="75" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-106" style="Level7_Line" stretchType="RelativeToBandHeight" x="90" y="0" width="15" height="18" uuid="1c56c795-1984-4406-a912-82861c0bbfd0"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="1c56c795-1984-4406-a912-82861c0bbfd0" key="textField-106" stretchType="ContainerHeight" x="90" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-107" style="Level8_Line" stretchType="RelativeToBandHeight" x="105" y="0" width="15" height="18" uuid="5d49b3b3-2253-4f89-9b60-2ba1be6aa5d0"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="5d49b3b3-2253-4f89-9b60-2ba1be6aa5d0" key="textField-107" stretchType="ContainerHeight" x="105" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level8_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-96" style="Level9_Line" stretchType="RelativeToBandHeight" x="120" y="0" width="70" height="18" uuid="77be46ab-82bd-45ad-8f77-3e8e3b25cf38"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="77be46ab-82bd-45ad-8f77-3e8e3b25cf38" key="textField-96" stretchType="ContainerHeight" x="120" y="0" width="70" height="18" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level9_Line">
+					<expression><![CDATA[$F{NIVEL9}]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL9}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-190" style="Level9_Line" stretchType="RelativeToBandHeight" x="190" y="0" width="55" height="18" uuid="babd27b7-e744-40aa-aa63-bc02b93aecbf"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="babd27b7-e744-40aa-aa63-bc02b93aecbf" key="textField-190" stretchType="ContainerHeight" x="190" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-191" style="Level9_Line" stretchType="RelativeToBandHeight" x="245" y="0" width="55" height="18" uuid="24546d04-321e-4a7b-a5f3-52a0867248fd"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="24546d04-321e-4a7b-a5f3-52a0867248fd" key="textField-191" stretchType="ContainerHeight" x="245" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{COST_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COST_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-192" style="Level9_Line" stretchType="RelativeToBandHeight" x="300" y="0" width="55" height="18" uuid="94df1714-26f2-46d7-8977-b3cf0116c3dd"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="94df1714-26f2-46d7-8977-b3cf0116c3dd" key="textField-192" stretchType="ContainerHeight" x="300" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{PROFIT_9}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFIT_9}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-193" style="Level9_Line" stretchType="RelativeToBandHeight" x="355" y="0" width="30" height="18" uuid="79cc9120-2d3e-4401-8d4e-1139fbe9a602"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="79cc9120-2d3e-4401-8d4e-1139fbe9a602" key="textField-193" stretchType="ContainerHeight" x="355" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{MARGIN_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGIN_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-194" style="Level9_Line" stretchType="RelativeToBandHeight" x="895" y="0" width="30" height="18" uuid="7c56651a-5b4a-4fe0-a10d-bf0c53ff80d0"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7c56651a-5b4a-4fe0-a10d-bf0c53ff80d0" key="textField-194" stretchType="ContainerHeight" x="895" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" isBlankWhenNull="false">
-					<reportElement key="textField-196" style="Level9_Line" stretchType="RelativeToBandHeight" x="985" y="0" width="55" height="18" uuid="b6443e15-b531-4ec8-9ceb-a0903cad9229">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b6443e15-b531-4ec8-9ceb-a0903cad9229" key="textField-196" stretchType="ContainerHeight" x="985" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-218" style="Level9_Line" stretchType="RelativeToBandHeight" x="1095" y="0" width="30" height="18" uuid="88000bd9-f7da-4b66-9b0e-b7e1ad09476f">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="88000bd9-f7da-4b66-9b0e-b7e1ad09476f" key="textField-218" stretchType="ContainerHeight" x="1095" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER9}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PER9}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" isBlankWhenNull="false">
-					<reportElement key="textField-228" style="Level9_Line" stretchType="RelativeToBandHeight" x="1040" y="0" width="55" height="18" uuid="6063bb39-894e-4322-8321-95a1fc044d93">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6063bb39-894e-4322-8321-95a1fc044d93" key="textField-228" stretchType="ContainerHeight" x="1040" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-238" style="Level9_Line" stretchType="RelativeToBandHeight" x="925" y="0" width="30" height="18" uuid="8b64aec6-3d51-4c43-bad6-8ee0e59438d7"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="8b64aec6-3d51-4c43-bad6-8ee0e59438d7" key="textField-238" stretchType="ContainerHeight" x="925" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-248" style="Level9_Line" stretchType="RelativeToBandHeight" x="610" y="0" width="30" height="18" uuid="8623bc21-a089-46e2-8c26-9d9df95a293c"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="8623bc21-a089-46e2-8c26-9d9df95a293c" key="textField-248" stretchType="ContainerHeight" x="610" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{MARGINDIFF_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-258" style="Level9_Line" stretchType="RelativeToBandHeight" x="580" y="0" width="30" height="18" uuid="20deed1c-f2e1-4599-9142-2ac118124ac0"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="20deed1c-f2e1-4599-9142-2ac118124ac0" key="textField-258" stretchType="ContainerHeight" x="580" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{AMOUNT_PER9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-268" style="Level9_Line" stretchType="RelativeToBandHeight" x="550" y="0" width="30" height="18" uuid="ae4f951b-99dd-407f-86fc-301d564e66a4"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ae4f951b-99dd-407f-86fc-301d564e66a4" key="textField-268" stretchType="ContainerHeight" x="550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{MARGINREF_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-278" style="Level9_Line" stretchType="RelativeToBandHeight" x="495" y="0" width="55" height="18" uuid="83147221-52b3-4cfa-85dc-cd7cdde89673"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="83147221-52b3-4cfa-85dc-cd7cdde89673" key="textField-278" stretchType="ContainerHeight" x="495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{PROFITREF_9}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF_9}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-288" style="Level9_Line" stretchType="RelativeToBandHeight" x="440" y="0" width="55" height="18" uuid="ea10ea4d-1fe4-4943-aa10-2628326cf096"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ea10ea4d-1fe4-4943-aa10-2628326cf096" key="textField-288" stretchType="ContainerHeight" x="440" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{COSTREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-298" style="Level9_Line" stretchType="RelativeToBandHeight" x="385" y="0" width="55" height="18" uuid="bd0bfc46-9e95-441f-8d6a-e4f80f3c201f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="bd0bfc46-9e95-441f-8d6a-e4f80f3c201f" key="textField-298" stretchType="ContainerHeight" x="385" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-308" style="Level9_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="55" height="18" uuid="9499d3c5-d8f0-411e-b225-9982bdf1188b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9499d3c5-d8f0-411e-b225-9982bdf1188b" key="textField-308" stretchType="ContainerHeight" x="640" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{AMOUNTREF2_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF2_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-318" style="Level9_Line" stretchType="RelativeToBandHeight" x="695" y="0" width="55" height="18" uuid="40d33563-57f1-4bda-98ee-79e9b3579fdf"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="40d33563-57f1-4bda-98ee-79e9b3579fdf" key="textField-318" stretchType="ContainerHeight" x="695" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{COSTREF2_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF2_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-328" style="Level9_Line" stretchType="RelativeToBandHeight" x="750" y="0" width="55" height="18" uuid="24d5e890-86bc-401e-bc33-1901223a7171"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="24d5e890-86bc-401e-bc33-1901223a7171" key="textField-328" stretchType="ContainerHeight" x="750" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{PROFITREF2_9}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF2_9}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-338" style="Level9_Line" stretchType="RelativeToBandHeight" x="805" y="0" width="30" height="18" uuid="0f8f4330-f1fe-4929-8b83-2442303363c2"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0f8f4330-f1fe-4929-8b83-2442303363c2" key="textField-338" stretchType="ContainerHeight" x="805" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{MARGINREF2_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF2_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-348" style="Level9_Line" stretchType="RelativeToBandHeight" x="835" y="0" width="30" height="18" uuid="06fa77c0-42a3-49c2-b536-333ff9fd9abd"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="06fa77c0-42a3-49c2-b536-333ff9fd9abd" key="textField-348" stretchType="ContainerHeight" x="835" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{AMOUNT2_PER9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT2_PER9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-358" style="Level9_Line" stretchType="RelativeToBandHeight" x="865" y="0" width="30" height="18" uuid="7156323e-2d58-4b72-8eb9-2556be57f339"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7156323e-2d58-4b72-8eb9-2556be57f339" key="textField-358" stretchType="ContainerHeight" x="865" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{MARGINDIFF2_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF2_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-368" style="Level9_Line" stretchType="RelativeToBandHeight" x="955" y="0" width="30" height="18" uuid="bc383bb1-7f82-498f-81d4-80a8477d9ed5"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="bc383bb1-7f82-498f-81d4-80a8477d9ed5" key="textField-368" stretchType="ContainerHeight" x="955" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{WEIGHTREF2_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF2_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" isBlankWhenNull="false">
-					<reportElement key="textField-378" style="Level9_Line" stretchType="RelativeToBandHeight" x="1125" y="0" width="55" height="18" uuid="347a1431-4e43-466d-ad53-88bb12418dea">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="347a1431-4e43-466d-ad53-88bb12418dea" key="textField-378" stretchType="ContainerHeight" x="1125" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF2_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF2_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-388" style="Level9_Line" stretchType="RelativeToBandHeight" x="1180" y="0" width="30" height="18" uuid="aeb99d70-943b-477c-8c20-5466402a6e27">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="aeb99d70-943b-477c-8c20-5466402a6e27" key="textField-388" stretchType="ContainerHeight" x="1180" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY2_PER9}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY2_PER9}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER9}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -5323,462 +4058,321 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL10">
-		<groupExpression><![CDATA[$F{NIVEL10}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL10}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=10)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-112" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="3d4855ac-11ba-489f-9865-c2562f1392df"/>
-					<box>
+				<element kind="textField" uuid="3d4855ac-11ba-489f-9865-c2562f1392df" key="textField-112" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-114" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="911c3620-3bb7-4c60-b013-2b6b0139cda2"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="911c3620-3bb7-4c60-b013-2b6b0139cda2" key="textField-114" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-113" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="937fae41-00e7-4566-a463-8a0ed05c8508"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="937fae41-00e7-4566-a463-8a0ed05c8508" key="textField-113" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-115" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="c3768869-733d-44a4-b30b-5abd53dd8239"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="c3768869-733d-44a4-b30b-5abd53dd8239" key="textField-115" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-116" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="15" height="18" uuid="29ef3d96-36ee-47df-b110-e9d9f03b6f68"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="29ef3d96-36ee-47df-b110-e9d9f03b6f68" key="textField-116" stretchType="ContainerHeight" x="60" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-117" style="Level6_Line" stretchType="RelativeToBandHeight" x="75" y="0" width="15" height="18" uuid="14758410-cb8b-481a-8c11-45f676330ba4"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="14758410-cb8b-481a-8c11-45f676330ba4" key="textField-117" stretchType="ContainerHeight" x="75" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-118" style="Level7_Line" stretchType="RelativeToBandHeight" x="90" y="0" width="15" height="18" uuid="58aee8e7-6981-47c8-9e0e-f84ed8796526"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="58aee8e7-6981-47c8-9e0e-f84ed8796526" key="textField-118" stretchType="ContainerHeight" x="90" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-119" style="Level8_Line" stretchType="RelativeToBandHeight" x="105" y="0" width="15" height="18" uuid="1410ce60-6e18-41f1-979a-72d2afed2152"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="1410ce60-6e18-41f1-979a-72d2afed2152" key="textField-119" stretchType="ContainerHeight" x="105" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level8_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-120" style="Level9_Line" stretchType="RelativeToBandHeight" x="120" y="0" width="15" height="18" uuid="f1084f8a-87fd-48c8-81d2-90b951e95308"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="f1084f8a-87fd-48c8-81d2-90b951e95308" key="textField-120" stretchType="ContainerHeight" x="120" y="0" width="15" height="18" rotation="Left" fontSize="7.0" blankWhenNull="true" style="Level9_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-108" style="Level10_Line" stretchType="RelativeToBandHeight" x="135" y="0" width="55" height="18" uuid="71f7cbd1-5269-4e89-9a71-5b7d66dd198e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="71f7cbd1-5269-4e89-9a71-5b7d66dd198e" key="textField-108" stretchType="ContainerHeight" x="135" y="0" width="55" height="18" fontSize="7.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level10_Line">
+					<expression><![CDATA[$F{NIVEL10}]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL10}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-197" style="Level10_Line" stretchType="RelativeToBandHeight" x="190" y="0" width="55" height="18" uuid="9bc1c414-4da5-4a99-b539-14e4863be114"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9bc1c414-4da5-4a99-b539-14e4863be114" key="textField-197" stretchType="ContainerHeight" x="190" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-198" style="Level10_Line" stretchType="RelativeToBandHeight" x="245" y="0" width="55" height="18" uuid="b7829a06-8ad5-4fbe-9b2c-589d3b255d50"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b7829a06-8ad5-4fbe-9b2c-589d3b255d50" key="textField-198" stretchType="ContainerHeight" x="245" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{COST_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COST_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-199" style="Level10_Line" stretchType="RelativeToBandHeight" x="300" y="0" width="55" height="18" uuid="ff84ce99-f8cf-4d21-aab6-aca97dcb96ea"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ff84ce99-f8cf-4d21-aab6-aca97dcb96ea" key="textField-199" stretchType="ContainerHeight" x="300" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{PROFIT_10}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFIT_10}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-200" style="Level10_Line" stretchType="RelativeToBandHeight" x="355" y="0" width="30" height="18" uuid="7cfef890-e83d-4d2a-b8ac-ca10964ca085"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7cfef890-e83d-4d2a-b8ac-ca10964ca085" key="textField-200" stretchType="ContainerHeight" x="355" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{MARGIN_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGIN_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-201" style="Level10_Line" stretchType="RelativeToBandHeight" x="895" y="0" width="30" height="18" uuid="137146eb-b6cd-4152-83a0-7543519428f7"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="137146eb-b6cd-4152-83a0-7543519428f7" key="textField-201" stretchType="ContainerHeight" x="895" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" isBlankWhenNull="false">
-					<reportElement key="textField-202" style="Level10_Line" stretchType="RelativeToBandHeight" x="985" y="0" width="55" height="18" uuid="145e1ebf-2bc6-4832-a6ec-65a2ebe1c499">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="145e1ebf-2bc6-4832-a6ec-65a2ebe1c499" key="textField-202" stretchType="ContainerHeight" x="985" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-219" style="Level10_Line" stretchType="RelativeToBandHeight" x="1095" y="0" width="30" height="18" uuid="bba6d7a3-9bee-432d-a1e1-f3bd6a16093d">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="bba6d7a3-9bee-432d-a1e1-f3bd6a16093d" key="textField-219" stretchType="ContainerHeight" x="1095" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PER10}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PER10}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PER10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" isBlankWhenNull="false">
-					<reportElement key="textField-229" style="Level10_Line" stretchType="RelativeToBandHeight" x="1040" y="0" width="55" height="18" uuid="450e5ae8-723f-44b7-bdc3-cbd6f1944f35">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="450e5ae8-723f-44b7-bdc3-cbd6f1944f35" key="textField-229" stretchType="ContainerHeight" x="1040" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-239" style="Level10_Line" stretchType="RelativeToBandHeight" x="925" y="0" width="30" height="18" uuid="806c77d9-d3db-494e-85aa-25e294f07a1d"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="806c77d9-d3db-494e-85aa-25e294f07a1d" key="textField-239" stretchType="ContainerHeight" x="925" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-249" style="Level10_Line" stretchType="RelativeToBandHeight" x="610" y="0" width="30" height="18" uuid="4c428c85-28ea-4d01-a14c-5b4b1a888425"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4c428c85-28ea-4d01-a14c-5b4b1a888425" key="textField-249" stretchType="ContainerHeight" x="610" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{MARGINDIFF_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-259" style="Level10_Line" stretchType="RelativeToBandHeight" x="580" y="0" width="30" height="18" uuid="1511d736-7c50-4efc-94da-086457ecc165"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1511d736-7c50-4efc-94da-086457ecc165" key="textField-259" stretchType="ContainerHeight" x="580" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{AMOUNT_PER10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_PER10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_PER10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-269" style="Level10_Line" stretchType="RelativeToBandHeight" x="550" y="0" width="30" height="18" uuid="82478d62-20d7-45da-bd23-a24cf99a26cb"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="82478d62-20d7-45da-bd23-a24cf99a26cb" key="textField-269" stretchType="ContainerHeight" x="550" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{MARGINREF_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-279" style="Level10_Line" stretchType="RelativeToBandHeight" x="495" y="0" width="55" height="18" uuid="8f12f63b-3bd7-44d0-af27-b106d7ce3e77"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="8f12f63b-3bd7-44d0-af27-b106d7ce3e77" key="textField-279" stretchType="ContainerHeight" x="495" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{PROFITREF_10}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF_10}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-289" style="Level10_Line" stretchType="RelativeToBandHeight" x="440" y="0" width="55" height="18" uuid="894f9268-40c8-4b4a-b216-ed6bc5dde8d0"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="894f9268-40c8-4b4a-b216-ed6bc5dde8d0" key="textField-289" stretchType="ContainerHeight" x="440" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{COSTREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-299" style="Level10_Line" stretchType="RelativeToBandHeight" x="385" y="0" width="55" height="18" uuid="d752bd5a-bfd1-49b8-b921-4269e4fc4bd2"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d752bd5a-bfd1-49b8-b921-4269e4fc4bd2" key="textField-299" stretchType="ContainerHeight" x="385" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{AMOUNTREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-309" style="Level10_Line" stretchType="RelativeToBandHeight" x="640" y="0" width="55" height="18" uuid="bbd259b9-f334-4f09-8222-da863f0ca06f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="bbd259b9-f334-4f09-8222-da863f0ca06f" key="textField-309" stretchType="ContainerHeight" x="640" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{AMOUNTREF2_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNTREF2_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNTREF2_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-319" style="Level10_Line" stretchType="RelativeToBandHeight" x="695" y="0" width="55" height="18" uuid="adb093a5-70c3-4a68-81ce-4b55e40a0eba"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="adb093a5-70c3-4a68-81ce-4b55e40a0eba" key="textField-319" stretchType="ContainerHeight" x="695" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{COSTREF2_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COSTREF2_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{COSTREF2_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-329" style="Level10_Line" stretchType="RelativeToBandHeight" x="750" y="0" width="55" height="18" uuid="3b7336ec-eb64-4add-9e62-eaf51bf5d669"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3b7336ec-eb64-4add-9e62-eaf51bf5d669" key="textField-329" stretchType="ContainerHeight" x="750" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{PROFITREF2_10}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFITREF2_10}!=null)?$P{NUMBERFORMAT}.format($V{PROFITREF2_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-339" style="Level10_Line" stretchType="RelativeToBandHeight" x="805" y="0" width="30" height="18" uuid="8ffb0258-ad01-439d-9fa2-46f76d87695b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="8ffb0258-ad01-439d-9fa2-46f76d87695b" key="textField-339" stretchType="ContainerHeight" x="805" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{MARGINREF2_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINREF2_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINREF2_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-349" style="Level10_Line" stretchType="RelativeToBandHeight" x="835" y="0" width="30" height="18" uuid="c2ff2933-6406-429d-b668-a48f9d6b4b7c"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c2ff2933-6406-429d-b668-a48f9d6b4b7c" key="textField-349" stretchType="ContainerHeight" x="835" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{AMOUNT2_PER10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT2_PER10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT2_PER10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-359" style="Level10_Line" stretchType="RelativeToBandHeight" x="865" y="0" width="30" height="18" uuid="d70b131c-d873-49f2-b3ea-6e3792baba40"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d70b131c-d873-49f2-b3ea-6e3792baba40" key="textField-359" stretchType="ContainerHeight" x="865" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{MARGINDIFF2_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGINDIFF2_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGINDIFF2_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-369" style="Level10_Line" stretchType="RelativeToBandHeight" x="955" y="0" width="30" height="18" uuid="764d451f-b129-4536-b4fc-639903dd1818"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="764d451f-b129-4536-b4fc-639903dd1818" key="textField-369" stretchType="ContainerHeight" x="955" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{WEIGHTREF2_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF2_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHTREF2_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" isBlankWhenNull="false">
-					<reportElement key="textField-379" style="Level10_Line" stretchType="RelativeToBandHeight" x="1125" y="0" width="55" height="18" uuid="6ed03112-6f58-47e2-a157-834ca31edffa">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6ed03112-6f58-47e2-a157-834ca31edffa" key="textField-379" stretchType="ContainerHeight" x="1125" y="0" width="55" height="18" fontSize="7.0" evaluationTime="Group" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF2_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF2_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF2_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-389" style="Level10_Line" stretchType="RelativeToBandHeight" x="1180" y="0" width="30" height="18" uuid="dc81849e-eb7d-4d37-941e-2df220bb5de7">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="dc81849e-eb7d-4d37-941e-2df220bb5de7" key="textField-389" stretchType="ContainerHeight" x="1180" y="0" width="30" height="18" fontSize="7.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY2_PER10}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY2_PER10}!=null)?$P{NUMBERFORMAT}.format($V{QTY2_PER10}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -5787,719 +4381,492 @@
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="140" splitType="Stretch">
-			<frame>
-				<reportElement key="frame-1" positionType="Float" mode="Opaque" x="0" y="117" width="1210" height="18" backcolor="#5D5D5D" uuid="c388299b-b60d-44ad-91c1-7d741e5989e0"/>
-				<box>
+	<background splitType="Stretch"/>
+	<title height="140" splitType="Stretch">
+		<element kind="frame" uuid="c388299b-b60d-44ad-91c1-7d741e5989e0" key="frame-1" positionType="Float" mode="Opaque" x="0" y="117" width="1210" height="18" backcolor="#5D5D5D">
+			<element kind="textField" uuid="c2511539-ac56-48b4-a778-5415b9dabbed" key="textField-61" positionType="Float" x="0" y="0" width="15" height="18" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-61" style="Detail_Header" positionType="Float" x="0" y="0" width="15" height="18" uuid="c2511539-ac56-48b4-a778-5415b9dabbed">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-62" style="Detail_Header" positionType="Float" x="15" y="0" width="15" height="18" uuid="a7816d27-529f-46d0-bb00-6f78fd0eb6e5">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-63" style="Detail_Header" positionType="Float" x="30" y="0" width="15" height="18" uuid="ef45b4e4-8464-419f-b83d-787520c6bafe">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-64" style="Detail_Header" positionType="Float" x="45" y="0" width="15" height="18" uuid="bcb6420c-59b1-482a-8e52-d23f84f4a52f">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-65" style="Detail_Header" positionType="Float" x="60" y="0" width="15" height="18" uuid="b2601050-66ec-40af-bf1e-67df74e7bccd">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-205" style="Detail_Header" positionType="Float" x="75" y="0" width="15" height="18" uuid="6fdbe13a-d38c-4f63-bf9e-473ce49abff2">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=6)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(6))>=0)?"6":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-206" style="Detail_Header" positionType="Float" x="90" y="0" width="15" height="18" uuid="38155ada-26a6-44f8-91e2-03c60b8e039e">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=7)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(7))>=0)?"7":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-207" style="Detail_Header" positionType="Float" x="105" y="0" width="15" height="18" uuid="07c25b90-6abb-40c7-ada7-12868ad941da">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=8)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(8))>=0)?"8":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-208" style="Detail_Header" positionType="Float" x="120" y="0" width="15" height="18" uuid="15464ed3-477e-4334-b72f-003fa1a99c9a">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=9)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(9))>=0)?"9":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-209" style="Detail_Header" positionType="Float" x="135" y="0" width="15" height="18" uuid="23c84b9d-8e2d-4d92-9707-3c1a91ae90f1">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=10)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(10))>=0)?"10":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-308" style="Detail_Header" positionType="Float" x="150" y="0" width="40" height="18" uuid="0a992d6a-846e-4f4b-b9cc-5ab6c3ec7a98"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Center" rotation="None">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-14" style="Detail_Header" positionType="Float" mode="Opaque" x="190" y="0" width="55" height="18" uuid="e473cb9e-2386-49ab-ac38-c06a792728c6"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-13" style="Detail_Header" positionType="Float" mode="Opaque" x="245" y="0" width="55" height="18" uuid="0d61bbea-38c0-4e84-b57b-09cccd2e9196"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Cost]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-12" style="Detail_Header" positionType="Float" mode="Opaque" x="300" y="0" width="55" height="18" uuid="f75848de-3bed-4f15-89ff-4d76dcf482f0"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Profit]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-9" style="Detail_Header" positionType="Float" mode="Opaque" x="355" y="0" width="30" height="18" uuid="eeac55d3-7281-4645-95b0-175a807ac842"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[M. %]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-15" style="Detail_Header" positionType="Float" mode="Opaque" x="385" y="0" width="55" height="18" uuid="1b29d528-f342-4f14-9ad6-c73ae0d64ab4"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Amt. ref]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-16" style="Detail_Header" positionType="Float" mode="Opaque" x="440" y="0" width="55" height="18" uuid="f1be451b-cc1f-4f82-83fc-4c334787f499"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Cost ref]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-17" style="Detail_Header" positionType="Float" mode="Opaque" x="495" y="0" width="55" height="18" uuid="5d24f3ae-36e8-4b12-87bd-aa73b86381fe"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Pro. ref]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-18" style="Detail_Header" positionType="Float" mode="Opaque" x="550" y="0" width="30" height="18" uuid="13c21663-5d4f-4742-8983-105d5b9b6ad4"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[M.r %]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-19" style="Detail_Header" positionType="Float" mode="Opaque" x="580" y="0" width="30" height="18" uuid="8eb2c1dd-be79-4607-a2e5-1028f41b66d2"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[A. %]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-20" style="Detail_Header" positionType="Float" mode="Opaque" x="610" y="0" width="30" height="18" uuid="7df683a3-6e8a-4695-8ec7-57d1b6be8bc0"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[M.dif]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-24" style="Detail_Header" positionType="Float" mode="Opaque" x="640" y="0" width="55" height="18" uuid="e9af3f2e-ffbb-4ee5-9c89-77c55cbf5ab7"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Amt. ref2]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-25" style="Detail_Header" positionType="Float" mode="Opaque" x="695" y="0" width="55" height="18" uuid="1f878cb2-f032-4f1c-bd3e-237624c76a5e"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Cost ref2]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-26" style="Detail_Header" positionType="Float" mode="Opaque" x="750" y="0" width="55" height="18" uuid="fc164802-c9dc-4d25-bda4-3619731866f9"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Pro. ref2]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-27" style="Detail_Header" positionType="Float" mode="Opaque" x="805" y="0" width="30" height="18" uuid="d00bb4cb-b84e-4704-b598-49953de72350"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[M.r2 %]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-28" style="Detail_Header" positionType="Float" mode="Opaque" x="835" y="0" width="30" height="18" uuid="a734603a-3b1f-43e9-aaab-45d9022af082"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[A.2 %]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-29" style="Detail_Header" positionType="Float" mode="Opaque" x="865" y="0" width="30" height="18" uuid="0de0cb9e-33c2-4729-9d68-63f60a3e2c52"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[M.dif2]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-11" style="Detail_Header" positionType="Float" mode="Opaque" x="895" y="0" width="30" height="18" uuid="39b00a66-fe48-44f8-99f6-4437b6c684aa"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Weight]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-21" style="Detail_Header" positionType="Float" mode="Opaque" x="925" y="0" width="30" height="18" uuid="8ecac167-2c13-4087-a8e3-22b398f4407c"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[W. Ref]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-30" style="Detail_Header" positionType="Float" mode="Opaque" x="955" y="0" width="30" height="18" uuid="765a6967-aa18-4f6a-933a-c7f54798c5b1"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[W.Ref2]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-10" style="Detail_Header" positionType="Float" mode="Opaque" x="985" y="0" width="55" height="18" uuid="4dc695fe-37a0-4b51-b34f-399012d048cd"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-23" style="Detail_Header" positionType="Float" mode="Opaque" x="1040" y="0" width="55" height="18" uuid="f98868c1-0ea7-4702-9b10-113cf697bd5f"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Q. ref]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-22" style="Detail_Header" positionType="Float" mode="Opaque" x="1095" y="0" width="30" height="18" uuid="0bce876f-52ca-4167-beb1-a88af320d8e7"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Qty%]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-31" style="Detail_Header" positionType="Float" mode="Opaque" x="1125" y="0" width="55" height="18" uuid="a3c8088e-3676-427c-8a9b-83982ffd427c"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Q. ref2]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-32" style="Detail_Header" positionType="Float" mode="Opaque" x="1180" y="0" width="30" height="18" uuid="abf51780-03fe-453e-8857-9ae47fcbb38b"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="7" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Qty2%]]></text>
-				</staticText>
-			</frame>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Report_Title" x="0" y="0" width="1210" height="26" uuid="dbd041f2-6a5b-44a3-a97a-506e5063f06f"/>
-				<box leftPadding="5">
+			</element>
+			<element kind="textField" uuid="a7816d27-529f-46d0-bb00-6f78fd0eb6e5" key="textField-62" positionType="Float" x="15" y="0" width="15" height="18" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Subtitle" x="0" y="31" width="1210" height="18" uuid="2b4b2486-8b19-4612-b469-842ebd02ddd2"/>
-				<box leftPadding="5">
+			</element>
+			<element kind="textField" uuid="ef45b4e4-8464-419f-b83d-787520c6bafe" key="textField-63" positionType="Float" x="30" y="0" width="15" height="18" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_SUBTITLE}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-5" style="Report_Data_Label" x="0" y="52" width="105" height="16" uuid="7f121299-61d7-45c6-8b2e-427b26c4281c"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="bcb6420c-59b1-482a-8e52-d23f84f4a52f" key="textField-64" positionType="Float" x="45" y="0" width="15" height="18" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="9"/>
-				</textElement>
-				<text><![CDATA[Grouping Levels:]]></text>
-			</staticText>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="105" y="52" width="1105" height="16" uuid="81eaeb3a-cb34-4abe-a839-2a1b248716c2"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="b2601050-66ec-40af-bf1e-67df74e7bccd" key="textField-65" positionType="Float" x="60" y="0" width="15" height="18" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{LEVEL_LABEL}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="26" width="1210" height="1" uuid="a9be3c18-8e83-4aeb-af21-bfead78f780f"/>
-			</line>
-			<line>
-				<reportElement key="line-2" x="0" y="49" width="1210" height="1" uuid="600f8e72-aee6-4bd1-9476-a74c40b14812"/>
-			</line>
-			<staticText>
-				<reportElement key="staticText-5" style="Report_Data_Label" x="0" y="68" width="105" height="16" uuid="0b0485fb-da50-40c2-9074-d9a1aaae1418"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="6fdbe13a-d38c-4f63-bf9e-473ce49abff2" key="textField-205" positionType="Float" x="75" y="0" width="15" height="18" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=6)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(6))>=0)?"6":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="9" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Secondary Filters:]]></text>
-			</staticText>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="179" y="68" width="1030" height="16" uuid="8b64ccc4-ae8e-4f9a-ac0a-268878a093c5"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="38155ada-26a6-44f8-91e2-03c60b8e039e" key="textField-206" positionType="Float" x="90" y="0" width="15" height="18" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=7)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(7))>=0)?"7":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{ORGANIZATION} + " and any child organization"]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="230" y="84" width="980" height="16" uuid="d69a5b37-89fd-4b84-af43-8f40c4f74119">
-					<printWhenExpression><![CDATA[!$P{BPGROUP}.equals("")]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="textField" uuid="07c25b90-6abb-40c7-ada7-12868ad941da" key="textField-207" positionType="Float" x="105" y="0" width="15" height="18" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=8)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(8))>=0)?"8":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{BPGROUP}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="190" y="100" width="1020" height="16" printWhenGroupChanges="DocumentType" uuid="bf3c79ec-fa48-4098-af7e-14b0b1fabc78">
-					<printWhenExpression><![CDATA[!$P{PRODUCTGROUP}.equals("")]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="textField" uuid="15464ed3-477e-4334-b72f-003fa1a99c9a" key="textField-208" positionType="Float" x="120" y="0" width="15" height="18" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=9)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(9))>=0)?"9":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{PRODUCTGROUP}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="105" y="84" width="125" height="16" uuid="fbf59805-2de5-4393-b6d5-3c94f0daa1b9">
-					<printWhenExpression><![CDATA[!$P{BPGROUP}.equals("")]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="textField" uuid="23c84b9d-8e2d-4d92-9707-3c1a91ae90f1" key="textField-209" positionType="Float" x="135" y="0" width="15" height="18" rotation="None" fontSize="7.0" blankWhenNull="true" style="Detail_Header">
+				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=10)]]></printWhenExpression>
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(10))>=0)?"10":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Business Partner Group- "]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="105" y="100" width="85" height="16" printWhenGroupChanges="DocumentType" uuid="5106fcd7-ac70-4d7d-8af1-8bc1c5c24573">
-					<printWhenExpression><![CDATA[!$P{PRODUCTGROUP}.equals("")]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="textField" uuid="0a992d6a-846e-4f4b-b9cc-5ab6c3ec7a98" key="textField-308" positionType="Float" x="150" y="0" width="40" height="18" rotation="None" fontSize="7.0" blankWhenNull="true" hTextAlign="Center" style="Detail_Header">
+				<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Product Group - "]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="105" y="68" width="74" height="16" uuid="38c33ed1-015f-4b6d-ad09-54769f4aa1bf"/>
-				<box>
+			</element>
+			<element kind="staticText" uuid="e473cb9e-2386-49ab-ac38-c06a792728c6" key="staticText-14" positionType="Float" mode="Opaque" x="190" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Amount]]></text>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Organization- "]]></textFieldExpression>
-			</textField>
-		</band>
+			</element>
+			<element kind="staticText" uuid="0d61bbea-38c0-4e84-b57b-09cccd2e9196" key="staticText-13" positionType="Float" mode="Opaque" x="245" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Cost]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="f75848de-3bed-4f15-89ff-4d76dcf482f0" key="staticText-12" positionType="Float" mode="Opaque" x="300" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Profit]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="eeac55d3-7281-4645-95b0-175a807ac842" key="staticText-9" positionType="Float" mode="Opaque" x="355" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[M. %]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="1b29d528-f342-4f14-9ad6-c73ae0d64ab4" key="staticText-15" positionType="Float" mode="Opaque" x="385" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Amt. ref]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="f1be451b-cc1f-4f82-83fc-4c334787f499" key="staticText-16" positionType="Float" mode="Opaque" x="440" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Cost ref]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="5d24f3ae-36e8-4b12-87bd-aa73b86381fe" key="staticText-17" positionType="Float" mode="Opaque" x="495" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Pro. ref]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="13c21663-5d4f-4742-8983-105d5b9b6ad4" key="staticText-18" positionType="Float" mode="Opaque" x="550" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[M.r %]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="8eb2c1dd-be79-4607-a2e5-1028f41b66d2" key="staticText-19" positionType="Float" mode="Opaque" x="580" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[A. %]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="7df683a3-6e8a-4695-8ec7-57d1b6be8bc0" key="staticText-20" positionType="Float" mode="Opaque" x="610" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[M.dif]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="e9af3f2e-ffbb-4ee5-9c89-77c55cbf5ab7" key="staticText-24" positionType="Float" mode="Opaque" x="640" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Amt. ref2]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="1f878cb2-f032-4f1c-bd3e-237624c76a5e" key="staticText-25" positionType="Float" mode="Opaque" x="695" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Cost ref2]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="fc164802-c9dc-4d25-bda4-3619731866f9" key="staticText-26" positionType="Float" mode="Opaque" x="750" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Pro. ref2]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="d00bb4cb-b84e-4704-b598-49953de72350" key="staticText-27" positionType="Float" mode="Opaque" x="805" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[M.r2 %]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="a734603a-3b1f-43e9-aaab-45d9022af082" key="staticText-28" positionType="Float" mode="Opaque" x="835" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[A.2 %]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="0de0cb9e-33c2-4729-9d68-63f60a3e2c52" key="staticText-29" positionType="Float" mode="Opaque" x="865" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[M.dif2]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="39b00a66-fe48-44f8-99f6-4437b6c684aa" key="staticText-11" positionType="Float" mode="Opaque" x="895" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Weight]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="8ecac167-2c13-4087-a8e3-22b398f4407c" key="staticText-21" positionType="Float" mode="Opaque" x="925" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[W. Ref]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="765a6967-aa18-4f6a-933a-c7f54798c5b1" key="staticText-30" positionType="Float" mode="Opaque" x="955" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[W.Ref2]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="4dc695fe-37a0-4b51-b34f-399012d048cd" key="staticText-10" positionType="Float" mode="Opaque" x="985" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Quantity]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="f98868c1-0ea7-4702-9b10-113cf697bd5f" key="staticText-23" positionType="Float" mode="Opaque" x="1040" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Q. ref]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="0bce876f-52ca-4167-beb1-a88af320d8e7" key="staticText-22" positionType="Float" mode="Opaque" x="1095" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Qty%]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="a3c8088e-3676-427c-8a9b-83982ffd427c" key="staticText-31" positionType="Float" mode="Opaque" x="1125" y="0" width="55" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Q. ref2]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="abf51780-03fe-453e-8857-9ae47fcbb38b" key="staticText-32" positionType="Float" mode="Opaque" x="1180" y="0" width="30" height="18" fontSize="7.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Qty2%]]></text>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="dbd041f2-6a5b-44a3-a97a-506e5063f06f" key="textField" x="0" y="0" width="1210" height="26" textAdjust="StretchHeight" blankWhenNull="true" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="2b4b2486-8b19-4612-b469-842ebd02ddd2" key="textField" x="0" y="31" width="1210" height="18" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="7f121299-61d7-45c6-8b2e-427b26c4281c" key="staticText-5" x="0" y="52" width="105" height="16" fontSize="9.0" style="Report_Data_Label">
+			<text><![CDATA[Grouping Levels:]]></text>
+			<box style="Report_Data_Label">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="81eaeb3a-cb34-4abe-a839-2a1b248716c2" key="textField-17" x="105" y="52" width="1105" height="16" fontSize="9.0" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Data_Field">
+			<expression><![CDATA[$P{LEVEL_LABEL}]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="a9be3c18-8e83-4aeb-af21-bfead78f780f" key="line-1" x="0" y="26" width="1210" height="1"/>
+		<element kind="line" uuid="600f8e72-aee6-4bd1-9476-a74c40b14812" key="line-2" x="0" y="49" width="1210" height="1"/>
+		<element kind="staticText" uuid="0b0485fb-da50-40c2-9074-d9a1aaae1418" key="staticText-5" x="0" y="68" width="105" height="16" fontSize="9.0" bold="true" style="Report_Data_Label">
+			<text><![CDATA[Secondary Filters:]]></text>
+			<box style="Report_Data_Label">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="8b64ccc4-ae8e-4f9a-ac0a-268878a093c5" key="textField-17" x="179" y="68" width="1030" height="16" fontSize="9.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<expression><![CDATA[$P{ORGANIZATION} + " and any child organization"]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="d69a5b37-89fd-4b84-af43-8f40c4f74119" key="textField-17" x="230" y="84" width="980" height="16" fontSize="9.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<printWhenExpression><![CDATA[!$P{BPGROUP}.equals("")]]></printWhenExpression>
+			<expression><![CDATA[$P{BPGROUP}]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="bf3c79ec-fa48-4098-af7e-14b0b1fabc78" key="textField-17" x="190" y="100" width="1020" height="16" printWhenGroupChanges="DocumentType" fontSize="9.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<printWhenExpression><![CDATA[!$P{PRODUCTGROUP}.equals("")]]></printWhenExpression>
+			<expression><![CDATA[$P{PRODUCTGROUP}]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="fbf59805-2de5-4393-b6d5-3c94f0daa1b9" key="textField-17" x="105" y="84" width="125" height="16" fontSize="9.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<printWhenExpression><![CDATA[!$P{BPGROUP}.equals("")]]></printWhenExpression>
+			<expression><![CDATA["Business Partner Group- "]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="5106fcd7-ac70-4d7d-8af1-8bc1c5c24573" key="textField-17" x="105" y="100" width="85" height="16" printWhenGroupChanges="DocumentType" fontSize="9.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<printWhenExpression><![CDATA[!$P{PRODUCTGROUP}.equals("")]]></printWhenExpression>
+			<expression><![CDATA["Product Group - "]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="38c33ed1-015f-4b6d-ad09-54769f4aa1bf" key="textField-17" x="105" y="68" width="74" height="16" fontSize="9.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<expression><![CDATA["Organization- "]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band splitType="Stretch"/>
 	</detail>
-	<pageFooter>
-		<band height="20" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-7" style="Report_Footer" x="391" y="3" width="78" height="16" uuid="ce71848b-2633-4981-a65c-bbbc0db164c8"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Generated on ]]></text>
-			</staticText>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-18" style="Report_Footer" x="469" y="3" width="90" height="16" uuid="7fa6a983-da93-4f14-a316-69f9ed9506d6"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-19" style="Report_Footer" x="748" y="3" width="95" height="16" uuid="23f721a6-e043-4e04-b990-456abca2c302"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-20" style="Report_Footer" x="845" y="3" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="2bca04dd-f8ac-4567-b768-831bc6aaf116"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-4" x="0" y="2" width="1210" height="1" uuid="c7a42f23-a298-487d-882c-0873e7cb27d3"/>
-			</line>
-		</band>
+	<pageFooter height="20" splitType="Stretch">
+		<element kind="staticText" uuid="ce71848b-2633-4981-a65c-bbbc0db164c8" key="staticText-7" x="391" y="3" width="78" height="16" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Generated on ]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="7fa6a983-da93-4f14-a316-69f9ed9506d6" key="textField-18" x="469" y="3" width="90" height="16" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="23f721a6-e043-4e04-b990-456abca2c302" key="textField-19" x="748" y="3" width="95" height="16" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="2bca04dd-f8ac-4567-b768-831bc6aaf116" key="textField-20" x="845" y="3" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle" style="Report_Footer">
+			<paragraph lineSpacing="Single" style="Report_Footer"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="c7a42f23-a298-487d-882c-0873e7cb27d3" key="line-4" x="0" y="2" width="1210" height="1"/>
 	</pageFooter>
-	<lastPageFooter>
-		<band height="58"/>
-	</lastPageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<lastPageFooter height="58"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesNoComparativeJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesNoComparativeJR.jrxml
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
-<!-- 2017-03-02T13:16:37 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportInvoiceCustomerDimensionalAnalysesNoComparativeJR" pageWidth="630" pageHeight="842" columnWidth="518" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="f36036af-e4bd-420a-b3eb-05289ad097f1">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportInvoiceCustomerDimensionalAnalysesNoComparativeJR" language="java" pageWidth="630" pageHeight="842" columnWidth="518" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="f36036af-e4bd-420a-b3eb-05289ad097f1">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
@@ -9,171 +7,140 @@
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
 	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" isDefault="true" vAlign="Middle" fontName="SansSerif" fontSize="11"/>
-	<style name="Report_Title" fontName="SansSerif" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="SansSerif" fontSize="14"/>
-	<style name="Report_Data_Label" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
-	<style name="Report_Data_Field" fontName="SansSerif" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="9" isBold="false"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle"/>
-	<style name="Detail_Line" fontName="SansSerif" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="11.0"/>
+	<style name="Report_Title" fontName="SansSerif" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="SansSerif" fontSize="14.0"/>
+	<style name="Report_Data_Label" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="11.0" bold="false"/>
+	<style name="Report_Data_Field" fontName="SansSerif" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="9.0" bold="false"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle"/>
+	<style name="Detail_Line" fontName="SansSerif" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level1_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level1_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==1)&&($V{NIVEL1_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==1)&&($V{NIVEL1_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level2_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level2_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==2)&&($V{NIVEL1_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==2)&&($V{NIVEL1_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level3_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level3_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==3)&&($V{NIVEL2_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==3)&&($V{NIVEL2_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level4_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level4_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
+		<conditionalStyle backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==4)&&($V{NIVEL3_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==4)&&($V{NIVEL3_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level5_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level5_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==5)&&($V{NIVEL4_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==5)&&($V{NIVEL4_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level6_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level6_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==6)&&($V{LEVEL5_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==6)&&($V{LEVEL5_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level7_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level7_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==7)&&($V{LEVEL6_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==7)&&($V{LEVEL6_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level8_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level8_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==8)&&($V{LEVEL7_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==8)&&($V{LEVEL7_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level9_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level9_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==9)&&($V{LEVEL8_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==9)&&($V{LEVEL8_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level10_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Level10_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==10)&&($V{LEVEL9_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==10)&&($V{LEVEL9_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle forecolor="#FF0000">
 			<conditionExpression><![CDATA[new Boolean($F{COSTCALCULATED}.intValue()>=1)]]></conditionExpression>
-			<style forecolor="#FF0000"/>
 		</conditionalStyle>
 	</style>
-	<style name="Report_Footer" vAlign="Middle" fontName="SansSerif" fontSize="11"/>
+	<style name="Report_Footer" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="11.0"/>
 	<style name="Detail_Border" forecolor="#8A8A8A"/>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["0,1000000"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["0,1000000"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_client" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_client" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{USER_CLIENT}.equals("") ? " " : " AND C_INVOICE.AD_CLIENT_ID IN(" + $P{USER_CLIENT} + ")"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="ORGANIZATION" class="java.lang.String"/>
@@ -181,97 +148,97 @@
 	<parameter name="PRODUCTGROUP" class="java.lang.String"/>
 	<parameter name="C_CURRENCY_ID" class="java.lang.String"/>
 	<parameter name="AD_ORG_ID" class="java.lang.String"/>
-	<parameter name="aux_org" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_org" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{AD_ORG_ID}.equals("") ? " " : " AND C_INVOICE.AD_ORG_ID IN(" + $P{AD_ORG_ID} + ")"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="DateFrom" class="java.lang.String"/>
 	<parameter name="DateTo" class="java.lang.String"/>
-	<parameter name="aux_DateFrom" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_DateFrom" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{DateFrom} == null || $P{DateFrom}.equals("")) ? "" : "AND C_INVOICE.DATEINVOICED >= TO_DATE('" + $P{DateFrom} + "', 'YYYY-MM-DD')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_DateTo" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_DateTo" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{DateTo} == null || $P{DateTo}.equals("")) ? "" : "AND C_INVOICE.DATEINVOICED <= TO_DATE('" + $P{DateTo} + "', 'YYYY-MM-DD')"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="C_BP_GROUP_ID" class="java.lang.String"/>
-	<parameter name="aux_bpgroup" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_bpgroup" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{C_BP_GROUP_ID}.equals("") ? " " : " AND C_BPARTNER.C_BP_GROUP_ID = '" + $P{C_BP_GROUP_ID} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="C_BPARTNER_ID" class="java.lang.String"/>
-	<parameter name="aux_partner" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_partner" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{C_BPARTNER_ID}.equals("") ? " " : " AND C_BPARTNER.C_BPARTNER_ID IN" + $P{C_BPARTNER_ID}]]></defaultValueExpression>
 	</parameter>
 	<parameter name="M_PRODUCT_CATEGORY_ID" class="java.lang.String"/>
-	<parameter name="aux_productcategory" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_productcategory" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{M_PRODUCT_CATEGORY_ID}.equals("") ? " " : " AND M_PRODUCT_CATEGORY.M_PRODUCT_CATEGORY_ID IN " + $P{M_PRODUCT_CATEGORY_ID}]]></defaultValueExpression>
 	</parameter>
 	<parameter name="M_PRODUCT_ID" class="java.lang.String"/>
-	<parameter name="aux_product" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_product" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{M_PRODUCT_ID}.equals("") ? " " : "  AND M_PRODUCT.M_PRODUCT_ID IN" + $P{M_PRODUCT_ID}]]></defaultValueExpression>
 	</parameter>
 	<parameter name="SALESREP_ID" class="java.lang.String"/>
-	<parameter name="aux_salesrep" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_salesrep" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{SALESREP_ID}.equals("") ? " " : " AND C_INVOICE.SALESREP_ID = '" + $P{SALESREP_ID} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="PARTNER_SALESREP_ID" class="java.lang.String"/>
-	<parameter name="aux_partnersalesrep" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_partnersalesrep" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{PARTNER_SALESREP_ID}.equals("") ? " " : " AND CB.C_BPARTNER_ID = '" + $P{PARTNER_SALESREP_ID} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="C_PROJECT_ID" class="java.lang.String"/>
-	<parameter name="aux_project" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_project" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{C_PROJECT_ID}.equals("") ? " " : " AND C_INVOICE.C_PROJECT_ID = '" + $P{C_PROJECT_ID} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="PRODUCTTYPE" class="java.lang.String"/>
-	<parameter name="aux_producttype" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_producttype" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{PRODUCTTYPE}.equals("") ? " " : " AND M_PRODUCT.PRODUCTTYPE = '" + $P{PRODUCTTYPE} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="C_DOCTYPE_ID" class="java.lang.String"/>
-	<parameter name="aux_doctype" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_doctype" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{C_DOCTYPE_ID}.equals("") ? " " : " AND C_INVOICE.C_DOCTYPE_ID IN" + $P{C_DOCTYPE_ID}]]></defaultValueExpression>
 	</parameter>
 	<parameter name="DOCSTATUS" class="java.lang.String"/>
-	<parameter name="aux_docstatus" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_docstatus" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{DOCSTATUS}.equals("") ? " " : " AND C_INVOICE.DOCSTATUS <> '" + $P{DOCSTATUS} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="LANGUAGE" class="java.lang.String"/>
-	<parameter name="SR_LINES" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="orderBy" class="java.lang.String" isForPrompting="false">
+	<parameter name="SR_LINES" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="orderBy" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[" ORDER BY 1 "]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Purchase Orders Report"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="PRODUCT_LEVEL" class="java.lang.Integer" isForPrompting="false">
+	<parameter name="PRODUCT_LEVEL" forPrompting="false" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[new Integer(3)]]></defaultValueExpression>
 	</parameter>
-	<parameter name="THEME" class="java.lang.String" isForPrompting="false">
+	<parameter name="THEME" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Default"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false">
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/var/lib/tomcat-5.5/webapps/alerts/web"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL1_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL1_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Partner Group"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL2_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL2_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Product Category"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL3_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL3_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Product"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL4_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL4_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Partner"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL5_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL6_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL7_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL8_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL9_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL10_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="DIMENSIONS" class="java.lang.Integer" isForPrompting="false">
+	<parameter name="LEVEL5_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL6_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL7_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL8_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL9_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL10_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="DIMENSIONS" forPrompting="false" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[new Integer(10)]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["1.- "+$P{LEVEL1_LABEL}
 +($P{LEVEL2_LABEL}==""?"":", 2.- "+$P{LEVEL2_LABEL})
 +($P{LEVEL3_LABEL}==""?"":", 3.- "+$P{LEVEL3_LABEL})
@@ -283,12 +250,11 @@
 +($P{LEVEL9_LABEL}==""?"":", 9.- "+$P{LEVEL9_LABEL})
 +($P{LEVEL10_LABEL}==""?"":", 10.- "+$P{LEVEL10_LABEL})]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale">
 		<defaultValueExpression><![CDATA[new Locale("en","US")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10,
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<query language="sql"><![CDATA[SELECT NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10,
       SUM(AMOUNT) AS AMOUNT, SUM(QTY) AS QTY, SUM(WEIGHT) AS WEIGHT, SUM(COST) AS COST,
       SUM(AMOUNTREF) AS AMOUNTREF, SUM(QTYREF) AS QTYREF, SUM(WEIGHTREF) AS WEIGHTREF, UOMSYMBOL,
       SUM(CONVAMOUNT) AS CONVAMOUNT,
@@ -332,8 +298,7 @@
       AND 1=1
       ORDER BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10) AA
       GROUP BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10, UOMSYMBOL, TRCURRENCYID, TRDATE, TRCLIENTID, TRORGID) ZZ
-      GROUP BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10, UOMSYMBOL, CONVSYM, CONVISOSYM, 1]]>
-	</queryString>
+      GROUP BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10, UOMSYMBOL, CONVSYM, CONVISOSYM, 1]]></query>
 	<field name="NIVEL1" class="java.lang.String"/>
 	<field name="NIVEL2" class="java.lang.String"/>
 	<field name="NIVEL3" class="java.lang.String"/>
@@ -361,533 +326,469 @@
 	<field name="CONVSYM" class="java.lang.String"/>
 	<field name="CONVISOSYM" class="java.lang.String"/>
 	<field name="COSTCALCULATED" class="java.lang.Integer"/>
-	<variable name="QTY_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM6" resetType="Group" calculation="Sum" resetGroup="LEVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM7" resetType="Group" calculation="Sum" resetGroup="LEVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM8" resetType="Group" calculation="Sum" resetGroup="LEVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM9" resetType="Group" calculation="Sum" resetGroup="LEVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM10" resetType="Group" calculation="Sum" resetGroup="LEVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="AMOUNT_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM6" resetType="Group" calculation="Sum" resetGroup="LEVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM7" resetType="Group" calculation="Sum" resetGroup="LEVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM8" resetType="Group" calculation="Sum" resetGroup="LEVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM9" resetType="Group" calculation="Sum" resetGroup="LEVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM10" resetType="Group" calculation="Sum" resetGroup="LEVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="COST_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM6" resetType="Group" calculation="Sum" resetGroup="LEVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM7" resetType="Group" calculation="Sum" resetGroup="LEVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM8" resetType="Group" calculation="Sum" resetGroup="LEVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM9" resetType="Group" calculation="Sum" resetGroup="LEVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="COST_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_SUM10" resetType="Group" calculation="Sum" resetGroup="LEVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
-	<variable name="PROFIT_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM1}.subtract($V{COST_SUM1})]]></variableExpression>
+	<variable name="PROFIT_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM1}.subtract($V{COST_SUM1})]]></expression>
 	</variable>
-	<variable name="PROFIT_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM2}.subtract($V{COST_SUM2})]]></variableExpression>
+	<variable name="PROFIT_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM2}.subtract($V{COST_SUM2})]]></expression>
 	</variable>
-	<variable name="PROFIT_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM3}.subtract($V{COST_SUM3})]]></variableExpression>
+	<variable name="PROFIT_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM3}.subtract($V{COST_SUM3})]]></expression>
 	</variable>
-	<variable name="PROFIT_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM4}.subtract($V{COST_SUM4})]]></variableExpression>
+	<variable name="PROFIT_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM4}.subtract($V{COST_SUM4})]]></expression>
 	</variable>
-	<variable name="PROFIT_5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM5}.subtract($V{COST_SUM5})]]></variableExpression>
+	<variable name="PROFIT_5" resetType="Group" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM5}.subtract($V{COST_SUM5})]]></expression>
 	</variable>
-	<variable name="PROFIT_6" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL6">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM6}.subtract($V{COST_SUM6})]]></variableExpression>
+	<variable name="PROFIT_6" resetType="Group" resetGroup="LEVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM6}.subtract($V{COST_SUM6})]]></expression>
 	</variable>
-	<variable name="PROFIT_7" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL7">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM7}.subtract($V{COST_SUM7})]]></variableExpression>
+	<variable name="PROFIT_7" resetType="Group" resetGroup="LEVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM7}.subtract($V{COST_SUM7})]]></expression>
 	</variable>
-	<variable name="PROFIT_8" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL8">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM8}.subtract($V{COST_SUM8})]]></variableExpression>
+	<variable name="PROFIT_8" resetType="Group" resetGroup="LEVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM8}.subtract($V{COST_SUM8})]]></expression>
 	</variable>
-	<variable name="PROFIT_9" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL9">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM9}.subtract($V{COST_SUM9})]]></variableExpression>
+	<variable name="PROFIT_9" resetType="Group" resetGroup="LEVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM9}.subtract($V{COST_SUM9})]]></expression>
 	</variable>
-	<variable name="PROFIT_10" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL10">
-		<variableExpression><![CDATA[$V{AMOUNT_SUM10}.subtract($V{COST_SUM10})]]></variableExpression>
+	<variable name="PROFIT_10" resetType="Group" resetGroup="LEVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{AMOUNT_SUM10}.subtract($V{COST_SUM10})]]></expression>
 	</variable>
-	<variable name="MARGIN_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM1}.compareTo(BigDecimal.ZERO)==0)?
+	<variable name="MARGIN_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM1}.compareTo(BigDecimal.ZERO)==0)?
 null:
-$V{PROFIT_1}.divide( $V{AMOUNT_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).abs().multiply( new BigDecimal("100") ).multiply(new BigDecimal($V{PROFIT_1}.signum()))]]></variableExpression>
+$V{PROFIT_1}.divide( $V{AMOUNT_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).abs().multiply( new BigDecimal("100") ).multiply(new BigDecimal($V{PROFIT_1}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM2}.compareTo(BigDecimal.ZERO)==0)? null: $V{PROFIT_2}.divide( $V{AMOUNT_SUM2}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply( new BigDecimal("100") ).multiply(new BigDecimal($V{PROFIT_2}.signum()))]]></variableExpression>
+	<variable name="MARGIN_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM2}.compareTo(BigDecimal.ZERO)==0)? null: $V{PROFIT_2}.divide( $V{AMOUNT_SUM2}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply( new BigDecimal("100") ).multiply(new BigDecimal($V{PROFIT_2}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM3}.compareTo(BigDecimal.ZERO)==0)? null: $V{PROFIT_3}.divide( $V{AMOUNT_SUM3}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply( new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_3}.signum()))]]></variableExpression>
+	<variable name="MARGIN_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM3}.compareTo(BigDecimal.ZERO)==0)? null: $V{PROFIT_3}.divide( $V{AMOUNT_SUM3}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply( new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_3}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM4}.compareTo(BigDecimal.ZERO)==0)? null: $V{PROFIT_4}.divide( $V{AMOUNT_SUM4}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply( new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_4}.signum()))]]></variableExpression>
+	<variable name="MARGIN_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM4}.compareTo(BigDecimal.ZERO)==0)? null: $V{PROFIT_4}.divide( $V{AMOUNT_SUM4}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply( new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_4}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM5}.compareTo(BigDecimal.ZERO)==0)? null: $V{PROFIT_5}.divide( $V{AMOUNT_SUM5}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply( new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_5}.signum()))]]></variableExpression>
+	<variable name="MARGIN_5" resetType="Group" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM5}.compareTo(BigDecimal.ZERO)==0)? null: $V{PROFIT_5}.divide( $V{AMOUNT_SUM5}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply( new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_5}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_6" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL6">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM6}.compareTo(BigDecimal.ZERO)==0)? null: $V{PROFIT_6}.divide( $V{AMOUNT_SUM6}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply( new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_6}.signum()))]]></variableExpression>
+	<variable name="MARGIN_6" resetType="Group" resetGroup="LEVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM6}.compareTo(BigDecimal.ZERO)==0)? null: $V{PROFIT_6}.divide( $V{AMOUNT_SUM6}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply( new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_6}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_7" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL7">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM7}.compareTo(BigDecimal.ZERO)==0)? null: $V{PROFIT_7}.divide( $V{AMOUNT_SUM7}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply( new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_7}.signum()))]]></variableExpression>
+	<variable name="MARGIN_7" resetType="Group" resetGroup="LEVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM7}.compareTo(BigDecimal.ZERO)==0)? null: $V{PROFIT_7}.divide( $V{AMOUNT_SUM7}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply( new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_7}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_8" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL8">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM8}.compareTo(BigDecimal.ZERO)==0)? null: $V{PROFIT_8}.divide( $V{AMOUNT_SUM8}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply( new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_8}.signum()))]]></variableExpression>
+	<variable name="MARGIN_8" resetType="Group" resetGroup="LEVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM8}.compareTo(BigDecimal.ZERO)==0)? null: $V{PROFIT_8}.divide( $V{AMOUNT_SUM8}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply( new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_8}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_9" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL9">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM9}.compareTo(BigDecimal.ZERO)==0)? null: $V{PROFIT_9}.divide( $V{AMOUNT_SUM9}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply( new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_9}.signum()))]]></variableExpression>
+	<variable name="MARGIN_9" resetType="Group" resetGroup="LEVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM9}.compareTo(BigDecimal.ZERO)==0)? null: $V{PROFIT_9}.divide( $V{AMOUNT_SUM9}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply( new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_9}.signum()))]]></expression>
 	</variable>
-	<variable name="MARGIN_10" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL10">
-		<variableExpression><![CDATA[($V{AMOUNT_SUM10}.compareTo(BigDecimal.ZERO)==0)? null:$V{PROFIT_10}.divide( $V{AMOUNT_SUM10}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply( new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_10}.signum()))]]></variableExpression>
+	<variable name="MARGIN_10" resetType="Group" resetGroup="LEVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNT_SUM10}.compareTo(BigDecimal.ZERO)==0)? null:$V{PROFIT_10}.divide( $V{AMOUNT_SUM10}, 4, BigDecimal.ROUND_HALF_UP).abs().multiply( new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_10}.signum()))]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM6" resetType="Group" calculation="Sum" resetGroup="LEVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM7" resetType="Group" calculation="Sum" resetGroup="LEVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM8" resetType="Group" calculation="Sum" resetGroup="LEVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM9" resetType="Group" calculation="Sum" resetGroup="LEVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM10" resetType="Group" calculation="Sum" resetGroup="LEVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="QTY_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="COST_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVCOST}]]></variableExpression>
+	<variable name="COST_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVCOST}]]></expression>
 	</variable>
 	<variable name="PROFIT_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{AMOUNT_TOTAL}.subtract($V{COST_TOTAL})]]></variableExpression>
+		<expression><![CDATA[$V{AMOUNT_TOTAL}.subtract($V{COST_TOTAL})]]></expression>
 	</variable>
 	<variable name="MARGIN_TOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[($V{AMOUNT_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_TOTAL}.divide($V{AMOUNT_TOTAL}, 10, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_TOTAL}.signum()))]]></variableExpression>
+		<expression><![CDATA[($V{AMOUNT_TOTAL}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{PROFIT_TOTAL}.divide($V{AMOUNT_TOTAL}, 10, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{PROFIT_TOTAL}.signum()))]]></expression>
 	</variable>
 	<group name="DocumentType">
 		<groupFooter>
 			<band height="60">
-				<subreport>
-					<reportElement stretchType="RelativeToBandHeight" x="0" y="6" width="518" height="50" uuid="7614471a-bdd5-4c59-a488-1015898d2283">
-						<property name="local_mesure_unitheight" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.height" value="px"/>
-					</reportElement>
-					<subreportParameter name="USER_CLIENT">
-						<subreportParameterExpression><![CDATA[$P{aux_client}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="AD_ORG_ID">
-						<subreportParameterExpression><![CDATA[$P{aux_org}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="C_CURRENCY_ID">
-						<subreportParameterExpression><![CDATA[$P{C_CURRENCY_ID}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="DATEFROM">
-						<subreportParameterExpression><![CDATA[$P{DateFrom}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="DATETO">
-						<subreportParameterExpression><![CDATA[$P{DateTo}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="C_BP_GROUP_ID">
-						<subreportParameterExpression><![CDATA[$P{aux_bpgroup}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="C_BPARTNER_ID">
-						<subreportParameterExpression><![CDATA[$P{aux_partner}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="M_PRODUCT_CATEGORY_ID">
-						<subreportParameterExpression><![CDATA[$P{aux_productcategory}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="M_PRODUCT_ID">
-						<subreportParameterExpression><![CDATA[$P{aux_product}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SALESREP_ID">
-						<subreportParameterExpression><![CDATA[$P{aux_salesrep}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="PARTNER_SALESREP_ID">
-						<subreportParameterExpression><![CDATA[$P{aux_partnersalesrep}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="C_PROJECT_ID">
-						<subreportParameterExpression><![CDATA[$P{aux_project}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="PRODUCTTYPE">
-						<subreportParameterExpression><![CDATA[$P{aux_producttype}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="C_DOCTYPE_ID">
-						<subreportParameterExpression><![CDATA[$P{aux_doctype}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="DOCSTATUS">
-						<subreportParameterExpression><![CDATA[$P{aux_docstatus}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="LANGUAGE">
-						<subreportParameterExpression><![CDATA[$P{LANGUAGE}]]></subreportParameterExpression>
-					</subreportParameter>
+				<element kind="subreport" uuid="7614471a-bdd5-4c59-a488-1015898d2283" stretchType="ContainerHeight" x="0" y="6" width="518" height="50">
 					<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-					<subreportExpression><![CDATA[$P{SR_LINES}]]></subreportExpression>
-				</subreport>
+					<expression><![CDATA[$P{SR_LINES}]]></expression>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<parameter name="USER_CLIENT">
+						<expression><![CDATA[$P{aux_client}]]></expression>
+					</parameter>
+					<parameter name="AD_ORG_ID">
+						<expression><![CDATA[$P{aux_org}]]></expression>
+					</parameter>
+					<parameter name="C_CURRENCY_ID">
+						<expression><![CDATA[$P{C_CURRENCY_ID}]]></expression>
+					</parameter>
+					<parameter name="DATEFROM">
+						<expression><![CDATA[$P{DateFrom}]]></expression>
+					</parameter>
+					<parameter name="DATETO">
+						<expression><![CDATA[$P{DateTo}]]></expression>
+					</parameter>
+					<parameter name="C_BP_GROUP_ID">
+						<expression><![CDATA[$P{aux_bpgroup}]]></expression>
+					</parameter>
+					<parameter name="C_BPARTNER_ID">
+						<expression><![CDATA[$P{aux_partner}]]></expression>
+					</parameter>
+					<parameter name="M_PRODUCT_CATEGORY_ID">
+						<expression><![CDATA[$P{aux_productcategory}]]></expression>
+					</parameter>
+					<parameter name="M_PRODUCT_ID">
+						<expression><![CDATA[$P{aux_product}]]></expression>
+					</parameter>
+					<parameter name="SALESREP_ID">
+						<expression><![CDATA[$P{aux_salesrep}]]></expression>
+					</parameter>
+					<parameter name="PARTNER_SALESREP_ID">
+						<expression><![CDATA[$P{aux_partnersalesrep}]]></expression>
+					</parameter>
+					<parameter name="C_PROJECT_ID">
+						<expression><![CDATA[$P{aux_project}]]></expression>
+					</parameter>
+					<parameter name="PRODUCTTYPE">
+						<expression><![CDATA[$P{aux_producttype}]]></expression>
+					</parameter>
+					<parameter name="C_DOCTYPE_ID">
+						<expression><![CDATA[$P{aux_doctype}]]></expression>
+					</parameter>
+					<parameter name="DOCSTATUS">
+						<expression><![CDATA[$P{aux_docstatus}]]></expression>
+					</parameter>
+					<parameter name="LANGUAGE">
+						<expression><![CDATA[$P{LANGUAGE}]]></expression>
+					</parameter>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="TOTALIZE">
-		<groupExpression><![CDATA[]]></groupExpression>
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band splitType="Stretch"/>
 		</groupHeader>
 		<groupFooter>
 			<band height="18" splitType="Stretch">
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-21" style="Total_Field" x="177" y="2" width="85" height="16" uuid="bbc4fbe7-c494-4cde-8f40-b495b45e7502"/>
-					<box leftPadding="0">
+				<element kind="textField" uuid="bbc4fbe7-c494-4cde-8f40-b495b45e7502" key="textField-21" x="177" y="2" width="85" height="16" evaluationTime="Report" pattern="" blankWhenNull="false" bold="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{AMOUNT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-8" style="Report_Data_Label" x="99" y="2" width="78" height="16" uuid="1a123df4-db65-4153-8c88-308685d92171"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle"/>
+				</element>
+				<element kind="staticText" uuid="1a123df4-db65-4153-8c88-308685d92171" key="staticText-8" x="99" y="2" width="78" height="16" hTextAlign="Right" vTextAlign="Middle" style="Report_Data_Label">
 					<text><![CDATA[Total:]]></text>
-				</staticText>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-23" style="Detail_Header" mode="Opaque" x="15" y="1" width="15" height="16" uuid="596fe255-cbcb-4b7c-aac2-2699fc1a5a9c">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+					<box style="Report_Data_Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" evaluationTime="Report" pattern="##0.00" isBlankWhenNull="true">
-					<reportElement key="textField-22" style="Detail_Header" x="0" y="1" width="15" height="16" uuid="6a8abcf0-8e56-493b-a8b5-cdedb8a97a37">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="596fe255-cbcb-4b7c-aac2-2699fc1a5a9c" key="textField-23" mode="Opaque" x="15" y="1" width="15" height="16" rotation="None" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-24" style="Detail_Header" mode="Opaque" x="30" y="1" width="15" height="16" uuid="8a323ec8-c656-466d-ba65-2f171c9850de">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="6a8abcf0-8e56-493b-a8b5-cdedb8a97a37" key="textField-22" x="0" y="1" width="15" height="16" rotation="None" textAdjust="StretchHeight" evaluationTime="Report" pattern="##0.00" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-25" style="Detail_Header" mode="Opaque" x="45" y="1" width="15" height="16" uuid="9228053e-5fc2-4ea0-9dd0-c54f707d8d0a">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="8a323ec8-c656-466d-ba65-2f171c9850de" key="textField-24" mode="Opaque" x="30" y="1" width="15" height="16" rotation="None" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-26" style="Detail_Header" mode="Opaque" x="60" y="1" width="15" height="16" uuid="836190ed-d41a-4f56-ac8d-c1a28f95d93c">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="1">
+				</element>
+				<element kind="textField" uuid="9228053e-5fc2-4ea0-9dd0-c54f707d8d0a" key="textField-25" mode="Opaque" x="45" y="1" width="15" height="16" rotation="None" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-204" style="Total_Field" x="416" y="2" width="46" height="16" uuid="4b4edc76-0c5f-4d8b-889e-b8bc344e3653"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="836190ed-d41a-4f56-ac8d-c1a28f95d93c" key="textField-26" mode="Opaque" x="60" y="1" width="15" height="16" rotation="None" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":" ")]]></expression>
+					<box leftPadding="1" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-5" x="0" y="0" width="518" height="1" uuid="6a9d0a59-4845-418b-9b3e-7852268b826c"/>
-				</line>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-204" style="Total_Field" stretchType="RelativeToBandHeight" x="462" y="2" width="56" height="16" uuid="80692873-0917-425f-9776-ee1d0e502da0">
-						<printWhenExpression><![CDATA[$P{LEVEL1_LABEL}.equals("Product") || $P{LEVEL2_LABEL}.equals("Product") || $P{LEVEL3_LABEL}.equals("Product") || $P{LEVEL4_LABEL}.equals("Product") || $P{LEVEL5_LABEL}.equals("Product") || $P{LEVEL6_LABEL}.equals("Product") || $P{LEVEL7_LABEL}.equals("Product") || $P{LEVEL8_LABEL}.equals("Product") || $P{LEVEL9_LABEL}.equals("Product") || $P{LEVEL10_LABEL}.equals("Product")]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="4b4edc76-0c5f-4d8b-889e-b8bc344e3653" key="textField-204" x="416" y="2" width="46" height="16" evaluationTime="Report" pattern="" blankWhenNull="false" bold="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{WEIGHT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{QTY_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-204" style="Total_Field" x="386" y="2" width="30" height="16" uuid="176760f3-0b6c-4770-afc7-5f598a01e176"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="line" uuid="6a9d0a59-4845-418b-9b3e-7852268b826c" key="line-5" x="0" y="0" width="518" height="1"/>
+				<element kind="textField" uuid="80692873-0917-425f-9776-ee1d0e502da0" key="textField-204" stretchType="ContainerHeight" x="462" y="2" width="56" height="16" evaluationTime="Report" pattern="" blankWhenNull="false" bold="false" hTextAlign="Right" style="Total_Field">
+					<printWhenExpression><![CDATA[$P{LEVEL1_LABEL}.equals("Product") || $P{LEVEL2_LABEL}.equals("Product") || $P{LEVEL3_LABEL}.equals("Product") || $P{LEVEL4_LABEL}.equals("Product") || $P{LEVEL5_LABEL}.equals("Product") || $P{LEVEL6_LABEL}.equals("Product") || $P{LEVEL7_LABEL}.equals("Product") || $P{LEVEL8_LABEL}.equals("Product") || $P{LEVEL9_LABEL}.equals("Product") || $P{LEVEL10_LABEL}.equals("Product")]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{QTY_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{MARGIN_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-204" style="Total_Field" x="325" y="2" width="61" height="16" uuid="44432605-4e5a-4f07-9ebb-ab5ed73add19"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="176760f3-0b6c-4770-afc7-5f598a01e176" key="textField-204" x="386" y="2" width="30" height="16" evaluationTime="Report" pattern="" blankWhenNull="false" bold="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{MARGIN_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{PROFIT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-204" style="Total_Field" x="262" y="2" width="63" height="16" uuid="7d45f0ce-7127-48dc-aa50-ce7a4429f2d2"/>
-					<box leftPadding="0">
+				</element>
+				<element kind="textField" uuid="44432605-4e5a-4f07-9ebb-ab5ed73add19" key="textField-204" x="325" y="2" width="61" height="16" evaluationTime="Report" pattern="" blankWhenNull="false" bold="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{PROFIT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{COST_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COST_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="7d45f0ce-7127-48dc-aa50-ce7a4429f2d2" key="textField-204" x="262" y="2" width="63" height="16" evaluationTime="Report" pattern="" blankWhenNull="false" bold="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{COST_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COST_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="0" style="Total_Field">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="NIVEL1">
-		<groupExpression><![CDATA[$F{NIVEL1}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL1}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="161" height="18" uuid="02d1404a-f76c-4011-b60b-1055a15b3a28"/>
-					<box leftPadding="2" rightPadding="2">
+				<element kind="textField" uuid="02d1404a-f76c-4011-b60b-1055a15b3a28" key="textField" stretchType="ContainerHeight" x="0" y="0" width="161" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[$F{NIVEL1}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL1}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-155" style="Level1_Line" stretchType="RelativeToBandHeight" x="203" y="0" width="61" height="18" uuid="4e638120-bcea-4898-a8e4-3c817afdac18"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4e638120-bcea-4898-a8e4-3c817afdac18" key="textField-155" stretchType="ContainerHeight" x="203" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-154" style="Level1_Line" stretchType="RelativeToBandHeight" x="264" y="0" width="61" height="18" uuid="987b09a9-e46c-454a-b64b-d16a614f9d45"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="987b09a9-e46c-454a-b64b-d16a614f9d45" key="textField-154" stretchType="ContainerHeight" x="264" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{COST_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COST_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-153" style="Level1_Line" stretchType="RelativeToBandHeight" x="325" y="0" width="61" height="18" uuid="174ed868-d7c7-4225-988e-0355dff89457"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="174ed868-d7c7-4225-988e-0355dff89457" key="textField-153" stretchType="ContainerHeight" x="325" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{PROFIT_1}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFIT_1}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" x="386" y="0" width="30" height="18" uuid="e3b44d3d-4da2-4e45-9df4-e9a747a3e08b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e3b44d3d-4da2-4e45-9df4-e9a747a3e08b" key="textField" stretchType="ContainerHeight" x="386" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{MARGIN_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGIN_1}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-152" style="Level1_Line" stretchType="RelativeToBandHeight" x="416" y="0" width="45" height="18" uuid="c1fa30b7-962b-44b0-9656-ea1cb004584c"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c1fa30b7-962b-44b0-9656-ea1cb004584c" key="textField-152" stretchType="ContainerHeight" x="416" y="0" width="45" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" x="461" y="0" width="57" height="18" uuid="12138c82-fe47-4b4b-a8b4-3a079a8253bf">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="12138c82-fe47-4b4b-a8b4-3a079a8253bf" key="textField" stretchType="ContainerHeight" x="461" y="0" width="57" height="18" evaluationTime="Group" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Auto" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-211" style="Level1_Line" stretchType="RelativeToBandHeight" x="161" y="0" width="42" height="18" uuid="5fb96d07-bba4-4408-b544-c23e469b701d"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="5fb96d07-bba4-4408-b544-c23e469b701d" key="textField-211" stretchType="ContainerHeight" x="161" y="0" width="42" height="18" fontSize="7.0" evaluationTime="Auto" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Level1_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM1}!=null && $V{AMOUNT_TOTAL}!=null)?new String("(") + $P{NUMBERFORMAT}.format($V{AMOUNT_SUM1}.doubleValue() / $V{AMOUNT_TOTAL}.doubleValue() * 100.00 ) + new String(" %)"):new String(" ")]]></expression>
+					<box rightPadding="3" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="7"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM1}!=null && $V{AMOUNT_TOTAL}!=null)?new String("(") + $P{NUMBERFORMAT}.format($V{AMOUNT_SUM1}.doubleValue() / $V{AMOUNT_TOTAL}.doubleValue() * 100.00 ) + new String(" %)"):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -897,99 +798,83 @@ $V{PROFIT_1}.divide( $V{AMOUNT_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).abs().multip
 		</groupFooter>
 	</group>
 	<group name="NIVEL2">
-		<groupExpression><![CDATA[$F{NIVEL2}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL2}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-2" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="6cf025d1-bb9a-4e93-9b0b-bdd2f587070a"/>
-					<box>
+				<element kind="textField" uuid="6cf025d1-bb9a-4e93-9b0b-bdd2f587070a" key="textField-2" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="188" height="18" uuid="09a4d1f3-07fd-4fd6-aa09-f53d834dede2"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="09a4d1f3-07fd-4fd6-aa09-f53d834dede2" key="textField" stretchType="ContainerHeight" x="15" y="0" width="188" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[$F{NIVEL2}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL2}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" x="203" y="0" width="61" height="18" uuid="f6ed5727-8cc8-4f23-808d-e059e11f6be5"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f6ed5727-8cc8-4f23-808d-e059e11f6be5" key="textField" stretchType="ContainerHeight" x="203" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" x="461" y="0" width="57" height="18" uuid="cce38e8e-4bcc-4c6c-a375-b9b17f67f4fc">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="cce38e8e-4bcc-4c6c-a375-b9b17f67f4fc" key="textField" stretchType="ContainerHeight" x="461" y="0" width="57" height="18" evaluationTime="Group" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-156" style="Level2_Line" stretchType="RelativeToBandHeight" x="264" y="0" width="61" height="18" uuid="36686175-8c40-4d05-9af4-50c6471367b3"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="36686175-8c40-4d05-9af4-50c6471367b3" key="textField-156" stretchType="ContainerHeight" x="264" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{COST_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COST_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-157" style="Level2_Line" stretchType="RelativeToBandHeight" x="325" y="0" width="61" height="18" uuid="60c470e7-4f9a-4549-aeae-b91dbddd05f9"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="60c470e7-4f9a-4549-aeae-b91dbddd05f9" key="textField-157" stretchType="ContainerHeight" x="325" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{PROFIT_2}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFIT_2}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-158" style="Level2_Line" stretchType="RelativeToBandHeight" x="386" y="0" width="30" height="18" uuid="09cae611-b663-4f26-842b-a361df598eb9"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="09cae611-b663-4f26-842b-a361df598eb9" key="textField-158" stretchType="ContainerHeight" x="386" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{MARGIN_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGIN_2}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-159" style="Level2_Line" stretchType="RelativeToBandHeight" x="416" y="0" width="45" height="18" uuid="ab61ccb8-11ce-4692-8359-ed521f786e51"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ab61ccb8-11ce-4692-8359-ed521f786e51" key="textField-159" stretchType="ContainerHeight" x="416" y="0" width="45" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -999,110 +884,92 @@ $V{PROFIT_1}.divide( $V{AMOUNT_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).abs().multip
 		</groupFooter>
 	</group>
 	<group name="NIVEL3">
-		<groupExpression><![CDATA[$F{NIVEL3}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL3}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-3" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="21047a1d-e409-4b7e-ba88-43d486d45afc"/>
-					<box>
+				<element kind="textField" uuid="21047a1d-e409-4b7e-ba88-43d486d45afc" key="textField-3" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-8" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="b040e42c-5be5-4fc1-8d8a-dc1540c5c089"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="b040e42c-5be5-4fc1-8d8a-dc1540c5c089" key="textField-8" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="173" height="18" uuid="31dc2a0b-a62d-4c26-aeae-478d20a5133a"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="31dc2a0b-a62d-4c26-aeae-478d20a5133a" key="textField" stretchType="ContainerHeight" x="30" y="0" width="173" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[$F{NIVEL3}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL3}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" x="203" y="0" width="61" height="18" uuid="1afce0ea-0c06-4b6d-adf3-7faf8dba44f2"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1afce0ea-0c06-4b6d-adf3-7faf8dba44f2" key="textField" stretchType="ContainerHeight" x="203" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" x="461" y="0" width="57" height="18" uuid="73868bbb-83ba-4551-a9f1-37fcad8adb74">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="73868bbb-83ba-4551-a9f1-37fcad8adb74" key="textField" stretchType="ContainerHeight" x="461" y="0" width="57" height="18" evaluationTime="Group" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-160" style="Level3_Line" stretchType="RelativeToBandHeight" x="264" y="0" width="61" height="18" uuid="7c47b4fa-9c62-4be9-952a-9b54c3ff886d"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7c47b4fa-9c62-4be9-952a-9b54c3ff886d" key="textField-160" stretchType="ContainerHeight" x="264" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{COST_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COST_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-161" style="Level3_Line" stretchType="RelativeToBandHeight" x="325" y="0" width="61" height="18" uuid="d16555ec-7481-4235-86d3-4f153b6517af"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d16555ec-7481-4235-86d3-4f153b6517af" key="textField-161" stretchType="ContainerHeight" x="325" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{PROFIT_3}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFIT_3}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-162" style="Level3_Line" stretchType="RelativeToBandHeight" x="386" y="0" width="30" height="18" uuid="c8964034-a1d4-43bc-8e93-e292ebab0f1a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c8964034-a1d4-43bc-8e93-e292ebab0f1a" key="textField-162" stretchType="ContainerHeight" x="386" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{MARGIN_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGIN_3}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-163" style="Level3_Line" stretchType="RelativeToBandHeight" x="416" y="0" width="45" height="18" uuid="7e0474c2-c801-4a41-82ee-0e20c20cb959"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7e0474c2-c801-4a41-82ee-0e20c20cb959" key="textField-163" stretchType="ContainerHeight" x="416" y="0" width="45" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -1112,121 +979,101 @@ $V{PROFIT_1}.divide( $V{AMOUNT_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).abs().multip
 		</groupFooter>
 	</group>
 	<group name="NIVEL4">
-		<groupExpression><![CDATA[$F{NIVEL4}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL4}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-4" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="3a034134-588a-4f27-8d21-b9cdfa996edf"/>
-					<box>
+				<element kind="textField" uuid="3a034134-588a-4f27-8d21-b9cdfa996edf" key="textField-4" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-9" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="0915a715-bd3d-4136-b0bf-7723bba004b6"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="0915a715-bd3d-4136-b0bf-7723bba004b6" key="textField-9" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-6" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="6687ce47-586e-41d4-9fdc-9c6167f7bafe"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="6687ce47-586e-41d4-9fdc-9c6167f7bafe" key="textField-6" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="158" height="18" uuid="72dbb929-f807-475c-98f3-ba4f0faf8866"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="72dbb929-f807-475c-98f3-ba4f0faf8866" key="textField" stretchType="ContainerHeight" x="45" y="0" width="158" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[$F{NIVEL4}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL4}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" x="203" y="0" width="61" height="18" uuid="53c81150-7e6a-47f6-9ce7-15e63c65fd00"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="53c81150-7e6a-47f6-9ce7-15e63c65fd00" key="textField" stretchType="ContainerHeight" x="203" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" x="461" y="0" width="57" height="18" uuid="027cf87e-3638-43e2-b06c-18dbaed8af5a">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="027cf87e-3638-43e2-b06c-18dbaed8af5a" key="textField" stretchType="ContainerHeight" x="461" y="0" width="57" height="18" evaluationTime="Group" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-164" style="Level4_Line" stretchType="RelativeToBandHeight" x="264" y="0" width="61" height="18" uuid="691b7b94-cca3-4586-9d42-d08fd1b35e05"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="691b7b94-cca3-4586-9d42-d08fd1b35e05" key="textField-164" stretchType="ContainerHeight" x="264" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{COST_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COST_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-165" style="Level4_Line" stretchType="RelativeToBandHeight" x="325" y="0" width="61" height="18" uuid="cfcdb29e-f7d5-4f0e-b226-4d056566274a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="cfcdb29e-f7d5-4f0e-b226-4d056566274a" key="textField-165" stretchType="ContainerHeight" x="325" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{PROFIT_4}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFIT_4}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-166" style="Level4_Line" stretchType="RelativeToBandHeight" x="386" y="0" width="30" height="18" uuid="643cc4eb-d8dc-4977-ab53-010744dad6ee"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="643cc4eb-d8dc-4977-ab53-010744dad6ee" key="textField-166" stretchType="ContainerHeight" x="386" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{MARGIN_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGIN_4}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-167" style="Level4_Line" stretchType="RelativeToBandHeight" x="416" y="0" width="45" height="18" uuid="e22bc59a-10c9-4b64-8655-cb476e94fa3b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e22bc59a-10c9-4b64-8655-cb476e94fa3b" key="textField-167" stretchType="ContainerHeight" x="416" y="0" width="45" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -1236,132 +1083,110 @@ $V{PROFIT_1}.divide( $V{AMOUNT_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).abs().multip
 		</groupFooter>
 	</group>
 	<group name="LEVEL5">
-		<groupExpression><![CDATA[$F{NIVEL5}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL5}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-5" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="51cf384e-3112-4c3e-8639-e223435650c7"/>
-					<box>
+				<element kind="textField" uuid="51cf384e-3112-4c3e-8639-e223435650c7" key="textField-5" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-10" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="ff8ffd49-ee4c-4794-916d-a6a6e923ed78"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="ff8ffd49-ee4c-4794-916d-a6a6e923ed78" key="textField-10" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-7" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="3bcb5298-971d-4399-af68-806699b2d993"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="3bcb5298-971d-4399-af68-806699b2d993" key="textField-7" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-11" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="f7648f0e-c514-422a-aa81-395d435cb3b6"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="f7648f0e-c514-422a-aa81-395d435cb3b6" key="textField-11" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="143" height="18" uuid="8160abc6-2b58-4c8d-bb5a-86cdff8694e2"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="8160abc6-2b58-4c8d-bb5a-86cdff8694e2" key="textField" stretchType="ContainerHeight" x="60" y="0" width="143" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[$F{NIVEL5}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL5}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" x="203" y="0" width="61" height="18" uuid="6cb953d3-2a6e-430d-a10f-943078f7e6ce"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6cb953d3-2a6e-430d-a10f-943078f7e6ce" key="textField" stretchType="ContainerHeight" x="203" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" x="461" y="0" width="57" height="18" uuid="620fa86e-f581-42cb-94d7-f33b8af4f36a">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="620fa86e-f581-42cb-94d7-f33b8af4f36a" key="textField" stretchType="ContainerHeight" x="461" y="0" width="57" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-168" style="Level5_Line" stretchType="RelativeToBandHeight" x="264" y="0" width="61" height="18" uuid="f15cfaf2-e999-4e82-bbd9-363dd73dc3ca"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f15cfaf2-e999-4e82-bbd9-363dd73dc3ca" key="textField-168" stretchType="ContainerHeight" x="264" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{COST_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COST_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-169" style="Level5_Line" stretchType="RelativeToBandHeight" x="325" y="0" width="61" height="18" uuid="23532939-c4d4-4c82-8e95-1f07159c9f11"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="23532939-c4d4-4c82-8e95-1f07159c9f11" key="textField-169" stretchType="ContainerHeight" x="325" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{PROFIT_5}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFIT_5}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-170" style="Level5_Line" stretchType="RelativeToBandHeight" x="386" y="0" width="30" height="18" uuid="d43a52e6-a532-4263-9b9d-e63fc19a9fb3"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d43a52e6-a532-4263-9b9d-e63fc19a9fb3" key="textField-170" stretchType="ContainerHeight" x="386" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{MARGIN_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGIN_5}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-171" style="Level5_Line" stretchType="RelativeToBandHeight" x="416" y="0" width="45" height="18" uuid="ff0fcd7d-250b-4c9f-aff4-5e12172d1c0f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ff0fcd7d-250b-4c9f-aff4-5e12172d1c0f" key="textField-171" stretchType="ContainerHeight" x="416" y="0" width="45" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -1371,143 +1196,119 @@ $V{PROFIT_1}.divide( $V{AMOUNT_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).abs().multip
 		</groupFooter>
 	</group>
 	<group name="LEVEL6">
-		<groupExpression><![CDATA[$F{NIVEL6}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL6}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=6)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-70" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="620d2cca-27fa-4f09-bbfc-1c7e33f32545"/>
-					<box>
+				<element kind="textField" uuid="620d2cca-27fa-4f09-bbfc-1c7e33f32545" key="textField-70" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-72" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="6992115b-03fe-416c-8443-b7b62f6a868a"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="6992115b-03fe-416c-8443-b7b62f6a868a" key="textField-72" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-71" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="2982257b-64fc-4324-9888-79f65ecd5d92"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="2982257b-64fc-4324-9888-79f65ecd5d92" key="textField-71" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-73" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="7970b2a5-d720-4134-85de-ab005ba4c56c"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="7970b2a5-d720-4134-85de-ab005ba4c56c" key="textField-73" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-74" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="15" height="18" uuid="e3913578-a2f0-46e9-95bb-8811ea31b27c"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="e3913578-a2f0-46e9-95bb-8811ea31b27c" key="textField-74" stretchType="ContainerHeight" x="60" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-66" style="Level6_Line" stretchType="RelativeToBandHeight" x="75" y="0" width="128" height="18" uuid="3b5e223c-4f80-48f1-868a-bdbfc07cb057"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3b5e223c-4f80-48f1-868a-bdbfc07cb057" key="textField-66" stretchType="ContainerHeight" x="75" y="0" width="128" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[$F{NIVEL6}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL6}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-69" style="Level6_Line" stretchType="RelativeToBandHeight" x="203" y="0" width="61" height="18" uuid="81bef209-64fb-4703-840c-1e5b80dc600f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="81bef209-64fb-4703-840c-1e5b80dc600f" key="textField-69" stretchType="ContainerHeight" x="203" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL6" isBlankWhenNull="false">
-					<reportElement key="textField-68" style="Level6_Line" stretchType="RelativeToBandHeight" x="461" y="0" width="57" height="18" uuid="b6549980-32fb-482b-b4b4-6bc5183a3c6c">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b6549980-32fb-482b-b4b4-6bc5183a3c6c" key="textField-68" stretchType="ContainerHeight" x="461" y="0" width="57" height="18" evaluationTime="Group" evaluationGroup="LEVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-172" style="Level6_Line" stretchType="RelativeToBandHeight" x="264" y="0" width="61" height="18" uuid="cf6ad0d5-1272-42b6-aab5-9e3e709ce2b3"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="cf6ad0d5-1272-42b6-aab5-9e3e709ce2b3" key="textField-172" stretchType="ContainerHeight" x="264" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{COST_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COST_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-173" style="Level6_Line" stretchType="RelativeToBandHeight" x="325" y="0" width="61" height="18" uuid="7af111b9-cbfa-47f3-884a-744c405f7f37"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7af111b9-cbfa-47f3-884a-744c405f7f37" key="textField-173" stretchType="ContainerHeight" x="325" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{PROFIT_6}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFIT_6}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-174" style="Level6_Line" stretchType="RelativeToBandHeight" x="386" y="0" width="30" height="18" uuid="45cc3484-8edd-4263-a4ae-a3d62a814397"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="45cc3484-8edd-4263-a4ae-a3d62a814397" key="textField-174" stretchType="ContainerHeight" x="386" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{MARGIN_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGIN_6}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_6}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-175" style="Level6_Line" stretchType="RelativeToBandHeight" x="416" y="0" width="45" height="18" uuid="f11608ee-44a2-4b52-8a92-ac4cf11f3a80"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f11608ee-44a2-4b52-8a92-ac4cf11f3a80" key="textField-175" stretchType="ContainerHeight" x="416" y="0" width="45" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM6}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM6}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM6}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -1517,154 +1318,128 @@ $V{PROFIT_1}.divide( $V{AMOUNT_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).abs().multip
 		</groupFooter>
 	</group>
 	<group name="LEVEL7">
-		<groupExpression><![CDATA[$F{NIVEL7}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL7}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=7)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-79" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="cde76098-3f9d-4a13-b953-6ae94dba83f1"/>
-					<box>
+				<element kind="textField" uuid="cde76098-3f9d-4a13-b953-6ae94dba83f1" key="textField-79" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-81" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="d4187696-a98d-47a1-9f3d-46479d66af67"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="d4187696-a98d-47a1-9f3d-46479d66af67" key="textField-81" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-80" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="93d448a8-391f-4026-a164-d2acf5502b09"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="93d448a8-391f-4026-a164-d2acf5502b09" key="textField-80" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-82" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="6886f733-00ac-4ebe-b86a-3e90c4bae687"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="6886f733-00ac-4ebe-b86a-3e90c4bae687" key="textField-82" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-83" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="15" height="18" uuid="aa610ab5-0eef-49e8-bafd-26f127aca115"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="aa610ab5-0eef-49e8-bafd-26f127aca115" key="textField-83" stretchType="ContainerHeight" x="60" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-84" style="Level6_Line" stretchType="RelativeToBandHeight" x="75" y="0" width="15" height="18" uuid="4322ee42-8815-4332-9a06-61b8bcbccc49"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="4322ee42-8815-4332-9a06-61b8bcbccc49" key="textField-84" stretchType="ContainerHeight" x="75" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-75" style="Level7_Line" stretchType="RelativeToBandHeight" x="90" y="0" width="113" height="18" uuid="46699bfc-0109-4ad9-b7d7-cd17a7daccf1"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="46699bfc-0109-4ad9-b7d7-cd17a7daccf1" key="textField-75" stretchType="ContainerHeight" x="90" y="0" width="113" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[$F{NIVEL7}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL7}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-176" style="Level7_Line" stretchType="RelativeToBandHeight" x="203" y="0" width="61" height="18" uuid="a2c6d673-cdca-407f-b127-025cad25fefe"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a2c6d673-cdca-407f-b127-025cad25fefe" key="textField-176" stretchType="ContainerHeight" x="203" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL7" isBlankWhenNull="false">
-					<reportElement key="textField-177" style="Level7_Line" stretchType="RelativeToBandHeight" x="461" y="0" width="57" height="18" uuid="43b4d47c-899c-4b4f-9828-bb789ecfd9e2">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="43b4d47c-899c-4b4f-9828-bb789ecfd9e2" key="textField-177" stretchType="ContainerHeight" x="461" y="0" width="57" height="18" evaluationTime="Group" evaluationGroup="LEVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-179" style="Level7_Line" stretchType="RelativeToBandHeight" x="264" y="0" width="61" height="18" uuid="2cc7fa84-edec-4707-baab-eaab4a2fe260"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2cc7fa84-edec-4707-baab-eaab4a2fe260" key="textField-179" stretchType="ContainerHeight" x="264" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{COST_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COST_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-180" style="Level7_Line" stretchType="RelativeToBandHeight" x="325" y="0" width="61" height="18" uuid="2a894be1-3c8f-450a-bd34-01113645cde1"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2a894be1-3c8f-450a-bd34-01113645cde1" key="textField-180" stretchType="ContainerHeight" x="325" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{PROFIT_7}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFIT_7}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-181" style="Level7_Line" stretchType="RelativeToBandHeight" x="386" y="0" width="30" height="18" uuid="75b8128f-682e-4d7e-9705-3760a4cd9024"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="75b8128f-682e-4d7e-9705-3760a4cd9024" key="textField-181" stretchType="ContainerHeight" x="386" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{MARGIN_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGIN_7}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_7}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-182" style="Level7_Line" stretchType="RelativeToBandHeight" x="416" y="0" width="45" height="18" uuid="be03cd73-b6e4-49cd-a7a6-a6b720299fc2"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="be03cd73-b6e4-49cd-a7a6-a6b720299fc2" key="textField-182" stretchType="ContainerHeight" x="416" y="0" width="45" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM7}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM7}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM7}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -1674,165 +1449,137 @@ $V{PROFIT_1}.divide( $V{AMOUNT_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).abs().multip
 		</groupFooter>
 	</group>
 	<group name="LEVEL8">
-		<groupExpression><![CDATA[$F{NIVEL8}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL8}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=8)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-89" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="6b702e2f-b1da-429e-ba0d-a4e7a968ef9f"/>
-					<box>
+				<element kind="textField" uuid="6b702e2f-b1da-429e-ba0d-a4e7a968ef9f" key="textField-89" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-91" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="f0db2c48-bb10-4aba-a971-feee15719305"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="f0db2c48-bb10-4aba-a971-feee15719305" key="textField-91" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-90" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="bfe7a472-6638-438d-86a6-1da70bf0e47c"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="bfe7a472-6638-438d-86a6-1da70bf0e47c" key="textField-90" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-92" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="c9f942f5-d011-4668-9bc6-270f2ea74d1e"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="c9f942f5-d011-4668-9bc6-270f2ea74d1e" key="textField-92" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-93" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="15" height="18" uuid="8cfd0a7d-e0bc-4ef2-a623-a092a14503d0"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="8cfd0a7d-e0bc-4ef2-a623-a092a14503d0" key="textField-93" stretchType="ContainerHeight" x="60" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-94" style="Level6_Line" stretchType="RelativeToBandHeight" x="75" y="0" width="15" height="18" uuid="d03129d2-9f06-4fd5-870a-583a29ca3b1d"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="d03129d2-9f06-4fd5-870a-583a29ca3b1d" key="textField-94" stretchType="ContainerHeight" x="75" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-95" style="Level7_Line" stretchType="RelativeToBandHeight" x="90" y="0" width="15" height="18" uuid="71170c13-1105-4014-bab0-4b4e3cef78dc"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="71170c13-1105-4014-bab0-4b4e3cef78dc" key="textField-95" stretchType="ContainerHeight" x="90" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-85" style="Level8_Line" stretchType="RelativeToBandHeight" x="105" y="0" width="98" height="18" uuid="a97b7432-c480-440e-9e42-d6af12d77236"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a97b7432-c480-440e-9e42-d6af12d77236" key="textField-85" stretchType="ContainerHeight" x="105" y="0" width="98" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level8_Line">
+					<expression><![CDATA[$F{NIVEL8}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL8}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-183" style="Level8_Line" stretchType="RelativeToBandHeight" x="203" y="0" width="61" height="18" uuid="3a6511c7-5da8-475a-ba59-bd1c0e737c2b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3a6511c7-5da8-475a-ba59-bd1c0e737c2b" key="textField-183" stretchType="ContainerHeight" x="203" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-186" style="Level8_Line" stretchType="RelativeToBandHeight" x="264" y="0" width="61" height="18" uuid="97d5584b-0eec-4cc5-80f9-2123deb17574"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="97d5584b-0eec-4cc5-80f9-2123deb17574" key="textField-186" stretchType="ContainerHeight" x="264" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{COST_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COST_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-187" style="Level8_Line" stretchType="RelativeToBandHeight" x="325" y="0" width="61" height="18" uuid="fc31007a-8962-431e-86c2-24d82734c1bb"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="fc31007a-8962-431e-86c2-24d82734c1bb" key="textField-187" stretchType="ContainerHeight" x="325" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{PROFIT_8}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFIT_8}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-188" style="Level8_Line" stretchType="RelativeToBandHeight" x="386" y="0" width="30" height="18" uuid="efefbeee-16b8-4990-9cdb-90c5cfbab667"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="efefbeee-16b8-4990-9cdb-90c5cfbab667" key="textField-188" stretchType="ContainerHeight" x="386" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{MARGIN_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGIN_8}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-189" style="Level8_Line" stretchType="RelativeToBandHeight" x="416" y="0" width="45" height="18" uuid="ecc9a41f-f1cf-4302-96ba-53a59b22714a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ecc9a41f-f1cf-4302-96ba-53a59b22714a" key="textField-189" stretchType="ContainerHeight" x="416" y="0" width="45" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL8" isBlankWhenNull="false">
-					<reportElement key="textField-184" style="Level8_Line" stretchType="RelativeToBandHeight" x="461" y="0" width="57" height="18" uuid="4cbd999c-c331-41b5-a2f6-ce7ef35bbc48">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4cbd999c-c331-41b5-a2f6-ce7ef35bbc48" key="textField-184" stretchType="ContainerHeight" x="461" y="0" width="57" height="18" evaluationTime="Group" evaluationGroup="LEVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM8}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM8}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM8}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -1842,176 +1589,146 @@ $V{PROFIT_1}.divide( $V{AMOUNT_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).abs().multip
 		</groupFooter>
 	</group>
 	<group name="LEVEL9">
-		<groupExpression><![CDATA[$F{NIVEL9}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL9}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=9)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-100" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="73d11c09-ac7b-4b2a-8c71-6df1b5b5b38d"/>
-					<box>
+				<element kind="textField" uuid="73d11c09-ac7b-4b2a-8c71-6df1b5b5b38d" key="textField-100" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-102" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="7b303656-0ca7-4f76-ab6d-288ff650388f"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="7b303656-0ca7-4f76-ab6d-288ff650388f" key="textField-102" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-101" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="8b1b570d-a827-46be-8511-fbb6b7456109"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="8b1b570d-a827-46be-8511-fbb6b7456109" key="textField-101" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-103" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="93e7ebd2-e54d-47df-a2a8-6897e0f2489d"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="93e7ebd2-e54d-47df-a2a8-6897e0f2489d" key="textField-103" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-104" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="15" height="18" uuid="1e871ed8-d186-4e90-9e81-58beef3e6f5a"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="1e871ed8-d186-4e90-9e81-58beef3e6f5a" key="textField-104" stretchType="ContainerHeight" x="60" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-105" style="Level6_Line" stretchType="RelativeToBandHeight" x="75" y="0" width="15" height="18" uuid="85299a7c-53ca-4b81-9b49-52eae7aae966"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="85299a7c-53ca-4b81-9b49-52eae7aae966" key="textField-105" stretchType="ContainerHeight" x="75" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-106" style="Level7_Line" stretchType="RelativeToBandHeight" x="90" y="0" width="15" height="18" uuid="1a2c5fcc-6c26-4bc1-a1a9-2d862e7a10a5"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="1a2c5fcc-6c26-4bc1-a1a9-2d862e7a10a5" key="textField-106" stretchType="ContainerHeight" x="90" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-107" style="Level8_Line" stretchType="RelativeToBandHeight" x="105" y="0" width="15" height="18" uuid="2ba01234-c3a1-443d-bbd5-ef3a9b889baf"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="2ba01234-c3a1-443d-bbd5-ef3a9b889baf" key="textField-107" stretchType="ContainerHeight" x="105" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level8_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-96" style="Level9_Line" stretchType="RelativeToBandHeight" x="120" y="0" width="83" height="18" uuid="50e5d317-d97a-4c7a-9c91-c9fb5ee1ed79"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="50e5d317-d97a-4c7a-9c91-c9fb5ee1ed79" key="textField-96" stretchType="ContainerHeight" x="120" y="0" width="83" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level9_Line">
+					<expression><![CDATA[$F{NIVEL9}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL9}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-190" style="Level9_Line" stretchType="RelativeToBandHeight" x="203" y="0" width="61" height="18" uuid="55dea3d7-eaf2-451e-a0c7-48a9fd7f2c9f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="55dea3d7-eaf2-451e-a0c7-48a9fd7f2c9f" key="textField-190" stretchType="ContainerHeight" x="203" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-191" style="Level9_Line" stretchType="RelativeToBandHeight" x="264" y="0" width="61" height="18" uuid="c492894f-53ac-401b-b389-50615308d96d"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c492894f-53ac-401b-b389-50615308d96d" key="textField-191" stretchType="ContainerHeight" x="264" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{COST_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COST_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-192" style="Level9_Line" stretchType="RelativeToBandHeight" x="325" y="0" width="61" height="18" uuid="0a8b6373-ea72-45e9-8981-df0f5a8869c7"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0a8b6373-ea72-45e9-8981-df0f5a8869c7" key="textField-192" stretchType="ContainerHeight" x="325" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{PROFIT_9}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFIT_9}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-193" style="Level9_Line" stretchType="RelativeToBandHeight" x="386" y="0" width="30" height="18" uuid="85a90216-9577-4431-ab48-a1a4ec6b996f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="85a90216-9577-4431-ab48-a1a4ec6b996f" key="textField-193" stretchType="ContainerHeight" x="386" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{MARGIN_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGIN_9}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-194" style="Level9_Line" stretchType="RelativeToBandHeight" x="416" y="0" width="45" height="18" uuid="556c76e2-031a-4604-9450-0653f4c5832e"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="556c76e2-031a-4604-9450-0653f4c5832e" key="textField-194" stretchType="ContainerHeight" x="416" y="0" width="45" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL9" isBlankWhenNull="false">
-					<reportElement key="textField-196" style="Level9_Line" stretchType="RelativeToBandHeight" x="461" y="0" width="57" height="18" uuid="41e24463-1994-4499-ae02-5894ecc59f6a">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="41e24463-1994-4499-ae02-5894ecc59f6a" key="textField-196" stretchType="ContainerHeight" x="461" y="0" width="57" height="18" evaluationTime="Group" evaluationGroup="LEVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM9}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM9}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM9}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -2021,187 +1738,155 @@ $V{PROFIT_1}.divide( $V{AMOUNT_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).abs().multip
 		</groupFooter>
 	</group>
 	<group name="LEVEL10">
-		<groupExpression><![CDATA[$F{NIVEL10}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL10}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=10)]]></printWhenExpression>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-112" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="68d6be4d-08d8-4a12-926e-2e8787e060e7"/>
-					<box>
+				<element kind="textField" uuid="68d6be4d-08d8-4a12-926e-2e8787e060e7" key="textField-112" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-114" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="8b024ac6-c4f3-48fc-97ab-f2baa40ab34d"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="8b024ac6-c4f3-48fc-97ab-f2baa40ab34d" key="textField-114" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-113" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="68c4414d-1c3a-4b44-9a8b-52295fe0c257"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="68c4414d-1c3a-4b44-9a8b-52295fe0c257" key="textField-113" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-115" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="0b8636e4-fbf1-4f50-bf7b-3cb0db318d31"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="0b8636e4-fbf1-4f50-bf7b-3cb0db318d31" key="textField-115" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-116" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="15" height="18" uuid="9ab772c0-504f-4e84-b5b4-b7fc0f18d809"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="9ab772c0-504f-4e84-b5b4-b7fc0f18d809" key="textField-116" stretchType="ContainerHeight" x="60" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-117" style="Level6_Line" stretchType="RelativeToBandHeight" x="75" y="0" width="15" height="18" uuid="97b15deb-00ad-4b1c-929b-e57a72336e2b"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="97b15deb-00ad-4b1c-929b-e57a72336e2b" key="textField-117" stretchType="ContainerHeight" x="75" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-118" style="Level7_Line" stretchType="RelativeToBandHeight" x="90" y="0" width="15" height="18" uuid="0eef449a-442c-4f53-a8ea-dd0ddfd08605"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="0eef449a-442c-4f53-a8ea-dd0ddfd08605" key="textField-118" stretchType="ContainerHeight" x="90" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-119" style="Level8_Line" stretchType="RelativeToBandHeight" x="105" y="0" width="15" height="18" uuid="f7322b78-949d-485a-a67a-0e8da0cd4576"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="f7322b78-949d-485a-a67a-0e8da0cd4576" key="textField-119" stretchType="ContainerHeight" x="105" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level8_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-120" style="Level9_Line" stretchType="RelativeToBandHeight" x="120" y="0" width="15" height="18" uuid="5021ea13-639c-44c7-84e0-c1bbeb521aef"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="5021ea13-639c-44c7-84e0-c1bbeb521aef" key="textField-120" stretchType="ContainerHeight" x="120" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level9_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField-108" style="Level10_Line" stretchType="RelativeToBandHeight" x="135" y="0" width="68" height="18" uuid="f1a90c2c-1a0c-409d-9749-b1e1fe27d01a"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f1a90c2c-1a0c-409d-9749-b1e1fe27d01a" key="textField-108" stretchType="ContainerHeight" x="135" y="0" width="68" height="18" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="Level10_Line">
+					<expression><![CDATA[$F{NIVEL10}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL10}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-197" style="Level10_Line" stretchType="RelativeToBandHeight" x="203" y="0" width="61" height="18" uuid="75d8d48e-2213-42cc-97ce-481be797be10"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="75d8d48e-2213-42cc-97ce-481be797be10" key="textField-197" stretchType="ContainerHeight" x="203" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{AMOUNT_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-198" style="Level10_Line" stretchType="RelativeToBandHeight" x="264" y="0" width="61" height="18" uuid="ebc92a53-35f1-470d-a437-6aa3be656b44"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ebc92a53-35f1-470d-a437-6aa3be656b44" key="textField-198" stretchType="ContainerHeight" x="264" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{COST_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{COST_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{COST_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-199" style="Level10_Line" stretchType="RelativeToBandHeight" x="325" y="0" width="61" height="18" uuid="1668e45c-dc72-4360-a047-c4b2a9373c06"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1668e45c-dc72-4360-a047-c4b2a9373c06" key="textField-199" stretchType="ContainerHeight" x="325" y="0" width="61" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{PROFIT_10}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{PROFIT_10}!=null)?$P{NUMBERFORMAT}.format($V{PROFIT_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-200" style="Level10_Line" stretchType="RelativeToBandHeight" x="386" y="0" width="30" height="18" uuid="79839f02-6798-486e-95aa-6726976a587a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="79839f02-6798-486e-95aa-6726976a587a" key="textField-200" stretchType="ContainerHeight" x="386" y="0" width="30" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{MARGIN_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{MARGIN_10}!=null)?$P{NUMBERFORMAT}.format($V{MARGIN_10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-201" style="Level10_Line" stretchType="RelativeToBandHeight" x="416" y="0" width="45" height="18" uuid="9b27ba9c-aafd-41ad-b254-e7ef5b1c6cd6"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9b27ba9c-aafd-41ad-b254-e7ef5b1c6cd6" key="textField-201" stretchType="ContainerHeight" x="416" y="0" width="45" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{WEIGHT_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL10" isBlankWhenNull="false">
-					<reportElement key="textField-202" style="Level10_Line" stretchType="RelativeToBandHeight" x="461" y="0" width="57" height="18" uuid="843d9ea9-1e23-458a-94af-5009a7878d2b">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="843d9ea9-1e23-458a-94af-5009a7878d2b" key="textField-202" stretchType="ContainerHeight" x="461" y="0" width="57" height="18" evaluationTime="Group" evaluationGroup="LEVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM10}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM10}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM10}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -2210,432 +1895,325 @@ $V{PROFIT_1}.divide( $V{AMOUNT_SUM1}, 4, BigDecimal.ROUND_HALF_UP ).abs().multip
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="160" splitType="Stretch">
-			<property name="local_mesure_unitheight" value="pixel"/>
-			<property name="com.jaspersoft.studio.unit.height" value="px"/>
-			<frame>
-				<reportElement key="frame-1" positionType="Float" mode="Opaque" x="0" y="141" width="518" height="19" backcolor="#5D5D5D" uuid="852b20b2-9ce0-4ffe-adb3-a223cd12b4ad"/>
-				<box>
+	<background splitType="Stretch"/>
+	<title height="160" splitType="Stretch">
+		<element kind="frame" uuid="852b20b2-9ce0-4ffe-adb3-a223cd12b4ad" key="frame-1" positionType="Float" mode="Opaque" x="0" y="141" width="518" height="19" backcolor="#5D5D5D">
+			<element kind="textField" uuid="756218e7-871e-49e1-b50f-d486091b226c" key="textField-61" positionType="Float" x="0" y="0" width="15" height="19" rotation="None" blankWhenNull="true" style="Detail_Header">
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-61" style="Detail_Header" positionType="Float" x="0" y="0" width="15" height="19" uuid="756218e7-871e-49e1-b50f-d486091b226c"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-62" style="Detail_Header" positionType="Float" x="15" y="0" width="15" height="19" uuid="e3d2173d-b7d0-4501-8336-e83c94505511"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-63" style="Detail_Header" positionType="Float" x="30" y="0" width="15" height="19" uuid="7eac0ab0-6b11-4f53-9286-8714ac5fb01e"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-64" style="Detail_Header" positionType="Float" x="45" y="0" width="15" height="19" uuid="b73cff8f-bd6d-436a-8d4b-b803f605e079"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-65" style="Detail_Header" positionType="Float" x="60" y="0" width="15" height="19" uuid="0c6459ab-6856-44e4-84f8-9e7544e893b5"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":"")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-9" style="Detail_Header" positionType="Float" mode="Opaque" x="386" y="0" width="30" height="19" uuid="c171ae3e-c8f8-4086-b87c-71129084fb02"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right"/>
-					<text><![CDATA[M. %]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-10" style="Detail_Header" positionType="Float" mode="Opaque" x="461" y="0" width="57" height="19" uuid="242deca0-f8a2-4df7-b7c8-d613035e6d53"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-11" style="Detail_Header" positionType="Float" mode="Opaque" x="416" y="0" width="45" height="19" uuid="eedd0de5-e234-4400-9581-42752900267d"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right"/>
-					<text><![CDATA[Weight]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-12" style="Detail_Header" positionType="Float" mode="Opaque" x="325" y="0" width="61" height="19" uuid="1990152d-b8fc-4567-a611-82bf6c20ddcd"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right"/>
-					<text><![CDATA[Profit]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-13" style="Detail_Header" positionType="Float" mode="Opaque" x="264" y="0" width="61" height="19" uuid="ad788004-a143-4ed2-bb6c-06109b5a82fb"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right"/>
-					<text><![CDATA[Cost]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-14" style="Detail_Header" positionType="Float" mode="Opaque" x="203" y="0" width="61" height="19" uuid="d631ffa8-d3a2-4465-9bce-fc62c9e88f21"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right"/>
-					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-205" style="Detail_Header" positionType="Float" x="75" y="0" width="15" height="19" uuid="e8c0987c-11fc-4b9f-825a-68374d56a918"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(6))>=0)?"6":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-206" style="Detail_Header" positionType="Float" x="90" y="0" width="15" height="19" uuid="8ce1b3ac-190a-44cc-be4c-1f1466c76dee"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(7))>=0)?"7":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-207" style="Detail_Header" positionType="Float" x="105" y="0" width="15" height="19" uuid="d839b984-ac14-4757-bd57-01eabc2a1431"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(8))>=0)?"8":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-208" style="Detail_Header" positionType="Float" x="120" y="0" width="15" height="19" uuid="fd3ca1c5-10db-48d4-bb67-670c2bceb7f2"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(9))>=0)?"9":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-209" style="Detail_Header" positionType="Float" x="135" y="0" width="15" height="19" uuid="90a009cf-158b-4df5-884f-41b11f7ce463"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(10))>=0)?"10":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-210" style="Detail_Header" positionType="Float" x="150" y="0" width="52" height="19" uuid="597b7d33-fe4d-41e1-a177-5929de429f5b"/>
-					<box leftPadding="1">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Center" rotation="None"/>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-			</frame>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Report_Title" x="0" y="0" width="518" height="26" uuid="8f8577e5-0ec1-4ec7-9633-05e52441100a"/>
-				<box leftPadding="5">
+			</element>
+			<element kind="textField" uuid="e3d2173d-b7d0-4501-8336-e83c94505511" key="textField-62" positionType="Float" x="15" y="0" width="15" height="19" rotation="None" blankWhenNull="true" style="Detail_Header">
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Subtitle" x="0" y="31" width="518" height="18" uuid="e7a68f4f-63ef-46b7-9c56-bcba568cbc12"/>
-				<box leftPadding="5">
+			</element>
+			<element kind="textField" uuid="7eac0ab0-6b11-4f53-9286-8714ac5fb01e" key="textField-63" positionType="Float" x="30" y="0" width="15" height="19" rotation="None" blankWhenNull="true" style="Detail_Header">
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_SUBTITLE}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-5" style="Report_Data_Label" x="0" y="52" width="114" height="16" uuid="0e46af4d-dc97-43d6-b383-1351a9d527e6"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="b73cff8f-bd6d-436a-8d4b-b803f605e079" key="textField-64" positionType="Float" x="45" y="0" width="15" height="19" rotation="None" blankWhenNull="true" style="Detail_Header">
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<text><![CDATA[Grouping Levels:]]></text>
-			</staticText>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="114" y="52" width="404" height="16" uuid="b74fa9ef-1ced-4cd7-935c-9523099d2c32"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="0c6459ab-6856-44e4-84f8-9e7544e893b5" key="textField-65" positionType="Float" x="60" y="0" width="15" height="19" rotation="None" blankWhenNull="true" style="Detail_Header">
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$P{LEVEL_LABEL}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="26" width="518" height="1" uuid="8b6b7054-bf7a-43ff-b6cf-dee766a2516c"/>
-			</line>
-			<line>
-				<reportElement key="line-2" x="0" y="49" width="518" height="1" uuid="dd51a642-a70f-41ed-a634-2e5c6f25c403"/>
-			</line>
-			<staticText>
-				<reportElement key="staticText-5" style="Report_Data_Label" x="0" y="68" width="114" height="16" uuid="b4605793-7d2c-4631-b2e3-2154d639de3a"/>
-				<box>
+			</element>
+			<element kind="staticText" uuid="c171ae3e-c8f8-4086-b87c-71129084fb02" key="staticText-9" positionType="Float" mode="Opaque" x="386" y="0" width="30" height="19" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[M. %]]></text>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="11" isBold="false"/>
-				</textElement>
-				<text><![CDATA[Secondary Filters:]]></text>
-			</staticText>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="209" y="68" width="309" height="16" uuid="e61dff39-311c-4aa2-8753-57754e54d23a"/>
-				<box>
+			</element>
+			<element kind="staticText" uuid="242deca0-f8a2-4df7-b7c8-d613035e6d53" key="staticText-10" positionType="Float" mode="Opaque" x="461" y="0" width="57" height="19" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Quantity]]></text>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="11"/>
-					<paragraph tabStopWidth="0"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{ORGANIZATION} + " and any child organization"]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="264" y="84" width="254" height="16" uuid="15b89717-7225-48f4-8f5e-34a0cb12917a">
-					<printWhenExpression><![CDATA[!$P{BPGROUP}.equals("")]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="staticText" uuid="eedd0de5-e234-4400-9581-42752900267d" key="staticText-11" positionType="Float" mode="Opaque" x="416" y="0" width="45" height="19" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Weight]]></text>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="11"/>
-					<paragraph tabStopWidth="0"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{BPGROUP}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="209" y="100" width="309" height="16" uuid="28bcf592-b1b4-45c7-ab08-da69714abf80">
-					<printWhenExpression><![CDATA[!$P{PRODUCTGROUP}.equals("")]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="staticText" uuid="1990152d-b8fc-4567-a611-82bf6c20ddcd" key="staticText-12" positionType="Float" mode="Opaque" x="325" y="0" width="61" height="19" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Profit]]></text>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="11"/>
-					<paragraph tabStopWidth="0"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{PRODUCTGROUP}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="114" y="68" width="95" height="16" uuid="60e9c200-4190-4098-bf5b-a2dea221228f"/>
-				<box>
+			</element>
+			<element kind="staticText" uuid="ad788004-a143-4ed2-bb6c-06109b5a82fb" key="staticText-13" positionType="Float" mode="Opaque" x="264" y="0" width="61" height="19" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Cost]]></text>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="11"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Organization- "]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="114" y="84" width="150" height="16" uuid="855e04d3-c93e-4132-a3ed-46702cc8c4ee">
-					<printWhenExpression><![CDATA[!$P{BPGROUP}.equals("")]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="staticText" uuid="d631ffa8-d3a2-4465-9bce-fc62c9e88f21" key="staticText-14" positionType="Float" mode="Opaque" x="203" y="0" width="61" height="19" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Amount]]></text>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="11"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Business Partner Group- "]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="113" y="100" width="96" height="16" uuid="4d63a12c-3e32-46d6-b49f-7d685212df84">
-					<printWhenExpression><![CDATA[!$P{PRODUCTGROUP}.equals("")]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="textField" uuid="e8c0987c-11fc-4b9f-825a-68374d56a918" key="textField-205" positionType="Float" x="75" y="0" width="15" height="19" rotation="None" blankWhenNull="true" style="Detail_Header">
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(6))>=0)?"6":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="11"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Product Group- "]]></textFieldExpression>
-			</textField>
-		</band>
+			</element>
+			<element kind="textField" uuid="8ce1b3ac-190a-44cc-be4c-1f1466c76dee" key="textField-206" positionType="Float" x="90" y="0" width="15" height="19" rotation="None" blankWhenNull="true" style="Detail_Header">
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(7))>=0)?"7":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="d839b984-ac14-4757-bd57-01eabc2a1431" key="textField-207" positionType="Float" x="105" y="0" width="15" height="19" rotation="None" blankWhenNull="true" style="Detail_Header">
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(8))>=0)?"8":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="fd3ca1c5-10db-48d4-bb67-670c2bceb7f2" key="textField-208" positionType="Float" x="120" y="0" width="15" height="19" rotation="None" blankWhenNull="true" style="Detail_Header">
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(9))>=0)?"9":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="90a009cf-158b-4df5-884f-41b11f7ce463" key="textField-209" positionType="Float" x="135" y="0" width="15" height="19" rotation="None" blankWhenNull="true" style="Detail_Header">
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(10))>=0)?"10":"")]]></expression>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="597b7d33-fe4d-41e1-a177-5929de429f5b" key="textField-210" positionType="Float" x="150" y="0" width="52" height="19" rotation="None" blankWhenNull="true" hTextAlign="Center" style="Detail_Header">
+				<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+				<box leftPadding="1" style="Detail_Header">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="8f8577e5-0ec1-4ec7-9633-05e52441100a" key="textField" x="0" y="0" width="518" height="26" textAdjust="StretchHeight" blankWhenNull="true" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="e7a68f4f-63ef-46b7-9c56-bcba568cbc12" key="textField" x="0" y="31" width="518" height="18" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="0e46af4d-dc97-43d6-b383-1351a9d527e6" key="staticText-5" x="0" y="52" width="114" height="16" style="Report_Data_Label">
+			<text><![CDATA[Grouping Levels:]]></text>
+			<box style="Report_Data_Label">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="b74fa9ef-1ced-4cd7-935c-9523099d2c32" key="textField-17" x="114" y="52" width="404" height="16" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Data_Field">
+			<expression><![CDATA[$P{LEVEL_LABEL}]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="8b6b7054-bf7a-43ff-b6cf-dee766a2516c" key="line-1" x="0" y="26" width="518" height="1"/>
+		<element kind="line" uuid="dd51a642-a70f-41ed-a634-2e5c6f25c403" key="line-2" x="0" y="49" width="518" height="1"/>
+		<element kind="staticText" uuid="b4605793-7d2c-4631-b2e3-2154d639de3a" key="staticText-5" x="0" y="68" width="114" height="16" fontSize="11.0" bold="false" style="Report_Data_Label">
+			<text><![CDATA[Secondary Filters:]]></text>
+			<box style="Report_Data_Label">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="e61dff39-311c-4aa2-8753-57754e54d23a" key="textField-17" x="209" y="68" width="309" height="16" fontSize="11.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<paragraph tabStopWidth="0" style="Report_Data_Field"/>
+			<expression><![CDATA[$P{ORGANIZATION} + " and any child organization"]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="15b89717-7225-48f4-8f5e-34a0cb12917a" key="textField-17" x="264" y="84" width="254" height="16" fontSize="11.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<printWhenExpression><![CDATA[!$P{BPGROUP}.equals("")]]></printWhenExpression>
+			<paragraph tabStopWidth="0" style="Report_Data_Field"/>
+			<expression><![CDATA[$P{BPGROUP}]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="28bcf592-b1b4-45c7-ab08-da69714abf80" key="textField-17" x="209" y="100" width="309" height="16" fontSize="11.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<printWhenExpression><![CDATA[!$P{PRODUCTGROUP}.equals("")]]></printWhenExpression>
+			<paragraph tabStopWidth="0" style="Report_Data_Field"/>
+			<expression><![CDATA[$P{PRODUCTGROUP}]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="60e9c200-4190-4098-bf5b-a2dea221228f" key="textField-17" x="114" y="68" width="95" height="16" fontSize="11.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<expression><![CDATA["Organization- "]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="855e04d3-c93e-4132-a3ed-46702cc8c4ee" key="textField-17" x="114" y="84" width="150" height="16" fontSize="11.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<printWhenExpression><![CDATA[!$P{BPGROUP}.equals("")]]></printWhenExpression>
+			<expression><![CDATA["Business Partner Group- "]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="4d63a12c-3e32-46d6-b49f-7d685212df84" key="textField-17" x="113" y="100" width="96" height="16" fontSize="11.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Report_Data_Field">
+			<printWhenExpression><![CDATA[!$P{PRODUCTGROUP}.equals("")]]></printWhenExpression>
+			<expression><![CDATA["Product Group- "]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<property name="local_mesure_unitheight" value="pixel"/>
+		<property name="com.jaspersoft.studio.unit.height" value="px"/>
 	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band splitType="Stretch"/>
 	</detail>
-	<pageFooter>
-		<band height="20" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-7" style="Report_Footer" x="161" y="3" width="78" height="16" uuid="a304439f-37d0-48f1-8fe5-c89ed1e5b801"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Generated on ]]></text>
-			</staticText>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-18" style="Report_Footer" x="237" y="3" width="90" height="16" uuid="7106bb15-fcae-4738-b11d-f772bd26196f"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-19" style="Report_Footer" x="350" y="3" width="95" height="16" uuid="c6142e22-2b70-4be4-a629-a35ff4db6cd2"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-20" style="Report_Footer" x="447" y="3" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="1a81196f-e840-4ea9-a006-0237bd7a5bc4"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-4" x="0" y="2" width="518" height="1" uuid="1be69e3d-a997-4394-80e6-1d9ec2ef02b3"/>
-			</line>
-		</band>
+	<pageFooter height="20" splitType="Stretch">
+		<element kind="staticText" uuid="a304439f-37d0-48f1-8fe5-c89ed1e5b801" key="staticText-7" x="161" y="3" width="78" height="16" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Generated on ]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="7106bb15-fcae-4738-b11d-f772bd26196f" key="textField-18" x="237" y="3" width="90" height="16" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="c6142e22-2b70-4be4-a629-a35ff4db6cd2" key="textField-19" x="350" y="3" width="95" height="16" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="1a81196f-e840-4ea9-a006-0237bd7a5bc4" key="textField-20" x="447" y="3" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle" style="Report_Footer">
+			<paragraph lineSpacing="Single" style="Report_Footer"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="1be69e3d-a997-4394-80e6-1d9ec2ef02b3" key="line-4" x="0" y="2" width="518" height="1"/>
 	</pageFooter>
-	<lastPageFooter>
-		<band height="58"/>
-	</lastPageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<lastPageFooter height="58"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesXLS.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalysesXLS.jrxml
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
-<!-- 2017-03-02T13:16:17 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportInvoiceCustomerDimensionalAnalysesXLS" pageWidth="1900" pageHeight="842" orientation="Landscape" columnWidth="1900" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" isIgnorePagination="true" uuid="59be190b-97b3-4951-842b-79d4e9d2d71b">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportInvoiceCustomerDimensionalAnalysesXLS" language="java" pageWidth="1900" pageHeight="842" orientation="Landscape" columnWidth="1900" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="59be190b-97b3-4951-842b-79d4e9d2d71b" ignorePagination="true">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
@@ -18,67 +16,66 @@
 	<property name="com.jaspersoft.studio.unit.rightMargin" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnWidth" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="11">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="11.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/opt/Apps230/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'0','1000000'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_client" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_client" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{USER_CLIENT}.equals("") ? " " : " AND C_INVOICE.AD_CLIENT_ID IN(" + $P{USER_CLIENT} + ")"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'1000000','1000001'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat("###,##0.00", new DecimalFormatSymbols())]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="strDateFormat" class="java.lang.String" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="strDateFormat" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["dd/MM/yyyy"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="ORGANIZATION" class="java.lang.String"/>
@@ -86,60 +83,59 @@
 	<parameter name="PRODUCTGROUP" class="java.lang.String"/>
 	<parameter name="C_CURRENCY_ID" class="java.lang.String"/>
 	<parameter name="AD_ORG_ID" class="java.lang.String"/>
-	<parameter name="aux_org" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_org" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{AD_ORG_ID}.equals("") ? " " : " AND C_INVOICE.AD_ORG_ID IN(" + $P{AD_ORG_ID} + ")"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="DateFrom" class="java.lang.String"/>
 	<parameter name="DateTo" class="java.lang.String"/>
-	<parameter name="aux_DateFrom" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_DateFrom" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{DateFrom} == null || $P{DateFrom}.equals("")) ? "" : "AND C_INVOICE.DATEINVOICED >= TO_DATE('" + $P{DateFrom} + "', 'YYYY-MM-DD')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_DateTo" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_DateTo" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{DateTo} == null || $P{DateTo}.equals("")) ? "" : "AND C_INVOICE.DATEINVOICED <= TO_DATE('" + $P{DateTo} + "', 'YYYY-MM-DD')"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="C_BP_GROUP_ID" class="java.lang.String"/>
-	<parameter name="aux_bpgroup" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_bpgroup" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{C_BP_GROUP_ID}.equals("") ? " " : " AND C_BPARTNER.C_BP_GROUP_ID = '" + $P{C_BP_GROUP_ID} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="C_BPARTNER_ID" class="java.lang.String"/>
-	<parameter name="aux_partner" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_partner" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{C_BPARTNER_ID}.equals("") ? " " : " AND C_BPARTNER.C_BPARTNER_ID IN" + $P{C_BPARTNER_ID}]]></defaultValueExpression>
 	</parameter>
 	<parameter name="M_PRODUCT_CATEGORY_ID" class="java.lang.String"/>
-	<parameter name="aux_productcategory" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_productcategory" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{M_PRODUCT_CATEGORY_ID}.equals("") ? " " : " AND M_PRODUCT_CATEGORY.M_PRODUCT_CATEGORY_ID IN" + $P{M_PRODUCT_CATEGORY_ID}]]></defaultValueExpression>
 	</parameter>
 	<parameter name="M_PRODUCT_ID" class="java.lang.String"/>
-	<parameter name="aux_product" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_product" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{M_PRODUCT_ID}.equals("") ? " " : "  AND M_PRODUCT.M_PRODUCT_ID IN" + $P{M_PRODUCT_ID}]]></defaultValueExpression>
 	</parameter>
 	<parameter name="SALESREP_ID" class="java.lang.String"/>
-	<parameter name="aux_salesrep" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_salesrep" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{SALESREP_ID}.equals("") ? " " : " AND C_INVOICE.SALESREP_ID = '" + $P{SALESREP_ID} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="PARTNER_SALESREP_ID" class="java.lang.String"/>
-	<parameter name="aux_partnersalesrep" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_partnersalesrep" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{PARTNER_SALESREP_ID}.equals("") ? " " : " AND CB.C_BPARTNER_ID = '" + $P{PARTNER_SALESREP_ID} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="C_PROJECT_ID" class="java.lang.String"/>
-	<parameter name="aux_project" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_project" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{C_PROJECT_ID}.equals("") ? " " : " AND C_INVOICE.C_PROJECT_ID = '" + $P{C_PROJECT_ID} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="PRODUCTTYPE" class="java.lang.String"/>
-	<parameter name="aux_producttype" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_producttype" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{PRODUCTTYPE}.equals("") ? " " : " AND M_PRODUCT.PRODUCTTYPE = '" + $P{PRODUCTTYPE} + "'"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="C_DOCTYPE_ID" class="java.lang.String"/>
-	<parameter name="aux_doctype" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_doctype" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{C_DOCTYPE_ID}.equals("") ? " " : " AND C_INVOICE.C_DOCTYPE_ID IN" + $P{C_DOCTYPE_ID}]]></defaultValueExpression>
 	</parameter>
 	<parameter name="DOCSTATUS" class="java.lang.String"/>
-	<parameter name="aux_docstatus" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_docstatus" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{DOCSTATUS}.equals("") ? " " : " AND C_INVOICE.DOCSTATUS <> '" + $P{DOCSTATUS} + "'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="SR_LINES" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<queryString language="SQL">
-		<![CDATA[SELECT ORG, DOCTYPENAME, PARTNERGROUP, PARTNER, DOCUMENTNO, INVOICEDATE, PRODCATEGORY, PRODUCT, SEARCHKEY, UNITPRICE,
+	<parameter name="SR_LINES" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<query language="SQL"><![CDATA[SELECT ORG, DOCTYPENAME, PARTNERGROUP, PARTNER, DOCUMENTNO, INVOICEDATE, PRODCATEGORY, PRODUCT, SEARCHKEY, UNITPRICE,
         AMOUNT, COST, (AMOUNT - COST) AS PROFIT, CASE WHEN AMOUNT <> 0 THEN ROUND((100 * (AMOUNT - COST) / AMOUNT), 2) ELSE 0 END AS MARGIN,
         WEIGHT, QTY, CONTACT, SALESREP, PROJECT, ADDRESS
         FROM (
@@ -186,8 +182,7 @@
             AND C_INVOICE.AD_CLIENT_ID IN ('7')
             AND 1=1
           AND 1=1) AA
-          ORDER BY ORG, DOCUMENTNO, INVOICEDATE]]>
-	</queryString>
+          ORDER BY ORG, DOCUMENTNO, INVOICEDATE]]></query>
 	<field name="ORG" class="java.lang.String"/>
 	<field name="DOCTYPENAME" class="java.lang.String"/>
 	<field name="PARTNERGROUP" class="java.lang.String"/>
@@ -208,780 +203,537 @@
 	<field name="SALESREP" class="java.lang.String"/>
 	<field name="PROJECT" class="java.lang.String"/>
 	<field name="ADDRESS" class="java.lang.String"/>
-	<variable name="totalQty" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="totalQty" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="totalPrice" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{UNITPRICE}]]></variableExpression>
+	<variable name="totalPrice" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{UNITPRICE}]]></expression>
 	</variable>
-	<variable name="totalAmt" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="totalAmt" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="totalCost" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{COST}]]></variableExpression>
+	<variable name="totalCost" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{COST}]]></expression>
 	</variable>
-	<variable name="totalProfit" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{PROFIT}]]></variableExpression>
+	<variable name="totalProfit" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{PROFIT}]]></expression>
 	</variable>
 	<variable name="totalMargin" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[($V{totalAmt}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{totalProfit}.divide($V{totalAmt}, 10, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{totalProfit}.signum()))]]></variableExpression>
+		<expression><![CDATA[($V{totalAmt}.compareTo(BigDecimal.ZERO)==0)? BigDecimal.ZERO: $V{totalProfit}.divide($V{totalAmt}, 10, BigDecimal.ROUND_HALF_UP).abs().multiply(new BigDecimal("100")).multiply(new BigDecimal($V{totalProfit}.signum()))]]></expression>
 	</variable>
-	<variable name="totalWeight" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="totalWeight" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
 	<group name="DocumentType">
 		<groupFooter>
 			<band height="16">
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement x="900" y="0" width="100" height="16" uuid="ad71c59c-13fd-4a50-a2bf-229163d449ef"/>
-					<box rightPadding="2"/>
-					<textElement textAlignment="Right">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{totalQty}]]></textFieldExpression>
+				<element kind="textField" uuid="ad71c59c-13fd-4a50-a2bf-229163d449ef" x="900" y="0" width="100" height="16" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" hTextAlign="Right">
+					<expression><![CDATA[$V{totalQty}]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement x="1100" y="0" width="100" height="16" uuid="7a0dc66f-1e1d-4dba-81b7-016d70c9bc69"/>
 					<box rightPadding="2"/>
-					<textElement textAlignment="Right">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{totalAmt}]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="7a0dc66f-1e1d-4dba-81b7-016d70c9bc69" x="1100" y="0" width="100" height="16" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" hTextAlign="Right">
+					<expression><![CDATA[$V{totalAmt}]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement x="1200" y="0" width="100" height="16" uuid="6601ab30-4e55-4798-af99-86ac9a0360fa"/>
 					<box rightPadding="2"/>
-					<textElement textAlignment="Right">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{totalCost}]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="6601ab30-4e55-4798-af99-86ac9a0360fa" x="1200" y="0" width="100" height="16" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" hTextAlign="Right">
+					<expression><![CDATA[$V{totalCost}]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement x="1300" y="0" width="100" height="16" uuid="a95e6755-6bce-4449-8f95-ea982b8a5bef"/>
 					<box rightPadding="2"/>
-					<textElement textAlignment="Right">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{totalProfit}]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="a95e6755-6bce-4449-8f95-ea982b8a5bef" x="1300" y="0" width="100" height="16" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" hTextAlign="Right">
+					<expression><![CDATA[$V{totalProfit}]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement x="1400" y="0" width="50" height="16" uuid="a53f8c90-bfaa-4ce7-94dd-033ca0e10da6"/>
 					<box rightPadding="2"/>
-					<textElement textAlignment="Right">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{totalMargin}!=null)?$V{totalMargin}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="a53f8c90-bfaa-4ce7-94dd-033ca0e10da6" x="1400" y="0" width="50" height="16" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" hTextAlign="Right">
+					<expression><![CDATA[($V{totalMargin}!=null)?$V{totalMargin}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement x="1450" y="0" width="50" height="16" uuid="e9aaf868-723e-4e05-80df-27c71e96d54e"/>
 					<box rightPadding="2"/>
-					<textElement textAlignment="Right">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{totalWeight}]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="e9aaf868-723e-4e05-80df-27c71e96d54e" x="1450" y="0" width="50" height="16" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" hTextAlign="Right">
+					<expression><![CDATA[$V{totalWeight}]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<staticText>
-					<reportElement x="800" y="0" width="100" height="16" uuid="a30644d0-a0c3-4836-960a-5fb330742476"/>
-					<box leftPadding="2"/>
-					<textElement>
-						<font size="9" isBold="true"/>
-					</textElement>
+					<box rightPadding="2"/>
+				</element>
+				<element kind="staticText" uuid="a30644d0-a0c3-4836-960a-5fb330742476" x="800" y="0" width="100" height="16" fontSize="9.0" bold="true">
 					<text><![CDATA[Total ]]></text>
-				</staticText>
+					<box leftPadding="2"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="34" splitType="Stretch">
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader height="34" splitType="Stretch">
+		<element kind="textField" uuid="2cc6c224-f056-4695-ac3f-d02e7887244a" x="140" y="0" width="660" height="15" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="false">
+			<expression><![CDATA[$P{ORGANIZATION} + " and any child organization"]]></expression>
 			<property name="local_mesure_unitheight" value="pixel"/>
 			<property name="com.jaspersoft.studio.unit.height" value="px"/>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement x="140" y="0" width="660" height="15" uuid="2cc6c224-f056-4695-ac3f-d02e7887244a">
-					<property name="local_mesure_unitheight" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.height" value="px"/>
-				</reportElement>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{ORGANIZATION} + " and any child organization"]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement x="910" y="0" width="390" height="15" uuid="ed92f5e1-fec8-401c-97e9-b9980a2edd3a">
-					<property name="local_mesure_unitheight" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.height" value="px"/>
-					<printWhenExpression><![CDATA[!$P{BPGROUP}.equals("")]]></printWhenExpression>
-				</reportElement>
-				<textElement>
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{BPGROUP}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement x="1370" y="0" width="530" height="15" uuid="79cb48af-e2bd-4646-9461-d2d091ab1568">
-					<property name="com.jaspersoft.studio.unit.height" value="px"/>
-					<printWhenExpression><![CDATA[!$P{PRODUCTGROUP}.equals("")]]></printWhenExpression>
-				</reportElement>
-				<textElement>
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{PRODUCTGROUP}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement x="0" y="0" width="80" height="15" uuid="482f8312-1ee5-465b-87aa-70745d8e560f"/>
-				<box leftPadding="2"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Secondary filters - ]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="80" y="0" width="60" height="15" uuid="a4c40ab4-0841-4245-a85c-97b0d2494c74"/>
-				<box leftPadding="2"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Organization- ]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="800" y="0" width="110" height="15" uuid="e4223a04-47fe-43af-a868-4f816bfbbdda">
-					<printWhenExpression><![CDATA[!$P{BPGROUP}.equals("")]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Business Partner Group- ]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="1300" y="0" width="70" height="15" uuid="a9aa0ee0-0b21-4060-bd27-1a3a0bc421f3">
-					<printWhenExpression><![CDATA[!$P{PRODUCTGROUP}.equals("")]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Product Group- ]]></text>
-			</staticText>
-		</band>
+		</element>
+		<element kind="textField" uuid="ed92f5e1-fec8-401c-97e9-b9980a2edd3a" x="910" y="0" width="390" height="15" fontSize="9.0" textAdjust="StretchHeight" blankWhenNull="false">
+			<printWhenExpression><![CDATA[!$P{BPGROUP}.equals("")]]></printWhenExpression>
+			<expression><![CDATA[$P{BPGROUP}]]></expression>
+			<property name="local_mesure_unitheight" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+		</element>
+		<element kind="textField" uuid="79cb48af-e2bd-4646-9461-d2d091ab1568" x="1370" y="0" width="530" height="15" fontSize="9.0" textAdjust="StretchHeight" blankWhenNull="false">
+			<printWhenExpression><![CDATA[!$P{PRODUCTGROUP}.equals("")]]></printWhenExpression>
+			<expression><![CDATA[$P{PRODUCTGROUP}]]></expression>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+		</element>
+		<element kind="staticText" uuid="482f8312-1ee5-465b-87aa-70745d8e560f" x="0" y="0" width="80" height="15" fontSize="8.0">
+			<text><![CDATA[Secondary filters - ]]></text>
+			<box leftPadding="2"/>
+		</element>
+		<element kind="staticText" uuid="a4c40ab4-0841-4245-a85c-97b0d2494c74" x="80" y="0" width="60" height="15" fontSize="8.0">
+			<text><![CDATA[Organization- ]]></text>
+			<box leftPadding="2"/>
+		</element>
+		<element kind="staticText" uuid="e4223a04-47fe-43af-a868-4f816bfbbdda" x="800" y="0" width="110" height="15" fontSize="8.0">
+			<printWhenExpression><![CDATA[!$P{BPGROUP}.equals("")]]></printWhenExpression>
+			<text><![CDATA[Business Partner Group- ]]></text>
+			<box leftPadding="2"/>
+		</element>
+		<element kind="staticText" uuid="a9aa0ee0-0b21-4060-bd27-1a3a0bc421f3" x="1300" y="0" width="70" height="15" fontSize="8.0">
+			<printWhenExpression><![CDATA[!$P{PRODUCTGROUP}.equals("")]]></printWhenExpression>
+			<text><![CDATA[Product Group- ]]></text>
+			<box leftPadding="2"/>
+		</element>
+		<property name="local_mesure_unitheight" value="pixel"/>
+		<property name="com.jaspersoft.studio.unit.height" value="px"/>
 	</pageHeader>
-	<columnHeader>
-		<band height="20" splitType="Stretch">
-			<property name="local_mesure_unitheight" value="pixel"/>
-			<property name="com.jaspersoft.studio.unit.height" value="px"/>
-			<staticText>
-				<reportElement key="element-1" style="Detail_Header" x="0" y="0" width="100" height="15" forecolor="#FFFFFF" uuid="cd51c2ad-6129-4915-a018-d59ea5544085"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Organization]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-2" style="Detail_Header" x="100" y="0" width="100" height="15" uuid="0261fe4d-2cd6-40ae-82a9-0279aedcfb01"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Business Partner Group]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-3" style="Detail_Header" x="200" y="0" width="100" height="15" uuid="dc740f96-6337-4087-a525-494136318473"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Business Partner]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-4" style="Detail_Header" x="400" y="0" width="100" height="15" uuid="9861ee48-d09d-4b31-b036-1a3d3014a703"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Document No]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-5" style="Detail_Header" x="500" y="0" width="100" height="15" uuid="40655256-630b-488d-8967-b58181cf809e"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Invoice Date]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-6" style="Detail_Header" x="600" y="0" width="100" height="15" uuid="af419a01-d9c3-4725-acef-426540c2c0e9"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Product Category]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-7" style="Detail_Header" x="700" y="0" width="100" height="15" uuid="3ccf0b09-7d81-45f5-bf17-af0dcd6da846"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Product]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-7-1" style="Detail_Header" x="800" y="0" width="100" height="15" uuid="190e7d16-6a2d-4e22-9575-5652f07f714e"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Product Search Key]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-7-3" style="Detail_Header" x="900" y="0" width="100" height="15" uuid="5d38d7b2-1aa8-4082-8ad8-2aa8a0f6aee6"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Quantity]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-7-2" style="Detail_Header" x="1000" y="0" width="100" height="15" uuid="2a41a8fb-6da1-4aa5-b2fc-1ed82d84c41d"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Unit Price]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-8" style="Detail_Header" x="1100" y="0" width="100" height="15" uuid="b03c90c1-ca4b-421c-b3c0-691a98e114f5"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Amount]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-9" style="Detail_Header" x="1200" y="0" width="100" height="15" uuid="4723d7ac-6850-430e-a4aa-577e94984f44"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Cost]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-10" style="Detail_Header" x="1300" y="0" width="100" height="15" uuid="5695ba74-05af-4c6b-8ea4-3a9ef0c6109b"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Profit]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-11" style="Detail_Header" x="1400" y="0" width="50" height="15" uuid="9f789559-d1de-4a31-80ac-8052c7080088"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[M.%]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-12" style="Detail_Header" x="1450" y="0" width="50" height="15" uuid="209d378a-71bc-48eb-a71a-83c2948f9286"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Weight]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-13" style="Detail_Header" x="1500" y="0" width="100" height="15" uuid="b7720fd1-f58b-43af-996f-ce19d09ca9bf"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Quantity]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-14" style="Detail_Header" x="1500" y="0" width="100" height="15" uuid="7cdf0b1e-d288-4be0-be37-f0f44e74e6a1"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Contact]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-15" style="Detail_Header" x="1600" y="0" width="100" height="15" uuid="d40acb18-ce14-465b-9427-c99a5c192c24"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Sales rep.]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-16" style="Detail_Header" x="1700" y="0" width="100" height="15" uuid="46e9cfee-0663-4bcc-99e2-559fe0c31be0"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Project]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-17" style="Detail_Header" x="1803" y="0" width="100" height="15" uuid="bd9a2711-395d-4ebd-856b-14005795d9d8"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Ship to address]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-3" style="Detail_Header" x="300" y="0" width="100" height="15" uuid="fcf8760c-2b97-4031-a7f4-f30760a1f69b"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Document Type]]></text>
-			</staticText>
-		</band>
+	<columnHeader height="20" splitType="Stretch">
+		<element kind="staticText" uuid="cd51c2ad-6129-4915-a018-d59ea5544085" key="element-1" x="0" y="0" width="100" height="15" forecolor="#FFFFFF" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Organization]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="0261fe4d-2cd6-40ae-82a9-0279aedcfb01" key="element-2" x="100" y="0" width="100" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Business Partner Group]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="dc740f96-6337-4087-a525-494136318473" key="element-3" x="200" y="0" width="100" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Business Partner]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="9861ee48-d09d-4b31-b036-1a3d3014a703" key="element-4" x="400" y="0" width="100" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Document No]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="40655256-630b-488d-8967-b58181cf809e" key="element-5" x="500" y="0" width="100" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Invoice Date]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="af419a01-d9c3-4725-acef-426540c2c0e9" key="element-6" x="600" y="0" width="100" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Product Category]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="3ccf0b09-7d81-45f5-bf17-af0dcd6da846" key="element-7" x="700" y="0" width="100" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Product]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="190e7d16-6a2d-4e22-9575-5652f07f714e" key="element-7-1" x="800" y="0" width="100" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Product Search Key]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="5d38d7b2-1aa8-4082-8ad8-2aa8a0f6aee6" key="element-7-3" x="900" y="0" width="100" height="15" fontSize="8.0" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Quantity]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="2a41a8fb-6da1-4aa5-b2fc-1ed82d84c41d" key="element-7-2" x="1000" y="0" width="100" height="15" fontSize="8.0" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Unit Price]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="b03c90c1-ca4b-421c-b3c0-691a98e114f5" key="element-8" x="1100" y="0" width="100" height="15" fontSize="8.0" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Amount]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="4723d7ac-6850-430e-a4aa-577e94984f44" key="element-9" x="1200" y="0" width="100" height="15" fontSize="8.0" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Cost]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="5695ba74-05af-4c6b-8ea4-3a9ef0c6109b" key="element-10" x="1300" y="0" width="100" height="15" fontSize="8.0" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Profit]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="9f789559-d1de-4a31-80ac-8052c7080088" key="element-11" x="1400" y="0" width="50" height="15" fontSize="8.0" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[M.%]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="209d378a-71bc-48eb-a71a-83c2948f9286" key="element-12" x="1450" y="0" width="50" height="15" fontSize="8.0" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Weight]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="b7720fd1-f58b-43af-996f-ce19d09ca9bf" key="element-13" x="1500" y="0" width="100" height="15" fontSize="8.0" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Quantity]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="7cdf0b1e-d288-4be0-be37-f0f44e74e6a1" key="element-14" x="1500" y="0" width="100" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Contact]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="d40acb18-ce14-465b-9427-c99a5c192c24" key="element-15" x="1600" y="0" width="100" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Sales rep.]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="46e9cfee-0663-4bcc-99e2-559fe0c31be0" key="element-16" x="1700" y="0" width="100" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Project]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="bd9a2711-395d-4ebd-856b-14005795d9d8" key="element-17" x="1803" y="0" width="100" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Ship to address]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="fcf8760c-2b97-4031-a7f4-f30760a1f69b" key="element-3" x="300" y="0" width="100" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Document Type]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<property name="local_mesure_unitheight" value="pixel"/>
+		<property name="com.jaspersoft.studio.unit.height" value="px"/>
 	</columnHeader>
 	<detail>
 		<band height="18" splitType="Stretch">
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-1" stretchType="RelativeToBandHeight" x="0" y="0" width="100" height="13" uuid="851d4da9-ad71-4aed-a01c-afe8a961473a"/>
+			<element kind="textField" uuid="851d4da9-ad71-4aed-a01c-afe8a961473a" key="textField-1" stretchType="ContainerHeight" x="0" y="0" width="100" height="13" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left">
+				<expression><![CDATA[$F{ORG}]]></expression>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{ORG}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-2" stretchType="RelativeToBandHeight" x="100" y="0" width="100" height="13" uuid="a1766026-b7ac-4c79-8f63-1c652af55b9d"/>
+			</element>
+			<element kind="textField" uuid="a1766026-b7ac-4c79-8f63-1c652af55b9d" key="textField-2" stretchType="ContainerHeight" x="100" y="0" width="100" height="13" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false">
+				<expression><![CDATA[$F{PARTNERGROUP}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="8" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PARTNERGROUP}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-3" stretchType="RelativeToBandHeight" x="200" y="0" width="100" height="13" uuid="53c1067c-2ebc-464e-9563-7f03c27f90c5"/>
+			</element>
+			<element kind="textField" uuid="53c1067c-2ebc-464e-9563-7f03c27f90c5" key="textField-3" stretchType="ContainerHeight" x="200" y="0" width="100" height="13" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false">
+				<expression><![CDATA[$F{PARTNER}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="8" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PARTNER}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-4" stretchType="RelativeToBandHeight" x="400" y="0" width="100" height="13" uuid="3d74edea-7b72-4e14-87d8-5ba66dc82eaa"/>
+			</element>
+			<element kind="textField" uuid="3d74edea-7b72-4e14-87d8-5ba66dc82eaa" key="textField-4" stretchType="ContainerHeight" x="400" y="0" width="100" height="13" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false">
+				<expression><![CDATA[$F{DOCUMENTNO}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="8" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DOCUMENTNO}]]></textFieldExpression>
-			</textField>
-			<textField pattern="dd/MM/yyyy" isBlankWhenNull="false">
-				<reportElement key="textField-5" stretchType="RelativeToBandHeight" x="500" y="0" width="100" height="13" uuid="a6dca618-0c58-4e52-b1a0-f7a8f6ce91c5"/>
+			</element>
+			<element kind="textField" uuid="a6dca618-0c58-4e52-b1a0-f7a8f6ce91c5" key="textField-5" stretchType="ContainerHeight" x="500" y="0" width="100" height="13" fontSize="8.0" pattern="dd/MM/yyyy" blankWhenNull="false" hTextAlign="Left">
+				<expression><![CDATA[(new SimpleDateFormat($P{strDateFormat})).format($F{INVOICEDATE})]]></expression>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[(new SimpleDateFormat($P{strDateFormat})).format($F{INVOICEDATE})]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField-6" stretchType="RelativeToBandHeight" x="600" y="0" width="100" height="13" uuid="a21dd594-d4ed-488a-a144-9c9d0a81b50e"/>
+			</element>
+			<element kind="textField" uuid="a21dd594-d4ed-488a-a144-9c9d0a81b50e" key="textField-6" stretchType="ContainerHeight" x="600" y="0" width="100" height="13" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true">
+				<expression><![CDATA[$F{PRODCATEGORY}]]></expression>
 				<box rightPadding="2"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRODCATEGORY}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField-7" stretchType="RelativeToBandHeight" x="700" y="0" width="100" height="13" uuid="681a5d1e-9a9f-45b1-940a-4fb1b48b09c4"/>
+			</element>
+			<element kind="textField" uuid="681a5d1e-9a9f-45b1-940a-4fb1b48b09c4" key="textField-7" stretchType="ContainerHeight" x="700" y="0" width="100" height="13" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true">
+				<expression><![CDATA[$F{PRODUCT}]]></expression>
 				<box rightPadding="2"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRODUCT}]]></textFieldExpression>
-			</textField>
-			<textField pattern="#,##0.00;-#,##0.00" isBlankWhenNull="true">
-				<reportElement key="textField-13" stretchType="RelativeToBandHeight" x="900" y="0" width="100" height="13" uuid="7c39b6bd-ff8d-48bf-b221-602d8c43900f"/>
+			</element>
+			<element kind="textField" uuid="7c39b6bd-ff8d-48bf-b221-602d8c43900f" key="textField-13" stretchType="ContainerHeight" x="900" y="0" width="100" height="13" fontSize="8.0" pattern="#,##0.00;-#,##0.00" blankWhenNull="true" hTextAlign="Right">
+				<expression><![CDATA[$F{QTY}]]></expression>
+				<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{QTY}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="09f0aa65-d2eb-4ee4-a68f-a368840c5904" key="textField-8" stretchType="ContainerHeight" x="1100" y="0" width="100" height="13" fontSize="8.0" pattern="#,##0.00;-#,##0.00" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[$F{AMOUNT}]]></expression>
 				<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField pattern="#,##0.00;-#,##0.00" isBlankWhenNull="false">
-				<reportElement key="textField-8" stretchType="RelativeToBandHeight" x="1100" y="0" width="100" height="13" uuid="09f0aa65-d2eb-4ee4-a68f-a368840c5904"/>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AMOUNT}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="485e1ead-f9d9-4b7e-9b69-de548e006df9" key="textField-9" stretchType="ContainerHeight" x="1200" y="0" width="100" height="13" fontSize="8.0" pattern="#,##0.00;-#,##0.00" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[$F{COST}]]></expression>
 				<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField pattern="#,##0.00;-#,##0.00" isBlankWhenNull="false">
-				<reportElement key="textField-9" stretchType="RelativeToBandHeight" x="1200" y="0" width="100" height="13" uuid="485e1ead-f9d9-4b7e-9b69-de548e006df9"/>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{COST}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="98e73443-30bf-4370-9c33-c03f18722331" key="textField-10" stretchType="ContainerHeight" x="1300" y="0" width="100" height="13" fontSize="8.0" pattern="#,##0.00;-#,##0.00" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[$F{PROFIT}]]></expression>
 				<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField pattern="#,##0.00;-#,##0.00" isBlankWhenNull="false">
-				<reportElement key="textField-10" stretchType="RelativeToBandHeight" x="1300" y="0" width="100" height="13" uuid="98e73443-30bf-4370-9c33-c03f18722331"/>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PROFIT}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="3d0815a2-b760-434e-bb63-ec856afae135" key="textField-11" stretchType="ContainerHeight" x="1400" y="0" width="50" height="13" fontSize="8.0" pattern="#,##0.00;-#,##0.00" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[$F{MARGIN}]]></expression>
 				<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField pattern="#,##0.00;-#,##0.00" isBlankWhenNull="false">
-				<reportElement key="textField-11" stretchType="RelativeToBandHeight" x="1400" y="0" width="50" height="13" uuid="3d0815a2-b760-434e-bb63-ec856afae135"/>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{MARGIN}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="d9693cbb-9d69-418a-becf-e47130fcc0a3" key="textField-12" stretchType="ContainerHeight" x="1450" y="0" width="50" height="13" fontSize="8.0" pattern="#,##0.00;-#,##0.00" blankWhenNull="true" hTextAlign="Right">
+				<expression><![CDATA[$F{WEIGHT}]]></expression>
 				<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField pattern="#,##0.00;-#,##0.00" isBlankWhenNull="true">
-				<reportElement key="textField-12" stretchType="RelativeToBandHeight" x="1450" y="0" width="50" height="13" uuid="d9693cbb-9d69-418a-becf-e47130fcc0a3"/>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{WEIGHT}]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-14" stretchType="RelativeToBandHeight" x="1500" y="0" width="100" height="13" uuid="79490dd4-4d29-4e5a-9301-aeb669776a2d"/>
+			</element>
+			<element kind="textField" uuid="79490dd4-4d29-4e5a-9301-aeb669776a2d" key="textField-14" stretchType="ContainerHeight" x="1500" y="0" width="100" height="13" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false">
+				<expression><![CDATA[$F{CONTACT}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="8" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONTACT}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-15" stretchType="RelativeToBandHeight" x="1600" y="0" width="100" height="13" uuid="bc1efd65-c636-44b1-b917-d996463d5051"/>
+			</element>
+			<element kind="textField" uuid="bc1efd65-c636-44b1-b917-d996463d5051" key="textField-15" stretchType="ContainerHeight" x="1600" y="0" width="100" height="13" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false">
+				<expression><![CDATA[$F{SALESREP}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="8" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{SALESREP}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-16" stretchType="RelativeToBandHeight" x="1700" y="0" width="100" height="13" uuid="6ebe8fea-d158-42b0-858d-92dcd3018570"/>
+			</element>
+			<element kind="textField" uuid="6ebe8fea-d158-42b0-858d-92dcd3018570" key="textField-16" stretchType="ContainerHeight" x="1700" y="0" width="100" height="13" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false">
+				<expression><![CDATA[$F{PROJECT}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="8" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PROJECT}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-17" stretchType="RelativeToBandHeight" x="1803" y="0" width="100" height="13" uuid="ba9df64a-1e05-46b2-ae62-7ac93a7698af"/>
+			</element>
+			<element kind="textField" uuid="ba9df64a-1e05-46b2-ae62-7ac93a7698af" key="textField-17" stretchType="ContainerHeight" x="1803" y="0" width="100" height="13" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false">
+				<expression><![CDATA[$F{ADDRESS}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="8" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{ADDRESS}]]></textFieldExpression>
-			</textField>
-			<textField pattern="#,##0.00;-#,##0.00" isBlankWhenNull="true">
-				<reportElement key="textField-13" stretchType="RelativeToBandHeight" x="1000" y="0" width="100" height="13" uuid="7a941f8e-beb0-405b-bd1b-b9983ac7468c"/>
+			</element>
+			<element kind="textField" uuid="7a941f8e-beb0-405b-bd1b-b9983ac7468c" key="textField-13" stretchType="ContainerHeight" x="1000" y="0" width="100" height="13" fontSize="8.0" pattern="#,##0.00;-#,##0.00" blankWhenNull="true" hTextAlign="Right">
+				<expression><![CDATA[$F{UNITPRICE}]]></expression>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{UNITPRICE}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField-7" stretchType="RelativeToBandHeight" x="800" y="0" width="100" height="13" uuid="f7c4ec5a-007d-406a-aa77-fd7b277b9d2a"/>
+			</element>
+			<element kind="textField" uuid="f7c4ec5a-007d-406a-aa77-fd7b277b9d2a" key="textField-7" stretchType="ContainerHeight" x="800" y="0" width="100" height="13" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true">
+				<expression><![CDATA[$F{SEARCHKEY}]]></expression>
 				<box rightPadding="2"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{SEARCHKEY}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-3" stretchType="RelativeToBandHeight" x="300" y="0" width="100" height="13" uuid="ddc76007-be7b-4320-be09-f792d467a1de"/>
+			</element>
+			<element kind="textField" uuid="ddc76007-be7b-4320-be09-f792d467a1de" key="textField-3" stretchType="ContainerHeight" x="300" y="0" width="100" height="13" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false">
+				<expression><![CDATA[$F{DOCTYPENAME}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="8" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DOCTYPENAME}]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch">
-			<property name="local_mesure_unitheight" value="pixel"/>
-			<property name="com.jaspersoft.studio.unit.height" value="px"/>
-		</band>
+	<columnFooter splitType="Stretch">
+		<property name="local_mesure_unitheight" value="pixel"/>
+		<property name="com.jaspersoft.studio.unit.height" value="px"/>
 	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<lastPageFooter>
-		<band height="58"/>
-	</lastPageFooter>
-	<summary>
-		<band height="60" splitType="Stretch">
+	<pageFooter splitType="Stretch"/>
+	<lastPageFooter height="58"/>
+	<summary height="60" splitType="Stretch">
+		<element kind="subreport" uuid="7614471a-bdd5-4c59-a488-1015898d2283" stretchType="ContainerHeight" x="0" y="5" width="600" height="50">
+			<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
+			<expression><![CDATA[$P{SR_LINES}]]></expression>
 			<property name="local_mesure_unitheight" value="pixel"/>
 			<property name="com.jaspersoft.studio.unit.height" value="px"/>
-			<subreport>
-				<reportElement stretchType="RelativeToBandHeight" x="0" y="5" width="600" height="50" uuid="7614471a-bdd5-4c59-a488-1015898d2283">
-					<property name="local_mesure_unitheight" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.height" value="px"/>
-				</reportElement>
-				<subreportParameter name="USER_CLIENT">
-					<subreportParameterExpression><![CDATA[$P{aux_client}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="AD_ORG_ID">
-					<subreportParameterExpression><![CDATA[$P{aux_org}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="C_CURRENCY_ID">
-					<subreportParameterExpression><![CDATA[$P{C_CURRENCY_ID}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="DATEFROM">
-					<subreportParameterExpression><![CDATA[$P{DateFrom}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="DATETO">
-					<subreportParameterExpression><![CDATA[$P{DateTo}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="C_BP_GROUP_ID">
-					<subreportParameterExpression><![CDATA[$P{aux_bpgroup}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="C_BPARTNER_ID">
-					<subreportParameterExpression><![CDATA[$P{aux_partner}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="M_PRODUCT_CATEGORY_ID">
-					<subreportParameterExpression><![CDATA[$P{aux_productcategory}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="M_PRODUCT_ID">
-					<subreportParameterExpression><![CDATA[$P{aux_product}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="SALESREP_ID">
-					<subreportParameterExpression><![CDATA[$P{aux_salesrep}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="PARTNER_SALESREP_ID">
-					<subreportParameterExpression><![CDATA[$P{aux_partnersalesrep}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="C_PROJECT_ID">
-					<subreportParameterExpression><![CDATA[$P{aux_project}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="PRODUCTTYPE">
-					<subreportParameterExpression><![CDATA[$P{aux_producttype}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="C_DOCTYPE_ID">
-					<subreportParameterExpression><![CDATA[$P{aux_doctype}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="DOCSTATUS">
-					<subreportParameterExpression><![CDATA[$P{aux_docstatus}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LANGUAGE">
-					<subreportParameterExpression><![CDATA[$P{LANGUAGE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{SR_LINES}]]></subreportExpression>
-			</subreport>
-		</band>
+			<parameter name="USER_CLIENT">
+				<expression><![CDATA[$P{aux_client}]]></expression>
+			</parameter>
+			<parameter name="AD_ORG_ID">
+				<expression><![CDATA[$P{aux_org}]]></expression>
+			</parameter>
+			<parameter name="C_CURRENCY_ID">
+				<expression><![CDATA[$P{C_CURRENCY_ID}]]></expression>
+			</parameter>
+			<parameter name="DATEFROM">
+				<expression><![CDATA[$P{DateFrom}]]></expression>
+			</parameter>
+			<parameter name="DATETO">
+				<expression><![CDATA[$P{DateTo}]]></expression>
+			</parameter>
+			<parameter name="C_BP_GROUP_ID">
+				<expression><![CDATA[$P{aux_bpgroup}]]></expression>
+			</parameter>
+			<parameter name="C_BPARTNER_ID">
+				<expression><![CDATA[$P{aux_partner}]]></expression>
+			</parameter>
+			<parameter name="M_PRODUCT_CATEGORY_ID">
+				<expression><![CDATA[$P{aux_productcategory}]]></expression>
+			</parameter>
+			<parameter name="M_PRODUCT_ID">
+				<expression><![CDATA[$P{aux_product}]]></expression>
+			</parameter>
+			<parameter name="SALESREP_ID">
+				<expression><![CDATA[$P{aux_salesrep}]]></expression>
+			</parameter>
+			<parameter name="PARTNER_SALESREP_ID">
+				<expression><![CDATA[$P{aux_partnersalesrep}]]></expression>
+			</parameter>
+			<parameter name="C_PROJECT_ID">
+				<expression><![CDATA[$P{aux_project}]]></expression>
+			</parameter>
+			<parameter name="PRODUCTTYPE">
+				<expression><![CDATA[$P{aux_producttype}]]></expression>
+			</parameter>
+			<parameter name="C_DOCTYPE_ID">
+				<expression><![CDATA[$P{aux_doctype}]]></expression>
+			</parameter>
+			<parameter name="DOCSTATUS">
+				<expression><![CDATA[$P{aux_docstatus}]]></expression>
+			</parameter>
+			<parameter name="LANGUAGE">
+				<expression><![CDATA[$P{LANGUAGE}]]></expression>
+			</parameter>
+		</element>
+		<property name="local_mesure_unitheight" value="pixel"/>
+		<property name="com.jaspersoft.studio.unit.height" value="px"/>
 	</summary>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalyses_srpt_doctypecount.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerDimensionalAnalyses_srpt_doctypecount.jrxml
@@ -1,15 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
-<!-- 2018-02-27T16:45:13 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportInvoiceCustomerDimensionalAnalyses_srpt_doctypecount" pageWidth="400" pageHeight="802" whenNoDataType="AllSectionsNoDetail" columnWidth="400" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" whenResourceMissingType="Error" uuid="dcc54a6a-4fa7-4363-918c-1e721f63d8f0">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportInvoiceCustomerDimensionalAnalyses_srpt_doctypecount" language="java" pageWidth="400" pageHeight="802" whenNoDataType="AllSectionsNoDetail" columnWidth="400" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" whenResourceMissingType="Error" uuid="dcc54a6a-4fa7-4363-918c-1e721f63d8f0">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="si"/>
 	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="SansSerif" fontSize="9" isBold="true"/>
-	<style name="Detail_Line" fontName="SansSerif" fontSize="8" isBold="false">
-		<conditionalStyle>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="9.0" bold="true"/>
+	<style name="Detail_Line" fontName="SansSerif" fontSize="8.0" bold="false">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<parameter name="USER_CLIENT" class="java.lang.String"/>
@@ -28,8 +25,7 @@
 	<parameter name="C_DOCTYPE_ID" class="java.lang.String"/>
 	<parameter name="DOCSTATUS" class="java.lang.String"/>
 	<parameter name="LANGUAGE" class="java.lang.String"/>
-	<queryString language="SQL">
-		<![CDATA[SELECT DOCTYPE, ORGID, DOCID, COUNT(*) AS DOCTYPECOUNT
+	<query language="SQL"><![CDATA[SELECT DOCTYPE, ORGID, DOCID, COUNT(*) AS DOCTYPECOUNT
         FROM
         (SELECT ad_org.name || '-' || coalesce(c_doctype_trl.name, c_doctype.name) AS DOCTYPE,
         ad_org.ad_org_id AS ORGID,
@@ -86,86 +82,61 @@
                   c_doctype.c_doctype_id, 
                   c_invoice.c_invoice_id) A
         GROUP BY DOCTYPE, ORGID, DOCID
-        ORDER BY DOCTYPE]]>
-	</queryString>
+        ORDER BY DOCTYPE]]></query>
 	<field name="doctypecount" class="java.lang.String"/>
 	<field name="doctype" class="java.lang.String"/>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<columnHeader>
-		<band height="13">
+	<background splitType="Stretch"/>
+	<columnHeader height="13">
+		<element kind="staticText" uuid="27582591-131e-420e-863d-caee79d44078" x="0" y="0" width="300" height="13" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Document Type]]></text>
 			<property name="local_mesure_unitheight" value="pixel"/>
 			<property name="com.jaspersoft.studio.unit.height" value="px"/>
-			<staticText>
-				<reportElement style="Detail_Header" x="0" y="0" width="300" height="13" uuid="27582591-131e-420e-863d-caee79d44078">
-					<property name="local_mesure_unitheight" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.height" value="px"/>
-				</reportElement>
-				<box leftPadding="2">
-					<topPen lineWidth="1.0"/>
-					<leftPen lineWidth="1.0"/>
-					<bottomPen lineWidth="1.0"/>
-					<rightPen lineWidth="1.0"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Document Type]]></text>
-			</staticText>
-			<staticText>
-				<reportElement style="Detail_Header" x="300" y="0" width="100" height="13" uuid="ab814f9f-ece4-4e62-b5a4-5d9bfda937a9">
-					<property name="local_mesure_unitheight" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.height" value="px"/>
-				</reportElement>
-				<box leftPadding="2">
-					<topPen lineWidth="1.0"/>
-					<leftPen lineWidth="0.0"/>
-					<bottomPen lineWidth="1.0"/>
-					<rightPen lineWidth="1.0"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Count]]></text>
-			</staticText>
-		</band>
+			<box leftPadding="2" style="Detail_Header">
+				<topPen lineWidth="1.0"/>
+				<leftPen lineWidth="1.0"/>
+				<bottomPen lineWidth="1.0"/>
+				<rightPen lineWidth="1.0"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="ab814f9f-ece4-4e62-b5a4-5d9bfda937a9" x="300" y="0" width="100" height="13" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Count]]></text>
+			<property name="local_mesure_unitheight" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<box leftPadding="2" style="Detail_Header">
+				<topPen lineWidth="1.0"/>
+				<leftPen lineWidth="0.0"/>
+				<bottomPen lineWidth="1.0"/>
+				<rightPen lineWidth="1.0"/>
+			</box>
+		</element>
+		<property name="local_mesure_unitheight" value="pixel"/>
+		<property name="com.jaspersoft.studio.unit.height" value="px"/>
 	</columnHeader>
 	<detail>
 		<band height="15">
-			<property name="local_mesure_unitheight" value="pixel"/>
-			<property name="com.jaspersoft.studio.unit.height" value="px"/>
-			<textField>
-				<reportElement style="Detail_Line" x="300" y="0" width="100" height="13" uuid="5ce07a41-f1e9-4199-99b0-de0cf018e31c">
-					<property name="local_mesure_unitheight" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.height" value="px"/>
-				</reportElement>
-				<box leftPadding="2">
+			<element kind="textField" uuid="5ce07a41-f1e9-4199-99b0-de0cf018e31c" x="300" y="0" width="100" height="13" fontSize="8.0" hTextAlign="Left" style="Detail_Line">
+				<expression><![CDATA[Integer.parseInt($F{doctypecount})]]></expression>
+				<property name="local_mesure_unitheight" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				<box leftPadding="2" style="Detail_Line">
 					<bottomPen lineWidth="0.0"/>
 					<rightPen lineWidth="0.0"/>
 				</box>
-				<textElement textAlignment="Left">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[Integer.parseInt($F{doctypecount})]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement style="Detail_Line" x="0" y="0" width="300" height="13" uuid="d4593cb6-8fa6-4f11-a6e1-d62b345662af">
-					<property name="local_mesure_unitheight" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.height" value="px"/>
-					<property name="local_mesure_unitx" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.x" value="px"/>
-				</reportElement>
-				<box leftPadding="2">
+			</element>
+			<element kind="textField" uuid="d4593cb6-8fa6-4f11-a6e1-d62b345662af" x="0" y="0" width="300" height="13" fontSize="8.0" hTextAlign="Left" style="Detail_Line">
+				<expression><![CDATA[$F{doctype}]]></expression>
+				<property name="local_mesure_unitheight" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				<property name="local_mesure_unitx" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.x" value="px"/>
+				<box leftPadding="2" style="Detail_Line">
 					<leftPen lineWidth="0.0"/>
 					<bottomPen lineWidth="0.0"/>
 					<rightPen lineWidth="0.0"/>
 				</box>
-				<textElement textAlignment="Left">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{doctype}]]></textFieldExpression>
-			</textField>
+			</element>
+			<property name="local_mesure_unitheight" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
 		</band>
 	</detail>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceCustomerJR.jrxml
@@ -1,74 +1,70 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
-<!-- 2016-07-13T11:53:22 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportInvoiceCustomerJR" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="4df7acd1-be6d-4c1a-9aff-94a5421b9a97">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportInvoiceCustomerJR" language="java" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="4df7acd1-be6d-4c1a-9aff-94a5421b9a97">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="11">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="11.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{DOCUMENTNO_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="ReportData" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="ReportData" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="isUOMManagementEnabled" class="java.lang.Boolean" isForPrompting="false">
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="isUOMManagementEnabled" forPrompting="false" class="java.lang.Boolean">
 		<defaultValueExpression><![CDATA[org.openbravo.materialmgmt.UOMUtil.isUomManagementEnabled()]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[SELECT COALESCE(C_INVOICE.POREFERENCE, C_INVOICE.DOCUMENTNO) AS DOCUMENTNO, C_INVOICE.DATEINVOICED AS DATEINVOICED, 
+	<query language="sql"><![CDATA[SELECT COALESCE(C_INVOICE.POREFERENCE, C_INVOICE.DOCUMENTNO) AS DOCUMENTNO, C_INVOICE.DATEINVOICED AS DATEINVOICED, 
       C_BPARTNER.NAME AS CLIENT_NAME, M_PRODUCT.NAME AS PRODUCT_NAME, SUM(C_INVOICELINE.QTYINVOICED) AS QUANTITYORDER, C_UOM.NAME AS UOMNAME, 
       C_INVOICELINE.PRICEACTUAL AS PRICEACTUAL, 
       C_CURRENCY_SYMBOL (C_INVOICE.C_CURRENCY_ID, C_INVOICELINE.PRICEACTUAL, 'Y') AS PRICEACTUALSYM,
@@ -95,8 +91,7 @@
       GROUP BY C_BPARTNER.NAME, M_PRODUCT.NAME, C_UOM.NAME, C_INVOICELINE.PRICEACTUAL, 
       COALESCE(C_INVOICE.POREFERENCE, C_INVOICE.DOCUMENTNO), C_INVOICE.DATEINVOICED,
       C_INVOICE.C_CURRENCY_ID, C_INVOICELINE.AD_CLIENT_ID, C_INVOICELINE.AD_ORG_ID, C_INVOICELINE.LINENETAMT
-      ORDER BY C_BPARTNER.NAME, COALESCE(C_INVOICE.POREFERENCE, C_INVOICE.DOCUMENTNO), C_INVOICE.DATEINVOICED]]>
-	</queryString>
+      ORDER BY C_BPARTNER.NAME, COALESCE(C_INVOICE.POREFERENCE, C_INVOICE.DOCUMENTNO), C_INVOICE.DATEINVOICED]]></query>
 	<field name="DOCUMENTNO" class="java.lang.String"/>
 	<field name="DATEINVOICED" class="java.util.Date"/>
 	<field name="CLIENT_NAME" class="java.lang.String"/>
@@ -113,799 +108,565 @@
 	<field name="PRICELISTSYM" class="java.lang.String"/>
 	<field name="AUM" class="java.lang.String"/>
 	<field name="AUMQTY" class="java.math.BigDecimal"/>
-	<variable name="DetailFieldTotal" class="java.math.BigDecimal" resetType="Group" resetGroup="CLIENT_NAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVPRICELIST}]]></variableExpression>
+	<variable name="DetailFieldTotal" resetType="Group" calculation="Sum" resetGroup="CLIENT_NAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVPRICELIST}]]></expression>
 	</variable>
-	<variable name="TotalQty" class="java.math.BigDecimal" resetType="Group" resetGroup="CLIENT_NAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{QUANTITYORDER}]]></variableExpression>
+	<variable name="TotalQty" resetType="Group" calculation="Sum" resetGroup="CLIENT_NAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QUANTITYORDER}]]></expression>
 	</variable>
 	<group name="CLIENT_NAME">
-		<groupExpression><![CDATA[$F{CLIENT_NAME}]]></groupExpression>
+		<expression><![CDATA[$F{CLIENT_NAME}]]></expression>
 		<groupHeader>
 			<band height="24" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="0" y="0" width="108" height="24" uuid="022e0360-8905-434c-94fa-6765a1d42801"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="022e0360-8905-434c-94fa-6765a1d42801" key="staticText" x="0" y="0" width="108" height="24" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[Customer]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="108" y="0" width="661" height="24" uuid="a841a9ef-537d-4775-aef1-85ce4b26ba88"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{CLIENT_NAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="769" y="0" width="1" height="24" forecolor="#555555" uuid="ae016bd0-1db7-4d29-a696-d67520e5bb17"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				</element>
+				<element kind="textField" uuid="a841a9ef-537d-4775-aef1-85ce4b26ba88" key="textField" x="108" y="0" width="661" height="24" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{CLIENT_NAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="ae016bd0-1db7-4d29-a696-d67520e5bb17" key="line-3" stretchType="ContainerHeight" x="769" y="0" width="1" height="24" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="32" splitType="Stretch">
-				<line>
-					<reportElement key="line-32" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="24" forecolor="#555555" uuid="73fba9ba-3c7c-4061-bc9a-84544420be0d"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="769" y="0" width="1" height="25" forecolor="#555555" uuid="72619d7c-142d-4619-b372-40785d3a55bf"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-34" x="0" y="24" width="769" height="1" forecolor="#555555" uuid="2c8bc827-7b1e-4ccf-8e20-a816aa5fe880"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-10" style="Report_Footer" x="10" y="2" width="80" height="18" uuid="360d011c-6cb8-40d7-ae67-9b9a10181ce8"/>
-					<box leftPadding="5">
+				<element kind="line" uuid="73fba9ba-3c7c-4061-bc9a-84544420be0d" key="line-32" stretchType="ContainerHeight" x="0" y="0" width="1" height="24" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="72619d7c-142d-4619-b372-40785d3a55bf" key="line-33" stretchType="ContainerHeight" x="769" y="0" width="1" height="25" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="2c8bc827-7b1e-4ccf-8e20-a816aa5fe880" key="line-34" x="0" y="24" width="769" height="1" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="360d011c-6cb8-40d7-ae67-9b9a10181ce8" key="staticText-10" x="10" y="2" width="80" height="18" hTextAlign="Right" style="Report_Footer">
+					<text><![CDATA[Total Client:]]></text>
+					<box leftPadding="5" style="Report_Footer">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<text><![CDATA[Total Client:]]></text>
-				</staticText>
-				<textField evaluationTime="Group" evaluationGroup="CLIENT_NAME" isBlankWhenNull="false">
-					<reportElement key="textField-13" style="Total_Field" mode="Opaque" x="260" y="2" width="482" height="18" uuid="ef9d8c8f-b08f-41aa-bffe-33c15687fb03"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="ef9d8c8f-b08f-41aa-bffe-33c15687fb03" key="textField-13" mode="Opaque" x="260" y="2" width="482" height="18" pdfFontName="Helvetica-Bold" evaluationTime="Group" evaluationGroup="CLIENT_NAME" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{DetailFieldTotal}!=null)?$P{NUMBERFORMAT}.format($V{DetailFieldTotal}):new String(" ")]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{DetailFieldTotal}!=null)?$P{NUMBERFORMAT}.format($V{DetailFieldTotal}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="CLIENT_NAME" isBlankWhenNull="false">
-					<reportElement key="textField-14" style="Total_Field" x="90" y="2" width="170" height="18" uuid="a4985125-c6d4-444a-bd37-568ef965430c"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="a4985125-c6d4-444a-bd37-568ef965430c" key="textField-14" x="90" y="2" width="170" height="18" pdfFontName="Helvetica-Bold" evaluationTime="Group" evaluationGroup="CLIENT_NAME" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{TotalQty}!=null)?$P{NUMBERFORMAT}.format($V{TotalQty}):new String(" ")]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{TotalQty}!=null)?$P{NUMBERFORMAT}.format($V{TotalQty}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="CLIENT_NAME" isBlankWhenNull="false">
-					<reportElement key="textField-19" style="Total_Field" mode="Opaque" x="742" y="2" width="22" height="18" uuid="2a0e4592-3c2a-47a4-8f7b-36f38d586286"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="2a0e4592-3c2a-47a4-8f7b-36f38d586286" key="textField-19" mode="Opaque" x="742" y="2" width="22" height="18" pdfFontName="Helvetica-Bold" evaluationTime="Group" evaluationGroup="CLIENT_NAME" blankWhenNull="false" hTextAlign="Center" style="Total_Field">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="DOCUMENTNO">
-		<groupExpression><![CDATA[$F{DOCUMENTNO}]]></groupExpression>
+		<expression><![CDATA[$F{DOCUMENTNO}]]></expression>
 		<groupHeader>
 			<band height="48" splitType="Stretch">
+				<element kind="textField" uuid="ec755524-18cf-4f2b-90c6-12f5cbe7c816" key="textField" x="178" y="10" width="150" height="16" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="Detail_Header">
+					<expression><![CDATA[$F{DOCUMENTNO}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="line" uuid="7470e74d-6e4a-4cd9-9a8e-d10236166775" key="line-8" stretchType="ContainerHeight" x="0" y="0" width="1" height="48" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="textField" uuid="406d3b5f-83cf-400e-80e8-b9b1bbc8425a" key="textField" x="456" y="10" width="313" height="16" fontName="Times-Roman" fontSize="10.0" textAdjust="StretchHeight" blankWhenNull="true" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{DATEINVOICED}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="dd216819-bae0-46e2-a6f7-85101616867e" key="element-90" x="20" y="32" width="176" height="16" fontSize="8.0" style="Detail_Header">
+					<text><![CDATA[Article]]></text>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="9307b502-2b5f-4312-823a-2b776b2bc3cd" key="element-90" x="196" y="32" width="64" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+					<text><![CDATA[Quantity]]></text>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="74be7127-2ab4-4909-99cf-9b0374b085f5" key="element-90" x="260" y="32" width="50" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+					<text><![CDATA[UOM]]></text>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="0ebd6c60-fdde-48f8-8a78-d38d6e45a449" key="element-90" x="453" y="32" width="79" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+					<text><![CDATA[Price	]]></text>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="3cb7ff35-de9e-4ce7-be56-31ef296f9423" key="staticText-9" x="328" y="10" width="128" height="16" style="Detail_Header">
+					<text><![CDATA[Invoice Date:]]></text>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="bae78b0e-f4e1-44aa-a5eb-7a3cc6aa6c46" key="staticText-11" x="10" y="10" width="168" height="16" style="Detail_Header">
+					<text><![CDATA[Invoice Doc No.]]></text>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="line" uuid="f586a366-f65a-411d-91de-62f8b5e1b21c" key="line-39" x="10" y="26" width="1" height="22" forecolor="#555555" style="Report_Footer"/>
+				<element kind="staticText" uuid="e63341b1-4a9c-4c82-9040-7d2c3f05c27d" key="element-91" x="532" y="32" width="30" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+					<text><![CDATA[Price	]]></text>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="77797d16-904c-4a04-a108-aa703714a535" key="element-92" x="690" y="32" width="30" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+					<text><![CDATA[Total]]></text>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="fe1cd3e1-d1f6-41c4-872b-dbb280532618" key="element-93" x="611" y="32" width="79" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+					<text><![CDATA[Total]]></text>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="f42da711-8f37-48b1-8c11-3ed37fd70589" key="textField-23" x="562" y="32" width="49" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="37d497f4-ba82-4f33-ba70-d358a2a55c7e" key="textField-24" x="720" y="32" width="49" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="line" uuid="7f61728e-6d76-4e55-8a81-07c1715fa3d9" key="line-6" stretchType="ContainerHeight" x="769" y="0" width="1" height="48" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="3a64927f-fe38-42b6-a734-09c9e80329fe" key="element-90" x="310" y="32" width="94" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+					<text><![CDATA[Quantity in AUM]]></text>
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="3adf1e29-1138-4e7e-bf56-65079ae63d95" key="element-90" x="404" y="32" width="49" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+					<text><![CDATA[AUM]]></text>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="d9d7c912-8a43-43cc-a466-3eb22ae7e578" key="element-90" x="196" y="32" width="114" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
+					<text><![CDATA[Quantity]]></text>
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="fadf9e35-2685-4b20-904e-e58782ad2b7a" key="element-90" x="310" y="32" width="143" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
+					<text><![CDATA[UOM]]></text>
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
 				<property name="local_mesure_unitheight" value="pixel"/>
 				<property name="com.jaspersoft.studio.unit.height" value="px"/>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="Detail_Header" x="178" y="10" width="150" height="16" uuid="ec755524-18cf-4f2b-90c6-12f5cbe7c816"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textFieldExpression><![CDATA[$F{DOCUMENTNO}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-8" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="48" forecolor="#555555" uuid="7470e74d-6e4a-4cd9-9a8e-d10236166775"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Detail_Header" x="456" y="10" width="313" height="16" uuid="406d3b5f-83cf-400e-80e8-b9b1bbc8425a"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Times-Roman" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{DATEINVOICED}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="20" y="32" width="176" height="16" uuid="dd216819-bae0-46e2-a6f7-85101616867e"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement>
-						<font size="8"/>
-					</textElement>
-					<text><![CDATA[Article]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="196" y="32" width="64" height="16" uuid="9307b502-2b5f-4312-823a-2b776b2bc3cd">
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="260" y="32" width="50" height="16" uuid="74be7127-2ab4-4909-99cf-9b0374b085f5">
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[UOM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="453" y="32" width="79" height="16" uuid="0ebd6c60-fdde-48f8-8a78-d38d6e45a449"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Price	]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-9" style="Detail_Header" x="328" y="10" width="128" height="16" uuid="3cb7ff35-de9e-4ce7-be56-31ef296f9423"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<text><![CDATA[Invoice Date:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-11" style="Detail_Header" x="10" y="10" width="168" height="16" uuid="bae78b0e-f4e1-44aa-a5eb-7a3cc6aa6c46"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<text><![CDATA[Invoice Doc No.]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-39" style="Report_Footer" x="10" y="26" width="1" height="22" forecolor="#555555" uuid="f586a366-f65a-411d-91de-62f8b5e1b21c"/>
-				</line>
-				<staticText>
-					<reportElement key="element-91" style="Detail_Header" x="532" y="32" width="30" height="16" uuid="e63341b1-4a9c-4c82-9040-7d2c3f05c27d"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Price	]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-92" style="Detail_Header" x="690" y="32" width="30" height="16" uuid="77797d16-904c-4a04-a108-aa703714a535"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Total]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-93" style="Detail_Header" x="611" y="32" width="79" height="16" uuid="fe1cd3e1-d1f6-41c4-872b-dbb280532618"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Total]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-23" style="Detail_Header" x="562" y="32" width="49" height="16" uuid="f42da711-8f37-48b1-8c11-3ed37fd70589"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-24" style="Detail_Header" x="720" y="32" width="49" height="16" uuid="37d497f4-ba82-4f33-ba70-d358a2a55c7e"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-6" stretchType="RelativeToBandHeight" x="769" y="0" width="1" height="48" forecolor="#555555" uuid="7f61728e-6d76-4e55-8a81-07c1715fa3d9"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="310" y="32" width="94" height="16" uuid="3a64927f-fe38-42b6-a734-09c9e80329fe">
-						<property name="local_mesure_unitx" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.x" value="px"/>
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Quantity in AUM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="404" y="32" width="49" height="16" uuid="3adf1e29-1138-4e7e-bf56-65079ae63d95">
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[AUM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="196" y="32" width="114" height="16" uuid="d9d7c912-8a43-43cc-a466-3eb22ae7e578">
-						<property name="local_mesure_unitx" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.x" value="px"/>
-						<property name="local_mesure_unity" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.y" value="px"/>
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="310" y="32" width="143" height="16" uuid="fadf9e35-2685-4b20-904e-e58782ad2b7a">
-						<property name="local_mesure_unitx" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.x" value="px"/>
-						<property name="local_mesure_unity" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.y" value="px"/>
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[UOM]]></text>
-				</staticText>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="15" splitType="Stretch">
-				<line>
-					<reportElement key="line-35" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="15" forecolor="#555555" uuid="c10b6a4f-3186-40f9-aead-91459fe62369"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-36" stretchType="RelativeToBandHeight" x="769" y="0" width="1" height="15" forecolor="#555555" uuid="eafa4224-185a-42e3-9ff0-a7cbd06c4877"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-37" style="Report_Footer" x="20" y="0" width="749" height="1" forecolor="#555555" uuid="4d7e764c-b9d0-459d-944b-0c6e18b7feb2"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-40" style="Report_Footer" x="10" y="0" width="1" height="10" forecolor="#555555" uuid="90d1471d-4fbd-4adf-9ad3-4cc4c55452fd"/>
-				</line>
-				<line>
-					<reportElement key="line-41" style="Report_Footer" x="10" y="10" width="759" height="1" forecolor="#555555" uuid="3db32d94-2376-4002-9234-401eb60748c5"/>
-				</line>
+				<element kind="line" uuid="c10b6a4f-3186-40f9-aead-91459fe62369" key="line-35" stretchType="ContainerHeight" x="0" y="0" width="1" height="15" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="eafa4224-185a-42e3-9ff0-a7cbd06c4877" key="line-36" stretchType="ContainerHeight" x="769" y="0" width="1" height="15" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="4d7e764c-b9d0-459d-944b-0c6e18b7feb2" key="line-37" x="20" y="0" width="749" height="1" forecolor="#555555" style="Report_Footer">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="90d1471d-4fbd-4adf-9ad3-4cc4c55452fd" key="line-40" x="10" y="0" width="1" height="10" forecolor="#555555" style="Report_Footer"/>
+				<element kind="line" uuid="3db32d94-2376-4002-9234-401eb60748c5" key="line-41" x="10" y="10" width="759" height="1" forecolor="#555555" style="Report_Footer"/>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="20" splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="59" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Title" mode="Transparent" x="0" y="0" width="705" height="20" uuid="32390f88-570b-4577-bf47-21ec09a90d4b"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="20" width="706" height="1" uuid="3348ce8a-bf12-4a94-a433-88c651a502b2"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Subtitle" x="0" y="20" width="705" height="20" uuid="36b7d2c7-b992-4ef0-8682-7d198748f355"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="14"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($P{REPORT_SUBTITLE}!=null)?$P{REPORT_SUBTITLE}:new String(" ")]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="20" splitType="Stretch"/>
+	<pageHeader height="59" splitType="Stretch">
+		<element kind="textField" uuid="32390f88-570b-4577-bf47-21ec09a90d4b" key="textField" mode="Transparent" x="0" y="0" width="705" height="20" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="3348ce8a-bf12-4a94-a433-88c651a502b2" key="line-1" x="0" y="20" width="706" height="1">
+			<pen lineWidth="1.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="36b7d2c7-b992-4ef0-8682-7d198748f355" key="textField" x="0" y="20" width="705" height="20" fontSize="14.0" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[($P{REPORT_SUBTITLE}!=null)?$P{REPORT_SUBTITLE}:new String(" ")]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band height="16" splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader height="16" splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
+			<element kind="line" uuid="674d4a00-6311-4837-a00d-bab7b4b3baf5" key="line-16" stretchType="ContainerHeight" x="769" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="ae81bab5-4ad2-4f7f-8562-e13e83307c27" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="4d95ae13-cd94-45d9-b704-a415fe68bbbc" key="textField-8" x="20" y="0" width="176" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PRODUCT_NAME}!=null)?$F{PRODUCT_NAME}:new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="2451e561-4227-4a86-a29d-6a375b5b8355" key="textField-9" x="196" y="0" width="64" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+				<expression><![CDATA[($F{QUANTITYORDER}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITYORDER}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="0e419dea-ba46-4b9a-bfb0-a99e51e77f87" key="textField-10" x="260" y="0" width="50" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+				<expression><![CDATA[($F{UOMNAME}!=null)?$F{UOMNAME}:new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="3489c9ca-3622-44a8-8cc9-88740cd74e09" key="textField-11" x="453" y="0" width="55" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}):new String(" ")]]></expression>
+				<property name="local_mesure_unitwidth" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				<box leftPadding="2" rightPadding="4" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="line" uuid="6df6acbd-e33d-47dd-8c00-bcc85d0f7fe8" key="line-38" x="10" y="0" width="1" height="16" forecolor="#555555" style="Report_Footer"/>
+			<element kind="textField" uuid="fa8ce461-657f-44ac-b0ad-0fba3095f447" key="textField-15" x="532" y="0" width="55" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVPRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{CONVPRICEACTUAL}):new String(" ")]]></expression>
+				<property name="local_mesure_unitwidth" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				<box leftPadding="2" rightPadding="4" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="8ced2e33-52f1-46a2-8474-38aaa7d91851" key="textField-16" x="690" y="0" width="55" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVPRICELIST}!=null)?$P{NUMBERFORMAT}.format($F{CONVPRICELIST}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="4" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="f8225159-c6c6-4d76-bc6d-1ec73b7a9213" key="textField-17" x="611" y="0" width="55" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PRICELIST}!=null)?$P{NUMBERFORMAT}.format($F{PRICELIST}):new String(" ")]]></expression>
+				<property name="local_mesure_unitwidth" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				<box leftPadding="2" rightPadding="4" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="077538bc-95b9-44ae-b324-e6be4f0cbc99" key="textField-18" x="745" y="0" width="24" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{CONVSYM}]]></expression>
+				<box leftPadding="2" rightPadding="4" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="e4b7756d-c7dd-4282-8670-187d9cc16d54" key="textField-20" x="666" y="0" width="24" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{PRICELISTSYM}]]></expression>
+				<box leftPadding="2" rightPadding="4" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="08a66d95-09ec-47fa-8d91-4922dce42b77" key="textField-21" x="587" y="0" width="24" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{CONVSYM}]]></expression>
+				<box leftPadding="2" rightPadding="4" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="598aa264-cc3e-4ae0-8750-65e77238d13f" key="textField-22" x="508" y="0" width="24" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{PRICEACTUALSYM}]]></expression>
+				<box leftPadding="2" rightPadding="4" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="383ef42f-045b-4f28-97e7-8db8c289a06a" key="textField-9" x="310" y="0" width="94" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+				<expression><![CDATA[($F{AUMQTY}!=null)?$P{NUMBERFORMAT}.format($F{AUMQTY}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="94f01054-7de7-46ae-8938-730f441aa80f" key="textField-10" x="404" y="0" width="48" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+				<expression><![CDATA[($F{AUM}!=null)?$F{AUM}:new String(" ")]]></expression>
+				<property name="local_mesure_unitx" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.x" value="px"/>
+				<property name="local_mesure_unitwidth" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="ccb01cdf-87bc-41b0-a826-e72c3e18d49e" key="textField-9" x="196" y="0" width="114" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
+				<expression><![CDATA[($F{QUANTITYORDER}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITYORDER}):new String(" ")]]></expression>
+				<property name="local_mesure_unitx" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.x" value="px"/>
+				<property name="local_mesure_unity" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				<property name="local_mesure_unitwidth" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="a1c45d5e-7c8a-499f-b95c-4651da8e72a3" key="textField-10" x="310" y="0" width="142" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
+				<expression><![CDATA[($F{UOMNAME}!=null)?$F{UOMNAME}:new String(" ")]]></expression>
+				<property name="local_mesure_unitx" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.x" value="px"/>
+				<property name="local_mesure_unity" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				<property name="local_mesure_unitwidth" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
 			<property name="local_mesure_unitheight" value="pixel"/>
 			<property name="com.jaspersoft.studio.unit.height" value="px"/>
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="769" y="0" width="1" height="16" forecolor="#555555" uuid="674d4a00-6311-4837-a00d-bab7b4b3baf5"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="16" forecolor="#555555" uuid="ae81bab5-4ad2-4f7f-8562-e13e83307c27"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-8" style="Detail_Line" x="20" y="0" width="176" height="16" uuid="4d95ae13-cd94-45d9-b704-a415fe68bbbc"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRODUCT_NAME}!=null)?$F{PRODUCT_NAME}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-9" style="Detail_Line" x="196" y="0" width="64" height="16" uuid="2451e561-4227-4a86-a29d-6a375b5b8355">
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QUANTITYORDER}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITYORDER}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-10" style="Detail_Line" x="260" y="0" width="50" height="16" uuid="0e419dea-ba46-4b9a-bfb0-a99e51e77f87">
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{UOMNAME}!=null)?$F{UOMNAME}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-11" style="Detail_Line" x="453" y="0" width="55" height="16" uuid="3489c9ca-3622-44a8-8cc9-88740cd74e09">
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-				</reportElement>
-				<box leftPadding="2" rightPadding="4">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-38" style="Report_Footer" x="10" y="0" width="1" height="16" forecolor="#555555" uuid="6df6acbd-e33d-47dd-8c00-bcc85d0f7fe8"/>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-15" style="Detail_Line" x="532" y="0" width="55" height="16" uuid="fa8ce461-657f-44ac-b0ad-0fba3095f447">
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-				</reportElement>
-				<box leftPadding="2" rightPadding="4">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVPRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{CONVPRICEACTUAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-16" style="Detail_Line" x="690" y="0" width="55" height="16" uuid="8ced2e33-52f1-46a2-8474-38aaa7d91851"/>
-				<box leftPadding="2" rightPadding="4">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVPRICELIST}!=null)?$P{NUMBERFORMAT}.format($F{CONVPRICELIST}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Detail_Line" x="611" y="0" width="55" height="16" uuid="f8225159-c6c6-4d76-bc6d-1ec73b7a9213">
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-				</reportElement>
-				<box leftPadding="2" rightPadding="4">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRICELIST}!=null)?$P{NUMBERFORMAT}.format($F{PRICELIST}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-18" style="Detail_Line" x="745" y="0" width="24" height="16" uuid="077538bc-95b9-44ae-b324-e6be4f0cbc99"/>
-				<box leftPadding="2" rightPadding="4">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-20" style="Detail_Line" x="666" y="0" width="24" height="16" uuid="e4b7756d-c7dd-4282-8670-187d9cc16d54"/>
-				<box leftPadding="2" rightPadding="4">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRICELISTSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-21" style="Detail_Line" x="587" y="0" width="24" height="16" uuid="08a66d95-09ec-47fa-8d91-4922dce42b77"/>
-				<box leftPadding="2" rightPadding="4">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-22" style="Detail_Line" x="508" y="0" width="24" height="16" uuid="598aa264-cc3e-4ae0-8750-65e77238d13f"/>
-				<box leftPadding="2" rightPadding="4">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRICEACTUALSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-9" style="Detail_Line" x="310" y="0" width="94" height="16" uuid="383ef42f-045b-4f28-97e7-8db8c289a06a">
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{AUMQTY}!=null)?$P{NUMBERFORMAT}.format($F{AUMQTY}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-10" style="Detail_Line" x="404" y="0" width="48" height="16" uuid="94f01054-7de7-46ae-8938-730f441aa80f">
-					<property name="local_mesure_unitx" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.x" value="px"/>
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{AUM}!=null)?$F{AUM}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-9" style="Detail_Line" x="196" y="0" width="114" height="16" uuid="ccb01cdf-87bc-41b0-a826-e72c3e18d49e">
-					<property name="local_mesure_unitx" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.x" value="px"/>
-					<property name="local_mesure_unity" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.y" value="px"/>
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QUANTITYORDER}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITYORDER}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-10" style="Detail_Line" x="310" y="0" width="142" height="16" uuid="a1c45d5e-7c8a-499f-b95c-4651da8e72a3">
-					<property name="local_mesure_unitx" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.x" value="px"/>
-					<property name="local_mesure_unity" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.y" value="px"/>
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{UOMNAME}!=null)?$F{UOMNAME}:new String(" ")]]></textFieldExpression>
-			</textField>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="16" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="20" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="632" y="4" width="95" height="16" uuid="88c77770-08b8-49bb-9df2-c949eab3fba5"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="729" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="b4fd65a7-3235-4b28-af93-b9492366d0f8"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="1" width="770" height="1" forecolor="#000000" uuid="33696fd8-6684-40e7-a9da-b2c3dc2f378b">
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-				</reportElement>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="277" y="4" width="69" height="16" uuid="436c29ce-cb2b-4981-a424-9c85fdca1f5a"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" style="Report_Footer" x="195" y="4" width="78" height="16" uuid="c7b228da-d8c9-487c-9e12-9522e9cefa2e"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="16" splitType="Stretch"/>
+	<pageFooter height="20" splitType="Stretch">
+		<element kind="textField" uuid="88c77770-08b8-49bb-9df2-c949eab3fba5" key="textField" x="632" y="4" width="95" height="16" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="b4fd65a7-3235-4b28-af93-b9492366d0f8" key="textField" x="729" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle" style="Report_Footer">
+			<paragraph lineSpacing="Single" style="Report_Footer"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="33696fd8-6684-40e7-a9da-b2c3dc2f378b" key="line" x="0" y="1" width="770" height="1" forecolor="#000000">
+			<property name="local_mesure_unitwidth" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.width" value="px"/>
+			<pen lineWidth="1.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="436c29ce-cb2b-4981-a424-9c85fdca1f5a" key="textField" x="277" y="4" width="69" height="16" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="c7b228da-d8c9-487c-9e12-9522e9cefa2e" key="staticText-1" x="195" y="4" width="78" height="16" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceDiscountJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceDiscountJR.jrxml
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
-<!-- 2016-07-12T15:04:28 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportInvoiceDiscountJR" pageWidth="930" pageHeight="595" orientation="Landscape" columnWidth="870" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="143e2f91-13e7-4c3a-ac89-f630de85c5f4">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportInvoiceDiscountJR" language="java" pageWidth="930" pageHeight="595" orientation="Landscape" columnWidth="870" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="143e2f91-13e7-4c3a-ac89-f630de85c5f4">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
@@ -14,59 +12,57 @@
 	<property name="com.jaspersoft.studio.unit.rightMargin" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnWidth" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{NAME_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
 	<parameter name="isUomManagementEnabled" class="java.lang.Boolean">
 		<defaultValueExpression><![CDATA[org.openbravo.materialmgmt.UOMUtil.isUomManagementEnabled()]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[SELECT C_BPARTNER_ID as ID, NAME, PRODUCTNAME, QTY,UOM, ROUND(C_DIVIDE(TOTALLINE,QTY),3) AS PRICEACTUAL, TOTALLINE, 
+	<query language="sql"><![CDATA[SELECT C_BPARTNER_ID as ID, NAME, PRODUCTNAME, QTY,UOM, ROUND(C_DIVIDE(TOTALLINE,QTY),3) AS PRICEACTUAL, TOTALLINE, 
 	ROUND(C_DIVIDE(TOTALLINEDISCOUNT,QTY),3) AS REALPRICE, TOTALLINEDISCOUNT,        
 	(ROUND(C_DIVIDE((ROUND(C_DIVIDE(TOTALLINE,QTY),3)-ROUND(C_DIVIDE(TOTALLINEDISCOUNT,QTY),3)),ROUND(C_DIVIDE(TOTALLINE,QTY),3)),2))*100 AS DISCOUNT,        
 	(CASE (ROUND(C_DIVIDE((ROUND(C_DIVIDE(TOTALLINE,QTY),3)-ROUND(C_DIVIDE(TOTALLINEDISCOUNT,QTY),3)),ROUND(C_DIVIDE(TOTALLINE,QTY),3)),2))*100 WHEN 0 THEN '' ELSE '' END)  AS CLASS_DESIGN,        
@@ -105,8 +101,7 @@
     C_INVOICE.C_CURRENCY_ID, C_INVOICE.DATEINVOICED, C_INVOICELINE.AD_CLIENT_ID, C_INVOICELINE.AD_ORG_ID) AA
     WHERE QTY<>0
     AND 2=2
-    ORDER BY NAME]]>
-	</queryString>
+    ORDER BY NAME]]></query>
 	<field name="ID" class="java.lang.String"/>
 	<field name="NAME" class="java.lang.String"/>
 	<field name="PRODUCTNAME" class="java.lang.String"/>
@@ -123,899 +118,619 @@
 	<field name="CONVISOSYM" class="java.lang.String"/>
 	<field name="AUMQTY" class="java.math.BigDecimal"/>
 	<field name="AUM" class="java.lang.String"/>
-	<variable name="totalWeight" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="totalWeight" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="totalLine" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{TOTALLINE}]]></variableExpression>
+	<variable name="totalLine" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{TOTALLINE}]]></expression>
 	</variable>
-	<variable name="totalWeightDetail" class="java.math.BigDecimal" resetType="Group" resetGroup="NAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="totalWeightDetail" resetType="Group" calculation="Sum" resetGroup="NAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="totalLineDetail" class="java.math.BigDecimal" resetType="Group" resetGroup="NAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{TOTALLINE}]]></variableExpression>
+	<variable name="totalLineDetail" resetType="Group" calculation="Sum" resetGroup="NAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{TOTALLINE}]]></expression>
 	</variable>
-	<variable name="totalLineDiscountDetail" class="java.math.BigDecimal" resetType="Group" resetGroup="NAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{TOTALLINEDISCOUNT}]]></variableExpression>
+	<variable name="totalLineDiscountDetail" resetType="Group" calculation="Sum" resetGroup="NAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{TOTALLINEDISCOUNT}]]></expression>
 	</variable>
-	<variable name="totalLineDiscount" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{TOTALLINEDISCOUNT}]]></variableExpression>
+	<variable name="totalLineDiscount" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{TOTALLINEDISCOUNT}]]></expression>
 	</variable>
 	<group name="NAME">
-		<groupExpression><![CDATA[$F{NAME}]]></groupExpression>
+		<expression><![CDATA[$F{NAME}]]></expression>
 		<groupHeader>
 			<band height="66" splitType="Stretch">
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="1" y="0" width="868" height="23" uuid="e6d28c79-0d54-4667-b908-097cc7d6e075"/>
-					<box leftPadding="5">
+				<element kind="textField" uuid="e6d28c79-0d54-4667-b908-097cc7d6e075" key="textField" x="1" y="0" width="868" height="23" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{NAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NAME}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" mode="Opaque" x="492" y="50" width="57" height="16" uuid="2bc0b169-d5bd-4f7a-8e68-ebc00e32396e"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="2bc0b169-d5bd-4f7a-8e68-ebc00e32396e" key="element-90" mode="Opaque" x="492" y="50" width="57" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Amt.]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="704" y="50" width="57" height="16" uuid="db8a8a51-7094-46c0-9d0a-8243ad778217"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="db8a8a51-7094-46c0-9d0a-8243ad778217" key="element-90" x="704" y="50" width="57" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Real Amt.]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="0" y="50" width="156" height="16" uuid="4be254d3-3614-412e-b238-bf02ed9f3553"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="4be254d3-3614-412e-b238-bf02ed9f3553" key="element-90" x="0" y="50" width="156" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Article]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="66" forecolor="#555555" uuid="9e0a858a-8a68-404c-b5a7-8a1eae27edd3"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="156" y="50" width="51" height="16" uuid="95add4c7-df18-4a60-a90d-fbd6a3c9b584">
-						<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="9e0a858a-8a68-404c-b5a7-8a1eae27edd3" key="line-2" stretchType="ContainerHeight" x="0" y="0" width="1" height="66" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="95add4c7-df18-4a60-a90d-fbd6a3c9b584" key="element-90" x="156" y="50" width="51" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="207" y="50" width="33" height="16" uuid="da63bfad-a47a-47bb-915f-384cbe22bee4">
-						<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="da63bfad-a47a-47bb-915f-384cbe22bee4" key="element-90" x="207" y="50" width="33" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
 					<text><![CDATA[UOM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="328" y="50" width="58" height="16" uuid="76f881cc-8d45-495b-9657-2e97f56dede8"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="76f881cc-8d45-495b-9657-2e97f56dede8" key="element-90" x="328" y="50" width="58" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Weight]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="386" y="50" width="57" height="16" uuid="187adde8-9526-40c9-9c3c-c9f4cb24ae8f"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="187adde8-9526-40c9-9c3c-c9f4cb24ae8f" key="element-90" x="386" y="50" width="57" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Avg. Pr.]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="810" y="50" width="34" height="16" uuid="e26c2376-eea2-41d7-848d-76fd0f415848"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="e26c2376-eea2-41d7-848d-76fd0f415848" key="element-90" x="810" y="50" width="34" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Disc.]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="598" y="50" width="57" height="16" uuid="93c2739b-5fb0-40fe-b027-0a805776157f"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="93c2739b-5fb0-40fe-b027-0a805776157f" key="element-90" x="598" y="50" width="57" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Avg. Net Pr.]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-8" style="Detail_Header" x="761" y="50" width="49" height="16" uuid="5ea6979e-db22-45b3-a717-dc38b635a3c7"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#555555"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-10" style="Detail_Header" x="655" y="50" width="49" height="16" uuid="a6d22be6-4a95-4fc4-bc35-2092e52ffa6a"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#555555"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-12" style="Detail_Header" x="549" y="50" width="49" height="16" uuid="20f39efe-64c0-46b3-bafd-60a8d2dd11aa"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#555555"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-91" style="Detail_Header" x="844" y="50" width="25" height="16" uuid="48d3c3ed-1e99-487a-a2a7-f1fff6b8a992">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="textField" uuid="5ea6979e-db22-45b3-a717-dc38b635a3c7" key="textField-8" x="761" y="50" width="49" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#555555"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="a6d22be6-4a95-4fc4-bc35-2092e52ffa6a" key="textField-10" x="655" y="50" width="49" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#555555"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="20f39efe-64c0-46b3-bafd-60a8d2dd11aa" key="textField-12" x="549" y="50" width="49" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#555555"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="48d3c3ed-1e99-487a-a2a7-f1fff6b8a992" key="element-91" x="844" y="50" width="25" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[%]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-14" style="Detail_Header" x="443" y="50" width="49" height="16" uuid="dc816d49-f951-43ea-b77c-14823c2bd97d"/>
-					<box leftPadding="5">
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="dc816d49-f951-43ea-b77c-14823c2bd97d" key="textField-14" x="443" y="50" width="49" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#555555"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="240" y="50" width="55" height="16" uuid="d1ebca4e-9fd5-43b8-9a7a-78fa2e2a3055">
-						<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="d1ebca4e-9fd5-43b8-9a7a-78fa2e2a3055" key="element-90" x="240" y="50" width="55" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
 					<text><![CDATA[Qty in AUM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="295" y="50" width="33" height="16" uuid="9cf1b57e-1ff1-46aa-a52d-47b57bccff6e">
-						<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="9cf1b57e-1ff1-46aa-a52d-47b57bccff6e" key="element-90" x="295" y="50" width="33" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
 					<text><![CDATA[AUM]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="869" y="0" width="1" height="66" forecolor="#555555" uuid="9fd2c151-6983-4102-8ba7-a974538fcc41"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="240" y="50" width="88" height="16" uuid="2fb5f766-fb2f-410b-8419-8035630abb01">
-						<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="9fd2c151-6983-4102-8ba7-a974538fcc41" key="line-3" stretchType="ContainerHeight" x="869" y="0" width="1" height="66" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="2fb5f766-fb2f-410b-8419-8035630abb01" key="element-90" x="240" y="50" width="88" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
 					<text><![CDATA[UOM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="156" y="50" width="84" height="16" uuid="1dd8ba78-ebb7-4455-9e2c-0df6e9bda7ea">
-						<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="1dd8ba78-ebb7-4455-9e2c-0df6e9bda7ea" key="element-90" x="156" y="50" width="84" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="42" splitType="Stretch">
-				<elementGroup/>
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="869" y="0" width="1" height="40" forecolor="#555555" uuid="8e424f86-a83d-4f05-9330-7542e7084eba"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-34" x="0" y="39" width="870" height="1" forecolor="#555555" uuid="a68f5492-2738-4e32-990c-076ddfb036f1"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-6" style="GroupHeader_Gray" mode="Transparent" x="232" y="7" width="69" height="16" uuid="29a00cdd-9676-4f81-9906-ae613df8f2da"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
+				<element kind="elementGroup"/>
+				<element kind="line" uuid="8e424f86-a83d-4f05-9330-7542e7084eba" key="line-33" stretchType="ContainerHeight" x="869" y="0" width="1" height="40" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="a68f5492-2738-4e32-990c-076ddfb036f1" key="line-34" x="0" y="39" width="870" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="29a00cdd-9676-4f81-9906-ae613df8f2da" key="staticText-6" mode="Transparent" x="232" y="7" width="69" height="16" fontName="Bitstream Vera Sans" hTextAlign="Right" style="GroupHeader_Gray">
 					<text><![CDATA[Total:]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Total_Gray" x="385" y="7" width="189" height="16" uuid="46cbdff6-f815-4a14-a341-28e32387c2be"/>
-					<box>
+					<box leftPadding="5" style="GroupHeader_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{totalLineDetail}!=null)?$P{NUMBERFORMAT}.format($V{totalLineDetail}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="Total_Gray" x="304" y="7" width="81" height="16" uuid="1bdf81d4-b12e-412a-b18a-8dc581d3e210"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="46cbdff6-f815-4a14-a341-28e32387c2be" key="textField" x="385" y="7" width="189" height="16" fontName="Bitstream Vera Sans" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Gray">
+					<expression><![CDATA[($V{totalLineDetail}!=null)?$P{NUMBERFORMAT}.format($V{totalLineDetail}):new String(" ")]]></expression>
+					<box style="Total_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{totalWeightDetail}!=null)?$P{NUMBERFORMAT}.format($V{totalWeightDetail}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Total_Gray" x="597" y="7" width="188" height="16" uuid="6afa5ac3-232e-4099-b7bc-5fa8a989cff2"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="1bdf81d4-b12e-412a-b18a-8dc581d3e210" key="textField" x="304" y="7" width="81" height="16" fontName="Bitstream Vera Sans" pattern="" blankWhenNull="true" hTextAlign="Right" style="Total_Gray">
+					<expression><![CDATA[($V{totalWeightDetail}!=null)?$P{NUMBERFORMAT}.format($V{totalWeightDetail}):new String(" ")]]></expression>
+					<box style="Total_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{totalLineDiscountDetail}!=null)?$P{NUMBERFORMAT}.format($V{totalLineDiscountDetail}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-16" style="Total_Gray" x="574" y="7" width="23" height="16" uuid="09378bfe-b883-4705-b4b0-6f0e68f7f0c5"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="6afa5ac3-232e-4099-b7bc-5fa8a989cff2" key="textField" x="597" y="7" width="188" height="16" fontName="Bitstream Vera Sans" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Gray">
+					<expression><![CDATA[($V{totalLineDiscountDetail}!=null)?$P{NUMBERFORMAT}.format($V{totalLineDiscountDetail}):new String(" ")]]></expression>
+					<box style="Total_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-17" style="Total_Gray" x="785" y="7" width="23" height="16" uuid="fbb555af-6cc6-4c30-9250-783ef98e1881"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="09378bfe-b883-4705-b4b0-6f0e68f7f0c5" key="textField-16" x="574" y="7" width="23" height="16" fontName="Bitstream Vera Sans" pattern="" blankWhenNull="false" hTextAlign="Center" style="Total_Gray">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Total_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-10" style="Total_Gray" x="808" y="7" width="58" height="16" uuid="3ca1236d-e87f-4acf-9f45-e28ce8122070"/>
-					<box topPadding="2" leftPadding="5">
+				</element>
+				<element kind="textField" uuid="fbb555af-6cc6-4c30-9250-783ef98e1881" key="textField-17" x="785" y="7" width="23" height="16" fontName="Bitstream Vera Sans" pattern="" blankWhenNull="false" hTextAlign="Center" style="Total_Gray">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Total_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Bottom">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="3ca1236d-e87f-4acf-9f45-e28ce8122070" key="staticText-10" x="808" y="7" width="58" height="16" fontName="Bitstream Vera Sans" hTextAlign="Center" vTextAlign="Bottom" style="Total_Gray">
 					<text><![CDATA[]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-35" x="1" y="0" width="868" height="1" uuid="588e020d-1ae5-4a25-a80d-df64cf1590a1"/>
-				</line>
-				<line>
-					<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="39" forecolor="#555555" uuid="f3cc2e2d-a716-48f1-bfdd-9b86294a4a1b"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+					<box topPadding="2" leftPadding="5" style="Total_Gray">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="588e020d-1ae5-4a25-a80d-df64cf1590a1" key="line-35" x="1" y="0" width="868" height="1"/>
+				<element kind="line" uuid="f3cc2e2d-a716-48f1-bfdd-9b86294a4a1b" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="39" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="60" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Title" mode="Transparent" x="0" y="7" width="870" height="30" uuid="2dd84320-bf57-44a4-9e62-247caf9bc0f9"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="37" width="870" height="2" uuid="105b7d1b-c7ac-4dcc-9183-9bae52e765f3"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" x="0" y="39" width="870" height="21" uuid="21b6d2fa-e16a-4ddd-bad2-a4388f95fc8d"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{REPORT_SUBTITLE}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader height="60" splitType="Stretch">
+		<element kind="textField" uuid="2dd84320-bf57-44a4-9e62-247caf9bc0f9" key="textField" mode="Transparent" x="0" y="7" width="870" height="30" fontName="Bitstream Vera Sans" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="105b7d1b-c7ac-4dcc-9183-9bae52e765f3" key="line-1" x="0" y="37" width="870" height="2">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="21b6d2fa-e16a-4ddd-bad2-a4388f95fc8d" key="textField" x="0" y="39" width="870" height="21" fontName="Bitstream Vera Sans" blankWhenNull="false">
+			<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band height="20" splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader height="20" splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="869" y="0" width="1" height="16" forecolor="#555555" uuid="e76f46a1-9d7f-4d26-baf8-9f0b7b3220cd"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="16" forecolor="#555555" uuid="4dddb3dd-b155-496a-b93b-bda32947166b"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="492" y="0" width="82" height="16" uuid="e6fd8531-47ec-4b0d-b6c8-85f7bc8634c6"/>
-				<box leftPadding="2" rightPadding="2">
+			<element kind="line" uuid="e76f46a1-9d7f-4d26-baf8-9f0b7b3220cd" key="line-16" stretchType="ContainerHeight" x="869" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="4dddb3dd-b155-496a-b93b-bda32947166b" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="e6fd8531-47ec-4b0d-b6c8-85f7bc8634c6" key="textField" stretchType="ContainerHeight" x="492" y="0" width="82" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{TOTALLINE}!=null)?$P{NUMBERFORMAT}.format($F{TOTALLINE}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{TOTALLINE}!=null)?$P{NUMBERFORMAT}.format($F{TOTALLINE}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="704" y="0" width="82" height="16" uuid="3db5e07f-a52f-4a7f-8dbb-e64b4a79e5c3"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="3db5e07f-a52f-4a7f-8dbb-e64b4a79e5c3" key="textField" stretchType="ContainerHeight" x="704" y="0" width="82" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{TOTALLINEDISCOUNT}!=null)?$P{NUMBERFORMAT}.format($F{TOTALLINEDISCOUNT}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{TOTALLINEDISCOUNT}!=null)?$P{NUMBERFORMAT}.format($F{TOTALLINEDISCOUNT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="1" y="0" width="155" height="16" uuid="440e77f0-d7f9-48a0-af7c-faa6cafaa2e0">
-					<property name="local_mesure_unitx" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.x" value="px"/>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="440e77f0-d7f9-48a0-af7c-faa6cafaa2e0" key="textField" stretchType="ContainerHeight" x="1" y="0" width="155" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{PRODUCTNAME}]]></expression>
+				<property name="local_mesure_unitx" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.x" value="px"/>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRODUCTNAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="156" y="0" width="51" height="16" uuid="815fd137-b0ea-42a6-8d4a-51dd84bfe788">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="815fd137-b0ea-42a6-8d4a-51dd84bfe788" key="textField" stretchType="ContainerHeight" x="156" y="0" width="51" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
+				<expression><![CDATA[($F{QTY}!=null)?$P{NUMBERFORMAT}.format($F{QTY}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QTY}!=null)?$P{NUMBERFORMAT}.format($F{QTY}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="207" y="0" width="33" height="16" uuid="db5d5635-6d27-466f-9e8d-407d1c0b61fc">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="db5d5635-6d27-466f-9e8d-407d1c0b61fc" key="textField" stretchType="ContainerHeight" x="207" y="0" width="33" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
+				<expression><![CDATA[$F{UOM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{UOM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="328" y="0" width="58" height="16" uuid="d3e3bfa6-e5a0-40fb-9fc0-982bd6af277d"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="d3e3bfa6-e5a0-40fb-9fc0-982bd6af277d" key="textField" stretchType="ContainerHeight" x="328" y="0" width="58" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{WEIGHT}!=null)?$P{NUMBERFORMAT}.format($F{WEIGHT}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{WEIGHT}!=null)?$P{NUMBERFORMAT}.format($F{WEIGHT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="386" y="0" width="82" height="16" uuid="3e776fa6-539f-4a7d-acec-2ba2bc43c956"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="3e776fa6-539f-4a7d-acec-2ba2bc43c956" key="textField" stretchType="ContainerHeight" x="386" y="0" width="82" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="810" y="0" width="59" height="16" uuid="886eb021-5cdc-447b-b289-b6200e89bab4">
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="886eb021-5cdc-447b-b289-b6200e89bab4" key="textField" stretchType="ContainerHeight" x="810" y="0" width="59" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{DISCOUNT}!=null)?$P{NUMBERFORMAT}.format($F{DISCOUNT}):new String(" ")]]></expression>
+				<property name="local_mesure_unitwidth" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{DISCOUNT}!=null)?$P{NUMBERFORMAT}.format($F{DISCOUNT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="598" y="0" width="82" height="16" uuid="5fa7ee22-ad19-4eb3-be97-6e200d2ab6a8"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="5fa7ee22-ad19-4eb3-be97-6e200d2ab6a8" key="textField" stretchType="ContainerHeight" mode="Opaque" x="598" y="0" width="82" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{REALPRICE}!=null)?$P{NUMBERFORMAT}.format($F{REALPRICE}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{REALPRICE}!=null)?$P{NUMBERFORMAT}.format($F{REALPRICE}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-9" style="Detail_Line" stretchType="RelativeToBandHeight" x="786" y="0" width="24" height="16" uuid="a9d34c5b-97ce-4411-9f38-721ae793ee56"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="a9d34c5b-97ce-4411-9f38-721ae793ee56" key="textField-9" stretchType="ContainerHeight" x="786" y="0" width="24" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{CONVSYM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-11" style="Detail_Line" stretchType="RelativeToBandHeight" x="680" y="0" width="24" height="16" uuid="faea10d2-adf6-4b07-b214-f34323d256d0"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="faea10d2-adf6-4b07-b214-f34323d256d0" key="textField-11" stretchType="ContainerHeight" x="680" y="0" width="24" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{CONVSYM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-13" style="Detail_Line" stretchType="RelativeToBandHeight" x="574" y="0" width="24" height="16" uuid="251adf14-d11c-40fa-bc8b-1069f71678f9"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="251adf14-d11c-40fa-bc8b-1069f71678f9" key="textField-13" stretchType="ContainerHeight" x="574" y="0" width="24" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{CONVSYM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-15" style="Detail_Line" stretchType="RelativeToBandHeight" x="468" y="0" width="24" height="16" uuid="a42d7f5e-3a87-4cfd-8748-f81ff960796e"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="a42d7f5e-3a87-4cfd-8748-f81ff960796e" key="textField-15" stretchType="ContainerHeight" x="468" y="0" width="24" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{CONVSYM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="240" y="0" width="55" height="16" uuid="3bd5391a-660e-4aae-8714-6ca898c11f48">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="3bd5391a-660e-4aae-8714-6ca898c11f48" key="textField" stretchType="ContainerHeight" x="240" y="0" width="55" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
+				<expression><![CDATA[($F{AUMQTY}!=null)?$P{NUMBERFORMAT}.format($F{AUMQTY}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{AUMQTY}!=null)?$P{NUMBERFORMAT}.format($F{AUMQTY}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="295" y="0" width="33" height="16" uuid="ec7fc12c-c238-4f46-863b-1873519f6b91">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="ec7fc12c-c238-4f46-863b-1873519f6b91" key="textField" stretchType="ContainerHeight" x="295" y="0" width="33" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
+				<expression><![CDATA[$F{AUM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AUM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="156" y="0" width="84" height="16" uuid="ec7d3aee-da1d-43a7-b860-2adb4358d6ed">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="ec7d3aee-da1d-43a7-b860-2adb4358d6ed" key="textField" stretchType="ContainerHeight" x="156" y="0" width="84" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
+				<expression><![CDATA[($F{QTY}!=null)?$P{NUMBERFORMAT}.format($F{QTY}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QTY}!=null)?$P{NUMBERFORMAT}.format($F{QTY}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="240" y="0" width="88" height="16" uuid="0692ccbf-60e2-4015-acdc-aa9e9607a149">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="0692ccbf-60e2-4015-acdc-aa9e9607a149" key="textField" stretchType="ContainerHeight" x="240" y="0" width="88" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
+				<expression><![CDATA[$F{UOM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{UOM}]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="16" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="27" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="734" y="4" width="95" height="19" uuid="04507f17-90c1-46e6-8b58-adeeed89f845"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="833" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="18a1946d-db91-453f-8571-cfc4f2eaf1c8"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Bottom" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="0" width="870" height="2" forecolor="#000000" uuid="a5edf652-b2c3-40bb-9670-2aaf240d6219"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="468" y="4" width="69" height="19" uuid="5fab59ce-9764-4ab3-b58e-092907d73013"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Bottom">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" x="387" y="4" width="78" height="19" uuid="70669d50-2e1a-4a71-9379-441b8144fa13"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="16" splitType="Stretch"/>
+	<pageFooter height="27" splitType="Stretch">
+		<element kind="textField" uuid="04507f17-90c1-46e6-8b58-adeeed89f845" key="textField" x="734" y="4" width="95" height="19" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Bottom">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="18a1946d-db91-453f-8571-cfc4f2eaf1c8" key="textField" x="833" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Bottom">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="a5edf652-b2c3-40bb-9670-2aaf240d6219" key="line" x="0" y="0" width="870" height="2" forecolor="#000000">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="5fab59ce-9764-4ab3-b58e-092907d73013" key="textField" x="468" y="4" width="69" height="19" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Bottom">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="70669d50-2e1a-4a71-9379-441b8144fa13" key="staticText-1" x="387" y="4" width="78" height="19" hTextAlign="Right" vTextAlign="Bottom">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band height="28" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-7" style="default" mode="Transparent" x="234" y="6" width="69" height="16" uuid="3feaeec9-05d3-4d83-9ff6-a67e9aa15fe6"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<text><![CDATA[Totals]]></text>
-			</staticText>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-2" style="Total_Gray" x="306" y="6" width="81" height="16" uuid="7b8f26b8-0283-4a2e-a5a1-1bbdc52e39cc"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{totalWeight}!=null)?$P{NUMBERFORMAT}.format($V{totalWeight}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-3" style="Total_Gray" x="387" y="6" width="189" height="16" uuid="430fd02b-cab9-4a47-8754-8a6b2f928a88"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{totalLine}!=null)?$P{NUMBERFORMAT}.format($V{totalLine}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-4" style="Total_Gray" x="599" y="6" width="188" height="16" uuid="448082d2-4d8a-41c4-b8f6-9cb98067417f"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{totalLineDetail}!=null)?$P{NUMBERFORMAT}.format($V{totalLineDetail}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-19" style="Total_Gray" x="576" y="6" width="23" height="16" uuid="f756d6eb-7e02-444b-ae87-5e6e2e627a5a"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-20" style="Total_Gray" x="787" y="6" width="23" height="16" uuid="3f0becab-f954-4276-8948-0b6d632e6021"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-9" style="Total_Gray" x="810" y="6" width="60" height="16" uuid="7730f5ee-4f3e-4750-8679-662e3628bfb6"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Bottom">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<text><![CDATA[]]></text>
-			</staticText>
-		</band>
+	<summary height="28" splitType="Stretch">
+		<element kind="staticText" uuid="3feaeec9-05d3-4d83-9ff6-a67e9aa15fe6" key="staticText-7" mode="Transparent" x="234" y="6" width="69" height="16" fontName="Bitstream Vera Sans" hTextAlign="Right" style="default">
+			<text><![CDATA[Totals]]></text>
+			<box style="default">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="7b8f26b8-0283-4a2e-a5a1-1bbdc52e39cc" key="textField-2" x="306" y="6" width="81" height="16" fontName="Bitstream Vera Sans" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Gray">
+			<expression><![CDATA[($V{totalWeight}!=null)?$P{NUMBERFORMAT}.format($V{totalWeight}):new String(" ")]]></expression>
+			<box style="Total_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="430fd02b-cab9-4a47-8754-8a6b2f928a88" key="textField-3" x="387" y="6" width="189" height="16" fontName="Bitstream Vera Sans" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Gray">
+			<expression><![CDATA[($V{totalLine}!=null)?$P{NUMBERFORMAT}.format($V{totalLine}):new String(" ")]]></expression>
+			<box style="Total_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="448082d2-4d8a-41c4-b8f6-9cb98067417f" key="textField-4" x="599" y="6" width="188" height="16" fontName="Bitstream Vera Sans" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Gray">
+			<expression><![CDATA[($V{totalLineDetail}!=null)?$P{NUMBERFORMAT}.format($V{totalLineDetail}):new String(" ")]]></expression>
+			<box style="Total_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="f756d6eb-7e02-444b-ae87-5e6e2e627a5a" key="textField-19" x="576" y="6" width="23" height="16" fontName="Bitstream Vera Sans" pattern="" blankWhenNull="false" hTextAlign="Center" style="Total_Gray">
+			<expression><![CDATA[$F{CONVSYM}]]></expression>
+			<box style="Total_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="3f0becab-f954-4276-8948-0b6d632e6021" key="textField-20" x="787" y="6" width="23" height="16" fontName="Bitstream Vera Sans" pattern="" blankWhenNull="false" hTextAlign="Center" style="Total_Gray">
+			<expression><![CDATA[$F{CONVSYM}]]></expression>
+			<box style="Total_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="7730f5ee-4f3e-4750-8679-662e3628bfb6" key="staticText-9" x="810" y="6" width="60" height="16" fontName="Bitstream Vera Sans" hTextAlign="Center" vTextAlign="Bottom" style="Total_Gray">
+			<text><![CDATA[]]></text>
+			<box topPadding="2" leftPadding="5" style="Total_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</summary>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceVendorDimensionalAnalysesXLS.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceVendorDimensionalAnalysesXLS.jrxml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="eportInvoiceVendorDimensionalAnalysesXLS" pageWidth="1720" pageHeight="842" orientation="Landscape" columnWidth="1720" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" isIgnorePagination="true" uuid="40dc54a6-0046-4a72-8725-73936874bae9">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="eportInvoiceVendorDimensionalAnalysesXLS" language="java" pageWidth="1720" pageHeight="842" orientation="Landscape" columnWidth="1720" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="40dc54a6-0046-4a72-8725-73936874bae9" ignorePagination="true">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
@@ -7,68 +7,66 @@
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
 	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="11">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="11.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/opt/Apps230/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'0','1000000'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'1000000','1000001'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat("###,##0.00", new DecimalFormatSymbols())]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="strDateFormat" class="java.lang.String" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="strDateFormat" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["dd/MM/yyyy"]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[SELECT ORG, PARTNERGROUP, PARTNER, DOCUMENTNO, INVOICEDATE, PRODCATEGORY, PRODUCT, SEARCHKEY, UNITPRICE, AMOUNT, QTY
+	<query language="sql"><![CDATA[SELECT ORG, PARTNERGROUP, PARTNER, DOCUMENTNO, INVOICEDATE, PRODCATEGORY, PRODUCT, SEARCHKEY, UNITPRICE, AMOUNT, QTY
       FROM
       (SELECT (SELECT O.NAME FROM AD_ORG O WHERE O.AD_ORG_ID = C_INVOICE.AD_ORG_ID) AS ORG,
        C_BP_GROUP.NAME AS PARTNERGROUP,
@@ -95,8 +93,7 @@
       AND 0=0 AND C_INVOICE.AD_ORG_ID IN ('1')
       AND C_INVOICE.AD_CLIENT_ID IN ('6')
       AND 1=1) AA
-      ORDER BY ORG, DOCUMENTNO, INVOICEDATE]]>
-	</queryString>
+      ORDER BY ORG, DOCUMENTNO, INVOICEDATE]]></query>
 	<field name="ORG" class="java.lang.String"/>
 	<field name="PARTNERGROUP" class="java.lang.String"/>
 	<field name="PARTNER" class="java.lang.String"/>
@@ -108,304 +105,202 @@
 	<field name="UNITPRICE" class="java.math.BigDecimal"/>
 	<field name="AMOUNT" class="java.math.BigDecimal"/>
 	<field name="QTY" class="java.math.BigDecimal"/>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="15" splitType="Stretch">
-			<staticText>
-				<reportElement key="element-1" style="Detail_Header" x="0" y="0" width="250" height="15" uuid="ff38608c-5f04-4ba7-ba7a-4b68891126ab"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Organization]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-2" style="Detail_Header" x="250" y="0" width="200" height="15" uuid="1a48e090-ae93-4522-81c5-3582694ce079"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Business Partner Group]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-3" style="Detail_Header" x="450" y="0" width="200" height="15" uuid="f0a4495e-c2ec-4527-826f-e4e19b98a69e"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Business Partner]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-4" style="Detail_Header" x="650" y="0" width="150" height="15" uuid="32df9f47-2a24-41cf-9187-576bec761bbd"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Document No]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-5" style="Detail_Header" x="800" y="0" width="100" height="15" uuid="90e8ab0b-2363-4774-8c93-e84dd39632e2"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Invoice Date]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-6" style="Detail_Header" x="900" y="0" width="200" height="15" uuid="9fa09bac-337f-4dc2-b92a-b93cfa9d7b4c"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Product Category]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-7" style="Detail_Header" x="1100" y="0" width="200" height="15" uuid="c63182b5-16d2-48b3-87ad-c4147d6f1d6e"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Product]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-7-1" style="Detail_Header" x="1300" y="0" width="120" height="15"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader height="15" splitType="Stretch">
+		<element kind="staticText" uuid="ff38608c-5f04-4ba7-ba7a-4b68891126ab" key="element-1" x="0" y="0" width="250" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Organization]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Product Search Key]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-9" style="Detail_Header" x="1420" y="0" width="100" height="15" uuid="b0747cc2-9380-4f8e-852e-08998bc98bb8"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Quantity]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-7-2" style="Detail_Header" x="1520" y="0" width="100" height="15"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Unit Price]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-8" style="Detail_Header" x="1620" y="0" width="100" height="15" uuid="bd70f22d-7f1c-4d11-a3d6-c402dc8a10ec"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Amount]]></text>
-			</staticText>
-		</band>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="1a48e090-ae93-4522-81c5-3582694ce079" key="element-2" x="250" y="0" width="200" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Business Partner Group]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="f0a4495e-c2ec-4527-826f-e4e19b98a69e" key="element-3" x="450" y="0" width="200" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Business Partner]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="32df9f47-2a24-41cf-9187-576bec761bbd" key="element-4" x="650" y="0" width="150" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Document No]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="90e8ab0b-2363-4774-8c93-e84dd39632e2" key="element-5" x="800" y="0" width="100" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Invoice Date]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="9fa09bac-337f-4dc2-b92a-b93cfa9d7b4c" key="element-6" x="900" y="0" width="200" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Product Category]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="c63182b5-16d2-48b3-87ad-c4147d6f1d6e" key="element-7" x="1100" y="0" width="200" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Product]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="1412bfb8-3e8f-4338-b01e-90a88cdc9d12" key="element-7-1" x="1300" y="0" width="120" height="15" fontSize="8.0" style="Detail_Header">
+			<text><![CDATA[Product Search Key]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="b0747cc2-9380-4f8e-852e-08998bc98bb8" key="element-9" x="1420" y="0" width="100" height="15" fontSize="8.0" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Quantity]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="39ceef89-debe-45c3-a9dc-28871e90137b" key="element-7-2" x="1520" y="0" width="100" height="15" fontSize="8.0" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Unit Price]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="bd70f22d-7f1c-4d11-a3d6-c402dc8a10ec" key="element-8" x="1620" y="0" width="100" height="15" fontSize="8.0" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Amount]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#333333"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="13" splitType="Stretch">
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-1" stretchType="RelativeToBandHeight" x="0" y="0" width="250" height="13" uuid="11e8033a-58ad-4ca5-9e6d-c1192015e833"/>
+			<element kind="textField" uuid="11e8033a-58ad-4ca5-9e6d-c1192015e833" key="textField-1" stretchType="ContainerHeight" x="0" y="0" width="250" height="13" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left">
+				<expression><![CDATA[$F{ORG}]]></expression>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{ORG}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-2" stretchType="RelativeToBandHeight" x="250" y="0" width="200" height="13" uuid="4c1b35cc-e442-4ce4-8428-f530e2895f8e"/>
+			</element>
+			<element kind="textField" uuid="4c1b35cc-e442-4ce4-8428-f530e2895f8e" key="textField-2" stretchType="ContainerHeight" x="250" y="0" width="200" height="13" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false">
+				<expression><![CDATA[$F{PARTNERGROUP}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="8" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PARTNERGROUP}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-3" stretchType="RelativeToBandHeight" x="450" y="0" width="200" height="13" uuid="f22b2f89-0942-4c05-981f-bbad12eb0a82"/>
+			</element>
+			<element kind="textField" uuid="f22b2f89-0942-4c05-981f-bbad12eb0a82" key="textField-3" stretchType="ContainerHeight" x="450" y="0" width="200" height="13" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false">
+				<expression><![CDATA[$F{PARTNER}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="8" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PARTNER}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-4" stretchType="RelativeToBandHeight" x="650" y="0" width="150" height="13" uuid="a0cd608a-240a-400a-994b-728b93cc8c0b"/>
+			</element>
+			<element kind="textField" uuid="a0cd608a-240a-400a-994b-728b93cc8c0b" key="textField-4" stretchType="ContainerHeight" x="650" y="0" width="150" height="13" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false">
+				<expression><![CDATA[$F{DOCUMENTNO}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="8" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DOCUMENTNO}]]></textFieldExpression>
-			</textField>
-			<textField pattern="dd/MM/yyyy" isBlankWhenNull="false">
-				<reportElement key="textField-5" stretchType="RelativeToBandHeight" x="800" y="0" width="100" height="13" uuid="5a449301-11ab-48e5-9acf-0b5be5ecca66"/>
+			</element>
+			<element kind="textField" uuid="5a449301-11ab-48e5-9acf-0b5be5ecca66" key="textField-5" stretchType="ContainerHeight" x="800" y="0" width="100" height="13" fontSize="8.0" pattern="dd/MM/yyyy" blankWhenNull="false" hTextAlign="Left">
+				<expression><![CDATA[(new SimpleDateFormat($P{strDateFormat})).format($F{INVOICEDATE})]]></expression>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[(new SimpleDateFormat($P{strDateFormat})).format($F{INVOICEDATE})]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField-6" stretchType="RelativeToBandHeight" x="900" y="0" width="200" height="13" uuid="67dce9ce-fe62-49f6-94fe-1f17056c2311"/>
+			</element>
+			<element kind="textField" uuid="67dce9ce-fe62-49f6-94fe-1f17056c2311" key="textField-6" stretchType="ContainerHeight" x="900" y="0" width="200" height="13" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true">
+				<expression><![CDATA[$F{PRODCATEGORY}]]></expression>
 				<box rightPadding="2"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRODCATEGORY}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField-7" stretchType="RelativeToBandHeight" x="1100" y="0" width="200" height="13" uuid="e5ca1abf-b38b-4f82-8c45-c2a71c37e075"/>
+			</element>
+			<element kind="textField" uuid="e5ca1abf-b38b-4f82-8c45-c2a71c37e075" key="textField-7" stretchType="ContainerHeight" x="1100" y="0" width="200" height="13" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true">
+				<expression><![CDATA[$F{PRODUCT}]]></expression>
 				<box rightPadding="2"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRODUCT}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField-7" stretchType="RelativeToBandHeight" x="1300" y="0" width="120" height="13"/>
+			</element>
+			<element kind="textField" uuid="39eb4f0b-9a20-4435-924f-e8b468ff2547" key="textField-7" stretchType="ContainerHeight" x="1300" y="0" width="120" height="13" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true">
+				<expression><![CDATA[$F{SEARCHKEY}]]></expression>
 				<box rightPadding="2"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression class="java.lang.String"><![CDATA[$F{SEARCHKEY}]]></textFieldExpression>
-			</textField>
-			<textField pattern="#,##0.00;-#,##0.00" isBlankWhenNull="true">
-				<reportElement key="textField-9" stretchType="RelativeToBandHeight" x="1420" y="0" width="100" height="13" uuid="5ada6fb4-da6b-473e-a02c-d9c6179d984c"/>
+			</element>
+			<element kind="textField" uuid="5ada6fb4-da6b-473e-a02c-d9c6179d984c" key="textField-9" stretchType="ContainerHeight" x="1420" y="0" width="100" height="13" fontSize="8.0" pattern="#,##0.00;-#,##0.00" blankWhenNull="true" hTextAlign="Right">
+				<expression><![CDATA[$F{QTY}]]></expression>
+				<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{QTY}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="b230f45b-0364-40cb-ae4d-72fc46e0a1c4" key="textField-8" stretchType="ContainerHeight" x="1520" y="0" width="100" height="13" fontSize="8.0" pattern="#,##0.00;-#,##0.00" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[$F{UNITPRICE}]]></expression>
 				<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField pattern="#,##0.00;-#,##0.00" isBlankWhenNull="false">
-				<reportElement key="textField-8" stretchType="RelativeToBandHeight" x="1520" y="0" width="100" height="13" uuid="b230f45b-0364-40cb-ae4d-72fc46e0a1c4"/>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression class="java.math.BigDecimal"><![CDATA[$F{UNITPRICE}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="4c383464-7d43-408f-9f4d-fc1341dc7b21" key="textField-8" stretchType="ContainerHeight" x="1620" y="0" width="100" height="13" fontSize="8.0" pattern="#,##0.00;-#,##0.00" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[$F{AMOUNT}]]></expression>
 				<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField pattern="#,##0.00;-#,##0.00" isBlankWhenNull="false">
-				<reportElement key="textField-8" stretchType="RelativeToBandHeight" x="1620" y="0" width="100" height="13"/>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AMOUNT}]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceVendorJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoiceVendorJR.jrxml
@@ -1,69 +1,67 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportInvoiceVendorJR" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="ddd3ad5f-4204-433a-bac3-9932a093c47f">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportInvoiceVendorJR" language="java" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="ddd3ad5f-4204-433a-bac3-9932a093c47f">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
-	<style name="Detail_Line" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9">
-		<conditionalStyle>
+	<style name="Detail_Line" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9.0">
 			<conditionExpression><![CDATA[new Boolean($V{DOCUMENTNO_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9"/>
 		</conditionalStyle>
 	</style>
-	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Data_Label" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Data_Label" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="ReportData" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="ReportData" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT COALESCE(C_INVOICE.POREFERENCE, C_INVOICE.DOCUMENTNO) AS DOCUMENTNO, C_INVOICE.DATEINVOICED AS DATEINVOICED, 
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT COALESCE(C_INVOICE.POREFERENCE, C_INVOICE.DOCUMENTNO) AS DOCUMENTNO, C_INVOICE.DATEINVOICED AS DATEINVOICED, 
       C_BPARTNER.NAME AS CLIENT_NAME, M_PRODUCT.NAME AS PRODUCT_NAME, SUM(C_INVOICELINE.QTYINVOICED) AS QUANTITYORDER, 
       C_UOM.NAME AS UOMNAME, C_INVOICELINE.PRICEACTUAL AS PRICEACTUAL, 
       C_CURRENCY_SYMBOL (C_INVOICE.C_CURRENCY_ID, C_INVOICELINE.PRICEACTUAL, 'Y') AS PRICEACTUALSYM,
@@ -89,8 +87,7 @@
       GROUP BY C_BPARTNER.NAME, M_PRODUCT.NAME, C_UOM.NAME, C_INVOICELINE.PRICEACTUAL, 
       COALESCE(C_INVOICE.POREFERENCE, C_INVOICE.DOCUMENTNO), C_INVOICE.DATEINVOICED,
       C_INVOICE.C_CURRENCY_ID, C_INVOICELINE.AD_CLIENT_ID, C_INVOICELINE.AD_ORG_ID, C_INVOICELINE.LINENETAMT
-      ORDER BY C_BPARTNER.NAME, COALESCE(C_INVOICE.POREFERENCE, C_INVOICE.DOCUMENTNO), C_INVOICE.DATEINVOICED]]>
-	</queryString>
+      ORDER BY C_BPARTNER.NAME, COALESCE(C_INVOICE.POREFERENCE, C_INVOICE.DOCUMENTNO), C_INVOICE.DATEINVOICED]]></query>
 	<field name="DOCUMENTNO" class="java.lang.String"/>
 	<field name="DATEINVOICED" class="java.util.Date"/>
 	<field name="CLIENT_NAME" class="java.lang.String"/>
@@ -104,575 +101,396 @@
 	<field name="CONVSYM" class="java.lang.String"/>
 	<field name="CONVPRICELIST" class="java.math.BigDecimal"/>
 	<field name="CONVISOSYM" class="java.lang.String"/>
-	<variable name="DetailFieldTotal" class="java.math.BigDecimal" resetType="Group" resetGroup="CLIENT_NAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVPRICELIST}]]></variableExpression>
+	<variable name="DetailFieldTotal" resetType="Group" calculation="Sum" resetGroup="CLIENT_NAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVPRICELIST}]]></expression>
 	</variable>
-	<variable name="TotalQty" class="java.math.BigDecimal" resetType="Group" resetGroup="CLIENT_NAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{QUANTITYORDER}]]></variableExpression>
+	<variable name="TotalQty" resetType="Group" calculation="Sum" resetGroup="CLIENT_NAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QUANTITYORDER}]]></expression>
 	</variable>
 	<group name="CLIENT_NAME">
-		<groupExpression><![CDATA[$F{CLIENT_NAME}]]></groupExpression>
+		<expression><![CDATA[$F{CLIENT_NAME}]]></expression>
 		<groupHeader>
 			<band height="33" splitType="Stretch">
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="1" y="0" width="705" height="23" uuid="89af594b-15b0-43e7-80db-e00ce74ccb26"/>
-					<box leftPadding="5">
+				<element kind="textField" uuid="89af594b-15b0-43e7-80db-e00ce74ccb26" key="textField" x="1" y="0" width="705" height="23" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{CLIENT_NAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{CLIENT_NAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="33" forecolor="#555555" uuid="62c52e82-fd84-4c43-9b16-e57aa8f58bdc"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="706" y="0" width="1" height="33" forecolor="#555555" uuid="526ec997-1ecc-4c90-a6d6-7a34d63caa75"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				</element>
+				<element kind="line" uuid="62c52e82-fd84-4c43-9b16-e57aa8f58bdc" key="line-2" stretchType="ContainerHeight" x="0" y="0" width="1" height="33" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="526ec997-1ecc-4c90-a6d6-7a34d63caa75" key="line-3" stretchType="ContainerHeight" x="706" y="0" width="1" height="33" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="32" splitType="Stretch">
-				<line>
-					<reportElement key="line-32" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="19" forecolor="#555555" uuid="cabab442-d530-406a-8c8f-970e78cf3582"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="706" y="0" width="1" height="19" forecolor="#555555" uuid="9882a691-8937-42d4-951e-e71f6215fd0f"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-34" x="0" y="19" width="707" height="1" forecolor="#555555" uuid="ea219179-4342-43ba-9d6a-5a0e6d9f5efb"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-10" style="Report_Data_Label" x="429" y="0" width="186" height="16" uuid="7e95a161-66f1-4f20-a979-20b66910efad"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle"/>
+				<element kind="line" uuid="cabab442-d530-406a-8c8f-970e78cf3582" key="line-32" stretchType="ContainerHeight" x="0" y="0" width="1" height="19" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="9882a691-8937-42d4-951e-e71f6215fd0f" key="line-33" stretchType="ContainerHeight" x="706" y="0" width="1" height="19" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="ea219179-4342-43ba-9d6a-5a0e6d9f5efb" key="line-34" x="0" y="19" width="707" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="7e95a161-66f1-4f20-a979-20b66910efad" key="staticText-10" x="429" y="0" width="186" height="16" hTextAlign="Right" vTextAlign="Middle" style="Report_Data_Label">
 					<text><![CDATA[Total:]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Total_Gray" x="615" y="0" width="65" height="16" uuid="466388db-bdb9-4dab-89b9-bee29a779267"/>
-					<box>
+					<box style="Report_Data_Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{DetailFieldTotal}!=null)?$P{NUMBERFORMAT}.format($V{DetailFieldTotal}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-13" style="Total_Gray" x="680" y="0" width="23" height="16" uuid="10870c72-52e3-4bf9-ab89-fe1eb910ace2"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="466388db-bdb9-4dab-89b9-bee29a779267" key="textField" x="615" y="0" width="65" height="16" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Gray">
+					<expression><![CDATA[($V{DetailFieldTotal}!=null)?$P{NUMBERFORMAT}.format($V{DetailFieldTotal}):new String(" ")]]></expression>
+					<box style="Total_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center"/>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="10870c72-52e3-4bf9-ab89-fe1eb910ace2" key="textField-13" x="680" y="0" width="23" height="16" pattern="" blankWhenNull="false" hTextAlign="Center" style="Total_Gray">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Total_Gray">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="DOCUMENTNO">
-		<groupExpression><![CDATA[$F{DOCUMENTNO}]]></groupExpression>
+		<expression><![CDATA[$F{DOCUMENTNO}]]></expression>
 		<groupHeader>
 			<band height="64" splitType="Stretch">
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="11" y="0" width="695" height="23" uuid="9e66060e-9e1d-475a-ba29-503045475b06"/>
-					<box leftPadding="5">
+				<element kind="textField" uuid="9e66060e-9e1d-475a-ba29-503045475b06" key="textField" x="11" y="0" width="695" height="23" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{DOCUMENTNO}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{DOCUMENTNO}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-6" stretchType="RelativeToBandHeight" x="706" y="0" width="1" height="64" forecolor="#555555" uuid="e387ec24-5542-4dfa-aead-47fc3532ed30"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-8" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="64" forecolor="#555555" uuid="898de947-a0f7-4a84-a79c-128de8b86175"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="Report_Data_Field" x="116" y="28" width="114" height="14" uuid="b00bfedc-f33d-4b8b-9f8f-11e4fab12be7"/>
-					<box topPadding="2" leftPadding="5" rightPadding="2">
+				</element>
+				<element kind="line" uuid="e387ec24-5542-4dfa-aead-47fc3532ed30" key="line-6" stretchType="ContainerHeight" x="706" y="0" width="1" height="64" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="898de947-a0f7-4a84-a79c-128de8b86175" key="line-8" stretchType="ContainerHeight" x="0" y="0" width="1" height="64" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="textField" uuid="b00bfedc-f33d-4b8b-9f8f-11e4fab12be7" key="textField" x="116" y="28" width="114" height="14" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Report_Data_Field">
+					<expression><![CDATA[$F{DATEINVOICED}]]></expression>
+					<box topPadding="2" leftPadding="5" rightPadding="2" style="Report_Data_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{DATEINVOICED}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-9" style="default" x="25" y="28" width="91" height="14" uuid="88094986-1367-491f-91ef-10c7885169fb"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="88094986-1367-491f-91ef-10c7885169fb" key="staticText-9" x="25" y="28" width="91" height="14" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" style="default">
 					<text><![CDATA[Invoice Date:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="25" y="48" width="220" height="16" uuid="cd69f216-79ec-4096-be51-327da0b7b028"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="cd69f216-79ec-4096-be51-327da0b7b028" key="element-90" x="25" y="48" width="220" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" style="Detail_Header">
 					<text><![CDATA[Item]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="245" y="48" width="100" height="16" uuid="6c4ed5fb-d52e-428a-8726-a5f9e6685dd6"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="6c4ed5fb-d52e-428a-8726-a5f9e6685dd6" key="element-90" x="245" y="48" width="100" height="16" fontSize="8.0" hTextAlign="Center" style="Detail_Header">
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="345" y="48" width="90" height="16" uuid="1ae56888-2538-44e2-a244-a513d7782114"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="1ae56888-2538-44e2-a244-a513d7782114" key="element-90" x="345" y="48" width="90" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
 					<text><![CDATA[Price]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-42" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="64" forecolor="#555555" uuid="8af284da-6862-4e12-a5e4-8eda72098431"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="element-91" style="Detail_Header" x="435" y="48" width="37" height="16" uuid="21fb1b9c-9494-4341-948b-424904e3d7eb"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="8af284da-6862-4e12-a5e4-8eda72098431" key="line-42" stretchType="ContainerHeight" x="10" y="0" width="1" height="64" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="21fb1b9c-9494-4341-948b-424904e3d7eb" key="element-91" x="435" y="48" width="37" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[Price]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-92" style="Detail_Header" x="615" y="48" width="34" height="16" uuid="60dec02b-b9ed-4dbd-99d7-eec855baa74d"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="60dec02b-b9ed-4dbd-99d7-eec855baa74d" key="element-92" x="615" y="48" width="34" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[Total]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-93" style="Detail_Header" x="525" y="48" width="90" height="16" uuid="8f33b415-61b5-4f4d-981b-19621d436b70"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="8f33b415-61b5-4f4d-981b-19621d436b70" key="element-93" x="525" y="48" width="90" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
 					<text><![CDATA[Total]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-11" style="Detail_Header" x="472" y="48" width="53" height="16" uuid="e85b5578-1fe4-4bc5-bbba-3dbe60844e05"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-12" style="Detail_Header" x="649" y="48" width="56" height="16" uuid="b590116f-2fa5-4209-99b0-7f6ad3b09aaa"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="e85b5578-1fe4-4bc5-bbba-3dbe60844e05" key="textField-11" x="472" y="48" width="53" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="b590116f-2fa5-4209-99b0-7f6ad3b09aaa" key="textField-12" x="649" y="48" width="56" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-38" x="25" y="0" width="679" height="1" forecolor="#666666" uuid="f04d1e6b-54d6-43de-bd47-c958a2d09f8c"/>
-					<graphicElement>
-						<pen lineWidth="0.25" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-39" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="2" forecolor="#555555" uuid="acc0feb8-8494-4591-a60c-b7d68d43cbaa"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-40" stretchType="RelativeToBandHeight" x="706" y="-1" width="1" height="2" forecolor="#555555" uuid="6abf7b48-febd-4a69-bd3f-d3d2772c2f43"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-41" x="10" y="10" width="696" height="1" forecolor="#555555" uuid="8f28233d-968e-4097-9fe3-8a1b350c611a"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-43" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="20" forecolor="#555555" uuid="d2283566-a6a7-45a5-8789-76c214d35361"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-44" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="10" forecolor="#555555" uuid="f8cbb5b6-47c2-4576-8366-d0ffe50cf214"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-45" stretchType="RelativeToBandHeight" x="706" y="0" width="1" height="20" forecolor="#555555" uuid="31ab619f-d340-4922-924e-5ebc63b26c52"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="f04d1e6b-54d6-43de-bd47-c958a2d09f8c" key="line-38" x="25" y="0" width="679" height="1" forecolor="#666666">
+					<pen lineWidth="0.25" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="acc0feb8-8494-4591-a60c-b7d68d43cbaa" key="line-39" stretchType="ContainerHeight" x="0" y="0" width="1" height="2" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="6abf7b48-febd-4a69-bd3f-d3d2772c2f43" key="line-40" stretchType="ContainerHeight" x="706" y="-1" width="1" height="2" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="8f28233d-968e-4097-9fe3-8a1b350c611a" key="line-41" x="10" y="10" width="696" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="d2283566-a6a7-45a5-8789-76c214d35361" key="line-43" stretchType="ContainerHeight" x="0" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="f8cbb5b6-47c2-4576-8366-d0ffe50cf214" key="line-44" stretchType="ContainerHeight" x="10" y="0" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="31ab619f-d340-4922-924e-5ebc63b26c52" key="line-45" stretchType="ContainerHeight" x="706" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="42" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Title" mode="Transparent" x="0" y="0" width="706" height="25" uuid="1cfe2f39-4c27-4af6-be9a-c2e315a4c4c0"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-37" x="0" y="29" width="706" height="1" uuid="bb8dc87e-6911-4981-9612-6507f924e956"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-		</band>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader height="42" splitType="Stretch">
+		<element kind="textField" uuid="1cfe2f39-4c27-4af6-be9a-c2e315a4c4c0" key="textField" mode="Transparent" x="0" y="0" width="706" height="25" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="bb8dc87e-6911-4981-9612-6507f924e956" key="line-37" x="0" y="29" width="706" height="1">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="14" splitType="Stretch">
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="706" y="0" width="1" height="14" forecolor="#555555" uuid="cfbd4193-cd59-47d1-b6ba-15528e51ca48"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="14" forecolor="#555555" uuid="ae519131-21ba-423b-bf6a-16105145ea46"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-1" style="Detail_Line" x="25" y="0" width="220" height="14" uuid="338755a9-85e4-4b60-b048-eba3b3cb38c4"/>
-				<box leftPadding="2" rightPadding="2">
+			<element kind="line" uuid="cfbd4193-cd59-47d1-b6ba-15528e51ca48" key="line-16" stretchType="ContainerHeight" x="706" y="0" width="1" height="14" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="ae519131-21ba-423b-bf6a-16105145ea46" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="14" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="338755a9-85e4-4b60-b048-eba3b3cb38c4" key="textField-1" x="25" y="0" width="220" height="14" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{PRODUCT_NAME}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRODUCT_NAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-2" style="Detail_Line" x="245" y="0" width="70" height="14" uuid="ebeb863f-4ed6-4d9c-b614-81d51bb8db3d"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="ebeb863f-4ed6-4d9c-b614-81d51bb8db3d" key="textField-2" x="245" y="0" width="70" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{QUANTITYORDER}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITYORDER}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QUANTITYORDER}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITYORDER}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-3" style="Detail_Line" x="315" y="0" width="30" height="14" uuid="7bba713d-af81-4c7d-ae40-caf3e13a46f0"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="7bba713d-af81-4c7d-ae40-caf3e13a46f0" key="textField-3" x="315" y="0" width="30" height="14" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{UOMNAME}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{UOMNAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-4" style="Detail_Line" x="345" y="0" width="75" height="14" uuid="fa6e980a-cc37-4b6a-8a66-40aec7a110d7"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="fa6e980a-cc37-4b6a-8a66-40aec7a110d7" key="textField-4" x="345" y="0" width="75" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#666666"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-46" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="14" forecolor="#555555" uuid="c052f0ed-480a-43f4-9a4e-12743826d542"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-6" style="Detail_Line" x="435" y="0" width="75" height="14" uuid="d24b1b01-c22a-4eb4-8de7-4de5e664241c"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="line" uuid="c052f0ed-480a-43f4-9a4e-12743826d542" key="line-46" stretchType="ContainerHeight" x="10" y="0" width="1" height="14" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="d24b1b01-c22a-4eb4-8de7-4de5e664241c" key="textField-6" x="435" y="0" width="75" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVPRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{CONVPRICEACTUAL}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#666666"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVPRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{CONVPRICEACTUAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-7" style="Detail_Line" x="615" y="0" width="74" height="14" uuid="b98e46ff-3aa0-4436-b27c-e5ceada4959d"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="b98e46ff-3aa0-4436-b27c-e5ceada4959d" key="textField-7" x="615" y="0" width="74" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVPRICELIST}!=null)?$P{NUMBERFORMAT}.format($F{CONVPRICELIST}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#666666"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVPRICELIST}!=null)?$P{NUMBERFORMAT}.format($F{CONVPRICELIST}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-8" style="Detail_Line" x="525" y="0" width="75" height="14" uuid="25a3481c-eb3f-4411-9cd2-069be609c030"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="25a3481c-eb3f-4411-9cd2-069be609c030" key="textField-8" x="525" y="0" width="75" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PRICELIST}!=null)?$P{NUMBERFORMAT}.format($F{PRICELIST}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#666666"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRICELIST}!=null)?$P{NUMBERFORMAT}.format($F{PRICELIST}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-9" style="Detail_Line" x="420" y="0" width="15" height="14" uuid="b3623221-2010-41c1-bc26-38c9a146eb14"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="b3623221-2010-41c1-bc26-38c9a146eb14" key="textField-9" x="420" y="0" width="15" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{PRICEACTUALSYM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRICEACTUALSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-10" style="Detail_Line" x="510" y="0" width="15" height="14" uuid="d9cc10c9-eca6-45c5-9ab9-60619dfe5bdb"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="d9cc10c9-eca6-45c5-9ab9-60619dfe5bdb" key="textField-10" x="510" y="0" width="15" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{CONVSYM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-14" style="Detail_Line" x="600" y="0" width="15" height="14" uuid="dd067f1a-68c1-4c37-8050-3ee0bedca415"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="dd067f1a-68c1-4c37-8050-3ee0bedca415" key="textField-14" x="600" y="0" width="15" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{PRICEACTUALSYM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRICEACTUALSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-15" style="Detail_Line" x="689" y="0" width="15" height="14" uuid="9a681431-c4d9-4a63-81e9-6d9892041e68"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="9a681431-c4d9-4a63-81e9-6d9892041e68" key="textField-15" x="689" y="0" width="15" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{CONVSYM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="16" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="20" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="572" y="4" width="95" height="16" uuid="12f36880-bc90-4358-8e02-70c80639ba14"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="669" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="25e0ae25-f50d-4d3e-b38c-588c034a84ae"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="1" width="706" height="3" forecolor="#000000" uuid="e14b102e-25e7-49bc-89f9-0f39e345c5dd"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="277" y="4" width="69" height="16" uuid="4920669b-32da-4f8c-97c0-278b74579bb7"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" style="Report_Footer" x="195" y="4" width="78" height="16" uuid="ec75f6cc-b009-41cb-84be-a224e43eca7e"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="16" splitType="Stretch"/>
+	<pageFooter height="20" splitType="Stretch">
+		<element kind="textField" uuid="12f36880-bc90-4358-8e02-70c80639ba14" key="textField" x="572" y="4" width="95" height="16" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="25e0ae25-f50d-4d3e-b38c-588c034a84ae" key="textField" x="669" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle" style="Report_Footer">
+			<paragraph lineSpacing="Single" style="Report_Footer"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="e14b102e-25e7-49bc-89f9-0f39e345c5dd" key="line" x="0" y="1" width="706" height="3" forecolor="#000000">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="4920669b-32da-4f8c-97c0-278b74579bb7" key="textField" x="277" y="4" width="69" height="16" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="ec75f6cc-b009-41cb-84be-a224e43eca7e" key="staticText-1" x="195" y="4" width="78" height="16" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportInvoicesEditJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportInvoicesEditJR.jrxml
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
-<!-- 2016-12-26T16:04:35 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportInvoicesEditJR" pageWidth="930" pageHeight="595" orientation="Landscape" columnWidth="870" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="d47540dd-b79e-4355-811f-a0b9f6886e2b">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportInvoicesEditJR" language="java" pageWidth="930" pageHeight="595" orientation="Landscape" columnWidth="870" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="d47540dd-b79e-4355-811f-a0b9f6886e2b">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
@@ -14,71 +12,69 @@
 	<property name="com.jaspersoft.studio.unit.rightMargin" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnWidth" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true">
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="10">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="10.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{INVOICEID_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="ReportData" class="java.lang.String" isForPrompting="false">
+	<parameter name="ReportData" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
 	<parameter name="isUomManagementEnabled" class="java.lang.Boolean">
 		<defaultValueExpression><![CDATA[org.openbravo.materialmgmt.UOMUtil.isUomManagementEnabled()]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[SELECT NAMEBPARTNER,INVOICEID, INVOICEDOCUMENTNO, DOCNOORDER, DESCRIPTIONINVOICE, DATEINVOICED, LINE, NAMEPRODUCT, 
+	<query language="sql"><![CDATA[SELECT NAMEBPARTNER,INVOICEID, INVOICEDOCUMENTNO, DOCNOORDER, DESCRIPTIONINVOICE, DATEINVOICED, LINE, NAMEPRODUCT, 
 	  QTYINVOICED, UOMSYMBOL, PRICEACTUAL, CONVPRICEACTUAL, TAX, BASE, CONVBASE, LINENETAMT, CONVLINENETAMT,
 	  C_CURRENCY_SYMBOL('102', 0, 'Y') AS CONVSYM, C_CURRENCY_ISOSYM('102') AS CONVISOSYM, INVOICECURRENCYSYM,
 	  TRANSCURRENCYID, TRANSDATE, TRANSCLIENTID, TRANSORGID
@@ -130,8 +126,7 @@
       AND I2.AD_Client_ID IN ('2')
       AND I2.AD_ORG_ID IN ('2')
       AND 2=2) A
-      ORDER BY NAMEBPARTNER, INVOICEDOCUMENTNO, LINE]]>
-	</queryString>
+      ORDER BY NAMEBPARTNER, INVOICEDOCUMENTNO, LINE]]></query>
 	<field name="NAMEBPARTNER" class="java.lang.String"/>
 	<field name="INVOICEID" class="java.lang.String"/>
 	<field name="INVOICEDOCUMENTNO" class="java.lang.String"/>
@@ -155,975 +150,687 @@
 	<field name="AUM" class="java.lang.String"/>
 	<field name="AUMQTY" class="java.math.BigDecimal"/>
 	<variable name="DetailFieldTotal" class="java.lang.String"/>
-	<variable name="TOTAL_INVOICE" class="java.math.BigDecimal" resetType="Group" resetGroup="INVOICEID" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVLINENETAMT}]]></variableExpression>
+	<variable name="TOTAL_INVOICE" resetType="Group" calculation="Sum" resetGroup="INVOICEID" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVLINENETAMT}]]></expression>
 	</variable>
-	<variable name="TOTAL_PARTNER" class="java.math.BigDecimal" resetType="Group" resetGroup="NAMEBPARTNER" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVLINENETAMT}]]></variableExpression>
+	<variable name="TOTAL_PARTNER" resetType="Group" calculation="Sum" resetGroup="NAMEBPARTNER" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVLINENETAMT}]]></expression>
 	</variable>
 	<group name="NAMEBPARTNER">
-		<groupExpression><![CDATA[$F{NAMEBPARTNER}]]></groupExpression>
+		<expression><![CDATA[$F{NAMEBPARTNER}]]></expression>
 		<groupHeader>
 			<band height="42" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="0" y="0" width="120" height="18" uuid="40cd6c5d-2786-404a-a903-4fb0f986673a"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
+				<element kind="staticText" uuid="40cd6c5d-2786-404a-a903-4fb0f986673a" key="staticText" x="0" y="0" width="120" height="18" style="GroupHeader_DarkGray">
 					<text><![CDATA[PARTNER]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="120" y="0" width="749" height="18" uuid="053d1301-29f0-4f15-ac23-4693191fb430"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[($F{NAMEBPARTNER}!=null)?$F{NAMEBPARTNER}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="18" width="1" height="24" forecolor="#555555" uuid="2162ef59-5e32-46cd-8ca4-e5b9799d01c3"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="869" y="0" width="1" height="42" forecolor="#555555" uuid="8f6e134a-d24f-493a-ac98-146dfbe308f0"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				</element>
+				<element kind="textField" uuid="053d1301-29f0-4f15-ac23-4693191fb430" key="textField" x="120" y="0" width="749" height="18" pattern="" blankWhenNull="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[($F{NAMEBPARTNER}!=null)?$F{NAMEBPARTNER}:new String(" ")]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="2162ef59-5e32-46cd-8ca4-e5b9799d01c3" key="line-2" stretchType="ContainerHeight" x="0" y="18" width="1" height="24" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="8f6e134a-d24f-493a-ac98-146dfbe308f0" key="line-3" stretchType="ContainerHeight" x="869" y="0" width="1" height="42" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="32" splitType="Stretch">
-				<line>
-					<reportElement key="line-32" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="22" forecolor="#555555" uuid="d657642d-badc-4945-8eb5-7ad65892da81"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="869" y="0" width="1" height="23" forecolor="#555555" uuid="ba9b4623-ee49-4959-b2e1-159efd0ad607"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-34" x="0" y="22" width="869" height="1" forecolor="#555555" uuid="d7237eec-efb0-4380-8359-55299f5f1d56"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-4" style="Report_Data_Label" x="349" y="0" width="150" height="16" uuid="f93bc4ce-89d1-4c1b-ae22-52759e5aad59"/>
-					<box leftPadding="4" rightPadding="4">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				<element kind="line" uuid="d657642d-badc-4945-8eb5-7ad65892da81" key="line-32" stretchType="ContainerHeight" x="0" y="0" width="1" height="22" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="ba9b4623-ee49-4959-b2e1-159efd0ad607" key="line-33" stretchType="ContainerHeight" x="869" y="0" width="1" height="23" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="d7237eec-efb0-4380-8359-55299f5f1d56" key="line-34" x="0" y="22" width="869" height="1" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="f93bc4ce-89d1-4c1b-ae22-52759e5aad59" key="staticText-4" x="349" y="0" width="150" height="16" pdfFontName="Helvetica-Bold" hTextAlign="Right" vTextAlign="Middle" style="Report_Data_Label">
 					<text><![CDATA[Total Partner:]]></text>
-				</staticText>
-				<textField evaluationTime="Group" evaluationGroup="NAMEBPARTNER" isBlankWhenNull="false">
-					<reportElement key="textField-3" style="Total_Field" x="499" y="0" width="354" height="16" uuid="1e56b8fb-4a7b-4f0d-ad11-20c76b51358a"/>
-					<box leftPadding="5">
+					<box leftPadding="4" rightPadding="4" style="Report_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="1e56b8fb-4a7b-4f0d-ad11-20c76b51358a" key="textField-3" x="499" y="0" width="354" height="16" pdfFontName="Helvetica-Bold" evaluationTime="Group" evaluationGroup="NAMEBPARTNER" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Field">
+					<expression><![CDATA[($V{TOTAL_PARTNER}!=null)?$P{NUMBERFORMAT}.format($V{TOTAL_PARTNER}):new String(" ")]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{TOTAL_PARTNER}!=null)?$P{NUMBERFORMAT}.format($V{TOTAL_PARTNER}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NAMEBPARTNER" isBlankWhenNull="false">
-					<reportElement key="textField-19" style="Total_Field" x="853" y="0" width="16" height="16" uuid="2a429ff9-6694-4a09-8ed3-2c0b9b8c315c"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="2a429ff9-6694-4a09-8ed3-2c0b9b8c315c" key="textField-19" x="853" y="0" width="16" height="16" pdfFontName="Helvetica-Bold" evaluationTime="Group" evaluationGroup="NAMEBPARTNER" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Total_Field">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="INVOICEID">
-		<groupExpression><![CDATA[$F{INVOICEID}]]></groupExpression>
+		<expression><![CDATA[$F{INVOICEID}]]></expression>
 		<groupHeader>
 			<band height="46" splitType="Stretch">
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="90" y="0" width="218" height="18" uuid="a05feee6-1253-46e3-8224-35ba971181e4"/>
-					<box leftPadding="5">
+				<element kind="textField" uuid="a05feee6-1253-46e3-8224-35ba971181e4" key="textField" x="90" y="0" width="218" height="18" pattern="" blankWhenNull="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[($F{INVOICEDOCUMENTNO}!=null)?$F{INVOICEDOCUMENTNO}.toString():new String(" ")]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[($F{INVOICEDOCUMENTNO}!=null)?$F{INVOICEDOCUMENTNO}.toString():new String(" ")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-4" stretchType="RelativeToBandHeight" x="10" y="18" width="1" height="28" forecolor="#555555" uuid="5711366c-33f1-48f9-8b8a-c03e64bd1654"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-8" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="46" forecolor="#555555" uuid="73ff092e-e1bf-451f-8dc0-d853f9a34880"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-9" style="GroupHeader_DarkGray" x="10" y="0" width="80" height="18" uuid="755bcdfe-973e-4bae-846b-800a4b5a5621"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
+				</element>
+				<element kind="line" uuid="5711366c-33f1-48f9-8b8a-c03e64bd1654" key="line-4" stretchType="ContainerHeight" x="10" y="18" width="1" height="28" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="73ff092e-e1bf-451f-8dc0-d853f9a34880" key="line-8" stretchType="ContainerHeight" x="0" y="0" width="1" height="46" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="755bcdfe-973e-4bae-846b-800a4b5a5621" key="staticText-9" x="10" y="0" width="80" height="18" style="GroupHeader_DarkGray">
 					<text><![CDATA[INVOICE]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-10" style="GroupHeader_DarkGray" x="308" y="0" width="100" height="18" uuid="f06efde4-3d45-447a-9ea3-7617f63d8a65"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="f06efde4-3d45-447a-9ea3-7617f63d8a65" key="staticText-10" x="308" y="0" width="100" height="18" style="GroupHeader_DarkGray">
 					<text><![CDATA[ORDER NO.]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-4" style="GroupHeader_DarkGray" x="408" y="0" width="295" height="18" uuid="113eff29-cb10-40d8-98a1-99ec1a7ba8bf"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[($F{DOCNOORDER}!=null)?$F{DOCNOORDER}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-11" style="GroupHeader_DarkGray" x="703" y="0" width="74" height="18" uuid="62a04fe9-225b-4efb-803a-a43001cc3d2b"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="113eff29-cb10-40d8-98a1-99ec1a7ba8bf" key="textField-4" x="408" y="0" width="295" height="18" pattern="" blankWhenNull="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[($F{DOCNOORDER}!=null)?$F{DOCNOORDER}:new String(" ")]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="62a04fe9-225b-4efb-803a-a43001cc3d2b" key="staticText-11" x="703" y="0" width="74" height="18" style="GroupHeader_DarkGray">
 					<text><![CDATA[DATE]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-12" style="Detail_Header" x="14" y="32" width="40" height="14" uuid="e62cf981-b775-4bb8-a162-0f930dbaaba9"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="e62cf981-b775-4bb8-a162-0f930dbaaba9" key="staticText-12" x="14" y="32" width="40" height="14" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Line]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-13" style="Detail_Header" x="54" y="32" width="100" height="14" uuid="99f44fb2-34a5-4a79-97af-7d84fd6a49e5"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="99f44fb2-34a5-4a79-97af-7d84fd6a49e5" key="staticText-13" x="54" y="32" width="100" height="14" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Item]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-14" style="Detail_Header" x="154" y="32" width="56" height="14" uuid="019ec229-359d-4878-a650-46b4100dee04">
-						<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="019ec229-359d-4878-a650-46b4100dee04" key="staticText-14" x="154" y="32" width="56" height="14" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-15" style="Detail_Header" x="210" y="32" width="44" height="14" uuid="fb1672f0-8c6d-49ab-8e3c-1bce2e9cc54b">
-						<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="fb1672f0-8c6d-49ab-8e3c-1bce2e9cc54b" key="staticText-15" x="210" y="32" width="44" height="14" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
 					<text><![CDATA[UOM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-16" style="Detail_Header" x="349" y="32" width="73" height="14" uuid="4955c536-0d1b-451a-854f-b50c54679f36"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="4955c536-0d1b-451a-854f-b50c54679f36" key="staticText-16" x="349" y="32" width="73" height="14" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Price]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-17" style="Detail_Header" x="495" y="32" width="48" height="14" uuid="88a3503e-dbad-4ff2-85de-e92e11b5a0d6"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="88a3503e-dbad-4ff2-85de-e92e11b5a0d6" key="staticText-17" x="495" y="32" width="48" height="14" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[% Tax]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-18" style="Detail_Header" x="543" y="32" width="88" height="14" uuid="5c5decb4-1fcd-4db7-bb54-b76166d052c7"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="5c5decb4-1fcd-4db7-bb54-b76166d052c7" key="staticText-18" x="543" y="32" width="88" height="14" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Base]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-19" style="Detail_Header" x="719" y="32" width="75" height="14" uuid="0d42987a-43f6-4af0-94db-2815dcc140ff"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="0d42987a-43f6-4af0-94db-2815dcc140ff" key="staticText-19" x="719" y="32" width="75" height="14" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-21" style="Detail_Header" x="422" y="32" width="31" height="14" uuid="91d797ff-561c-4b79-b38c-ac71309b4082">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="91d797ff-561c-4b79-b38c-ac71309b4082" key="staticText-21" x="422" y="32" width="31" height="14" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Price]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-22" style="Detail_Header" x="631" y="32" width="46" height="14" uuid="fe181b13-7a5d-49d2-8dcf-520330947475">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					</reportElement>
-					<box leftPadding="5">
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="fe181b13-7a5d-49d2-8dcf-520330947475" key="staticText-22" x="631" y="32" width="46" height="14" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Base]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-23" style="Detail_Header" x="794" y="32" width="33" height="14" uuid="5b5df695-e5cf-4435-a05c-657804a3ad65">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					</reportElement>
-					<box leftPadding="5" rightPadding="1">
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="5b5df695-e5cf-4435-a05c-657804a3ad65" key="staticText-23" x="794" y="32" width="33" height="14" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Amt.]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-9" style="Detail_Header" x="452" y="32" width="43" height="14" uuid="777a1024-dc5e-48af-bddc-8383ac938455"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-10" style="Detail_Header" x="676" y="32" width="43" height="14" uuid="e234ddeb-b2d6-4fba-9adb-7ac60f9c97c8"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-11" style="Detail_Header" x="826" y="32" width="43" height="14" uuid="5535b3a7-7a68-4868-8558-ebd6ff3f2566"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-5" style="GroupHeader_DarkGray" x="777" y="0" width="92" height="18" uuid="bd8ecff2-1fb1-4050-86e6-e2cd881f127e"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textFieldExpression><![CDATA[$F{DATEINVOICED}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-6" stretchType="RelativeToBandHeight" x="869" y="0" width="1" height="46" forecolor="#555555" uuid="5afdab75-b32b-4928-85e3-1da13701cb55"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-14" style="Detail_Header" x="254" y="32" width="51" height="14" uuid="17c9616c-6568-42ad-8422-13e6819f1ae1">
-						<printWhenExpression><![CDATA[true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<box leftPadding="5" rightPadding="1" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="textField" uuid="777a1024-dc5e-48af-bddc-8383ac938455" key="textField-9" x="452" y="32" width="43" height="14" fontSize="8.0" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="e234ddeb-b2d6-4fba-9adb-7ac60f9c97c8" key="textField-10" x="676" y="32" width="43" height="14" fontSize="8.0" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="5535b3a7-7a68-4868-8558-ebd6ff3f2566" key="textField-11" x="826" y="32" width="43" height="14" fontSize="8.0" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="bd8ecff2-1fb1-4050-86e6-e2cd881f127e" key="textField-5" x="777" y="0" width="92" height="18" blankWhenNull="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{DATEINVOICED}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="5afdab75-b32b-4928-85e3-1da13701cb55" key="line-6" stretchType="ContainerHeight" x="869" y="0" width="1" height="46" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="17c9616c-6568-42ad-8422-13e6819f1ae1" key="staticText-14" x="254" y="32" width="51" height="14" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
+					<printWhenExpression><![CDATA[true]]></printWhenExpression>
 					<text><![CDATA[Qty in AUM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-15" style="Detail_Header" x="305" y="32" width="44" height="14" uuid="5d1facc4-8a9f-4245-9331-ce510b0703eb">
-						<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="5d1facc4-8a9f-4245-9331-ce510b0703eb" key="staticText-15" x="305" y="32" width="44" height="14" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
 					<text><![CDATA[AUM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-14" style="Detail_Header" x="154" y="32" width="100" height="14" uuid="903fdc77-78ed-4d00-bce7-d4fe4b3a468b">
-						<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="903fdc77-78ed-4d00-bce7-d4fe4b3a468b" key="staticText-14" x="154" y="32" width="100" height="14" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-15" style="Detail_Header" x="254" y="32" width="94" height="14" uuid="bb61c222-74d3-4328-b054-fa6d0a617055">
-						<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="bb61c222-74d3-4328-b054-fa6d0a617055" key="staticText-15" x="254" y="32" width="94" height="14" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
 					<text><![CDATA[UOM]]></text>
-				</staticText>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="36" splitType="Stretch">
-				<line>
-					<reportElement key="line-28" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="36" forecolor="#555555" uuid="ca293785-e217-47fb-8586-c59f0c67e58b"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-29" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="24" forecolor="#555555" uuid="bcb77b49-5d9c-41d7-a757-2d4be1e8851e"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-30" stretchType="RelativeToBandHeight" x="869" y="0" width="1" height="36" forecolor="#555555" uuid="3a903ec1-facf-4131-a842-fa914111b472"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-31" x="10" y="24" width="859" height="1" forecolor="#555555" uuid="e91bafd8-5dfd-4e58-8583-3a47e1969015"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-35" style="Report_Footer" x="14" y="0" width="855" height="1" forecolor="#555555" uuid="6eb360fb-5d04-48e4-ba20-b0e6188561e6"/>
-				</line>
-				<textField evaluationTime="Group" evaluationGroup="INVOICEID" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Total_Gray" x="738" y="5" width="115" height="16" uuid="7c2f5179-27a4-423d-a280-d161976c3954"/>
-					<box leftPadding="4" rightPadding="4">
+				<element kind="line" uuid="ca293785-e217-47fb-8586-c59f0c67e58b" key="line-28" stretchType="ContainerHeight" x="0" y="0" width="1" height="36" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="bcb77b49-5d9c-41d7-a757-2d4be1e8851e" key="line-29" stretchType="ContainerHeight" x="10" y="0" width="1" height="24" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="3a903ec1-facf-4131-a842-fa914111b472" key="line-30" stretchType="ContainerHeight" x="869" y="0" width="1" height="36" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="e91bafd8-5dfd-4e58-8583-3a47e1969015" key="line-31" x="10" y="24" width="859" height="1" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="6eb360fb-5d04-48e4-ba20-b0e6188561e6" key="line-35" x="14" y="0" width="855" height="1" forecolor="#555555" style="Report_Footer"/>
+				<element kind="textField" uuid="7c2f5179-27a4-423d-a280-d161976c3954" key="textField" x="738" y="5" width="115" height="16" evaluationTime="Group" pattern="" evaluationGroup="INVOICEID" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Gray">
+					<expression><![CDATA[($V{TOTAL_INVOICE}!=null)?$P{NUMBERFORMAT}.format($V{TOTAL_INVOICE}):new String(" ")]]></expression>
+					<box leftPadding="4" rightPadding="4" style="Total_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[($V{TOTAL_INVOICE}!=null)?$P{NUMBERFORMAT}.format($V{TOTAL_INVOICE}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-20" style="Group_Footer" x="638" y="5" width="99" height="16" uuid="fde2a2e4-8d2d-4898-bdfe-b9b524ea8724"/>
-					<box leftPadding="4" rightPadding="4">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="fde2a2e4-8d2d-4898-bdfe-b9b524ea8724" key="staticText-20" x="638" y="5" width="99" height="16" pdfFontName="Helvetica-Bold" hTextAlign="Right" vTextAlign="Middle" style="Group_Footer">
 					<text><![CDATA[Total]]></text>
-				</staticText>
-				<textField evaluationTime="Group" evaluationGroup="INVOICEID" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-18" style="Total_Gray" x="853" y="5" width="16" height="16" uuid="1978af13-7cfb-4a67-b33a-4aa138a57f66"/>
-					<box leftPadding="4" rightPadding="4">
+					<box leftPadding="4" rightPadding="4" style="Group_Footer">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="1978af13-7cfb-4a67-b33a-4aa138a57f66" key="textField-18" x="853" y="5" width="16" height="16" evaluationTime="Group" pattern="" evaluationGroup="INVOICEID" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Total_Gray">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box leftPadding="4" rightPadding="4" style="Total_Gray">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="20" splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="59" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Title" mode="Transparent" x="0" y="4" width="869" height="20" uuid="3a2f11d5-d96f-4408-84a0-e82fe8519429"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="24" width="869" height="1" uuid="372d0eef-4182-49e1-bbcb-d9336181df0b"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Subtitle" x="0" y="27" width="870" height="20" uuid="e7111fc3-6f9a-4616-8703-73cb3b16dc89"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="14"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{REPORT_SUBTITLE}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="20" splitType="Stretch"/>
+	<pageHeader height="59" splitType="Stretch">
+		<element kind="textField" uuid="3a2f11d5-d96f-4408-84a0-e82fe8519429" key="textField" mode="Transparent" x="0" y="4" width="869" height="20" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="372d0eef-4182-49e1-bbcb-d9336181df0b" key="line-1" x="0" y="24" width="869" height="1">
+			<pen lineWidth="1.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="e7111fc3-6f9a-4616-8703-73cb3b16dc89" key="textField" x="0" y="27" width="870" height="20" fontSize="14.0" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band height="16" splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader height="16" splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="869" y="0" width="1" height="16" forecolor="#555555" uuid="f22a4e4b-5837-492c-9eb1-ed2124930b62"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="16" forecolor="#555555" uuid="89e3b588-92b7-4f17-a7e9-5a3214059ad7"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-18" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="16" forecolor="#555555" uuid="a0509f77-a021-4332-ab5e-8beda7f95537"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="14" y="0" width="40" height="16" uuid="26171e51-e8db-4f08-9dd0-4c06f73a360d"/>
-				<box leftPadding="4" rightPadding="4">
+			<element kind="line" uuid="f22a4e4b-5837-492c-9eb1-ed2124930b62" key="line-16" stretchType="ContainerHeight" x="869" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="89e3b588-92b7-4f17-a7e9-5a3214059ad7" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="a0509f77-a021-4332-ab5e-8beda7f95537" key="line-18" stretchType="ContainerHeight" x="10" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="26171e51-e8db-4f08-9dd0-4c06f73a360d" key="textField" x="14" y="0" width="40" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{LINE}!=null)?$F{LINE}.toString():new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{LINE}!=null)?$F{LINE}.toString():new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="54" y="0" width="100" height="16" uuid="a85ea478-4e12-4a30-8d53-96b5fcb21e4b"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="a85ea478-4e12-4a30-8d53-96b5fcb21e4b" key="textField" x="54" y="0" width="100" height="16" fontSize="8.0" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{NAMEPRODUCT}!=null)?$F{NAMEPRODUCT}:new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{NAMEPRODUCT}!=null)?$F{NAMEPRODUCT}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="154" y="0" width="56" height="16" uuid="912dd624-d1e3-416a-97db-7f8668133a38">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="912dd624-d1e3-416a-97db-7f8668133a38" key="textField" x="154" y="0" width="56" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
+				<expression><![CDATA[($F{QTYINVOICED}!=null)?$P{NUMBERFORMAT}.format($F{QTYINVOICED}):new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QTYINVOICED}!=null)?$P{NUMBERFORMAT}.format($F{QTYINVOICED}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="210" y="0" width="44" height="16" uuid="d20233fe-c992-4f58-ac18-59a48f9e3c0c">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="d20233fe-c992-4f58-ac18-59a48f9e3c0c" key="textField" x="210" y="0" width="44" height="16" fontSize="8.0" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
+				<expression><![CDATA[($F{UOMSYMBOL}!=null)?$F{UOMSYMBOL}:new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{UOMSYMBOL}!=null)?$F{UOMSYMBOL}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToTallestObject" x="349" y="0" width="56" height="16" uuid="d3e7eaa3-a4b3-4508-9dff-16c1b46bfcea"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="d3e7eaa3-a4b3-4508-9dff-16c1b46bfcea" key="textField" stretchType="ElementGroupHeight" x="349" y="0" width="56" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}):new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="495" y="0" width="48" height="16" uuid="279a6d3c-6d8b-4b02-8ee5-fda8c7862154"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="279a6d3c-6d8b-4b02-8ee5-fda8c7862154" key="textField" x="495" y="0" width="48" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{TAX}!=null)?$P{NUMBERFORMAT}.format($F{TAX}):new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{TAX}!=null)?$P{NUMBERFORMAT}.format($F{TAX}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="543" y="0" width="71" height="16" uuid="d1601e8d-ee7d-4929-b7d4-c928cf7c6539"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="d1601e8d-ee7d-4929-b7d4-c928cf7c6539" key="textField" x="543" y="0" width="71" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{BASE}!=null)?$P{NUMBERFORMAT}.format($F{BASE}):new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{BASE}!=null)?$P{NUMBERFORMAT}.format($F{BASE}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="719" y="0" width="58" height="16" uuid="bca73148-2167-4033-a6c9-d2bf5deafe91"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="bca73148-2167-4033-a6c9-d2bf5deafe91" key="textField" x="719" y="0" width="58" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}):new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-6" style="Detail_Line" x="422" y="0" width="56" height="16" uuid="78dd84b1-e670-4527-a0a7-13521a23f20a"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="78dd84b1-e670-4527-a0a7-13521a23f20a" key="textField-6" x="422" y="0" width="56" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVPRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{CONVPRICEACTUAL}):new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVPRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{CONVPRICEACTUAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-7" style="Detail_Line" x="631" y="0" width="71" height="16" uuid="0adcc127-971e-42d1-a075-52523c3086a2"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="0adcc127-971e-42d1-a075-52523c3086a2" key="textField-7" x="631" y="0" width="71" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVBASE}!=null)?$P{NUMBERFORMAT}.format($F{CONVBASE}):new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVBASE}!=null)?$P{NUMBERFORMAT}.format($F{CONVBASE}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-8" style="Detail_Line" x="794" y="0" width="58" height="16" uuid="a5eef7c3-cbfe-4a4f-9ae9-835c64ba352d"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="a5eef7c3-cbfe-4a4f-9ae9-835c64ba352d" key="textField-8" x="794" y="0" width="58" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVLINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{CONVLINENETAMT}):new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVLINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{CONVLINENETAMT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-12" style="Detail_Line" x="852" y="0" width="17" height="16" uuid="7e6b57a7-24c5-43d7-a2ce-0a25640b4e82"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="7e6b57a7-24c5-43d7-a2ce-0a25640b4e82" key="textField-12" x="852" y="0" width="17" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{CONVSYM}]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-13" style="Detail_Line" x="702" y="0" width="17" height="16" uuid="349f24d1-67a6-4fbf-bc8e-b953982a2fcd"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="349f24d1-67a6-4fbf-bc8e-b953982a2fcd" key="textField-13" x="702" y="0" width="17" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVBASE}!=null)?$F{CONVSYM}:new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVBASE}!=null)?$F{CONVSYM}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-14" style="Detail_Line" x="478" y="0" width="17" height="16" uuid="706e85fc-9eec-4b71-b168-547d140acbdb"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="706e85fc-9eec-4b71-b168-547d140acbdb" key="textField-14" x="478" y="0" width="17" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVPRICEACTUAL}!=null)?$F{CONVSYM}:new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVPRICEACTUAL}!=null)?$F{CONVSYM}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-15" style="Detail_Line" x="405" y="0" width="17" height="16" uuid="46e1eb68-459f-4c05-8c39-c0116bb92de1"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="46e1eb68-459f-4c05-8c39-c0116bb92de1" key="textField-15" x="405" y="0" width="17" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PRICEACTUAL}!=null)?$F{INVOICECURRENCYSYM}:new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRICEACTUAL}!=null)?$F{INVOICECURRENCYSYM}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-16" style="Detail_Line" x="614" y="0" width="17" height="16" uuid="bdd77844-f11a-46a3-813e-627622f5c0f2"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="bdd77844-f11a-46a3-813e-627622f5c0f2" key="textField-16" x="614" y="0" width="17" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{BASE}!=null)?$F{INVOICECURRENCYSYM}:new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{BASE}!=null)?$F{INVOICECURRENCYSYM}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Detail_Line" x="777" y="0" width="17" height="16" uuid="b5bc8e0b-c4d7-452c-ade4-94e45cfe92de"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="b5bc8e0b-c4d7-452c-ade4-94e45cfe92de" key="textField-17" x="777" y="0" width="17" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{INVOICECURRENCYSYM}]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{INVOICECURRENCYSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="254" y="0" width="51" height="16" uuid="98e252ec-ad51-40ec-b444-13aae4328493">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="98e252ec-ad51-40ec-b444-13aae4328493" key="textField" x="254" y="0" width="51" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
+				<expression><![CDATA[($F{AUMQTY}!=null)?$P{NUMBERFORMAT}.format($F{AUMQTY}):new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{AUMQTY}!=null)?$P{NUMBERFORMAT}.format($F{AUMQTY}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="305" y="0" width="44" height="16" uuid="6aa0a168-31a0-4d16-a03c-ce44512ab878">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="6aa0a168-31a0-4d16-a03c-ce44512ab878" key="textField" x="305" y="0" width="44" height="16" fontSize="8.0" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
+				<expression><![CDATA[($F{AUM}!=null)?$F{AUM}:new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{AUM}!=null)?$F{AUM}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="154" y="0" width="100" height="16" uuid="c150018f-f6b1-4bc2-8b80-e267374c8506">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="c150018f-f6b1-4bc2-8b80-e267374c8506" key="textField" x="154" y="0" width="100" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
+				<expression><![CDATA[($F{QTYINVOICED}!=null)?$P{NUMBERFORMAT}.format($F{QTYINVOICED}):new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QTYINVOICED}!=null)?$P{NUMBERFORMAT}.format($F{QTYINVOICED}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="254" y="0" width="94" height="16" uuid="10408681-9a36-49b4-80fb-8fb2f309605c">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="10408681-9a36-49b4-80fb-8fb2f309605c" key="textField" x="254" y="0" width="94" height="16" fontSize="8.0" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
+				<expression><![CDATA[($F{UOMSYMBOL}!=null)?$F{UOMSYMBOL}:new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{UOMSYMBOL}!=null)?$F{UOMSYMBOL}:new String(" ")]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="16" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="20" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="737" y="4" width="95" height="16" uuid="2a42cd5e-aa23-416e-b61d-b5c58c7d1245"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="834" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="9790956f-1e54-4ece-9b39-afed859feffe"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Bottom" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="1" width="870" height="1" forecolor="#000000" uuid="ae5212ba-f242-4ef5-9f24-3b9f96969b45"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="444" y="4" width="69" height="16" uuid="f9681c6e-a4de-419a-857d-387e6400f1a1"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Bottom">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" style="Report_Footer" x="365" y="4" width="78" height="16" uuid="c7b5695f-5b8f-4b51-9465-7d2c286d040b"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-5" style="Report_Footer" x="0" y="4" width="140" height="16" uuid="be6b4c78-2b56-40cf-9b31-73c92f3c0413">
-					<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
-				</reportElement>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Bottom"/>
-				<text><![CDATA[other footer data]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="16" splitType="Stretch"/>
+	<pageFooter height="20" splitType="Stretch">
+		<element kind="textField" uuid="2a42cd5e-aa23-416e-b61d-b5c58c7d1245" key="textField" x="737" y="4" width="95" height="16" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Bottom" style="Report_Footer">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="9790956f-1e54-4ece-9b39-afed859feffe" key="textField" x="834" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Bottom" style="Report_Footer">
+			<paragraph lineSpacing="Single" style="Report_Footer"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="ae5212ba-f242-4ef5-9f24-3b9f96969b45" key="line" x="0" y="1" width="870" height="1" forecolor="#000000">
+			<pen lineWidth="1.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="f9681c6e-a4de-419a-857d-387e6400f1a1" key="textField" x="444" y="4" width="69" height="16" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Bottom" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="c7b5695f-5b8f-4b51-9465-7d2c286d040b" key="staticText-1" x="365" y="4" width="78" height="16" hTextAlign="Right" vTextAlign="Bottom" style="Report_Footer">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="be6b4c78-2b56-40cf-9b31-73c92f3c0413" key="staticText-5" x="0" y="4" width="140" height="16" vTextAlign="Bottom" style="Report_Footer">
+			<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
+			<text><![CDATA[other footer data]]></text>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportMaterialTransactionEditionJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportMaterialTransactionEditionJR.jrxml
@@ -1,22 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportMaterialTransactionEditionJR" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="5d9f80d7-9a05-47eb-b2e4-4f40c42ab02b">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportMaterialTransactionEditionJR" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="5d9f80d7-9a05-47eb-b2e4-4f40c42ab02b">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5">
 			<pen lineWidth="0.0"/>
 			<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
@@ -25,37 +25,35 @@
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#666666"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="9">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="9.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="9.0">
 			<conditionExpression><![CDATA[new Boolean($V{DOCUMENTNO_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="9"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT M_INOUT.DOCUMENTNO AS DOCUMENTNO, M_INOUT.MOVEMENTDATE AS MOVEMENTDATE, C_BPARTNER.NAME AS CLIENT_NAME, M_PRODUCT.NAME AS PRODUCT_NAME, SUM(M_INOUTLINE.MOVEMENTQTY) AS QUANTITYORDER, C_UOM.NAME AS UOMNAME, (CASE M_INOUT.ISSOTRX 
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT M_INOUT.DOCUMENTNO AS DOCUMENTNO, M_INOUT.MOVEMENTDATE AS MOVEMENTDATE, C_BPARTNER.NAME AS CLIENT_NAME, M_PRODUCT.NAME AS PRODUCT_NAME, SUM(M_INOUTLINE.MOVEMENTQTY) AS QUANTITYORDER, C_UOM.NAME AS UOMNAME, (CASE M_INOUT.ISSOTRX 
   		WHEN 'Y' THEN TO_CHAR(AD_MESSAGE_GET2('GOODSHIPMENT',?))
   		WHEN 'N' THEN TO_CHAR(AD_MESSAGE_GET2('GOODRECEIPT',?))
   		END) AS ISSOTRX
@@ -65,8 +63,7 @@
       AND M_INOUTLINE.M_PRODUCT_ID = M_PRODUCT.M_PRODUCT_ID
       AND M_INOUTLINE.C_UOM_ID = C_UOM.C_UOM_ID
       GROUP BY C_BPARTNER.NAME, M_PRODUCT.NAME, C_UOM.NAME, M_INOUT.DOCUMENTNO, M_INOUT.MOVEMENTDATE, M_INOUT.ISSOTRX
-      ORDER BY C_BPARTNER.NAME, M_INOUT.MOVEMENTDATE]]>
-	</queryString>
+      ORDER BY C_BPARTNER.NAME, M_INOUT.MOVEMENTDATE]]></query>
 	<field name="DOCUMENTNO" class="java.lang.String"/>
 	<field name="MOVEMENTDATE" class="java.util.Date"/>
 	<field name="CLIENT_NAME" class="java.lang.String"/>
@@ -77,382 +74,273 @@
 	<field name="LOCATORNAME" class="java.lang.String"/>
 	<field name="WAREHOUSENAME" class="java.lang.String"/>
 	<group name="CLIENT_NAME">
-		<groupExpression><![CDATA[$F{CLIENT_NAME}]]></groupExpression>
+		<expression><![CDATA[$F{CLIENT_NAME}]]></expression>
 		<groupHeader>
 			<band height="33" splitType="Stretch">
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="1" y="0" width="534" height="23" uuid="ffc1f8dc-5788-46da-8b12-d0d20f882c1a"/>
-					<box topPadding="2" leftPadding="5">
+				<element kind="textField" uuid="ffc1f8dc-5788-46da-8b12-d0d20f882c1a" key="textField" x="1" y="0" width="534" height="23" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{CLIENT_NAME}]]></expression>
+					<box topPadding="2" leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.5" lineStyle="Solid" lineColor="#666666"/>
 						<bottomPen lineWidth="0.5" lineStyle="Solid" lineColor="#666666"/>
 						<rightPen lineWidth="0.5" lineStyle="Solid" lineColor="#666666"/>
 					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CLIENT_NAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="1" width="1" height="32" forecolor="#555555" uuid="f820963f-ffb7-47b8-963f-72caf052a035"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="535" y="1" width="1" height="32" forecolor="#555555" uuid="cb9f8820-5b4a-4d1d-9d47-375ed845d54e"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				</element>
+				<element kind="line" uuid="f820963f-ffb7-47b8-963f-72caf052a035" key="line-2" stretchType="ContainerHeight" x="0" y="1" width="1" height="32" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="cb9f8820-5b4a-4d1d-9d47-375ed845d54e" key="line-3" stretchType="ContainerHeight" x="535" y="1" width="1" height="32" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-32" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="10" forecolor="#555555" uuid="a4a3af7b-119a-480d-b566-d20332328ca3"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="10" forecolor="#555555" uuid="f8de3881-2b3c-47f1-a20b-f38462c1e277"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-34" x="0" y="10" width="535" height="1" forecolor="#555555" uuid="fe371cab-f090-47e7-95bd-99d6a8729908"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="a4a3af7b-119a-480d-b566-d20332328ca3" key="line-32" stretchType="ContainerHeight" x="0" y="0" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="f8de3881-2b3c-47f1-a20b-f38462c1e277" key="line-33" stretchType="ContainerHeight" x="535" y="0" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="fe371cab-f090-47e7-95bd-99d6a8729908" key="line-34" x="0" y="10" width="535" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="DOCUMENTNO">
-		<groupExpression><![CDATA[$F{DOCUMENTNO}]]></groupExpression>
+		<expression><![CDATA[$F{DOCUMENTNO}]]></expression>
 		<groupHeader>
 			<band height="45" splitType="Stretch">
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="11" y="0" width="524" height="23" uuid="6bf017b9-cdef-4cb7-ab75-823edcbbe815"/>
-					<box topPadding="2" leftPadding="5">
+				<element kind="textField" uuid="6bf017b9-cdef-4cb7-ab75-823edcbbe815" key="textField" x="11" y="0" width="524" height="23" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{ISSOTRX}+"  "+$F{DOCUMENTNO}]]></expression>
+					<box topPadding="2" leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 						<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 						<bottomPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					</box>
-					<textElement>
-						<font isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{ISSOTRX}+"  "+$F{DOCUMENTNO}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-4" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="45" forecolor="#555555" uuid="c9f8884b-86df-4fb2-97bd-e1f3acc63830"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-6" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="45" forecolor="#555555" uuid="c466539a-1326-4f90-b17e-bf5b0ddae4a1"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-8" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="45" forecolor="#555555" uuid="612eb72d-e891-4196-a355-c6683947d86f"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="20" y="29" width="90" height="16" uuid="2fbb4e89-7334-4d77-9282-cd7b5a324d9e"/>
-					<box leftPadding="5" rightPadding="2">
+				</element>
+				<element kind="line" uuid="c9f8884b-86df-4fb2-97bd-e1f3acc63830" key="line-4" stretchType="ContainerHeight" x="10" y="0" width="1" height="45" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="c466539a-1326-4f90-b17e-bf5b0ddae4a1" key="line-6" stretchType="ContainerHeight" x="535" y="0" width="1" height="45" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="612eb72d-e891-4196-a355-c6683947d86f" key="line-8" stretchType="ContainerHeight" x="0" y="0" width="1" height="45" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="2fbb4e89-7334-4d77-9282-cd7b5a324d9e" key="element-90" x="20" y="29" width="90" height="16" style="Detail_Header">
+					<text><![CDATA[Movement Date]]></text>
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#CCCCCC"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<text><![CDATA[Movement Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="110" y="29" width="147" height="16" uuid="30c817d7-f692-4bd2-8ded-34e3c0e05de7"/>
-					<box leftPadding="5" rightPadding="2">
+				</element>
+				<element kind="staticText" uuid="30c817d7-f692-4bd2-8ded-34e3c0e05de7" key="element-90" x="110" y="29" width="147" height="16" style="Detail_Header">
+					<text><![CDATA[Product]]></text>
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#CCCCCC"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#CCCCCC"/>
 					</box>
-					<text><![CDATA[Product]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="412" y="29" width="113" height="16" uuid="58e22fc0-5689-4555-95d4-c21c3684e1b0"/>
-					<box leftPadding="5" rightPadding="2">
+				</element>
+				<element kind="staticText" uuid="58e22fc0-5689-4555-95d4-c21c3684e1b0" key="element-90" x="412" y="29" width="113" height="16" hTextAlign="Left" style="Detail_Header">
+					<text><![CDATA[Quantity]]></text>
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#CCCCCC"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#CCCCCC"/>
 					</box>
-					<textElement textAlignment="Left"/>
-					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-91" style="Detail_Header" x="257" y="29" width="77" height="16" uuid="815322a3-5917-405c-819c-1145e3530339"/>
-					<box leftPadding="5" rightPadding="2">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#CCCCCC"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#CCCCCC"/>
-					</box>
+				</element>
+				<element kind="staticText" uuid="815322a3-5917-405c-819c-1145e3530339" key="element-91" x="257" y="29" width="77" height="16" style="Detail_Header">
 					<text><![CDATA[Warehouse]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-92" style="Detail_Header" x="334" y="29" width="78" height="16" uuid="12bba4a5-a0c4-4d43-9809-ea53522b1436"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#CCCCCC"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#CCCCCC"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="12bba4a5-a0c4-4d43-9809-ea53522b1436" key="element-92" x="334" y="29" width="78" height="16" style="Detail_Header">
 					<text><![CDATA[Storage bin]]></text>
-				</staticText>
+					<box leftPadding="5" rightPadding="2" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#CCCCCC"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#CCCCCC"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-28" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="20" forecolor="#555555" uuid="2b4f98de-2c8a-4fab-a7f1-8f5e93c50cec"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-29" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="10" forecolor="#555555" uuid="805888f6-e79d-4980-ad3e-a750f7b3aa93"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-30" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="20" forecolor="#555555" uuid="c44f7bab-a30a-4d39-b2be-9a892bb5d19c"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-31" x="10" y="10" width="525" height="1" forecolor="#555555" uuid="53fcb41b-78c6-4cfc-a54f-33f7bb50f5c3"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-35" x="20" y="0" width="505" height="1" forecolor="#666666" uuid="c105004c-956c-472b-9c81-91eeb20c0995"/>
-					<graphicElement>
-						<pen lineWidth="0.25" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="2b4f98de-2c8a-4fab-a7f1-8f5e93c50cec" key="line-28" stretchType="ContainerHeight" x="0" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="805888f6-e79d-4980-ad3e-a750f7b3aa93" key="line-29" stretchType="ContainerHeight" x="10" y="0" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="c44f7bab-a30a-4d39-b2be-9a892bb5d19c" key="line-30" stretchType="ContainerHeight" x="535" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="53fcb41b-78c6-4cfc-a54f-33f7bb50f5c3" key="line-31" x="10" y="10" width="525" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="c105004c-956c-472b-9c81-91eeb20c0995" key="line-35" x="20" y="0" width="505" height="1" forecolor="#666666">
+					<pen lineWidth="0.25" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="20" splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="39" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Title" mode="Transparent" x="0" y="0" width="535" height="20" uuid="802d4b99-fec3-4377-b511-a7f73cb0ef7e"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="22" width="535" height="1" uuid="e4c7f394-a8ad-40f0-be82-195a517d31b4"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="20" splitType="Stretch"/>
+	<pageHeader height="39" splitType="Stretch">
+		<element kind="textField" uuid="802d4b99-fec3-4377-b511-a7f73cb0ef7e" key="textField" mode="Transparent" x="0" y="0" width="535" height="20" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="e4c7f394-a8ad-40f0-be82-195a517d31b4" key="line-1" x="0" y="22" width="535" height="1">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="14" splitType="Stretch">
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="14" forecolor="#555555" uuid="9237092d-5043-482c-b0d5-253eb3d4f511"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="14" forecolor="#555555" uuid="73742876-4db5-4cd2-be15-b60063b47626"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-18" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="14" forecolor="#555555" uuid="07006a71-54cd-438a-b6ca-ab5423748d9e"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-1" style="Detail_Line" stretchType="RelativeToBandHeight" x="20" y="0" width="90" height="14" uuid="f365a2b9-628a-4865-9175-6388135ce605"/>
-				<box leftPadding="2" rightPadding="2">
+			<element kind="line" uuid="9237092d-5043-482c-b0d5-253eb3d4f511" key="line-16" stretchType="ContainerHeight" x="535" y="0" width="1" height="14" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="73742876-4db5-4cd2-be15-b60063b47626" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="14" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="07006a71-54cd-438a-b6ca-ab5423748d9e" key="line-18" stretchType="ContainerHeight" x="10" y="0" width="1" height="14" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="f365a2b9-628a-4865-9175-6388135ce605" key="textField-1" stretchType="ContainerHeight" x="20" y="0" width="90" height="14" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{MOVEMENTDATE}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{MOVEMENTDATE}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-2" style="Detail_Line" stretchType="RelativeToBandHeight" x="110" y="0" width="147" height="14" uuid="35eca2ef-4cf9-49bb-be48-15dbaea4f294"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="35eca2ef-4cf9-49bb-be48-15dbaea4f294" key="textField-2" stretchType="ContainerHeight" x="110" y="0" width="147" height="14" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{PRODUCT_NAME}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{PRODUCT_NAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-3" style="Detail_Line" stretchType="RelativeToBandHeight" x="412" y="0" width="75" height="14" uuid="e8dbdc03-644d-4682-b0d7-7defd2fd85fa"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="e8dbdc03-644d-4682-b0d7-7defd2fd85fa" key="textField-3" stretchType="ContainerHeight" x="412" y="0" width="75" height="14" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{QUANTITYORDER}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITYORDER}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[($F{QUANTITYORDER}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITYORDER}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-4" style="Detail_Line" stretchType="RelativeToBandHeight" x="487" y="0" width="38" height="14" uuid="5b775838-a1fb-4f34-8d9b-085bed37238c"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="5b775838-a1fb-4f34-8d9b-085bed37238c" key="textField-4" stretchType="ContainerHeight" x="487" y="0" width="38" height="14" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{UOMNAME}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 				</box>
-				<textElement verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{UOMNAME}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-5" style="Detail_Line" stretchType="RelativeToBandHeight" x="257" y="0" width="77" height="14" uuid="bc73cee0-cb1a-4f5b-88fc-3595b5b40fd4"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="bc73cee0-cb1a-4f5b-88fc-3595b5b40fd4" key="textField-5" stretchType="ContainerHeight" x="257" y="0" width="77" height="14" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{WAREHOUSENAME}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{WAREHOUSENAME}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-6" style="Detail_Line" stretchType="RelativeToBandHeight" x="334" y="0" width="78" height="14" uuid="76f86a8a-ec31-4663-87d5-ea6eeafc03fd"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="76f86a8a-ec31-4663-87d5-ea6eeafc03fd" key="textField-6" stretchType="ContainerHeight" x="334" y="0" width="78" height="14" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{LOCATORNAME}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{LOCATORNAME}]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="16" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="27" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="400" y="4" width="95" height="19" uuid="023ca453-8c3e-48dd-b1c6-ac4a0130fc4a"/>
-				<box>
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="499" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="7f9300df-a148-4f0a-acce-2091688cffea"/>
-				<box>
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="1" width="535" height="1" forecolor="#000000" uuid="836393d7-e05d-4c65-96c9-ff54cec630f9"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="277" y="4" width="69" height="19" uuid="0083494e-8932-4af9-bb15-f9cca26576c5"/>
-				<box>
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" x="195" y="4" width="78" height="19" uuid="cf7bd37d-975c-42b3-95bd-1340b07806d8"/>
-				<box topPadding="2" leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="16" splitType="Stretch"/>
+	<pageFooter height="27" splitType="Stretch">
+		<element kind="textField" uuid="023ca453-8c3e-48dd-b1c6-ac4a0130fc4a" key="textField" x="400" y="4" width="95" height="19" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="7f9300df-a148-4f0a-acce-2091688cffea" key="textField" x="499" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="836393d7-e05d-4c65-96c9-ff54cec630f9" key="line" x="0" y="1" width="535" height="1" forecolor="#000000">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="0083494e-8932-4af9-bb15-f9cca26576c5" key="textField" x="277" y="4" width="69" height="19" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="cf7bd37d-975c-42b3-95bd-1340b07806d8" key="staticText-1" x="195" y="4" width="78" height="19" hTextAlign="Right">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportOrderNotInvoiceJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportOrderNotInvoiceJR.jrxml
@@ -1,76 +1,74 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportOrderNotInvoiceJR" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="4e35e7d6-9d9f-424c-aa14-e29210dbe636">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportOrderNotInvoiceJR" language="java" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="4e35e7d6-9d9f-424c-aa14-e29210dbe636">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true">
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="10">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="10.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="ReportData" class="java.lang.String" isForPrompting="false">
+	<parameter name="ReportData" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DECIMAL_FORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<parameter name="DECIMAL_FORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat()]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT ORGNAME, C_BPARTNER_ID, BPARTNERNAME, C_ORDER_ID, DOCUMENTNO, DATEORDERED, GRANDTOTAL, ISO_CODE, INVOICERULE,
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT ORGNAME, C_BPARTNER_ID, BPARTNERNAME, C_ORDER_ID, DOCUMENTNO, DATEORDERED, GRANDTOTAL, ISO_CODE, INVOICERULE,
       LINE, PRODUCT, PRICE, QTYORDERED, UOMSYMBOL, TAX, TAXBASE, LINENETAMT
       FROM (
       SELECT AD_ORG.NAME AS ORGNAME, C_BPARTNER.C_BPARTNER_ID, C_BPARTNER.NAME AS BPARTNERNAME, C_ORDER.C_ORDER_ID, C_ORDER.DOCUMENTNO,
@@ -116,8 +114,7 @@
                  and c2.c_order_id=cl.c_order_id
                  and cl.QTYORDERED<>cl.QTYINVOICED)
       ) AAA
-      ORDER BY ORGNAME, BPARTNERNAME, DATEORDERED DESC, DOCUMENTNO, LINE]]>
-	</queryString>
+      ORDER BY ORGNAME, BPARTNERNAME, DATEORDERED DESC, DOCUMENTNO, LINE]]></query>
 	<field name="ORGNAME" class="java.lang.String"/>
 	<field name="C_BPARTNER_ID" class="java.lang.String"/>
 	<field name="BPARTNERNAME" class="java.lang.String"/>
@@ -144,961 +141,678 @@
 	<field name="CONVISOSYM" class="java.lang.String"/>
 	<variable name="DetailFieldTotal" class="java.lang.String"/>
 	<group name="ORGNAME">
-		<groupExpression><![CDATA[$F{ORGNAME}]]></groupExpression>
+		<expression><![CDATA[$F{ORGNAME}]]></expression>
 		<groupHeader>
 			<band height="32" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="0" y="0" width="120" height="18" uuid="ac212499-92d2-40cd-b15b-1399f01396eb"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
+				<element kind="staticText" uuid="ac212499-92d2-40cd-b15b-1399f01396eb" key="staticText" x="0" y="0" width="120" height="18" style="GroupHeader_DarkGray">
 					<text><![CDATA[ORGANIZATION]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="120" y="0" width="661" height="18" uuid="c9d40e63-2800-4db9-b4ee-931795498638"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{ORGNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="18" width="1" height="14" forecolor="#555555" uuid="a485b89d-e7b1-44ba-9c16-08a67c1cdce2"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="781" y="0" width="1" height="32" forecolor="#555555" uuid="6f7a2b41-c331-4d6f-8c50-e2a73852de4a"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				</element>
+				<element kind="textField" uuid="c9d40e63-2800-4db9-b4ee-931795498638" key="textField" x="120" y="0" width="661" height="18" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{ORGNAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="a485b89d-e7b1-44ba-9c16-08a67c1cdce2" key="line-2" stretchType="ContainerHeight" x="0" y="18" width="1" height="14" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="6f7a2b41-c331-4d6f-8c50-e2a73852de4a" key="line-3" stretchType="ContainerHeight" x="781" y="0" width="1" height="32" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-32" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="14" forecolor="#555555" uuid="b8f804c3-16e2-4e9f-aacc-936419be1a01"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="781" y="0" width="1" height="14" forecolor="#555555" uuid="1d73a091-ec32-401c-a279-94e485848da7"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-34" x="0" y="14" width="782" height="1" forecolor="#555555" uuid="49e16712-94d7-4349-bcaa-97c6640816f9"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="b8f804c3-16e2-4e9f-aacc-936419be1a01" key="line-32" stretchType="ContainerHeight" x="0" y="0" width="1" height="14" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="1d73a091-ec32-401c-a279-94e485848da7" key="line-33" stretchType="ContainerHeight" x="781" y="0" width="1" height="14" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="49e16712-94d7-4349-bcaa-97c6640816f9" key="line-34" x="0" y="14" width="782" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="C_BPARTNER_ID">
-		<groupExpression><![CDATA[$F{C_BPARTNER_ID}]]></groupExpression>
+		<expression><![CDATA[$F{C_BPARTNER_ID}]]></expression>
 		<groupHeader>
 			<band height="32" splitType="Stretch">
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="130" y="0" width="650" height="18" uuid="61ba6636-3ab2-4969-a45a-35eca98d40d4"/>
-					<box leftPadding="5">
+				<element kind="textField" uuid="61ba6636-3ab2-4969-a45a-35eca98d40d4" key="textField" x="130" y="0" width="650" height="18" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{BPARTNERNAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{BPARTNERNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-4" stretchType="RelativeToBandHeight" x="10" y="18" width="1" height="14" forecolor="#555555" uuid="e1ebc250-2b84-4532-a535-d221cb99bab8"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-6" stretchType="RelativeToBandHeight" x="781" y="0" width="1" height="32" forecolor="#555555" uuid="fbcb45c3-165a-447d-8852-257a63f482c6"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-8" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="32" forecolor="#555555" uuid="c2cdd55c-f216-413f-bc0c-d46279084fd2"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-9" style="GroupHeader_DarkGray" x="10" y="0" width="120" height="18" uuid="93dadb6f-40e6-49ef-a5de-24e4f4898014"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
+				</element>
+				<element kind="line" uuid="e1ebc250-2b84-4532-a535-d221cb99bab8" key="line-4" stretchType="ContainerHeight" x="10" y="18" width="1" height="14" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="fbcb45c3-165a-447d-8852-257a63f482c6" key="line-6" stretchType="ContainerHeight" x="781" y="0" width="1" height="32" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="c2cdd55c-f216-413f-bc0c-d46279084fd2" key="line-8" stretchType="ContainerHeight" x="0" y="0" width="1" height="32" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="93dadb6f-40e6-49ef-a5de-24e4f4898014" key="staticText-9" x="10" y="0" width="120" height="18" style="GroupHeader_DarkGray">
 					<text><![CDATA[PARTNER NAME]]></text>
-				</staticText>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-28" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="20" forecolor="#555555" uuid="28f46118-3f5b-494a-8d8c-0e5bfa4bee5a"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-29" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="10" forecolor="#555555" uuid="4844b6e3-efd3-401a-a104-9acc4900e3cb"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-30" stretchType="RelativeToBandHeight" x="781" y="0" width="1" height="20" forecolor="#555555" uuid="3f7a51f6-7343-4370-8180-10a05ad71b88"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-31" x="10" y="10" width="771" height="1" forecolor="#555555" uuid="bb942be9-6338-4b7b-83d4-d02cdf6f8581"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="28f46118-3f5b-494a-8d8c-0e5bfa4bee5a" key="line-28" stretchType="ContainerHeight" x="0" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="4844b6e3-efd3-401a-a104-9acc4900e3cb" key="line-29" stretchType="ContainerHeight" x="10" y="0" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="3f7a51f6-7343-4370-8180-10a05ad71b88" key="line-30" stretchType="ContainerHeight" x="781" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="bb942be9-6338-4b7b-83d4-d02cdf6f8581" key="line-31" x="10" y="10" width="771" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="C_ORDER_ID">
-		<groupExpression><![CDATA[$F{C_ORDER_ID}]]></groupExpression>
+		<expression><![CDATA[$F{C_ORDER_ID}]]></expression>
 		<groupHeader>
 			<band height="62" splitType="Stretch">
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="default" stretchType="RelativeToTallestObject" x="20" y="18" width="80" height="18" uuid="be6828f1-de5f-468f-994e-5ec39c1b1703"/>
-					<box topPadding="2" leftPadding="5">
+				<element kind="textField" uuid="be6828f1-de5f-468f-994e-5ec39c1b1703" key="textField" stretchType="ElementGroupHeight" x="20" y="18" width="80" height="18" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="default">
+					<expression><![CDATA[$F{DOCUMENTNO}]]></expression>
+					<box topPadding="2" leftPadding="5" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 						<bottomPen lineWidth="0.0" lineColor="#555555"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{DOCUMENTNO}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-7" stretchType="RelativeToBandHeight" x="781" y="0" width="1" height="62" forecolor="#555555" uuid="e6da47aa-fdf3-4779-b622-c738ed4b743d"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-9" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="62" forecolor="#555555" uuid="70f74567-79a6-468f-b91c-e1de6278471b"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-10" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="62" forecolor="#555555" uuid="af66a298-133f-46c2-9829-5ed31cc416cf"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-10" style="GroupHeader_DarkGray" x="20" y="0" width="80" height="18" uuid="1e3d453a-ffeb-4e09-8466-18c86019e6d8"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement verticalAlignment="Middle"/>
+				</element>
+				<element kind="line" uuid="e6da47aa-fdf3-4779-b622-c738ed4b743d" key="line-7" stretchType="ContainerHeight" x="781" y="0" width="1" height="62" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="70f74567-79a6-468f-b91c-e1de6278471b" key="line-9" stretchType="ContainerHeight" x="0" y="0" width="1" height="62" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="af66a298-133f-46c2-9829-5ed31cc416cf" key="line-10" stretchType="ContainerHeight" x="10" y="0" width="1" height="62" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="1e3d453a-ffeb-4e09-8466-18c86019e6d8" key="staticText-10" x="20" y="0" width="80" height="18" vTextAlign="Middle" style="GroupHeader_DarkGray">
 					<text><![CDATA[ORDER]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-11" style="GroupHeader_DarkGray" x="100" y="0" width="100" height="18" uuid="8aa91861-d8b5-4aea-806c-0d0d8c50d383"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="8aa91861-d8b5-4aea-806c-0d0d8c50d383" key="staticText-11" x="100" y="0" width="100" height="18" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<text><![CDATA[ORDER DATE]]></text>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle"/>
-					<text><![CDATA[ORDER DATE]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-4" style="default" x="100" y="18" width="100" height="18" uuid="6a511f90-0860-4e59-b6d7-f191da4ea541"/>
-					<box topPadding="2" leftPadding="5">
+				</element>
+				<element kind="textField" uuid="6a511f90-0860-4e59-b6d7-f191da4ea541" key="textField-4" x="100" y="18" width="100" height="18" textAdjust="StretchHeight" blankWhenNull="true" hTextAlign="Center" vTextAlign="Middle" style="default">
+					<expression><![CDATA[$F{DATEORDERED}]]></expression>
+					<box topPadding="2" leftPadding="5" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 						<bottomPen lineWidth="0.0" lineColor="#555555"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{DATEORDERED}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-12" style="GroupHeader_DarkGray" x="200" y="0" width="165" height="18" uuid="a5646efe-9a1b-49cf-86a2-3bf77ee09928"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="staticText" uuid="a5646efe-9a1b-49cf-86a2-3bf77ee09928" key="staticText-12" x="200" y="0" width="165" height="18" pdfFontName="Helvetica-Bold" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<text><![CDATA[AMOUNT]]></text>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[AMOUNT]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-5" style="default" x="200" y="18" width="137" height="18" uuid="19de6b39-1767-49af-b274-8d72b2fafd40"/>
-					<box topPadding="2" leftPadding="5" rightPadding="4">
+				</element>
+				<element kind="textField" uuid="19de6b39-1767-49af-b274-8d72b2fafd40" key="textField-5" x="200" y="18" width="137" height="18" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+					<expression><![CDATA[($F{GRANDTOTAL}!=null)?$P{NUMBERFORMAT}.format($F{GRANDTOTAL}):new String(" ")]]></expression>
+					<box topPadding="2" leftPadding="5" rightPadding="4" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 						<bottomPen lineWidth="0.0" lineColor="#555555"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[($F{GRANDTOTAL}!=null)?$P{NUMBERFORMAT}.format($F{GRANDTOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-14" style="GroupHeader_DarkGray" x="530" y="0" width="250" height="18" uuid="64ee2c26-7ac7-40c1-9645-18a5244603bb"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="staticText" uuid="64ee2c26-7ac7-40c1-9645-18a5244603bb" key="staticText-14" x="530" y="0" width="250" height="18" pdfFontName="Helvetica-Bold" hTextAlign="Left" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<text><![CDATA[TYPE]]></text>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[TYPE]]></text>
-				</staticText>
-				<textField pattern="#,##0.00" isBlankWhenNull="true">
-					<reportElement key="textField-7" style="default" x="530" y="18" width="250" height="18" uuid="4513dca8-eda4-4891-a47d-c669a305f86d"/>
-					<box topPadding="2" leftPadding="5" rightPadding="4">
+				</element>
+				<element kind="textField" uuid="4513dca8-eda4-4891-a47d-c669a305f86d" key="textField-7" x="530" y="18" width="250" height="18" pattern="#,##0.00" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle" style="default">
+					<expression><![CDATA[$F{INVOICERULE}]]></expression>
+					<box topPadding="2" leftPadding="5" rightPadding="4" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 						<bottomPen lineWidth="0.0" lineColor="#555555"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#666666"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{INVOICERULE}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-35" stretchType="RelativeToBandHeight" x="20" y="36" width="1" height="26" forecolor="#555555" uuid="f54f67ae-544c-4d41-9e3e-aaa2d6a740b8"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-16" style="GroupHeader_DarkGray" x="30" y="46" width="140" height="16" uuid="db2d66be-217b-4642-a9a8-e853b7e72471"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="f54f67ae-544c-4d41-9e3e-aaa2d6a740b8" key="line-35" stretchType="ContainerHeight" x="20" y="36" width="1" height="26" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="db2d66be-217b-4642-a9a8-e853b7e72471" key="staticText-16" x="30" y="46" width="140" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" vTextAlign="Middle" style="GroupHeader_DarkGray">
 					<text><![CDATA[Concept]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-17" style="GroupHeader_DarkGray" x="170" y="46" width="66" height="16" uuid="81ea0331-d456-4349-86db-7ba8c3613847"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="81ea0331-d456-4349-86db-7ba8c3613847" key="staticText-17" x="170" y="46" width="66" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_DarkGray">
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-18" style="GroupHeader_DarkGray" x="236" y="46" width="39" height="16" uuid="28bad640-f4f2-4829-923e-4fbe919abc92"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="28bad640-f4f2-4829-923e-4fbe919abc92" key="staticText-18" x="236" y="46" width="39" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_DarkGray">
 					<text><![CDATA[UOM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-19" style="GroupHeader_DarkGray" x="405" y="46" width="52" height="16" uuid="414fb527-2a87-44c1-83ec-4c5b4e530851"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="414fb527-2a87-44c1-83ec-4c5b4e530851" key="staticText-19" x="405" y="46" width="52" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_DarkGray">
 					<text><![CDATA[%Tax]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-20" style="GroupHeader_DarkGray" x="537" y="46" width="41" height="16" uuid="ffbaa596-e1bd-4499-8dba-72be014e9c98"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="ffbaa596-e1bd-4499-8dba-72be014e9c98" key="staticText-20" x="537" y="46" width="41" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" vTextAlign="Middle" style="GroupHeader_DarkGray">
 					<text><![CDATA[Base]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-21" style="GroupHeader_DarkGray" x="699" y="46" width="42" height="16" uuid="ba44690f-84d4-4b93-9878-63de5cf301ac"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="ba44690f-84d4-4b93-9878-63de5cf301ac" key="staticText-21" x="699" y="46" width="42" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" vTextAlign="Middle" style="GroupHeader_DarkGray">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-22" style="GroupHeader_DarkGray" x="617" y="46" width="82" height="16" uuid="be13c823-71f6-4590-8010-bc143a2dfe69"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="be13c823-71f6-4590-8010-bc143a2dfe69" key="staticText-22" x="617" y="46" width="82" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_DarkGray">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-23" style="GroupHeader_DarkGray" x="457" y="46" width="80" height="16" uuid="70a5cbec-52ca-4cda-900d-8ec02d0f44a2"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="70a5cbec-52ca-4cda-900d-8ec02d0f44a2" key="staticText-23" x="457" y="46" width="80" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_DarkGray">
 					<text><![CDATA[Base]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-24" style="GroupHeader_DarkGray" x="275" y="46" width="65" height="16" uuid="a9f00988-8c9e-449b-b209-b8f49a29b74d"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="a9f00988-8c9e-449b-b209-b8f49a29b74d" key="staticText-24" x="275" y="46" width="65" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_DarkGray">
 					<text><![CDATA[Price]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-25" style="GroupHeader_DarkGray" x="340" y="46" width="26" height="16" uuid="55d005a1-8e0f-4d6a-ab11-0e3e60ad105e"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="55d005a1-8e0f-4d6a-ab11-0e3e60ad105e" key="staticText-25" x="340" y="46" width="26" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" vTextAlign="Middle" style="GroupHeader_DarkGray">
 					<text><![CDATA[Price]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-14" style="GroupHeader_DarkGray" x="366" y="46" width="39" height="16" uuid="45e5e9c0-bf38-47ab-9370-cfd1a89dc3e1"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="45e5e9c0-bf38-47ab-9370-cfd1a89dc3e1" key="textField-14" x="366" y="46" width="39" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-19" style="GroupHeader_DarkGray" x="578" y="46" width="39" height="16" uuid="372daab1-b5dd-4013-940d-c6ce460c66ee"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="372daab1-b5dd-4013-940d-c6ce460c66ee" key="textField-19" x="578" y="46" width="39" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-20" style="GroupHeader_DarkGray" x="741" y="46" width="39" height="16" uuid="b4d61bfd-fec1-42de-901b-26ddbf6f8fbb"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="b4d61bfd-fec1-42de-901b-26ddbf6f8fbb" key="textField-20" x="741" y="46" width="39" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-26" style="GroupHeader_DarkGray" x="365" y="0" width="91" height="18" uuid="767d64a7-d26e-4313-9442-03ae2f4043a2"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="staticText" uuid="767d64a7-d26e-4313-9442-03ae2f4043a2" key="staticText-26" x="365" y="0" width="91" height="18" pdfFontName="Helvetica-Bold" hTextAlign="Right" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<text><![CDATA[AMOUNT]]></text>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[AMOUNT]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-22" style="default" x="365" y="18" width="137" height="18" uuid="c0494ba0-b1bf-4dbe-8b87-46a76ea7ee8b"/>
-					<box topPadding="2" leftPadding="5" rightPadding="4">
+				</element>
+				<element kind="textField" uuid="c0494ba0-b1bf-4dbe-8b87-46a76ea7ee8b" key="textField-22" x="365" y="18" width="137" height="18" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+					<expression><![CDATA[($F{CONVGRANDTOTAL}!=null)?$P{NUMBERFORMAT}.format($F{CONVGRANDTOTAL}):new String(" ")]]></expression>
+					<box topPadding="2" leftPadding="5" rightPadding="4" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 						<bottomPen lineWidth="0.0" lineColor="#555555"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[($F{CONVGRANDTOTAL}!=null)?$P{NUMBERFORMAT}.format($F{CONVGRANDTOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-23" style="GroupHeader_DarkGray" x="456" y="0" width="74" height="18" uuid="a322d6cb-662f-4ba5-855d-a5301b9b5705"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="a322d6cb-662f-4ba5-855d-a5301b9b5705" key="textField-23" x="456" y="0" width="74" height="18" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-24" style="default" x="502" y="18" width="28" height="18" uuid="9db9ba6e-f862-4ef2-a1ec-0a665ee8c086"/>
-					<box topPadding="2" leftPadding="5" rightPadding="4">
+				</element>
+				<element kind="textField" uuid="9db9ba6e-f862-4ef2-a1ec-0a665ee8c086" key="textField-24" x="502" y="18" width="28" height="18" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="default">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box topPadding="2" leftPadding="5" rightPadding="4" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 						<bottomPen lineWidth="0.0" lineColor="#555555"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-25" style="default" x="337" y="18" width="28" height="18" uuid="a28107b5-1814-469e-8688-3b18adb6dfde"/>
-					<box topPadding="2" leftPadding="5" rightPadding="4">
+				</element>
+				<element kind="textField" uuid="a28107b5-1814-469e-8688-3b18adb6dfde" key="textField-25" x="337" y="18" width="28" height="18" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="default">
+					<expression><![CDATA[$F{ORDERCURRENCYSYM}]]></expression>
+					<box topPadding="2" leftPadding="5" rightPadding="4" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 						<bottomPen lineWidth="0.0" lineColor="#555555"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{ORDERCURRENCYSYM}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-23" stretchType="RelativeToBandHeight" x="20" y="0" width="1" height="10" forecolor="#555555" uuid="c912185a-845b-46bc-b746-ad5371ab9bb2"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-24" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="20" forecolor="#555555" uuid="ad6e1ffc-c3e2-4be2-acd7-f32939bd9ead"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-25" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="20" forecolor="#555555" uuid="10a63684-4e2b-4d41-aca8-32507fc0e51f"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-26" stretchType="RelativeToBandHeight" x="781" y="0" width="1" height="20" forecolor="#555555" uuid="7431ce3a-83ff-4dbd-83c1-1c3887da758a"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-27" x="20" y="10" width="761" height="1" forecolor="#555555" uuid="794e1636-722a-4bff-9cf5-b62cf168e147"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-36" style="Report_Footer" x="30" y="0" width="750" height="1" forecolor="#555555" uuid="c3831248-8dba-4be3-b90d-c2d5018dcf13"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="c912185a-845b-46bc-b746-ad5371ab9bb2" key="line-23" stretchType="ContainerHeight" x="20" y="0" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="ad6e1ffc-c3e2-4be2-acd7-f32939bd9ead" key="line-24" stretchType="ContainerHeight" x="0" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="10a63684-4e2b-4d41-aca8-32507fc0e51f" key="line-25" stretchType="ContainerHeight" x="10" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="7431ce3a-83ff-4dbd-83c1-1c3887da758a" key="line-26" stretchType="ContainerHeight" x="781" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="794e1636-722a-4bff-9cf5-b62cf168e147" key="line-27" x="20" y="10" width="761" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="c3831248-8dba-4be3-b90d-c2d5018dcf13" key="line-36" x="30" y="0" width="750" height="1" forecolor="#555555" style="Report_Footer">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="20" splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="65" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Title" mode="Transparent" x="0" y="4" width="782" height="20" uuid="525f85e0-4508-4282-94db-cd647a950875"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="24" width="782" height="1" uuid="7d5a3b07-c2c2-4a7c-b69e-eabd08952a7d"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Subtitle" x="0" y="27" width="782" height="20" uuid="90f93116-d7ba-4b62-ae0b-b299de25f77c"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="14"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{REPORT_SUBTITLE}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-2" style="Report_Data_Label" x="402" y="50" width="48" height="15" uuid="55b4718e-0f6c-4e1d-b41f-5ec38d097e52">
-					<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
-				</reportElement>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Total:]]></text>
-			</staticText>
-			<textField evaluationTime="Report" isBlankWhenNull="false">
-				<reportElement key="textField-1" style="Total_Field" x="450" y="50" width="332" height="15" uuid="31ab592d-17ca-4695-8671-ba8f7e8af3f2">
-					<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$V{DetailFieldTotal}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-3" style="Report_Data_Label" x="0" y="50" width="91" height="14" uuid="927e2756-dc77-41a3-924b-4e2d7e88b09e">
-					<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
-				</reportElement>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<text><![CDATA[Conditions:]]></text>
-			</staticText>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-2" style="Report_Data_Field" x="91" y="50" width="88" height="14" uuid="ad80cafd-309a-4418-8b17-c224f6c6d417">
-					<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
-				</reportElement>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{ReportData}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="20" splitType="Stretch"/>
+	<pageHeader height="65" splitType="Stretch">
+		<element kind="textField" uuid="525f85e0-4508-4282-94db-cd647a950875" key="textField" mode="Transparent" x="0" y="4" width="782" height="20" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="7d5a3b07-c2c2-4a7c-b69e-eabd08952a7d" key="line-1" x="0" y="24" width="782" height="1">
+			<pen lineWidth="1.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="90f93116-d7ba-4b62-ae0b-b299de25f77c" key="textField" x="0" y="27" width="782" height="20" fontSize="14.0" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="55b4718e-0f6c-4e1d-b41f-5ec38d097e52" key="staticText-2" x="402" y="50" width="48" height="15" hTextAlign="Right" style="Report_Data_Label">
+			<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
+			<text><![CDATA[Total:]]></text>
+			<box style="Report_Data_Label">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="31ab592d-17ca-4695-8671-ba8f7e8af3f2" key="textField-1" x="450" y="50" width="332" height="15" evaluationTime="Report" blankWhenNull="false" style="Total_Field">
+			<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
+			<expression><![CDATA[$V{DetailFieldTotal}]]></expression>
+			<box leftPadding="5" style="Total_Field">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="927e2756-dc77-41a3-924b-4e2d7e88b09e" key="staticText-3" x="0" y="50" width="91" height="14" style="Report_Data_Label">
+			<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
+			<text><![CDATA[Conditions:]]></text>
+			<box style="Report_Data_Label">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="ad80cafd-309a-4418-8b17-c224f6c6d417" key="textField-2" x="91" y="50" width="88" height="14" blankWhenNull="false" style="Report_Data_Field">
+			<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
+			<expression><![CDATA[$P{ReportData}]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band height="16" splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader height="16" splitType="Stretch"/>
 	<detail>
 		<band height="14" splitType="Stretch">
-			<line>
-				<reportElement key="line-15" stretchType="RelativeToBandHeight" x="20" y="0" width="1" height="14" forecolor="#555555" uuid="60e00b30-a419-40db-969b-9cc24b660437"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="781" y="0" width="1" height="14" forecolor="#555555" uuid="359d6245-0424-4962-a956-1412c6f0d837"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="14" forecolor="#555555" uuid="ff2084c8-53bd-452c-9da5-2fd43aa091ac"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-18" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="14" forecolor="#555555" uuid="14270fbd-7a7d-4e4e-bea2-1845e5b1c77e"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="30" y="0" width="140" height="14" uuid="00649927-f55b-43fb-8081-4fa42f2610de"/>
-				<box leftPadding="4">
+			<element kind="line" uuid="60e00b30-a419-40db-969b-9cc24b660437" key="line-15" stretchType="ContainerHeight" x="20" y="0" width="1" height="14" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="359d6245-0424-4962-a956-1412c6f0d837" key="line-16" stretchType="ContainerHeight" x="781" y="0" width="1" height="14" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="ff2084c8-53bd-452c-9da5-2fd43aa091ac" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="14" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="14270fbd-7a7d-4e4e-bea2-1845e5b1c77e" key="line-18" stretchType="ContainerHeight" x="10" y="0" width="1" height="14" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="00649927-f55b-43fb-8081-4fa42f2610de" key="textField" x="30" y="0" width="140" height="14" fontSize="8.0" blankWhenNull="false" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PRODUCT}!=null)?$F{PRODUCT}:new String(" ")]]></expression>
+				<box leftPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRODUCT}!=null)?$F{PRODUCT}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="170" y="0" width="66" height="14" uuid="ecd57e9a-0694-4a81-a363-7e3d98ce3927"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="ecd57e9a-0694-4a81-a363-7e3d98ce3927" key="textField" x="170" y="0" width="66" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{QTYORDERED}!=null)?$P{NUMBERFORMAT}.format($F{QTYORDERED}):new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QTYORDERED}!=null)?$P{NUMBERFORMAT}.format($F{QTYORDERED}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="236" y="0" width="39" height="14" uuid="1e3d936b-0a07-45b6-995f-7f3f6492053d"/>
-				<box leftPadding="4">
+			</element>
+			<element kind="textField" uuid="1e3d936b-0a07-45b6-995f-7f3f6492053d" key="textField" x="236" y="0" width="39" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{UOMSYMBOL}!=null)?$F{UOMSYMBOL}:new String(" ")]]></expression>
+				<box leftPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{UOMSYMBOL}!=null)?$F{UOMSYMBOL}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="537" y="0" width="59" height="14" uuid="58f488a1-1c47-4936-bb5c-3c07161fb8e4"/>
-				<box leftPadding="5" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="58f488a1-1c47-4936-bb5c-3c07161fb8e4" key="textField" x="537" y="0" width="59" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVTAXBASE}!=null)?$P{NUMBERFORMAT}.format($F{CONVTAXBASE}):new String(" ")]]></expression>
+				<box leftPadding="5" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVTAXBASE}!=null)?$P{NUMBERFORMAT}.format($F{CONVTAXBASE}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="699" y="0" width="60" height="14" uuid="565b7034-4ea2-4e92-8ac1-9ab471ee8320"/>
-				<box leftPadding="5" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="565b7034-4ea2-4e92-8ac1-9ab471ee8320" key="textField" x="699" y="0" width="60" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVLINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{CONVLINENETAMT}):new String(" ")]]></expression>
+				<box leftPadding="5" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVLINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{CONVLINENETAMT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-8" style="Detail_Line" x="617" y="0" width="61" height="14" uuid="0d073c06-d09f-46cf-bcc6-f3d755d36df1"/>
-				<box leftPadding="5" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="0d073c06-d09f-46cf-bcc6-f3d755d36df1" key="textField-8" x="617" y="0" width="61" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}):new String(" ")]]></expression>
+				<box leftPadding="5" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-9" style="Detail_Line" x="457" y="0" width="59" height="14" uuid="05aadd71-3db8-4f64-985d-a968a864283a"/>
-				<box leftPadding="5" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="05aadd71-3db8-4f64-985d-a968a864283a" key="textField-9" x="457" y="0" width="59" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{TAXBASE}!=null)?$P{NUMBERFORMAT}.format($F{TAXBASE}):new String(" ")]]></expression>
+				<box leftPadding="5" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{TAXBASE}!=null)?$P{NUMBERFORMAT}.format($F{TAXBASE}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-10" style="Detail_Line" x="275" y="0" width="44" height="14" uuid="31adda2f-44ef-4771-aa65-d903b4b5279f"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="31adda2f-44ef-4771-aa65-d903b4b5279f" key="textField-10" x="275" y="0" width="44" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PRICE}!=null)?$P{NUMBERFORMAT}.format($F{PRICE}):new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRICE}!=null)?$P{NUMBERFORMAT}.format($F{PRICE}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-11" style="Detail_Line" x="340" y="0" width="44" height="14" uuid="89f6a86c-38e6-4aff-9d76-f3367994439b"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="89f6a86c-38e6-4aff-9d76-f3367994439b" key="textField-11" x="340" y="0" width="44" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVPRICE}!=null)?$P{NUMBERFORMAT}.format($F{CONVPRICE}):new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVPRICE}!=null)?$P{NUMBERFORMAT}.format($F{CONVPRICE}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-12" style="Detail_Line" x="384" y="0" width="21" height="14" uuid="7f6ba4bd-fada-4110-8ea2-e23e22063ac6"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="7f6ba4bd-fada-4110-8ea2-e23e22063ac6" key="textField-12" x="384" y="0" width="21" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVPRICE}!=null)?$F{CONVSYM}:new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVPRICE}!=null)?$F{CONVSYM}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-13" style="Detail_Line" x="405" y="0" width="52" height="14" uuid="e2889662-60e7-4b1c-820c-60066f2095c1"/>
-				<box leftPadding="5" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="e2889662-60e7-4b1c-820c-60066f2095c1" key="textField-13" x="405" y="0" width="52" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{TAX}!=null)?$P{NUMBERFORMAT}.format($F{TAX}):new String(" ")]]></expression>
+				<box leftPadding="5" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{TAX}!=null)?$P{NUMBERFORMAT}.format($F{TAX}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-15" style="Detail_Line" x="319" y="0" width="21" height="14" uuid="9e8669a8-e96e-40f8-b14d-c6ddc2d78806"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="9e8669a8-e96e-40f8-b14d-c6ddc2d78806" key="textField-15" x="319" y="0" width="21" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PRICE}!=null)?$F{LINECURRENCYSYM}:new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRICE}!=null)?$F{LINECURRENCYSYM}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-16" style="Detail_Line" x="516" y="0" width="21" height="14" uuid="d85a820a-68cc-4edb-9815-cd3eec6a71b1"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="d85a820a-68cc-4edb-9815-cd3eec6a71b1" key="textField-16" x="516" y="0" width="21" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{TAXBASE}!=null)?$F{LINECURRENCYSYM}:new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{TAXBASE}!=null)?$F{LINECURRENCYSYM}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Detail_Line" x="678" y="0" width="21" height="14" uuid="563b0046-adea-4878-bf19-f573e3eb1611"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="563b0046-adea-4878-bf19-f573e3eb1611" key="textField-17" x="678" y="0" width="21" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{LINECURRENCYSYM}]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{LINECURRENCYSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-18" style="Detail_Line" x="596" y="0" width="21" height="14" uuid="d9598507-7536-46ef-9698-7b67589ab92c"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="d9598507-7536-46ef-9698-7b67589ab92c" key="textField-18" x="596" y="0" width="21" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVTAXBASE}!=null)?$F{CONVSYM}:new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVTAXBASE}!=null)?$F{CONVSYM}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-26" style="Detail_Line" x="759" y="0" width="21" height="14" uuid="a6185ca1-fc63-437a-86f9-3d8ffe4818a1"/>
-				<box leftPadding="5" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="a6185ca1-fc63-437a-86f9-3d8ffe4818a1" key="textField-26" x="759" y="0" width="21" height="14" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{CONVSYM}]]></expression>
+				<box leftPadding="5" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="16" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="20" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="643" y="4" width="95" height="16" uuid="67ac4e5a-f9f6-430e-a0ab-78731a1fdb9b"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="740" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="a0dfa127-e499-475c-b2cd-f94f9f2b16eb"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Bottom" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="1" width="782" height="1" forecolor="#000000" uuid="3842823c-fbd3-457f-a728-eba02463acd3"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="383" y="4" width="69" height="16" uuid="6ac6bcf6-3a87-468c-892e-cba0ee601246"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Bottom">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" style="Report_Footer" x="304" y="4" width="78" height="16" uuid="67987058-9b3e-4375-a461-01ce6909af65"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-5" style="Report_Footer" x="0" y="4" width="140" height="16" uuid="fc32adec-aa35-47ba-8be6-36710e3b2570">
-					<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
-				</reportElement>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Bottom"/>
-				<text><![CDATA[other footer data]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="16" splitType="Stretch"/>
+	<pageFooter height="20" splitType="Stretch">
+		<element kind="textField" uuid="67ac4e5a-f9f6-430e-a0ab-78731a1fdb9b" key="textField" x="643" y="4" width="95" height="16" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Bottom" style="Report_Footer">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="a0dfa127-e499-475c-b2cd-f94f9f2b16eb" key="textField" x="740" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Bottom" style="Report_Footer">
+			<paragraph lineSpacing="Single" style="Report_Footer"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="3842823c-fbd3-457f-a728-eba02463acd3" key="line" x="0" y="1" width="782" height="1" forecolor="#000000">
+			<pen lineWidth="1.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="6ac6bcf6-3a87-468c-892e-cba0ee601246" key="textField" x="383" y="4" width="69" height="16" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Bottom" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="67987058-9b3e-4375-a461-01ce6909af65" key="staticText-1" x="304" y="4" width="78" height="16" hTextAlign="Right" vTextAlign="Bottom" style="Report_Footer">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="fc32adec-aa35-47ba-8be6-36710e3b2570" key="staticText-5" x="0" y="4" width="140" height="16" vTextAlign="Bottom" style="Report_Footer">
+			<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
+			<text><![CDATA[other footer data]]></text>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportPendingProductionJr.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportPendingProductionJr.jrxml
@@ -1,53 +1,51 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportPendingProductionJr" pageWidth="595" pageHeight="842" columnWidth="595" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="0bdfad47-abfb-49cb-ba61-39148e3fd3ca">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportPendingProductionJr" language="java" pageWidth="595" pageHeight="842" columnWidth="595" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="0bdfad47-abfb-49cb-ba61-39148e3fd3ca">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="true"/>
-	<style name="Detail_Line" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="true"/>
+	<style name="Detail_Line" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC" vAlign="Middle"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<subDataset name="SubDataset1" uuid="43db9ef4-8f56-4f7b-ac66-414e7b04cde1"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<dataset name="SubDataset1" uuid="43db9ef4-8f56-4f7b-ac66-414e7b04cde1"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT C_ORDER.DOCUMENTNO AS docno, C_ORDER.DATEORDERED as ordered, C_ORDER.DATEPROMISED as promised,
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT C_ORDER.DOCUMENTNO AS docno, C_ORDER.DATEORDERED as ordered, C_ORDER.DATEPROMISED as promised,
              C_BPARTNER.NAME AS bpname, C_REGION.NAME AS rname, M_PRODUCT.VALUE, M_PRODUCT.NAME AS pname,
              C_ORDERLINE.QTYORDERED, STORAGE_DETAIL.QTYONHAND, STORAGE_DETAIL.PREQTYONHAND,
               CASE  WHEN C_ORDERLINE.QTYORDERED - STORAGE_DETAIL.QTYONHAND - STORAGE_DETAIL.PREQTYONHAND>0 THEN 'Color' ELSE 'Bordes' END as negative
@@ -64,8 +62,7 @@
            AND C_ORDER.DOCSTATUS='CO'
            AND C_ORDER.C_ORDER_ID IN (SELECT C_Order_ID FROM M_InOut_Candidate_v)
            AND C_ORDER.ISSOTRX='Y'
-         ORDER BY C_ORDER.DATEORDERED]]>
-	</queryString>
+         ORDER BY C_ORDER.DATEORDERED]]></query>
 	<field name="DOCNO" class="java.lang.String"/>
 	<field name="ORDERED" class="java.util.Date"/>
 	<field name="PROMISED" class="java.util.Date"/>
@@ -77,319 +74,237 @@
 	<field name="QTYONHAND" class="java.math.BigDecimal"/>
 	<field name="PREQTYONHAND" class="java.math.BigDecimal"/>
 	<field name="NEGATIVE" class="java.lang.String"/>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="40" splitType="Stretch">
-			<line>
-				<reportElement key="line-1" x="0" y="34" width="535" height="1" uuid="ff1d2a04-dce4-436e-9ae6-97f0630febcb"/>
-			</line>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Title" x="0" y="9" width="535" height="22" uuid="bbb282d4-418a-401d-bb44-a783ee8dbcb5"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="40" splitType="Stretch">
+		<element kind="line" uuid="ff1d2a04-dce4-436e-9ae6-97f0630febcb" key="line-1" x="0" y="34" width="535" height="1"/>
+		<element kind="textField" uuid="bbb282d4-418a-401d-bb44-a783ee8dbcb5" key="textField" x="0" y="9" width="535" height="22" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</title>
-	<pageHeader>
-		<band height="10" splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band height="32" splitType="Stretch">
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="0" y="0" width="40" height="32" uuid="f2f7cc19-6dab-4804-a6e0-904d3476c068"/>
-				<box leftPadding="3">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Order]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="40" y="0" width="50" height="32" uuid="5e033738-60c3-4b8e-a190-7e3709a07720"/>
-				<box leftPadding="3">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Ordered Date]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="90" y="0" width="50" height="32" uuid="e4fd1385-abd3-46f1-b290-6517254973f5"/>
-				<box leftPadding="3">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Promised Date]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="140" y="0" width="105" height="32" uuid="99316ffc-956f-450d-9ea1-c9461c534a38"/>
-				<box leftPadding="3">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Customer]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="245" y="0" width="50" height="32" uuid="3cd7e9f4-6dff-4b84-bf90-7daed26c4f46"/>
-				<box leftPadding="3">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Region]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="295" y="0" width="155" height="32" uuid="e4ef6af0-8191-4a50-a836-ded324acd840"/>
-				<box leftPadding="3">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Product]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="450" y="0" width="50" height="32" uuid="086621c1-8ea9-4182-8b90-84fddab080eb"/>
-				<box leftPadding="3">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Ordered Quantity]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="500" y="0" width="50" height="32" uuid="c7d7911c-2c23-47cc-a28c-06711a11ed58"/>
-				<box leftPadding="3">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[On hand Quantity]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="550" y="0" width="45" height="32" uuid="c249425c-d227-487c-aaec-4b0f76737999"/>
-				<box leftPadding="3">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Preqty]]></text>
-			</staticText>
-		</band>
+	<pageHeader height="10" splitType="Stretch"/>
+	<columnHeader height="32" splitType="Stretch">
+		<element kind="staticText" uuid="f2f7cc19-6dab-4804-a6e0-904d3476c068" key="element-90" x="0" y="0" width="40" height="32" pdfFontName="Helvetica-Bold" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Order]]></text>
+			<box leftPadding="3" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="5e033738-60c3-4b8e-a190-7e3709a07720" key="element-90" x="40" y="0" width="50" height="32" pdfFontName="Helvetica-Bold" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Ordered Date]]></text>
+			<box leftPadding="3" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="e4fd1385-abd3-46f1-b290-6517254973f5" key="element-90" x="90" y="0" width="50" height="32" pdfFontName="Helvetica-Bold" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Promised Date]]></text>
+			<box leftPadding="3" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="99316ffc-956f-450d-9ea1-c9461c534a38" key="element-90" x="140" y="0" width="105" height="32" pdfFontName="Helvetica-Bold" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Customer]]></text>
+			<box leftPadding="3" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="3cd7e9f4-6dff-4b84-bf90-7daed26c4f46" key="element-90" x="245" y="0" width="50" height="32" pdfFontName="Helvetica-Bold" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Region]]></text>
+			<box leftPadding="3" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="e4ef6af0-8191-4a50-a836-ded324acd840" key="element-90" x="295" y="0" width="155" height="32" pdfFontName="Helvetica-Bold" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Product]]></text>
+			<box leftPadding="3" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="086621c1-8ea9-4182-8b90-84fddab080eb" key="element-90" x="450" y="0" width="50" height="32" pdfFontName="Helvetica-Bold" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Ordered Quantity]]></text>
+			<box leftPadding="3" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="c7d7911c-2c23-47cc-a28c-06711a11ed58" key="element-90" x="500" y="0" width="50" height="32" pdfFontName="Helvetica-Bold" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[On hand Quantity]]></text>
+			<box leftPadding="3" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="c249425c-d227-487c-aaec-4b0f76737999" key="element-90" x="550" y="0" width="45" height="32" pdfFontName="Helvetica-Bold" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Preqty]]></text>
+			<box leftPadding="3" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</columnHeader>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="40" height="16" uuid="12e7271e-c2ab-4445-89fb-a30f5ba1beb8"/>
-				<box leftPadding="2" rightPadding="2">
+			<element kind="textField" uuid="12e7271e-c2ab-4445-89fb-a30f5ba1beb8" key="textField" stretchType="ContainerHeight" x="0" y="0" width="40" height="16" textAdjust="StretchHeight" blankWhenNull="true" style="Detail_Line">
+				<expression><![CDATA[$F{DOCNO}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$F{DOCNO}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="40" y="0" width="50" height="16" uuid="51518027-aaab-4535-8f80-9b406e3a2e32"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="51518027-aaab-4535-8f80-9b406e3a2e32" key="textField" stretchType="ContainerHeight" x="40" y="0" width="50" height="16" textAdjust="StretchHeight" blankWhenNull="true" style="Detail_Line">
+				<expression><![CDATA[$F{ORDERED}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$F{ORDERED}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="90" y="0" width="50" height="16" uuid="41a51c02-2ad3-4fcb-a944-74184e3a1314"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="41a51c02-2ad3-4fcb-a944-74184e3a1314" key="textField" stretchType="ContainerHeight" x="90" y="0" width="50" height="16" textAdjust="StretchHeight" blankWhenNull="true" style="Detail_Line">
+				<expression><![CDATA[$F{PROMISED}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$F{PROMISED}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="140" y="0" width="105" height="16" uuid="baf7b411-7c80-4ba9-a73c-8a7ba4fc90ec"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="baf7b411-7c80-4ba9-a73c-8a7ba4fc90ec" key="textField" stretchType="ContainerHeight" x="140" y="0" width="105" height="16" textAdjust="StretchHeight" blankWhenNull="true" style="Detail_Line">
+				<expression><![CDATA[$F{BPNAME}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$F{BPNAME}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="245" y="0" width="50" height="16" uuid="8e6ee6f5-d802-4dd3-adfe-0620d00040c2"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="8e6ee6f5-d802-4dd3-adfe-0620d00040c2" key="textField" stretchType="ContainerHeight" x="245" y="0" width="50" height="16" textAdjust="StretchHeight" blankWhenNull="true" style="Detail_Line">
+				<expression><![CDATA[$F{RNAME}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$F{RNAME}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="295" y="0" width="55" height="16" uuid="64a4bc11-4ba9-4e33-9bd7-1485dd49ac75"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="64a4bc11-4ba9-4e33-9bd7-1485dd49ac75" key="textField" stretchType="ContainerHeight" x="295" y="0" width="55" height="16" textAdjust="StretchHeight" blankWhenNull="true" style="Detail_Line">
+				<expression><![CDATA[$F{VALUE}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$F{VALUE}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="350" y="0" width="100" height="16" uuid="87a03e44-7ee6-4e54-9fb1-a95556e525a3"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="87a03e44-7ee6-4e54-9fb1-a95556e525a3" key="textField" stretchType="ContainerHeight" x="350" y="0" width="100" height="16" textAdjust="StretchHeight" blankWhenNull="true" style="Detail_Line">
+				<expression><![CDATA[$F{PNAME}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$F{PNAME}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="450" y="0" width="50" height="16" uuid="2a1bef0e-5bf4-4a58-be5e-9c7e669e37bc"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="2a1bef0e-5bf4-4a58-be5e-9c7e669e37bc" key="textField" stretchType="ContainerHeight" x="450" y="0" width="50" height="16" blankWhenNull="false" hTextAlign="Right" style="Detail_Line">
+				<expression><![CDATA[($F{QTYORDERED}!=null)?$P{NUMBERFORMAT}.format($F{QTYORDERED}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA[($F{QTYORDERED}!=null)?$P{NUMBERFORMAT}.format($F{QTYORDERED}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="500" y="0" width="50" height="16" uuid="990b3667-b3ea-4249-acbb-f52a311a6713"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="990b3667-b3ea-4249-acbb-f52a311a6713" key="textField" stretchType="ContainerHeight" x="500" y="0" width="50" height="16" blankWhenNull="false" hTextAlign="Right" style="Detail_Line">
+				<expression><![CDATA[($F{QTYONHAND}!=null)?$P{NUMBERFORMAT}.format($F{QTYONHAND}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA[($F{QTYONHAND}!=null)?$P{NUMBERFORMAT}.format($F{QTYONHAND}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" stretchType="RelativeToBandHeight" x="550" y="0" width="45" height="16" uuid="b160d095-6cb6-46e1-8dd6-c1a451ef3c80"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="b160d095-6cb6-46e1-8dd6-c1a451ef3c80" key="textField" stretchType="ContainerHeight" x="550" y="0" width="45" height="16" blankWhenNull="false" hTextAlign="Right" style="Detail_Line">
+				<expression><![CDATA[($F{PREQTYONHAND}!=null)?$P{NUMBERFORMAT}.format($F{PREQTYONHAND}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA[($F{PREQTYONHAND}!=null)?$P{NUMBERFORMAT}.format($F{PREQTYONHAND}):new String(" ")]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="12" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="27" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="455" y="4" width="95" height="19" uuid="95b8c9f5-0bbc-4807-9f30-716cb31d04c6"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="554" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="40f2ac08-bdae-4a2a-8e1f-2e62e4c9ad06"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="1" width="595" height="1" forecolor="#000000" uuid="8719d891-647b-47ee-814f-00b4dc6cfc66"/>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="296" y="4" width="69" height="19" uuid="38fef5cf-17fb-47db-8499-32d679864baf"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" x="215" y="4" width="78" height="19" uuid="39a9da45-a343-4b6d-ac7c-ee063f05ee56"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Top"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="12" splitType="Stretch"/>
+	<pageFooter height="27" splitType="Stretch">
+		<element kind="textField" uuid="95b8c9f5-0bbc-4807-9f30-716cb31d04c6" key="textField" x="455" y="4" width="95" height="19" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="40f2ac08-bdae-4a2a-8e1f-2e62e4c9ad06" key="textField" x="554" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="8719d891-647b-47ee-814f-00b4dc6cfc66" key="line" x="0" y="1" width="595" height="1" forecolor="#000000"/>
+		<element kind="textField" uuid="38fef5cf-17fb-47db-8499-32d679864baf" key="textField" x="296" y="4" width="69" height="19" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="39a9da45-a343-4b6d-ac7c-ee063f05ee56" key="staticText-1" x="215" y="4" width="78" height="19" hTextAlign="Right" vTextAlign="Top">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportProductionRun.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportProductionRun.jrxml
@@ -1,58 +1,56 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportProductionRun" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="756c6650-814d-4daf-ad52-183a7df51014">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportProductionRun" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="756c6650-814d-4daf-ad52-183a7df51014">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["('1000000')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["('0')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="Subtitle" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT wr.DocumentNo AS wrname, wr.CLOSED AS wrclosed, wr.LAUNCHDATE AS wrlaunch, wr.STARTDATE AS wrstart, wr.ENDDATE AS wrend,
+	<parameter name="Subtitle" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT wr.DocumentNo AS wrname, wr.CLOSED AS wrclosed, wr.LAUNCHDATE AS wrlaunch, wr.STARTDATE AS wrstart, wr.ENDDATE AS wrend,
         wrp.SeqNo AS wrpname, wrp.QUANTITY AS wrpqty, wrp.DONEQUANTITY AS wrpdone, (wrp.QUANTITY - wrp.DONEQUANTITY ) AS wrpleft,
         p.NAME AS pname, wrp.COSTCENTERUSE AS wrpph, wrp.PREPTIME AS wrppt, wrp.CLOSED AS wrpclosed,
         pr.LINE AS prname, we.DocumentNo AS wename, pr.NEEDEDQUANTITY AS prneeded, pr.PRODUCTIONQTY AS prdone, pr.REJECTEDQUANTITY As prrej,
@@ -62,8 +60,7 @@
         AND wrp.MA_PROCESS_ID = p.MA_PROCESS_ID
         AND pr.MA_WRPHASE_ID = wrp.MA_WRPHASE_ID
         AND pr.M_PRODUCTION_ID = we.M_PRODUCTION_ID
-      ORDER BY wrlaunch, wr.MA_WorkRequirement_ID, wrpseq, wename, prname]]>
-	</queryString>
+      ORDER BY wrlaunch, wr.MA_WorkRequirement_ID, wrpseq, wename, prname]]></query>
 	<field name="WRNAME" class="java.lang.String"/>
 	<field name="WRCLOSED" class="java.lang.String"/>
 	<field name="WRLAUNCH" class="java.util.Date"/>
@@ -87,697 +84,490 @@
 	<field name="WRID" class="java.lang.String"/>
 	<field name="WRPID" class="java.lang.String"/>
 	<group name="WRNAME">
-		<groupExpression><![CDATA[$F{WRNAME}]]></groupExpression>
+		<expression><![CDATA[$F{WRNAME}]]></expression>
 		<groupHeader>
 			<band height="63" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="1" y="0" width="186" height="23" uuid="d72a71aa-b544-4db5-8749-809b419dacbe"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="d72a71aa-b544-4db5-8749-809b419dacbe" key="staticText" x="1" y="0" width="186" height="23" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[Work Requirement]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="187" y="0" width="348" height="23" uuid="63f3631b-1f1c-4825-a5d2-bffa597c11b5"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{WRNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="1" width="1" height="62" forecolor="#555555" uuid="c71e6838-a2ce-4e8c-a7b4-e18dc82283bd"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="535" y="1" width="1" height="62" forecolor="#555555" uuid="298e6ce2-9d7f-4d6d-8320-2a13d0e35817"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="default" x="353" y="23" width="36" height="16" uuid="fe624cb3-575a-42d1-88f9-89df45f531cb"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="63f3631b-1f1c-4825-a5d2-bffa597c11b5" key="textField" x="187" y="0" width="348" height="23" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{WRNAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{WRCLOSED}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="default" x="142" y="23" width="79" height="16" uuid="5ec76396-8ca5-4931-884c-0a8afa2d853d"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="line" uuid="c71e6838-a2ce-4e8c-a7b4-e18dc82283bd" key="line-2" stretchType="ContainerHeight" x="0" y="1" width="1" height="62" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="298e6ce2-9d7f-4d6d-8320-2a13d0e35817" key="line-3" stretchType="ContainerHeight" x="535" y="1" width="1" height="62" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="textField" uuid="fe624cb3-575a-42d1-88f9-89df45f531cb" key="textField" x="353" y="23" width="36" height="16" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="default">
+					<expression><![CDATA[$F{WRCLOSED}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{WRLAUNCH}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="default" x="142" y="41" width="79" height="16" uuid="216685b0-b8f2-433a-b67e-c02a5139a344"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5ec76396-8ca5-4931-884c-0a8afa2d853d" key="textField" x="142" y="23" width="79" height="16" pattern="" blankWhenNull="true" vTextAlign="Middle" style="default">
+					<expression><![CDATA[$F{WRLAUNCH}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{WRSTART}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="default" x="353" y="41" width="79" height="16" uuid="0473b8cb-0cab-4162-9bfe-05d4df988513"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="216685b0-b8f2-433a-b67e-c02a5139a344" key="textField" x="142" y="41" width="79" height="16" pattern="" blankWhenNull="true" vTextAlign="Middle" style="default">
+					<expression><![CDATA[$F{WRSTART}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{WREND}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-2" style="default" x="305" y="23" width="48" height="16" uuid="486ab32a-785a-4156-9e74-3dcfdd182f10"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0473b8cb-0cab-4162-9bfe-05d4df988513" key="textField" x="353" y="41" width="79" height="16" pattern="" blankWhenNull="true" vTextAlign="Middle" style="default">
+					<expression><![CDATA[$F{WREND}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="486ab32a-785a-4156-9e74-3dcfdd182f10" key="staticText-2" x="305" y="23" width="48" height="16" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" style="default">
 					<text><![CDATA[Closed]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-3" style="default" x="11" y="23" width="131" height="16" uuid="0349912c-23bf-4d7d-bc48-bc26f3e602b8"/>
-					<box rightPadding="2">
+					<box rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="0349912c-23bf-4d7d-bc48-bc26f3e602b8" key="staticText-3" x="11" y="23" width="131" height="16" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" style="default">
 					<text><![CDATA[Starting Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-16" style="default" x="11" y="41" width="131" height="16" uuid="84a49419-7488-48d6-a13c-83f68a6bbc82"/>
-					<box rightPadding="2">
+					<box rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="84a49419-7488-48d6-a13c-83f68a6bbc82" key="staticText-16" x="11" y="41" width="131" height="16" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" style="default">
 					<text><![CDATA[Initial Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-17" style="default" x="282" y="41" width="71" height="16" uuid="6e0c81c7-17d1-4496-86ad-092755df137e"/>
-					<box rightPadding="2">
+					<box rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="6e0c81c7-17d1-4496-86ad-092755df137e" key="staticText-17" x="282" y="41" width="71" height="16" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" style="default">
 					<text><![CDATA[Final Date]]></text>
-				</staticText>
+					<box rightPadding="2" style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-34" x="0" y="10" width="535" height="1" forecolor="#555555" uuid="82bffcdf-c6f9-4fc5-b051-7533e7c37b66"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-32" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="10" forecolor="#555555" uuid="e54c56fa-df50-4a6c-8166-57fdffd19eb0"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="10" forecolor="#555555" uuid="8a763051-8b8e-43da-a38b-55681e8999fe"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="82bffcdf-c6f9-4fc5-b051-7533e7c37b66" key="line-34" x="0" y="10" width="535" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="e54c56fa-df50-4a6c-8166-57fdffd19eb0" key="line-32" stretchType="ContainerHeight" x="0" y="0" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="8a763051-8b8e-43da-a38b-55681e8999fe" key="line-33" stretchType="ContainerHeight" x="535" y="0" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="WRPNAME">
-		<groupExpression><![CDATA[$F{WRPNAME}]]></groupExpression>
+		<expression><![CDATA[$F{WRPNAME}]]></expression>
 		<groupHeader>
 			<band height="77" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="11" y="0" width="114" height="23" uuid="4cad70e6-948c-45d9-b941-2699b889d4e9"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="4cad70e6-948c-45d9-b941-2699b889d4e9" key="staticText" x="11" y="0" width="114" height="23" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[Operation WR]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="125" y="0" width="410" height="23" uuid="2f91a87b-2be7-428f-b443-71c048ef510b"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{WRPNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-4" stretchType="RelativeToBandHeight" x="10" y="1" width="1" height="76" forecolor="#555555" uuid="6fe1438e-5f47-43c6-a8b9-45b27b0fcb70"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-6" stretchType="RelativeToBandHeight" x="535" y="1" width="1" height="76" forecolor="#555555" uuid="3af7f5ff-7c69-416b-b5a9-1235d257f05a"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-8" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="77" forecolor="#555555" uuid="a8fb74b6-c17f-4e01-9617-d3389e9e267c"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="default" x="75" y="23" width="62" height="16" uuid="74b89f2a-6613-4053-8c54-3672a685748e"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2f91a87b-2be7-428f-b443-71c048ef510b" key="textField" x="125" y="0" width="410" height="23" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{WRPNAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[($F{WRPQTY}!=null)?$P{NUMBERFORMAT}.format($F{WRPQTY}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="default" x="219" y="23" width="62" height="16" uuid="60b0c317-3386-4fb1-bd19-5601895c9554"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="line" uuid="6fe1438e-5f47-43c6-a8b9-45b27b0fcb70" key="line-4" stretchType="ContainerHeight" x="10" y="1" width="1" height="76" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="3af7f5ff-7c69-416b-b5a9-1235d257f05a" key="line-6" stretchType="ContainerHeight" x="535" y="1" width="1" height="76" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="a8fb74b6-c17f-4e01-9617-d3389e9e267c" key="line-8" stretchType="ContainerHeight" x="0" y="0" width="1" height="77" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="textField" uuid="74b89f2a-6613-4053-8c54-3672a685748e" key="textField" x="75" y="23" width="62" height="16" pattern="" blankWhenNull="false" vTextAlign="Middle" style="default">
+					<expression><![CDATA[($F{WRPQTY}!=null)?$P{NUMBERFORMAT}.format($F{WRPQTY}):new String(" ")]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[($F{WRPDONE}!=null)?$P{NUMBERFORMAT}.format($F{WRPDONE}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="default" x="400" y="23" width="62" height="16" uuid="57cb5b95-f106-46e5-91a5-ae1a450bf245"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="60b0c317-3386-4fb1-bd19-5601895c9554" key="textField" x="219" y="23" width="62" height="16" pattern="" blankWhenNull="false" vTextAlign="Middle" style="default">
+					<expression><![CDATA[($F{WRPDONE}!=null)?$P{NUMBERFORMAT}.format($F{WRPDONE}):new String(" ")]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[($F{WRPLEFT}!=null)?$P{NUMBERFORMAT}.format($F{WRPLEFT}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="default" x="75" y="39" width="191" height="16" uuid="4abcb4f4-f5b7-434a-8e9d-0c675b05bcf2"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="57cb5b95-f106-46e5-91a5-ae1a450bf245" key="textField" x="400" y="23" width="62" height="16" pattern="" blankWhenNull="false" vTextAlign="Middle" style="default">
+					<expression><![CDATA[($F{WRPLEFT}!=null)?$P{NUMBERFORMAT}.format($F{WRPLEFT}):new String(" ")]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{PNAME}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="default" x="338" y="39" width="35" height="16" uuid="6d64fa75-c2c9-4155-9365-e324428577ab"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4abcb4f4-f5b7-434a-8e9d-0c675b05bcf2" key="textField" x="75" y="39" width="191" height="16" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="default">
+					<expression><![CDATA[$F{PNAME}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[($F{WRPPH}!=null)?$P{NUMBERFORMAT}.format($F{WRPPH}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="default" x="427" y="39" width="26" height="16" uuid="77f7b59c-7d0b-4a19-a3bb-d7f138ede478"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6d64fa75-c2c9-4155-9365-e324428577ab" key="textField" x="338" y="39" width="35" height="16" pattern="" blankWhenNull="false" vTextAlign="Middle" style="default">
+					<expression><![CDATA[($F{WRPPH}!=null)?$P{NUMBERFORMAT}.format($F{WRPPH}):new String(" ")]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[($F{WRPPT}!=null)?$P{NUMBERFORMAT}.format($F{WRPPT}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="default" x="506" y="39" width="27" height="16" uuid="1cb2fe44-d8a5-4b76-bbf4-27c0a4e7e457"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="77f7b59c-7d0b-4a19-a3bb-d7f138ede478" key="textField" x="427" y="39" width="26" height="16" pattern="" blankWhenNull="false" vTextAlign="Middle" style="default">
+					<expression><![CDATA[($F{WRPPT}!=null)?$P{NUMBERFORMAT}.format($F{WRPPT}):new String(" ")]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{WRPCLOSED}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-4" style="default" x="21" y="23" width="54" height="16" uuid="b71d52f3-d707-4112-b70b-19e9f09af98a"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="1cb2fe44-d8a5-4b76-bbf4-27c0a4e7e457" key="textField" x="506" y="39" width="27" height="16" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="default">
+					<expression><![CDATA[$F{WRPCLOSED}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="b71d52f3-d707-4112-b70b-19e9f09af98a" key="staticText-4" x="21" y="23" width="54" height="16" pdfFontName="Helvetica-Bold" bold="true" style="default">
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-5" style="default" x="156" y="23" width="63" height="16" uuid="8e3021a4-a141-4ed0-b3d5-ff150fa1fa9d"/>
-					<box>
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="8e3021a4-a141-4ed0-b3d5-ff150fa1fa9d" key="staticText-5" x="156" y="23" width="63" height="16" pdfFontName="Helvetica-Bold" bold="true" style="default">
 					<text><![CDATA[Q. Done]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-6" style="default" x="306" y="23" width="94" height="16" uuid="38ff135f-3592-4b82-9882-389c7260b96d"/>
-					<box>
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="38ff135f-3592-4b82-9882-389c7260b96d" key="staticText-6" x="306" y="23" width="94" height="16" pdfFontName="Helvetica-Bold" bold="true" style="default">
 					<text><![CDATA[Q. Left]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-7" style="default" x="21" y="39" width="54" height="16" uuid="ffc4aad8-a439-43c9-8203-d63c39e9c15e"/>
-					<box>
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="ffc4aad8-a439-43c9-8203-d63c39e9c15e" key="staticText-7" x="21" y="39" width="54" height="16" pdfFontName="Helvetica-Bold" bold="true" style="default">
 					<text><![CDATA[Process]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-8" style="default" x="266" y="39" width="72" height="16" uuid="1c62e48c-094f-46ed-ba1b-1e033fe7ec4d"/>
-					<box>
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="1c62e48c-094f-46ed-ba1b-1e033fe7ec4d" key="staticText-8" x="266" y="39" width="72" height="16" pdfFontName="Helvetica-Bold" bold="true" style="default">
 					<text><![CDATA[Units/hour]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-9" style="default" x="374" y="39" width="53" height="16" uuid="bda7c1a2-a8f6-4bda-b020-9df68102888b"/>
-					<box>
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="bda7c1a2-a8f6-4bda-b020-9df68102888b" key="staticText-9" x="374" y="39" width="53" height="16" pdfFontName="Helvetica-Bold" bold="true" style="default">
 					<text><![CDATA[Time to prepare]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-10" style="default" x="454" y="39" width="52" height="16" uuid="a992b76c-61e3-4f41-8ca3-b9c8e66b027e"/>
-					<box>
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="a992b76c-61e3-4f41-8ca3-b9c8e66b027e" key="staticText-10" x="454" y="39" width="52" height="16" pdfFontName="Helvetica-Bold" bold="true" style="default">
 					<text><![CDATA[Closed]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-11" style="Detail_Header" x="21" y="59" width="121" height="18" uuid="0c17434f-6e5f-4a08-8495-5ffde0073003"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="9"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="0c17434f-6e5f-4a08-8495-5ffde0073003" key="staticText-11" x="21" y="59" width="121" height="18" fontSize="9.0" style="Detail_Header">
 					<text><![CDATA[Work effort]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-12" style="Detail_Header" x="142" y="59" width="102" height="18" uuid="39ec12bb-bcea-4526-bc18-d4761e419a77"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement>
-						<font size="9"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="39ec12bb-bcea-4526-bc18-d4761e419a77" key="staticText-12" x="142" y="59" width="102" height="18" fontSize="9.0" style="Detail_Header">
 					<text><![CDATA[Production Run]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-13" style="Detail_Header" x="244" y="59" width="102" height="18" uuid="2a231733-dfb1-4f86-812d-cce4250027fd"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement>
-						<font size="9"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="2a231733-dfb1-4f86-812d-cce4250027fd" key="staticText-13" x="244" y="59" width="102" height="18" fontSize="9.0" style="Detail_Header">
 					<text><![CDATA[Required Qty.]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-14" style="Detail_Header" x="346" y="59" width="92" height="18" uuid="036c1b6e-0d49-4e83-9dbd-e7576f4887b3"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement>
-						<font size="9"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="036c1b6e-0d49-4e83-9dbd-e7576f4887b3" key="staticText-14" x="346" y="59" width="92" height="18" fontSize="9.0" style="Detail_Header">
 					<text><![CDATA[Qty. Fulfill]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-15" style="Detail_Header" x="438" y="59" width="92" height="18" uuid="2e026914-27d1-45b2-9050-2d9a9529f9e2"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement>
-						<font size="9"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="2e026914-27d1-45b2-9050-2d9a9529f9e2" key="staticText-15" x="438" y="59" width="92" height="18" fontSize="9.0" style="Detail_Header">
 					<text><![CDATA[Refund Qty.]]></text>
-				</staticText>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-28" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="20" forecolor="#555555" uuid="afd11d55-617e-4d52-bb52-6050615b9ea1"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-29" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="10" forecolor="#555555" uuid="4ca3b8de-19b6-44d5-92b1-7f61d2e632f6"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-30" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="20" forecolor="#555555" uuid="a385848c-b0f6-473d-8f9f-0f78a3579378"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-31" x="10" y="10" width="525" height="1" forecolor="#555555" uuid="76ed7764-0cfb-4edc-82ea-2857ee0aaac0"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-35" x="21" y="0" width="508" height="1" forecolor="#666666" uuid="bb160a04-544c-41fd-ad33-8762f6272329"/>
-					<graphicElement>
-						<pen lineWidth="0.25" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="afd11d55-617e-4d52-bb52-6050615b9ea1" key="line-28" stretchType="ContainerHeight" x="0" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="4ca3b8de-19b6-44d5-92b1-7f61d2e632f6" key="line-29" stretchType="ContainerHeight" x="10" y="0" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="a385848c-b0f6-473d-8f9f-0f78a3579378" key="line-30" stretchType="ContainerHeight" x="535" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="76ed7764-0cfb-4edc-82ea-2857ee0aaac0" key="line-31" x="10" y="10" width="525" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="bb160a04-544c-41fd-ad33-8762f6272329" key="line-35" x="21" y="0" width="508" height="1" forecolor="#666666">
+					<pen lineWidth="0.25" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="20" splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="49" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Title" mode="Transparent" x="0" y="0" width="535" height="20" uuid="e2aa239c-b1ea-4d6b-a81c-37c630e1a1fc"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="20" width="535" height="1" uuid="2d148d3e-209b-4901-a284-4b6cccf04688"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Report_Subtitle" x="0" y="20" width="535" height="20" uuid="280e4a31-54e3-412a-99e7-c3c521d48a7f"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{Subtitle}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="20" splitType="Stretch"/>
+	<pageHeader height="49" splitType="Stretch">
+		<element kind="textField" uuid="e2aa239c-b1ea-4d6b-a81c-37c630e1a1fc" key="textField" mode="Transparent" x="0" y="0" width="535" height="20" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="2d148d3e-209b-4901-a284-4b6cccf04688" key="line-1" x="0" y="20" width="535" height="1">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="280e4a31-54e3-412a-99e7-c3c521d48a7f" key="textField" x="0" y="20" width="535" height="20" textAdjust="StretchHeight" blankWhenNull="true" style="Report_Subtitle">
+			<expression><![CDATA[$P{Subtitle}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="16" forecolor="#555555" uuid="7aed3dbb-bc27-4893-a1ee-0081dd3a4907"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="16" forecolor="#555555" uuid="5eb47f09-2772-4207-b48f-ace4f008a145"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-18" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="16" forecolor="#555555" uuid="36ca2eea-a0fa-422a-80d7-8eff690e9fd5"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<frame>
-				<reportElement key="frame-1" style="Detail_Line" stretchType="RelativeToBandHeight" x="21" y="0" width="508" height="16" uuid="63f3694d-2909-42e9-8a59-83595dc227bd"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-1" style="default" stretchType="RelativeToBandHeight" x="121" y="0" width="102" height="16" uuid="a014cc37-9da7-4feb-a457-d5428e53b608"/>
-					<box rightPadding="2">
+			<element kind="line" uuid="7aed3dbb-bc27-4893-a1ee-0081dd3a4907" key="line-16" stretchType="ContainerHeight" x="535" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="5eb47f09-2772-4207-b48f-ace4f008a145" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="36ca2eea-a0fa-422a-80d7-8eff690e9fd5" key="line-18" stretchType="ContainerHeight" x="10" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="frame" uuid="63f3694d-2909-42e9-8a59-83595dc227bd" key="frame-1" stretchType="ContainerHeight" x="21" y="0" width="508" height="16" style="Detail_Line">
+				<element kind="textField" uuid="a014cc37-9da7-4feb-a457-d5428e53b608" key="textField-1" stretchType="ContainerHeight" x="121" y="0" width="102" height="16" fontSize="9.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+					<expression><![CDATA[($F{PRNAME}!=null)?$P{NUMBERFORMAT}.format($F{PRNAME}):new String(" ")]]></expression>
+					<box rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="9"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{PRNAME}!=null)?$P{NUMBERFORMAT}.format($F{PRNAME}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField-2" style="default" stretchType="RelativeToBandHeight" x="0" y="0" width="121" height="16" uuid="6be43e95-c260-47fa-b49a-7b5648c930c3"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6be43e95-c260-47fa-b49a-7b5648c930c3" key="textField-2" stretchType="ContainerHeight" x="0" y="0" width="121" height="16" fontSize="9.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle" style="default">
+					<expression><![CDATA[$F{WENAME}]]></expression>
+					<box rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="9"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{WENAME}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-3" style="default" stretchType="RelativeToBandHeight" x="223" y="0" width="102" height="16" uuid="89732aa0-06dd-4fed-8e23-825e4c6ba501"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="89732aa0-06dd-4fed-8e23-825e4c6ba501" key="textField-3" stretchType="ContainerHeight" x="223" y="0" width="102" height="16" fontSize="9.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+					<expression><![CDATA[($F{PRNEEDED}!=null)?$P{NUMBERFORMAT}.format($F{PRNEEDED}):new String(" ")]]></expression>
+					<box rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="9"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{PRNEEDED}!=null)?$P{NUMBERFORMAT}.format($F{PRNEEDED}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-4" style="default" stretchType="RelativeToBandHeight" x="325" y="0" width="92" height="16" uuid="307ea0c7-d1cf-4f8a-a1da-29505698305c"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="307ea0c7-d1cf-4f8a-a1da-29505698305c" key="textField-4" stretchType="ContainerHeight" x="325" y="0" width="92" height="16" fontSize="9.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+					<expression><![CDATA[($F{PRDONE}!=null)?$P{NUMBERFORMAT}.format($F{PRDONE}):new String(" ")]]></expression>
+					<box rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="9"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{PRDONE}!=null)?$P{NUMBERFORMAT}.format($F{PRDONE}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-5" style="default" stretchType="RelativeToBandHeight" x="417" y="0" width="91" height="16" uuid="a1fe8c8a-eef9-4c2b-9a5f-b1db37e6a789"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a1fe8c8a-eef9-4c2b-9a5f-b1db37e6a789" key="textField-5" stretchType="ContainerHeight" x="417" y="0" width="91" height="16" fontSize="9.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+					<expression><![CDATA[($F{PRREJ}!=null)?$P{NUMBERFORMAT}.format($F{PRREJ}):new String(" ")]]></expression>
+					<box rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="9"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{PRREJ}!=null)?$P{NUMBERFORMAT}.format($F{PRREJ}):new String(" ")]]></textFieldExpression>
-				</textField>
-			</frame>
+				</element>
+				<box style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="27" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="400" y="4" width="95" height="19" uuid="e4b4a335-f940-41d8-b18d-6f0837d47064"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="499" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="21233e5d-e06b-4a92-8aab-f4b28953c4ff"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="1" width="535" height="1" forecolor="#000000" uuid="6ec3c38e-6ef9-4bc7-9401-01f17b796f64"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="277" y="4" width="69" height="19" uuid="52059883-4203-45de-b37d-1158948780f8"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" x="195" y="4" width="78" height="19" uuid="2b3c5ee7-4604-4f0b-a1bb-9f28252ad4d4"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="27" splitType="Stretch">
+		<element kind="textField" uuid="e4b4a335-f940-41d8-b18d-6f0837d47064" key="textField" x="400" y="4" width="95" height="19" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="21233e5d-e06b-4a92-8aab-f4b28953c4ff" key="textField" x="499" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="6ec3c38e-6ef9-4bc7-9401-01f17b796f64" key="line" x="0" y="1" width="535" height="1" forecolor="#000000">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="52059883-4203-45de-b37d-1158948780f8" key="textField" x="277" y="4" width="69" height="19" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="2b3c5ee7-4604-4f0b-a1bb-9f28252ad4d4" key="staticText-1" x="195" y="4" width="78" height="19" hTextAlign="Right">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportProjectBuildingSiteJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportProjectBuildingSiteJR.jrxml
@@ -1,58 +1,56 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportProjectBuildingSiteJR" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="8e5abae8-2672-4583-b80f-770a1b4f70fd">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportProjectBuildingSiteJR" language="java" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="8e5abae8-2672-4583-b80f-770a1b4f70fd">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{PROJECTNAME_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT C_PROJECT.VALUE||' - '||C_PROJECT.NAME AS PROJECTNAME, (CASE WHEN C_BPARTNER.NAME IS NULL THEN '' ELSE REPLACE(TO_CHAR(C_BPARTNER.NAME), '&', '') END) AS BPARTNERNAME, M_PRODUCT.NAME AS PRODUCTNAME, 
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT C_PROJECT.VALUE||' - '||C_PROJECT.NAME AS PROJECTNAME, (CASE WHEN C_BPARTNER.NAME IS NULL THEN '' ELSE REPLACE(TO_CHAR(C_BPARTNER.NAME), '&', '') END) AS BPARTNERNAME, M_PRODUCT.NAME AS PRODUCTNAME, 
       SUM(C_PROJECTLINE.PLANNEDQTY) AS PLANNEDQTY, C_PROJECTLINE.PLANNEDPRICE AS PLANNEDPRICE,
       C_CURRENCY_SYMBOL(C_PROJECT.C_CURRENCY_ID, C_PROJECTLINE.PLANNEDPRICE, 'Y') AS PLANNEDPRICESYM,
 	  C_CURRENCY_CONVERT(C_PROJECTLINE.PLANNEDPRICE, C_PROJECT.C_CURRENCY_ID, '102', TO_DATE(COALESCE(C_PROJECT.DATECONTRACT, C_PROJECT.DATEFINISH, NOW())), NULL, C_PROJECTLINE.AD_CLIENT_ID, C_PROJECTLINE.AD_ORG_ID) AS CONVPLANNEDPRICE, 
@@ -78,8 +76,7 @@
       AND 1=1
       GROUP BY C_BPARTNER.NAME, C_PROJECT.NAME, M_PRODUCT.NAME, C_PROJECTLINE.PLANNEDQTY, C_PROJECTLINE.PLANNEDPRICE, C_PROJECT.VALUE,
       C_PROJECT.C_CURRENCY_ID, C_PROJECT.DATECONTRACT, C_PROJECT.DATEFINISH, C_PROJECTLINE.AD_CLIENT_ID, C_PROJECTLINE.AD_ORG_ID       
-      ORDER BY C_BPARTNER.NAME, C_PROJECT.VALUE]]>
-	</queryString>
+      ORDER BY C_BPARTNER.NAME, C_PROJECT.VALUE]]></query>
 	<field name="PROJECTNAME" class="java.lang.String"/>
 	<field name="BPARTNERNAME" class="java.lang.String"/>
 	<field name="PRODUCTNAME" class="java.lang.String"/>
@@ -95,668 +92,455 @@
 	<field name="NUMBER_PROJECT" class="java.lang.String"/>
 	<field name="NAME" class="java.lang.String"/>
 	<field name="ID" class="java.lang.String"/>
-	<variable name="totalQtyBP" class="java.math.BigDecimal" resetType="Group" resetGroup="BPARTNERNAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{PLANNEDQTY}]]></variableExpression>
+	<variable name="totalQtyBP" resetType="Group" calculation="Sum" resetGroup="BPARTNERNAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{PLANNEDQTY}]]></expression>
 	</variable>
-	<variable name="totalAmountBP" class="java.math.BigDecimal" resetType="Group" resetGroup="BPARTNERNAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVPLANNEDPOPRICE}]]></variableExpression>
+	<variable name="totalAmountBP" resetType="Group" calculation="Sum" resetGroup="BPARTNERNAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVPLANNEDPOPRICE}]]></expression>
 	</variable>
-	<variable name="totalQty" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{PLANNEDQTY}]]></variableExpression>
+	<variable name="totalQty" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{PLANNEDQTY}]]></expression>
 	</variable>
-	<variable name="totalAmount" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[($F{CONVPLANNEDPOPRICE}!=null)? $F{CONVPLANNEDPOPRICE}: new BigDecimal("0")]]></variableExpression>
+	<variable name="totalAmount" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[($F{CONVPLANNEDPOPRICE}!=null)? $F{CONVPLANNEDPOPRICE}: new BigDecimal("0")]]></expression>
 	</variable>
-	<variable name="totalProjects" class="java.lang.Integer" incrementType="Group" incrementGroup="PROJECTNAME" calculation="Count">
-		<variableExpression><![CDATA[$F{PROJECTNAME}]]></variableExpression>
+	<variable name="totalProjects" incrementType="Group" calculation="Count" incrementGroup="PROJECTNAME" class="java.lang.Integer">
+		<expression><![CDATA[$F{PROJECTNAME}]]></expression>
 	</variable>
 	<group name="BPARTNERNAME">
-		<groupExpression><![CDATA[$F{BPARTNERNAME}]]></groupExpression>
+		<expression><![CDATA[$F{BPARTNERNAME}]]></expression>
 		<groupHeader>
 			<band height="33" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="0" y="0" width="130" height="23" uuid="5dd26975-6c0b-4f64-bad4-0b4c0605ba1e"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="5dd26975-6c0b-4f64-bad4-0b4c0605ba1e" key="staticText" x="0" y="0" width="130" height="23" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[Business Partner]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="130" y="0" width="648" height="23" uuid="0a762cc7-f65c-4c46-a19a-5a81c77ac0f0"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{BPARTNERNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="23" width="1" height="10" forecolor="#555555" uuid="67599de9-998a-4124-bc81-06118137c84b"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="778" y="0" width="1" height="33" forecolor="#555555" uuid="21f2f75d-3d90-4bec-be88-ecb19d1632b9"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				</element>
+				<element kind="textField" uuid="0a762cc7-f65c-4c46-a19a-5a81c77ac0f0" key="textField" x="130" y="0" width="648" height="23" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{BPARTNERNAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="67599de9-998a-4124-bc81-06118137c84b" key="line-2" stretchType="ContainerHeight" x="0" y="23" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="21f2f75d-3d90-4bec-be88-ecb19d1632b9" key="line-3" stretchType="ContainerHeight" x="778" y="0" width="1" height="33" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="40" splitType="Stretch">
-				<line>
-					<reportElement key="line-32" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="31" forecolor="#555555" uuid="609fa869-74c6-4b16-971b-5a369a625bac"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="778" y="0" width="1" height="32" forecolor="#555555" uuid="c52ac68e-f638-4db0-b669-1a2bb3e173bb"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-34" x="0" y="31" width="778" height="1" forecolor="#555555" uuid="a8660d06-6e7d-47ac-a1bd-6eadf86a4214"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-5" style="default" x="21" y="9" width="123" height="16" uuid="60834478-c1a1-43b9-8781-65009086a97d"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
+				<element kind="line" uuid="609fa869-74c6-4b16-971b-5a369a625bac" key="line-32" stretchType="ContainerHeight" x="0" y="0" width="1" height="31" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="c52ac68e-f638-4db0-b669-1a2bb3e173bb" key="line-33" stretchType="ContainerHeight" x="778" y="0" width="1" height="32" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="a8660d06-6e7d-47ac-a1bd-6eadf86a4214" key="line-34" x="0" y="31" width="778" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="60834478-c1a1-43b9-8781-65009086a97d" key="staticText-5" x="21" y="9" width="123" height="16" fontName="Bitstream Vera Sans" hTextAlign="Right" style="default">
 					<text><![CDATA[Business Partner Total:]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-5" style="Total_Gray" stretchType="RelativeToBandHeight" x="149" y="9" width="120" height="16" uuid="f6cbbf15-c1a0-4003-8d0c-b142f61cd8ed"/>
-					<box>
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{totalQtyBP}!=null)?$P{NUMBERFORMAT}.format($V{totalQtyBP}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-6" style="Total_Gray" stretchType="RelativeToBandHeight" x="269" y="9" width="484" height="16" uuid="3b1ce470-36f7-4720-99dc-899d2508a461"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="f6cbbf15-c1a0-4003-8d0c-b142f61cd8ed" key="textField-5" stretchType="ContainerHeight" x="149" y="9" width="120" height="16" fontName="Bitstream Vera Sans" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Gray">
+					<expression><![CDATA[($V{totalQtyBP}!=null)?$P{NUMBERFORMAT}.format($V{totalQtyBP}):new String(" ")]]></expression>
+					<box style="Total_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{totalAmountBP}!=null)?$P{NUMBERFORMAT}.format($V{totalAmountBP}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-17" style="Total_Gray" stretchType="RelativeToBandHeight" x="753" y="9" width="23" height="16" uuid="90e9dae9-5a0d-4d4d-a288-ecce30a99cbf"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="3b1ce470-36f7-4720-99dc-899d2508a461" key="textField-6" stretchType="ContainerHeight" x="269" y="9" width="484" height="16" fontName="Bitstream Vera Sans" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Gray">
+					<expression><![CDATA[($V{totalAmountBP}!=null)?$P{NUMBERFORMAT}.format($V{totalAmountBP}):new String(" ")]]></expression>
+					<box style="Total_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="90e9dae9-5a0d-4d4d-a288-ecce30a99cbf" key="textField-17" stretchType="ContainerHeight" x="753" y="9" width="23" height="16" fontName="Bitstream Vera Sans" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Total_Gray">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Total_Gray">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="PROJECTNAME">
-		<groupExpression><![CDATA[$F{PROJECTNAME}]]></groupExpression>
+		<expression><![CDATA[$F{PROJECTNAME}]]></expression>
 		<groupHeader>
 			<band height="60" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="10" y="0" width="120" height="23" uuid="9bbca97a-4b6e-4488-81a5-7ba44042c3e9"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="9bbca97a-4b6e-4488-81a5-7ba44042c3e9" key="staticText" x="10" y="0" width="120" height="23" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[Project]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="130" y="0" width="647" height="23" uuid="4de5878b-74de-4416-b039-6b201e24aa47"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{PROJECTNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-4" stretchType="RelativeToBandHeight" x="10" y="23" width="1" height="37" forecolor="#555555" uuid="d76ad2a6-b405-4081-af27-46233308faa3"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-6" stretchType="RelativeToBandHeight" x="778" y="0" width="1" height="60" forecolor="#555555" uuid="542fa6d7-d501-4f2b-827c-c9ee40d0293e"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-8" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="60" forecolor="#555555" uuid="997b6f83-e604-4d5e-ada5-8e022ead4495"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="16" y="44" width="127" height="16" uuid="b0883c82-272b-4954-b783-2758db113103"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="4de5878b-74de-4416-b039-6b201e24aa47" key="textField" x="130" y="0" width="647" height="23" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{PROJECTNAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="d76ad2a6-b405-4081-af27-46233308faa3" key="line-4" stretchType="ContainerHeight" x="10" y="23" width="1" height="37" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="542fa6d7-d501-4f2b-827c-c9ee40d0293e" key="line-6" stretchType="ContainerHeight" x="778" y="0" width="1" height="60" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="997b6f83-e604-4d5e-ada5-8e022ead4495" key="line-8" stretchType="ContainerHeight" x="0" y="0" width="1" height="60" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="b0883c82-272b-4954-b783-2758db113103" key="element-90" x="16" y="44" width="127" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" style="Detail_Header">
 					<text><![CDATA[Product]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="143" y="44" width="127" height="16" uuid="1a28826f-6302-4411-bfe1-98c75fdaeaf5"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="1a28826f-6302-4411-bfe1-98c75fdaeaf5" key="element-90" x="143" y="44" width="127" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Center" style="Detail_Header">
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="270" y="44" width="127" height="16" uuid="5dfcca95-97d7-4fb6-92d6-e487415691d5"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="5dfcca95-97d7-4fb6-92d6-e487415691d5" key="element-90" x="270" y="44" width="127" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Center" style="Detail_Header">
 					<text><![CDATA[Price]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="524" y="44" width="127" height="16" uuid="7854879e-3645-4846-a97e-2527c76883df"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="7854879e-3645-4846-a97e-2527c76883df" key="element-90" x="524" y="44" width="127" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Center" style="Detail_Header">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-92" style="Detail_Header" x="651" y="44" width="76" height="16" uuid="ad261785-2872-4a19-b290-8222f1a79713"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="ad261785-2872-4a19-b290-8222f1a79713" key="element-92" x="651" y="44" width="76" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-93" style="Detail_Header" x="397" y="44" width="77" height="16" uuid="fba8bda4-f04b-4348-9353-cd6528d46fd1"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="fba8bda4-f04b-4348-9353-cd6528d46fd1" key="element-93" x="397" y="44" width="77" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[Price]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-15" style="Detail_Header" x="474" y="44" width="50" height="16" uuid="9e7c835b-ec33-46b6-b5a0-7695e901cdb3"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="9e7c835b-ec33-46b6-b5a0-7695e901cdb3" key="textField-15" x="474" y="44" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#555555"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-16" style="Detail_Header" x="727" y="44" width="50" height="16" uuid="154e1cc3-6ec9-4136-af3e-dccfe927fc30"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="154e1cc3-6ec9-4136-af3e-dccfe927fc30" key="textField-16" x="727" y="44" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#555555"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-28" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="20" forecolor="#555555" uuid="79eb22f9-2d15-4efd-85f3-953e61f546ae"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-29" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="10" forecolor="#555555" uuid="74ae70c0-8fca-4447-b506-b1ba6ead4f41"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-30" stretchType="RelativeToBandHeight" x="778" y="0" width="1" height="20" forecolor="#555555" uuid="9778a6e8-04c1-4dd6-9104-f358bb6a86c6"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-31" x="11" y="9" width="767" height="1" forecolor="#555555" uuid="31bd6356-7da9-42a6-ac3f-7e436716aacf"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-35" x="16" y="0" width="761" height="1" uuid="8016a731-ba9a-4194-8324-e779e821ddda"/>
-				</line>
+				<element kind="line" uuid="79eb22f9-2d15-4efd-85f3-953e61f546ae" key="line-28" stretchType="ContainerHeight" x="0" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="74ae70c0-8fca-4447-b506-b1ba6ead4f41" key="line-29" stretchType="ContainerHeight" x="10" y="0" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="9778a6e8-04c1-4dd6-9104-f358bb6a86c6" key="line-30" stretchType="ContainerHeight" x="778" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="31bd6356-7da9-42a6-ac3f-7e436716aacf" key="line-31" x="11" y="9" width="767" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="8016a731-ba9a-4194-8324-e779e821ddda" key="line-35" x="16" y="0" width="761" height="1"/>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="20" splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="60" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Title" mode="Transparent" x="0" y="0" width="778" height="20" uuid="b8625396-9317-4ca2-85a3-705b48091927"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="20" width="778" height="1" uuid="d8b787be-22e6-467e-8852-b2c85d3abdda"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Subtitle" x="0" y="28" width="778" height="20" uuid="bf1deca8-eb70-4ab0-beb6-75e9bd061b92"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{REPORT_SUBTITLE}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="20" splitType="Stretch"/>
+	<pageHeader height="60" splitType="Stretch">
+		<element kind="textField" uuid="b8625396-9317-4ca2-85a3-705b48091927" key="textField" mode="Transparent" x="0" y="0" width="778" height="20" fontName="Bitstream Vera Sans" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="d8b787be-22e6-467e-8852-b2c85d3abdda" key="line-1" x="0" y="20" width="778" height="1">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="bf1deca8-eb70-4ab0-beb6-75e9bd061b92" key="textField" x="0" y="28" width="778" height="20" fontName="Bitstream Vera Sans" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="778" y="0" width="1" height="16" forecolor="#555555" uuid="b157f265-ae2e-433c-a957-945f06f51e24"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="16" forecolor="#555555" uuid="4de37ce6-9496-4a9d-bb92-951436a0d9fe"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-18" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="16" forecolor="#555555" uuid="9eaf0eab-caec-45a1-95a7-c68657d40118"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-1" style="Detail_Line" stretchType="RelativeToBandHeight" x="16" y="0" width="127" height="16" uuid="9a6dd03f-1281-4207-b0c9-45ba83a5f2dc"/>
-				<box leftPadding="2" rightPadding="2">
+			<element kind="line" uuid="b157f265-ae2e-433c-a957-945f06f51e24" key="line-16" stretchType="ContainerHeight" x="778" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="4de37ce6-9496-4a9d-bb92-951436a0d9fe" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="9eaf0eab-caec-45a1-95a7-c68657d40118" key="line-18" stretchType="ContainerHeight" x="10" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="9a6dd03f-1281-4207-b0c9-45ba83a5f2dc" key="textField-1" stretchType="ContainerHeight" x="16" y="0" width="127" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PRODUCTNAME}==null)? new String("  "): $F{PRODUCTNAME}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRODUCTNAME}==null)? new String("  "): $F{PRODUCTNAME}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-2" style="Detail_Line" stretchType="RelativeToBandHeight" isPrintRepeatedValues="false" mode="Opaque" x="143" y="0" width="127" height="16" uuid="9cdacbf3-e19e-4ddf-885c-7d2f4391a65d"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="9cdacbf3-e19e-4ddf-885c-7d2f4391a65d" key="textField-2" stretchType="ContainerHeight" mode="Opaque" x="143" y="0" width="127" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" blankWhenNull="false" printRepeatedValues="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PLANNEDQTY}!=null)?$P{NUMBERFORMAT}.format($F{PLANNEDQTY}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PLANNEDQTY}!=null)?$P{NUMBERFORMAT}.format($F{PLANNEDQTY}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-3" style="Detail_Line" stretchType="RelativeToBandHeight" x="270" y="0" width="103" height="16" uuid="f1ce9baf-2bc3-40ac-873a-565c1e311066"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="f1ce9baf-2bc3-40ac-873a-565c1e311066" key="textField-3" stretchType="ContainerHeight" x="270" y="0" width="103" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PLANNEDPRICE}!=null)?$P{NUMBERFORMAT}.format($F{PLANNEDPRICE}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PLANNEDPRICE}!=null)?$P{NUMBERFORMAT}.format($F{PLANNEDPRICE}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-4" style="Detail_Line" stretchType="RelativeToBandHeight" x="524" y="0" width="103" height="16" uuid="0b1d3d5b-1614-4a32-b286-aea961867f2e"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="0b1d3d5b-1614-4a32-b286-aea961867f2e" key="textField-4" stretchType="ContainerHeight" x="524" y="0" width="103" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PLANNEDPOPRICE}!=null)?$P{NUMBERFORMAT}.format($F{PLANNEDPOPRICE}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PLANNEDPOPRICE}!=null)?$P{NUMBERFORMAT}.format($F{PLANNEDPOPRICE}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-11" style="Detail_Line" stretchType="RelativeToBandHeight" x="651" y="0" width="102" height="16" uuid="7b7a1bce-09fc-4add-af98-491bb113d34d"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="7b7a1bce-09fc-4add-af98-491bb113d34d" key="textField-11" stretchType="ContainerHeight" x="651" y="0" width="102" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVPLANNEDPOPRICE}!=null)?$P{NUMBERFORMAT}.format($F{CONVPLANNEDPOPRICE}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVPLANNEDPOPRICE}!=null)?$P{NUMBERFORMAT}.format($F{CONVPLANNEDPOPRICE}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-12" style="Detail_Line" stretchType="RelativeToBandHeight" x="397" y="0" width="103" height="16" uuid="748387a5-ea99-4a10-ada2-fde7f0a255ec"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="748387a5-ea99-4a10-ada2-fde7f0a255ec" key="textField-12" stretchType="ContainerHeight" x="397" y="0" width="103" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVPLANNEDPRICE}!=null)?$P{NUMBERFORMAT}.format($F{CONVPLANNEDPRICE}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVPLANNEDPRICE}!=null)?$P{NUMBERFORMAT}.format($F{CONVPLANNEDPRICE}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-13" style="Detail_Line" stretchType="RelativeToBandHeight" x="753" y="0" width="24" height="16" uuid="e7077ef9-958b-4632-9ad5-d3ec7c521079"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="e7077ef9-958b-4632-9ad5-d3ec7c521079" key="textField-13" stretchType="ContainerHeight" x="753" y="0" width="24" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{CONVSYM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-14" style="Detail_Line" stretchType="RelativeToBandHeight" x="500" y="0" width="24" height="16" uuid="ab055361-c5af-4d66-8782-2f8bc375d531"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="ab055361-c5af-4d66-8782-2f8bc375d531" key="textField-14" stretchType="ContainerHeight" x="500" y="0" width="24" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{CONVSYM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-18" style="Detail_Line" stretchType="RelativeToBandHeight" x="627" y="0" width="24" height="16" uuid="0710de23-b981-471c-8517-6ec9ac4a449e"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="0710de23-b981-471c-8517-6ec9ac4a449e" key="textField-18" stretchType="ContainerHeight" x="627" y="0" width="24" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{PLANNEDPOPRICESYM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PLANNEDPOPRICESYM}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-19" style="Detail_Line" stretchType="RelativeToBandHeight" x="373" y="0" width="24" height="16" uuid="8bb2a563-7423-4544-bcb9-bd0b76fe4484"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="8bb2a563-7423-4544-bcb9-bd0b76fe4484" key="textField-19" stretchType="ContainerHeight" x="373" y="0" width="24" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{PLANNEDPRICESYM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PLANNEDPRICESYM}]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="16" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="27" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="642" y="4" width="95" height="19" uuid="062e238c-9025-49d6-8eea-5b537d56af05"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="741" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="3ade1b49-5c04-4c2d-956c-3708ac804aa9"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Bottom" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="1" width="777" height="1" forecolor="#000000" uuid="b64ce567-b041-4414-a1db-92be4e1cc1ce"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="277" y="4" width="69" height="19" uuid="d84f7e2b-b75d-4092-b417-779654957c90"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Bottom">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" x="195" y="4" width="78" height="19" uuid="e5478837-bad0-4672-8f88-7f5fbea3e18a"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="16" splitType="Stretch"/>
+	<pageFooter height="27" splitType="Stretch">
+		<element kind="textField" uuid="062e238c-9025-49d6-8eea-5b537d56af05" key="textField" x="642" y="4" width="95" height="19" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Bottom">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="3ade1b49-5c04-4c2d-956c-3708ac804aa9" key="textField" x="741" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Bottom">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="b64ce567-b041-4414-a1db-92be4e1cc1ce" key="line" x="0" y="1" width="777" height="1" forecolor="#000000">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="d84f7e2b-b75d-4092-b417-779654957c90" key="textField" x="277" y="4" width="69" height="19" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Bottom">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="e5478837-bad0-4672-8f88-7f5fbea3e18a" key="staticText-1" x="195" y="4" width="78" height="19" hTextAlign="Right" vTextAlign="Bottom">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band height="20" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-4" style="default" x="0" y="0" width="75" height="16" uuid="63eb2177-feff-4787-9073-fe993324ddb9"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<text><![CDATA[Projects Total:]]></text>
-			</staticText>
-			<textField isStretchWithOverflow="true" evaluationTime="Report" isBlankWhenNull="true">
-				<reportElement key="textField-7" style="Total_Gray" stretchType="RelativeToBandHeight" x="82" y="0" width="67" height="16" uuid="17808250-a674-4a3b-b8f5-f3f74814415e"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{totalProjects}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-8" style="Total_Gray" stretchType="RelativeToBandHeight" x="149" y="0" width="119" height="16" uuid="d1247df3-4e15-4946-ac16-eda4aa9a3ce5"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{totalQty}!=null)?$P{NUMBERFORMAT}.format($V{totalQty}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-9" style="Total_Gray" stretchType="RelativeToBandHeight" x="268" y="0" width="485" height="16" uuid="592c0a78-c02f-4f5e-b87e-a7c6965d3486"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{totalAmount}!=null)?$P{NUMBERFORMAT}.format($V{totalAmount}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-20" style="Total_Gray" stretchType="RelativeToBandHeight" x="753" y="0" width="23" height="16" uuid="3e44bcac-c46d-418b-bb81-fbe6ddc863a1"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
-		</band>
+	<summary height="20" splitType="Stretch">
+		<element kind="staticText" uuid="63eb2177-feff-4787-9073-fe993324ddb9" key="staticText-4" x="0" y="0" width="75" height="16" fontName="Bitstream Vera Sans" hTextAlign="Right" style="default">
+			<text><![CDATA[Projects Total:]]></text>
+			<box style="default">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="17808250-a674-4a3b-b8f5-f3f74814415e" key="textField-7" stretchType="ContainerHeight" x="82" y="0" width="67" height="16" fontName="Bitstream Vera Sans" textAdjust="StretchHeight" evaluationTime="Report" blankWhenNull="true" hTextAlign="Center" vTextAlign="Middle" style="Total_Gray">
+			<expression><![CDATA[$V{totalProjects}]]></expression>
+			<box style="Total_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="d1247df3-4e15-4946-ac16-eda4aa9a3ce5" key="textField-8" stretchType="ContainerHeight" x="149" y="0" width="119" height="16" fontName="Bitstream Vera Sans" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Gray">
+			<expression><![CDATA[($V{totalQty}!=null)?$P{NUMBERFORMAT}.format($V{totalQty}):new String(" ")]]></expression>
+			<box style="Total_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="592c0a78-c02f-4f5e-b87e-a7c6965d3486" key="textField-9" stretchType="ContainerHeight" x="268" y="0" width="485" height="16" fontName="Bitstream Vera Sans" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Gray">
+			<expression><![CDATA[($V{totalAmount}!=null)?$P{NUMBERFORMAT}.format($V{totalAmount}):new String(" ")]]></expression>
+			<box style="Total_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="3e44bcac-c46d-418b-bb81-fbe6ddc863a1" key="textField-20" stretchType="ContainerHeight" x="753" y="0" width="23" height="16" fontName="Bitstream Vera Sans" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Total_Gray">
+			<expression><![CDATA[$F{CONVSYM}]]></expression>
+			<box style="Total_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</summary>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportProjectProfitabilityJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportProjectProfitabilityJR.jrxml
@@ -1,58 +1,56 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportProjectProfitabilityJR" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="f900737c-ab48-488b-88a7-ef101d1a9b29">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportProjectProfitabilityJR" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="f900737c-ab48-488b-88a7-ef101d1a9b29">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["('1000000')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["('0','1000000')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT P.NAME AS PROJECTNAME, P.DATECONTRACT AS INITDATE, BPRESP.NAME AS RESPONSIBLE,
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT P.NAME AS PROJECTNAME, P.DATECONTRACT AS INITDATE, BPRESP.NAME AS RESPONSIBLE,
           P.AD_ORG_ID AS ORG, BPCLIENT.NAME AS PARTNER, ORG.NAME AS ORGNAME,PT.NAME AS PROJECTTYPE,
           C_CURRENCY_ISOSYM('102') AS CONVISOSYM, 
           C_CURRENCY_CONVERT(COALESCE(P.SERVREVENUE,0), P.C_CURRENCY_ID, '102', TO_DATE(COALESCE(P.DATECONTRACT, P.DATEFINISH, NOW())), NULL, P.AD_CLIENT_ID, P.AD_ORG_ID) AS PLANREVENUE, 
@@ -161,8 +159,7 @@
           AND p.AD_Org_ID IN ('1')
           AND p.AD_Client_ID IN ('1')
           AND 6=6
-        ORDER BY orgname, partner, initdate]]>
-	</queryString>
+        ORDER BY orgname, partner, initdate]]></query>
 	<field name="ORGNAME" class="java.lang.String"/>
 	<field name="PARTNER" class="java.lang.String"/>
 	<field name="PROJECTTYPE" class="java.lang.String"/>
@@ -184,1426 +181,1017 @@
 	<field name="REALOUTSOURCED" class="java.math.BigDecimal"/>
 	<field name="PLANSERVICES" class="java.math.BigDecimal"/>
 	<field name="REALSERVICES" class="java.math.BigDecimal"/>
-	<variable name="PlanSerNetMargin" class="java.math.BigDecimal" resetType="Group" resetGroup="PARTNER">
-		<variableExpression><![CDATA[$F{PLANREVENUE}.subtract( $F{PLANCOST})]]></variableExpression>
+	<variable name="PlanSerNetMargin" resetType="Group" resetGroup="PARTNER" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{PLANREVENUE}.subtract( $F{PLANCOST})]]></expression>
 	</variable>
 	<variable name="PlanSerNetReinvoincing" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$F{PLANREINVOICING}.subtract($F{PLANEXPENSES})]]></variableExpression>
+		<expression><![CDATA[$F{PLANREINVOICING}.subtract($F{PLANEXPENSES})]]></expression>
 	</variable>
 	<variable name="PlanGrossMarginNet" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{PlanSerNetMargin}.add( $V{PlanSerNetReinvoincing} )]]></variableExpression>
+		<expression><![CDATA[$V{PlanSerNetMargin}.add( $V{PlanSerNetReinvoincing} )]]></expression>
 	</variable>
-	<variable name="PlanTotalRevenue" class="java.math.BigDecimal" resetType="Group" resetGroup="PARTNER">
-		<variableExpression><![CDATA[$F{PLANREVENUE}.add( $F{PLANREINVOICING} )]]></variableExpression>
+	<variable name="PlanTotalRevenue" resetType="Group" resetGroup="PARTNER" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{PLANREVENUE}.add( $F{PLANREINVOICING} )]]></expression>
 	</variable>
-	<variable name="TotalPlanRevenue" class="java.math.BigDecimal" resetType="None">
-		<variableExpression><![CDATA[($V{TotalPlanRevenue}.intValue()==0) ? new BigDecimal(0.0):$V{PlanGrossMarginNet}.divide( $V{PlanTotalRevenue} )]]></variableExpression>
+	<variable name="TotalPlanRevenue" resetType="None" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{TotalPlanRevenue}.intValue()==0) ? new BigDecimal(0.0):$V{PlanGrossMarginNet}.divide( $V{PlanTotalRevenue} )]]></expression>
 	</variable>
 	<variable name="RealSerNetMargin" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$F{REALREVENUE}.subtract( $F{REALCOST})]]></variableExpression>
+		<expression><![CDATA[$F{REALREVENUE}.subtract( $F{REALCOST})]]></expression>
 	</variable>
 	<variable name="RealSerNetReinvoincing" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$F{REALREINVOICED}.subtract($F{REALEXPENSES})]]></variableExpression>
+		<expression><![CDATA[$F{REALREINVOICED}.subtract($F{REALEXPENSES})]]></expression>
 	</variable>
 	<variable name="RealGrossMarginNet" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{RealSerNetMargin}.add( $V{RealSerNetReinvoincing} )]]></variableExpression>
+		<expression><![CDATA[$V{RealSerNetMargin}.add( $V{RealSerNetReinvoincing} )]]></expression>
 	</variable>
 	<variable name="RealTotalRevenue" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$F{REALREVENUE}.add( $F{REALREINVOICED} )]]></variableExpression>
+		<expression><![CDATA[$F{REALREVENUE}.add( $F{REALREINVOICED} )]]></expression>
 	</variable>
-	<variable name="PLANREVENUETOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{PLANREVENUE}]]></variableExpression>
+	<variable name="PLANREVENUETOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{PLANREVENUE}]]></expression>
 	</variable>
-	<variable name="PLANCOSTTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{PLANCOST}]]></variableExpression>
+	<variable name="PLANCOSTTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{PLANCOST}]]></expression>
 	</variable>
-	<variable name="PLANSERNETMARGINTOTAL" class="java.math.BigDecimal" resetType="Group" resetGroup="PARTNER">
-		<variableExpression><![CDATA[$V{PLANREVENUETOTAL}.subtract( $V{PLANCOSTTOTAL})]]></variableExpression>
+	<variable name="PLANSERNETMARGINTOTAL" resetType="Group" resetGroup="PARTNER" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{PLANREVENUETOTAL}.subtract( $V{PLANCOSTTOTAL})]]></expression>
 	</variable>
-	<variable name="PLANREINVOINCINGTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{PLANREINVOICING}]]></variableExpression>
+	<variable name="PLANREINVOINCINGTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{PLANREINVOICING}]]></expression>
 	</variable>
-	<variable name="PLANEXPENSESTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{PLANEXPENSES}]]></variableExpression>
+	<variable name="PLANEXPENSESTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{PLANEXPENSES}]]></expression>
 	</variable>
 	<variable name="PLANSERNETREINVOINCINGTOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{PLANREINVOINCINGTOTAL}.subtract($V{PLANEXPENSESTOTAL})]]></variableExpression>
+		<expression><![CDATA[$V{PLANREINVOINCINGTOTAL}.subtract($V{PLANEXPENSESTOTAL})]]></expression>
 	</variable>
-	<variable name="PLANCROSSMARGINNETTOAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$V{PlanGrossMarginNet}]]></variableExpression>
+	<variable name="PLANCROSSMARGINNETTOAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{PlanGrossMarginNet}]]></expression>
 	</variable>
-	<variable name="PLANTOTALREVENUETOTAL" class="java.math.BigDecimal" resetType="None">
-		<variableExpression><![CDATA[$V{PLANREVENUETOTAL}.add( $V{PLANREINVOINCINGTOTAL} )]]></variableExpression>
+	<variable name="PLANTOTALREVENUETOTAL" resetType="None" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{PLANREVENUETOTAL}.add( $V{PLANREINVOINCINGTOTAL} )]]></expression>
 	</variable>
-	<variable name="REALREVENUETOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{REALREVENUE}]]></variableExpression>
+	<variable name="REALREVENUETOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{REALREVENUE}]]></expression>
 	</variable>
-	<variable name="REALCOSTTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{REALCOST}]]></variableExpression>
+	<variable name="REALCOSTTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{REALCOST}]]></expression>
 	</variable>
-	<variable name="REALSERNETMARGINTOTAL" class="java.math.BigDecimal" resetType="Group" resetGroup="PARTNER">
-		<variableExpression><![CDATA[$V{REALREVENUETOTAL}.subtract( $V{REALCOSTTOTAL})]]></variableExpression>
+	<variable name="REALSERNETMARGINTOTAL" resetType="Group" resetGroup="PARTNER" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{REALREVENUETOTAL}.subtract( $V{REALCOSTTOTAL})]]></expression>
 	</variable>
-	<variable name="REALREINVOINCINGTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{REALREINVOICED}]]></variableExpression>
+	<variable name="REALREINVOINCINGTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{REALREINVOICED}]]></expression>
 	</variable>
-	<variable name="REALEXPENSESTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{REALEXPENSES}]]></variableExpression>
+	<variable name="REALEXPENSESTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{REALEXPENSES}]]></expression>
 	</variable>
 	<variable name="REALSERNETREINVOINCINGTOTAL" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{REALREINVOINCINGTOTAL}.subtract($V{REALEXPENSESTOTAL})]]></variableExpression>
+		<expression><![CDATA[$V{REALREINVOINCINGTOTAL}.subtract($V{REALEXPENSESTOTAL})]]></expression>
 	</variable>
-	<variable name="REALGROSSMARGINNETTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$V{RealGrossMarginNet}]]></variableExpression>
+	<variable name="REALGROSSMARGINNETTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{RealGrossMarginNet}]]></expression>
 	</variable>
-	<variable name="REALTOTALREVENUETOTAL" class="java.math.BigDecimal" resetType="None">
-		<variableExpression><![CDATA[$V{REALREVENUETOTAL}.add( $V{REALREINVOINCINGTOTAL} )]]></variableExpression>
+	<variable name="REALTOTALREVENUETOTAL" resetType="None" class="java.math.BigDecimal">
+		<expression><![CDATA[$V{REALREVENUETOTAL}.add( $V{REALREINVOINCINGTOTAL} )]]></expression>
 	</variable>
-	<variable name="COLLECTEDTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{COLLECTED}]]></variableExpression>
+	<variable name="COLLECTEDTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{COLLECTED}]]></expression>
 	</variable>
-	<variable name="REALSERVICESTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{REALSERVICES}]]></variableExpression>
+	<variable name="REALSERVICESTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{REALSERVICES}]]></expression>
 	</variable>
-	<variable name="REALOUTSOURCEDTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{REALOUTSOURCED}]]></variableExpression>
+	<variable name="REALOUTSOURCEDTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{REALOUTSOURCED}]]></expression>
 	</variable>
-	<variable name="PLANSERVICESTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{PLANSERVICES}]]></variableExpression>
+	<variable name="PLANSERVICESTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{PLANSERVICES}]]></expression>
 	</variable>
-	<variable name="PLANOUTSOURCEDTOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{PLANOUTSOURCED}]]></variableExpression>
+	<variable name="PLANOUTSOURCEDTOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{PLANOUTSOURCED}]]></expression>
 	</variable>
-	<group name="ORG" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[$F{ORG}]]></groupExpression>
+	<group name="ORG" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[$F{ORG}]]></expression>
 		<groupHeader>
 			<band height="30" splitType="Stretch">
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="109" y="0" width="426" height="24" uuid="ac584319-67c8-4560-8bf4-46965bddc9b1"/>
-					<box leftPadding="5">
+				<element kind="textField" uuid="ac584319-67c8-4560-8bf4-46965bddc9b1" key="textField" x="109" y="0" width="426" height="24" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{ORGNAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{ORGNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="24" width="1" height="6" forecolor="#555555" uuid="7e798238-3b81-4a51-8c79-1b2f9e9632e9"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="30" forecolor="#555555" uuid="39181401-c91c-4e6d-82a5-b2d612ee1f0f"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-54" style="GroupHeader_DarkGray" x="0" y="0" width="109" height="24" uuid="e3bcc6d2-02b4-4f91-9532-d77a1ebd22e4"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" size="14"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="7e798238-3b81-4a51-8c79-1b2f9e9632e9" key="line-2" stretchType="ContainerHeight" x="0" y="24" width="1" height="6" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="39181401-c91c-4e6d-82a5-b2d612ee1f0f" key="line-3" stretchType="ContainerHeight" x="535" y="0" width="1" height="30" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="e3bcc6d2-02b4-4f91-9532-d77a1ebd22e4" key="staticText-54" x="0" y="0" width="109" height="24" fontName="Bitstream Vera Sans" fontSize="14.0" style="GroupHeader_DarkGray">
 					<text><![CDATA[Organization]]></text>
-				</staticText>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="17" splitType="Stretch">
-				<line>
-					<reportElement key="line-32" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="10" forecolor="#555555" uuid="be73528c-4e3c-42ca-9484-136ff5c8f87d"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="11" forecolor="#555555" uuid="bc155fb7-f53c-4fbf-b8c3-5f8c02d74608"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-34" x="0" y="10" width="535" height="1" forecolor="#555555" uuid="9eea6e7e-bec0-4c79-b5f7-ac6217d037ad"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="be73528c-4e3c-42ca-9484-136ff5c8f87d" key="line-32" stretchType="ContainerHeight" x="0" y="0" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="bc155fb7-f53c-4fbf-b8c3-5f8c02d74608" key="line-33" stretchType="ContainerHeight" x="535" y="0" width="1" height="11" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="9eea6e7e-bec0-4c79-b5f7-ac6217d037ad" key="line-34" x="0" y="10" width="535" height="1" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<group name="PARTNER" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[$F{PARTNER}]]></groupExpression>
+	<group name="PARTNER" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[$F{PARTNER}]]></expression>
 		<groupHeader>
 			<band height="25" splitType="Stretch">
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="140" y="0" width="394" height="22" uuid="ca2ecb65-f725-42c7-9ea1-466fe2d22de6"/>
-					<box leftPadding="5">
+				<element kind="textField" uuid="ca2ecb65-f725-42c7-9ea1-466fe2d22de6" key="textField" x="140" y="0" width="394" height="22" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{PARTNER}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{PARTNER}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-4" stretchType="RelativeToBandHeight" x="10" y="22" width="1" height="3" forecolor="#555555" uuid="6c2109b0-8674-46e9-b0a7-0f7ed6700e62"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-6" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="25" forecolor="#555555" uuid="26dd7bd9-b5a7-43f7-954f-6ad6ef06c552"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-8" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="25" forecolor="#555555" uuid="24157758-f99a-4515-aacc-d5d124003963"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-55" style="GroupHeader_DarkGray" x="10" y="0" width="130" height="22" uuid="9f6e81ad-15d7-451c-a390-ccfb88825e6a"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" size="14"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="6c2109b0-8674-46e9-b0a7-0f7ed6700e62" key="line-4" stretchType="ContainerHeight" x="10" y="22" width="1" height="3" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="26dd7bd9-b5a7-43f7-954f-6ad6ef06c552" key="line-6" stretchType="ContainerHeight" x="535" y="0" width="1" height="25" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="24157758-f99a-4515-aacc-d5d124003963" key="line-8" stretchType="ContainerHeight" x="0" y="0" width="1" height="25" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="9f6e81ad-15d7-451c-a390-ccfb88825e6a" key="staticText-55" x="10" y="0" width="130" height="22" fontName="Bitstream Vera Sans" fontSize="14.0" style="GroupHeader_DarkGray">
 					<text><![CDATA[Business Partner]]></text>
-				</staticText>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-28" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="20" forecolor="#555555" uuid="233ffb4f-97d7-41a2-89ad-a1e043b0017e"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-29" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="10" forecolor="#555555" uuid="e69a4b27-467a-43b3-a95e-eb596f3f9d2a"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-30" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="20" forecolor="#555555" uuid="f358f9da-c0ef-4b59-89da-bb5ca1fc7d39"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-31" x="10" y="10" width="525" height="1" forecolor="#555555" uuid="9c071070-0f50-4bb5-9872-02ffd048147f"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="233ffb4f-97d7-41a2-89ad-a1e043b0017e" key="line-28" stretchType="ContainerHeight" x="0" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="e69a4b27-467a-43b3-a95e-eb596f3f9d2a" key="line-29" stretchType="ContainerHeight" x="10" y="0" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="f358f9da-c0ef-4b59-89da-bb5ca1fc7d39" key="line-30" stretchType="ContainerHeight" x="535" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="9c071070-0f50-4bb5-9872-02ffd048147f" key="line-31" x="10" y="10" width="525" height="1" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="19" splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="30" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Title" mode="Transparent" x="0" y="0" width="535" height="26" uuid="dd75cfc7-705c-4fa9-a21b-009cf041eea2"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="27" width="535" height="1" uuid="06d7f6f2-8ad1-4f15-8a1b-ca504a8738ef"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="19" splitType="Stretch"/>
+	<pageHeader height="30" splitType="Stretch">
+		<element kind="textField" uuid="dd75cfc7-705c-4fa9-a21b-009cf041eea2" key="textField" mode="Transparent" x="0" y="0" width="535" height="26" fontName="Bitstream Vera Sans" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="06d7f6f2-8ad1-4f15-8a1b-ca504a8738ef" key="line-1" x="0" y="27" width="535" height="1">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band height="25" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-56" x="5" y="5" width="123" height="16" isPrintWhenDetailOverflows="true" uuid="20eb0449-4a91-41d4-8f9d-83e785ea8879"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Currency of the report:]]></text>
-			</staticText>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-39" x="135" y="5" width="75" height="16" isPrintWhenDetailOverflows="true" uuid="d7f4016d-eeea-489b-9f24-8de4789cce94"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVISOSYM}!=null)?$F{CONVISOSYM}:new String(" ")]]></textFieldExpression>
-			</textField>
-		</band>
+	<columnHeader height="25" splitType="Stretch">
+		<element kind="staticText" uuid="20eb0449-4a91-41d4-8f9d-83e785ea8879" key="staticText-56" x="5" y="5" width="123" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" printWhenDetailOverflows="true" bold="true" hTextAlign="Left" vTextAlign="Middle">
+			<text><![CDATA[Currency of the report:]]></text>
+			<box leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="d7f4016d-eeea-489b-9f24-8de4789cce94" key="textField-39" x="135" y="5" width="75" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="false" printWhenDetailOverflows="true" hTextAlign="Left" vTextAlign="Middle">
+			<expression><![CDATA[($F{CONVISOSYM}!=null)?$F{CONVISOSYM}:new String(" ")]]></expression>
+			<box leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
 	</columnHeader>
 	<detail>
 		<band height="131" splitType="Stretch">
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="131" forecolor="#555555" uuid="e97bebe9-89b0-4391-bd3f-ab91bd4eb18b"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="131" forecolor="#555555" uuid="c776623d-2234-40f2-9e36-9811356cc4f5"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-18" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="131" forecolor="#555555" uuid="8e4b5ac8-d9cc-425c-b329-fb8aee491e10"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="108" y="6" width="153" height="16" isPrintWhenDetailOverflows="true" uuid="a9fbe738-d61d-4c48-af74-033b2bb21b66"/>
+			<element kind="line" uuid="e97bebe9-89b0-4391-bd3f-ab91bd4eb18b" key="line-16" stretchType="ContainerHeight" x="535" y="0" width="1" height="131" forecolor="#555555">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="c776623d-2234-40f2-9e36-9811356cc4f5" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="131" forecolor="#555555">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="8e4b5ac8-d9cc-425c-b329-fb8aee491e10" key="line-18" stretchType="ContainerHeight" x="10" y="0" width="1" height="131" forecolor="#555555">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="a9fbe738-d61d-4c48-af74-033b2bb21b66" key="textField" x="108" y="6" width="153" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="false" printWhenDetailOverflows="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[($F{PROJECTNAME}!=null)?$F{PROJECTNAME}:new String(" ")]]></expression>
 				<box leftPadding="5">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PROJECTNAME}!=null)?$F{PROJECTNAME}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" x="109" y="26" width="151" height="16" isPrintWhenDetailOverflows="true" uuid="c6385665-1fd2-4e79-9abf-8b392c5e52b3"/>
+			</element>
+			<element kind="textField" uuid="c6385665-1fd2-4e79-9abf-8b392c5e52b3" key="textField" x="109" y="26" width="151" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="false" printWhenDetailOverflows="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{PROJECTTYPE}==null?"":$F{PROJECTTYPE}]]></expression>
 				<box leftPadding="5">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PROJECTTYPE}==null?"":$F{PROJECTTYPE}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-6" x="13" y="26" width="95" height="16" isPrintWhenDetailOverflows="true" uuid="ec8f1d48-8264-4452-a579-f81e963d785f"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
+			</element>
+			<element kind="staticText" uuid="ec8f1d48-8264-4452-a579-f81e963d785f" key="staticText-6" x="13" y="26" width="95" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" printWhenDetailOverflows="true" bold="true" hTextAlign="Left" vTextAlign="Middle">
 				<text><![CDATA[Project Type:]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-7" x="262" y="26" width="107" height="16" isPrintWhenDetailOverflows="true" uuid="ef56c57a-8fb3-42fd-9a62-c3d09f2ae40c"/>
 				<box leftPadding="5">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
+			</element>
+			<element kind="staticText" uuid="ef56c57a-8fb3-42fd-9a62-c3d09f2ae40c" key="staticText-7" x="262" y="26" width="107" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" printWhenDetailOverflows="true" bold="true" hTextAlign="Right" vTextAlign="Middle">
 				<text><![CDATA[Planned End Date:]]></text>
-			</staticText>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" x="373" y="26" width="88" height="16" isPrintWhenDetailOverflows="true" uuid="e07fc5d2-e0bf-495b-826d-ee611cf439e9"/>
 				<box leftPadding="5">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{INITDATE}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-8" x="263" y="6" width="106" height="16" isPrintWhenDetailOverflows="true" uuid="be143462-b351-4a93-b5fb-fddf42f9d094"/>
+			</element>
+			<element kind="textField" uuid="e07fc5d2-e0bf-495b-826d-ee611cf439e9" key="textField" x="373" y="26" width="88" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" printWhenDetailOverflows="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{INITDATE}]]></expression>
 				<box leftPadding="5">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
+			</element>
+			<element kind="staticText" uuid="be143462-b351-4a93-b5fb-fddf42f9d094" key="staticText-8" x="263" y="6" width="106" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" printWhenDetailOverflows="true" bold="true" hTextAlign="Right" vTextAlign="Middle">
 				<text><![CDATA[Person in Charge:]]></text>
-			</staticText>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" x="372" y="6" width="149" height="16" isPrintWhenDetailOverflows="true" uuid="ee1cab9f-873d-4df3-a200-190cd7c785d7"/>
 				<box leftPadding="5">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{RESPONSIBLE}==null?"":$F{RESPONSIBLE}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-10" style="Detail_Header" x="66" y="46" width="200" height="16" uuid="2f2a1799-3c0c-458b-bd29-c4f7c112afed"/>
+			</element>
+			<element kind="textField" uuid="ee1cab9f-873d-4df3-a200-190cd7c785d7" key="textField" x="372" y="6" width="149" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="false" printWhenDetailOverflows="true" hTextAlign="Left" vTextAlign="Middle">
+				<expression><![CDATA[$F{RESPONSIBLE}==null?"":$F{RESPONSIBLE}]]></expression>
 				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#FFFFFF"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center">
-					<font fontName="Bitstream Vera Sans" size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
+			</element>
+			<element kind="staticText" uuid="2f2a1799-3c0c-458b-bd29-c4f7c112afed" key="staticText-10" x="66" y="46" width="200" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Center" style="Detail_Header">
 				<text><![CDATA[Services]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-11" style="Detail_Header" x="274" y="46" width="157" height="16" uuid="2c3413e5-49d6-4173-a1e0-67e5b33b4e04"/>
-				<box leftPadding="5">
+				<box leftPadding="5" style="Detail_Header">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					<bottomPen lineWidth="0.0" lineColor="#FFFFFF"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<textElement textAlignment="Center">
-					<font fontName="Bitstream Vera Sans" size="8" isBold="true"/>
-				</textElement>
+			</element>
+			<element kind="staticText" uuid="2c3413e5-49d6-4173-a1e0-67e5b33b4e04" key="staticText-11" x="274" y="46" width="157" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" bold="true" hTextAlign="Center" style="Detail_Header">
 				<text><![CDATA[Expenses]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-12" style="Detail_Header" x="14" y="79" width="52" height="16" uuid="7b2813e3-f9c8-4aee-9712-c3993bef186b"/>
-				<box leftPadding="5">
+				<box leftPadding="5" style="Detail_Header">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#FFFFFF"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<textElement>
-					<font fontName="Bitstream Vera Sans" size="7" isBold="true"/>
-				</textElement>
+			</element>
+			<element kind="staticText" uuid="7b2813e3-f9c8-4aee-9712-c3993bef186b" key="staticText-12" x="14" y="79" width="52" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" bold="true" style="Detail_Header">
 				<text><![CDATA[Planned]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-13" style="Detail_Header" x="14" y="95" width="52" height="16" uuid="110da421-0f2d-43a3-8c72-3e5706034dd5"/>
-				<box leftPadding="5">
+				<box leftPadding="5" style="Detail_Header">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<textElement>
-					<font fontName="Bitstream Vera Sans" size="7" isBold="true"/>
-				</textElement>
+			</element>
+			<element kind="staticText" uuid="110da421-0f2d-43a3-8c72-3e5706034dd5" key="staticText-13" x="14" y="95" width="52" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" bold="true" style="Detail_Header">
 				<text><![CDATA[Real]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-14" style="Detail_Header" x="14" y="111" width="52" height="16" uuid="5cae877a-3b16-4ee7-8a96-5d61e19c326a"/>
-				<box leftPadding="5">
+				<box leftPadding="5" style="Detail_Header">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="7" isBold="true"/>
-				</textElement>
+			</element>
+			<element kind="staticText" uuid="5cae877a-3b16-4ee7-8a96-5d61e19c326a" key="staticText-14" x="14" y="111" width="52" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 				<text><![CDATA[Collected]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-15" style="Detail_Header" x="66" y="62" width="50" height="16" uuid="d0fd2089-1058-4a8c-bee1-4146a75a6819"/>
-				<box leftPadding="5">
+				<box leftPadding="5" style="Detail_Header">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="7" isBold="true"/>
-				</textElement>
+			</element>
+			<element kind="staticText" uuid="d0fd2089-1058-4a8c-bee1-4146a75a6819" key="staticText-15" x="66" y="62" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" bold="true" hTextAlign="Right" style="Detail_Header">
 				<text><![CDATA[Revenue]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-16" style="Detail_Header" x="116" y="62" width="50" height="16" uuid="b4ed4c8f-c013-4d16-8201-3e3ad3666132"/>
-				<box leftPadding="5">
+				<box leftPadding="5" style="Detail_Header">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="7" isBold="true"/>
-				</textElement>
+			</element>
+			<element kind="staticText" uuid="b4ed4c8f-c013-4d16-8201-3e3ad3666132" key="staticText-16" x="116" y="62" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" bold="true" hTextAlign="Right" style="Detail_Header">
 				<text><![CDATA[Cost]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-17" style="Detail_Header" x="216" y="62" width="50" height="16" uuid="68ae5577-35ed-4eb0-b603-c061764df9de"/>
-				<box leftPadding="5">
+				<box leftPadding="5" style="Detail_Header">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="7" isBold="true"/>
-				</textElement>
+			</element>
+			<element kind="staticText" uuid="68ae5577-35ed-4eb0-b603-c061764df9de" key="staticText-17" x="216" y="62" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 				<text><![CDATA[Margin %]]></text>
-			</staticText>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="66" y="79" width="50" height="16" uuid="ac1a225b-ac47-47aa-80e6-90c4cd07bce5"/>
+				<box leftPadding="5" style="Detail_Header">
+					<pen lineWidth="0.0"/>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="ac1a225b-ac47-47aa-80e6-90c4cd07bce5" key="textField" x="66" y="79" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[($F{PLANREVENUE}!=null)?$P{NUMBERFORMAT}.format($F{PLANREVENUE}):new String(" ")]]></expression>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PLANREVENUE}!=null)?$P{NUMBERFORMAT}.format($F{PLANREVENUE}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="116" y="79" width="50" height="16" uuid="61c821cb-7c76-4714-9420-48aeedb66478"/>
+			</element>
+			<element kind="textField" uuid="61c821cb-7c76-4714-9420-48aeedb66478" key="textField" x="116" y="79" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[($F{PLANSERVICES}!=null)?$P{NUMBERFORMAT}.format($F{PLANSERVICES}):new String(" ")]]></expression>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PLANSERVICES}!=null)?$P{NUMBERFORMAT}.format($F{PLANSERVICES}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" mode="Transparent" x="216" y="79" width="50" height="16" uuid="016a2a5b-b3d3-4107-96dc-58f26c1e675a"/>
-				<box rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PLANREVENUE}.intValue()==0)?
+			</element>
+			<element kind="textField" uuid="016a2a5b-b3d3-4107-96dc-58f26c1e675a" key="textField" mode="Transparent" x="216" y="79" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[($F{PLANREVENUE}.intValue()==0)?
 	$P{NUMBERFORMAT}.format(new BigDecimal(0.0)):
-	$P{NUMBERFORMAT}.format(($V{PlanSerNetMargin}.divide($F{PLANREVENUE},200,$V{PlanSerNetMargin}.ROUND_HALF_UP)).multiply(new BigDecimal(100.0)))]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="274" y="79" width="58" height="16" uuid="637e87d6-2275-4e4e-a617-26156a15b41d"/>
+	$P{NUMBERFORMAT}.format(($V{PlanSerNetMargin}.divide($F{PLANREVENUE},200,$V{PlanSerNetMargin}.ROUND_HALF_UP)).multiply(new BigDecimal(100.0)))]]></expression>
+				<box rightPadding="2">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="637e87d6-2275-4e4e-a617-26156a15b41d" key="textField" x="274" y="79" width="58" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[($F{PLANREINVOICING}!=null)?$P{NUMBERFORMAT}.format($F{PLANREINVOICING}):new String(" ")]]></expression>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PLANREINVOICING}!=null)?$P{NUMBERFORMAT}.format($F{PLANREINVOICING}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="333" y="79" width="49" height="16" uuid="0da7275d-41be-48b0-8001-98c2c9e4d701"/>
+			</element>
+			<element kind="textField" uuid="0da7275d-41be-48b0-8001-98c2c9e4d701" key="textField" x="333" y="79" width="49" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[($F{PLANEXPENSES}!=null)?$P{NUMBERFORMAT}.format($F{PLANEXPENSES}):new String(" ")]]></expression>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PLANEXPENSES}!=null)?$P{NUMBERFORMAT}.format($F{PLANEXPENSES}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-1" x="382" y="79" width="49" height="16" uuid="d3a68a7a-0c54-4173-9227-dfa69d6bd0a1"/>
+			</element>
+			<element kind="textField" uuid="d3a68a7a-0c54-4173-9227-dfa69d6bd0a1" key="textField-1" x="382" y="79" width="49" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[($F{PLANREINVOICING}.intValue()==0)?$P{NUMBERFORMAT}.format(new BigDecimal(0.0)):$P{NUMBERFORMAT}.format(($V{PlanSerNetReinvoincing}.divide($F{PLANREINVOICING},200,$V{PlanSerNetReinvoincing}.ROUND_HALF_UP)).multiply(new BigDecimal(100.0)))]]></expression>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PLANREINVOICING}.intValue()==0)?$P{NUMBERFORMAT}.format(new BigDecimal(0.0)):$P{NUMBERFORMAT}.format(($V{PlanSerNetReinvoincing}.divide($F{PLANREINVOICING},200,$V{PlanSerNetReinvoincing}.ROUND_HALF_UP)).multiply(new BigDecimal(100.0)))]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-18" style="Detail_Header" x="274" y="62" width="59" height="16" uuid="7a05a3e1-31c5-4f52-a617-d2c1592628cd"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="7" isBold="true"/>
-				</textElement>
+			</element>
+			<element kind="staticText" uuid="7a05a3e1-31c5-4f52-a617-d2c1592628cd" key="staticText-18" x="274" y="62" width="59" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" bold="true" hTextAlign="Right" style="Detail_Header">
 				<text><![CDATA[Reinvoicing]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-19" style="Detail_Header" x="383" y="62" width="48" height="16" uuid="f0cf3ba6-05bf-4da8-8053-e07c7d4b6b26"/>
-				<box leftPadding="5">
+				<box leftPadding="5" style="Detail_Header">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="7" isBold="true"/>
-				</textElement>
+			</element>
+			<element kind="staticText" uuid="f0cf3ba6-05bf-4da8-8053-e07c7d4b6b26" key="staticText-19" x="383" y="62" width="48" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" bold="true" hTextAlign="Right" style="Detail_Header">
 				<text><![CDATA[Margin %]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-20" style="Detail_Header" x="333" y="62" width="49" height="16" uuid="fead1356-d51a-47eb-b8f5-db233c73c884"/>
-				<box leftPadding="5">
+				<box leftPadding="5" style="Detail_Header">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="7" isBold="true"/>
-				</textElement>
+			</element>
+			<element kind="staticText" uuid="fead1356-d51a-47eb-b8f5-db233c73c884" key="staticText-20" x="333" y="62" width="49" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" bold="true" hTextAlign="Right" style="Detail_Header">
 				<text><![CDATA[Expenses]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-21" style="Detail_Header" x="441" y="62" width="83" height="16" uuid="c22f5e2b-044e-4d74-8c63-43daa936a10f"/>
-				<box leftPadding="5">
+				<box leftPadding="5" style="Detail_Header">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<textElement textAlignment="Center">
-					<font fontName="Bitstream Vera Sans" size="7" isBold="true"/>
-				</textElement>
+			</element>
+			<element kind="staticText" uuid="c22f5e2b-044e-4d74-8c63-43daa936a10f" key="staticText-21" x="441" y="62" width="83" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" bold="true" hTextAlign="Center" style="Detail_Header">
 				<text><![CDATA[Gross margin]]></text>
-			</staticText>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-2" x="441" y="79" width="42" height="16" uuid="f0993fe2-8611-47ef-9a04-7a4b2130d708"/>
+				<box leftPadding="5" style="Detail_Header">
+					<pen lineWidth="0.0"/>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="f0993fe2-8611-47ef-9a04-7a4b2130d708" key="textField-2" x="441" y="79" width="42" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[($V{PlanGrossMarginNet}!=null)?$P{NUMBERFORMAT}.format($V{PlanGrossMarginNet}):new String(" ")]]></expression>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{PlanGrossMarginNet}!=null)?$P{NUMBERFORMAT}.format($V{PlanGrossMarginNet}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="483" y="79" width="41" height="16" uuid="3e881923-7e20-4bb7-b78b-76b08dd42391"/>
-				<box rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{PlanTotalRevenue}.intValue()==0?
+			</element>
+			<element kind="textField" uuid="3e881923-7e20-4bb7-b78b-76b08dd42391" key="textField" x="483" y="79" width="41" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[$V{PlanTotalRevenue}.intValue()==0?
 	$P{NUMBERFORMAT}.format(new BigDecimal("0.00")):
-	$P{NUMBERFORMAT}.format($V{PlanGrossMarginNet}.divide($V{PlanTotalRevenue},200,$V{PlanTotalRevenue}.ROUND_HALF_UP).multiply(new BigDecimal(100.0)))]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-3" style="Total_Field" x="66" y="95" width="50" height="16" uuid="b4487f68-4b85-4d25-9e0d-e591ac8795a7"/>
-				<box leftPadding="5">
+	$P{NUMBERFORMAT}.format($V{PlanGrossMarginNet}.divide($V{PlanTotalRevenue},200,$V{PlanTotalRevenue}.ROUND_HALF_UP).multiply(new BigDecimal(100.0)))]]></expression>
+				<box rightPadding="2">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="b4487f68-4b85-4d25-9e0d-e591ac8795a7" key="textField-3" x="66" y="95" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+				<expression><![CDATA[($F{REALREVENUE}!=null)?$P{NUMBERFORMAT}.format($F{REALREVENUE}):new String(" ")]]></expression>
+				<box leftPadding="5" style="Total_Field">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{REALREVENUE}!=null)?$P{NUMBERFORMAT}.format($F{REALREVENUE}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-4" style="Total_Field" x="116" y="95" width="50" height="16" uuid="3025f3e9-bd18-4af7-84ae-6996f150f6a9"/>
-				<box leftPadding="5">
+			</element>
+			<element kind="textField" uuid="3025f3e9-bd18-4af7-84ae-6996f150f6a9" key="textField-4" x="116" y="95" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+				<expression><![CDATA[($F{REALSERVICES}!=null)?$P{NUMBERFORMAT}.format($F{REALSERVICES}):new String(" ")]]></expression>
+				<box leftPadding="5" style="Total_Field">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{REALSERVICES}!=null)?$P{NUMBERFORMAT}.format($F{REALSERVICES}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-5" style="Total_Field" x="216" y="95" width="50" height="16" uuid="1f30cf46-9e5e-4624-a590-8f5ada6c5926"/>
-				<box leftPadding="5">
+			</element>
+			<element kind="textField" uuid="1f30cf46-9e5e-4624-a590-8f5ada6c5926" key="textField-5" x="216" y="95" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+				<expression><![CDATA[($F{REALREVENUE}.intValue()==0)?$P{NUMBERFORMAT}.format(new BigDecimal(0.0)):$P{NUMBERFORMAT}.format(($V{RealSerNetMargin}.divide($F{REALREVENUE},200,$V{RealSerNetMargin}.ROUND_HALF_UP)).multiply(new BigDecimal(100.0)))]]></expression>
+				<box leftPadding="5" style="Total_Field">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{REALREVENUE}.intValue()==0)?$P{NUMBERFORMAT}.format(new BigDecimal(0.0)):$P{NUMBERFORMAT}.format(($V{RealSerNetMargin}.divide($F{REALREVENUE},200,$V{RealSerNetMargin}.ROUND_HALF_UP)).multiply(new BigDecimal(100.0)))]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-6" style="Total_Field" x="274" y="95" width="58" height="16" uuid="d84f1bae-2e5a-4676-9cbb-6cad09560e84"/>
-				<box leftPadding="5">
+			</element>
+			<element kind="textField" uuid="d84f1bae-2e5a-4676-9cbb-6cad09560e84" key="textField-6" x="274" y="95" width="58" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+				<expression><![CDATA[($F{REALREINVOICED}!=null)?$P{NUMBERFORMAT}.format($F{REALREINVOICED}):new String(" ")]]></expression>
+				<box leftPadding="5" style="Total_Field">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{REALREINVOICED}!=null)?$P{NUMBERFORMAT}.format($F{REALREINVOICED}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-7" style="Total_Field" x="333" y="95" width="49" height="16" uuid="920e2a3c-d3d9-405c-bfbc-3c9a8b79f761"/>
-				<box leftPadding="5">
+			</element>
+			<element kind="textField" uuid="920e2a3c-d3d9-405c-bfbc-3c9a8b79f761" key="textField-7" x="333" y="95" width="49" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+				<expression><![CDATA[($F{REALEXPENSES}!=null)?$P{NUMBERFORMAT}.format($F{REALEXPENSES}):new String(" ")]]></expression>
+				<box leftPadding="5" style="Total_Field">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{REALEXPENSES}!=null)?$P{NUMBERFORMAT}.format($F{REALEXPENSES}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-8" style="Total_Field" x="382" y="95" width="49" height="16" uuid="5beb6142-c1e5-4058-b2b8-3278ed053ac0"/>
-				<box leftPadding="5">
+			</element>
+			<element kind="textField" uuid="5beb6142-c1e5-4058-b2b8-3278ed053ac0" key="textField-8" x="382" y="95" width="49" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+				<expression><![CDATA[($F{REALREINVOICED}.intValue()==0)?$P{NUMBERFORMAT}.format(new BigDecimal(0.0)):$P{NUMBERFORMAT}.format(($V{RealSerNetReinvoincing}.divide($F{REALREINVOICED},200,$V{RealSerNetReinvoincing}.ROUND_HALF_UP)).multiply(new BigDecimal(100.0)))]]></expression>
+				<box leftPadding="5" style="Total_Field">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{REALREINVOICED}.intValue()==0)?$P{NUMBERFORMAT}.format(new BigDecimal(0.0)):$P{NUMBERFORMAT}.format(($V{RealSerNetReinvoincing}.divide($F{REALREINVOICED},200,$V{RealSerNetReinvoincing}.ROUND_HALF_UP)).multiply(new BigDecimal(100.0)))]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-9" style="Total_Field" x="441" y="95" width="42" height="16" uuid="e0c2360d-a940-43f0-a622-3008a38ab693"/>
-				<box leftPadding="5">
+			</element>
+			<element kind="textField" uuid="e0c2360d-a940-43f0-a622-3008a38ab693" key="textField-9" x="441" y="95" width="42" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+				<expression><![CDATA[($V{RealGrossMarginNet}!=null)?$P{NUMBERFORMAT}.format($V{RealGrossMarginNet}):new String(" ")]]></expression>
+				<box leftPadding="5" style="Total_Field">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{RealGrossMarginNet}!=null)?$P{NUMBERFORMAT}.format($V{RealGrossMarginNet}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-10" style="Total_Field" x="483" y="95" width="41" height="16" uuid="45f769c3-8f6b-4af3-a2ac-a67973b92600"/>
-				<box leftPadding="5">
+			</element>
+			<element kind="textField" uuid="45f769c3-8f6b-4af3-a2ac-a67973b92600" key="textField-10" x="483" y="95" width="41" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+				<expression><![CDATA[($V{RealTotalRevenue}.intValue()==0)?
+$P{NUMBERFORMAT}.format(new BigDecimal("0.00")):
+$P{NUMBERFORMAT}.format($V{RealGrossMarginNet}.divide($V{RealTotalRevenue},200,$V{RealGrossMarginNet}.ROUND_HALF_UP).multiply(new BigDecimal(100.0)))]]></expression>
+				<box leftPadding="5" style="Total_Field">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{RealTotalRevenue}.intValue()==0)?
-$P{NUMBERFORMAT}.format(new BigDecimal("0.00")):
-$P{NUMBERFORMAT}.format($V{RealGrossMarginNet}.divide($V{RealTotalRevenue},200,$V{RealGrossMarginNet}.ROUND_HALF_UP).multiply(new BigDecimal(100.0)))]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-11" x="66" y="111" width="50" height="16" uuid="695db932-a173-4e19-96db-9f204490388b"/>
+			</element>
+			<element kind="textField" uuid="695db932-a173-4e19-96db-9f204490388b" key="textField-11" x="66" y="111" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[($F{COLLECTED}!=null)?$P{NUMBERFORMAT}.format($F{COLLECTED}):new String(" ")]]></expression>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{COLLECTED}!=null)?$P{NUMBERFORMAT}.format($F{COLLECTED}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-41" x="14" y="6" width="94" height="16" isPrintWhenDetailOverflows="true" uuid="9a3fd030-706e-4e78-aa9f-1d80c9339439"/>
+			</element>
+			<element kind="staticText" uuid="9a3fd030-706e-4e78-aa9f-1d80c9339439" key="staticText-41" x="14" y="6" width="94" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" printWhenDetailOverflows="true" bold="true" hTextAlign="Left" vTextAlign="Middle">
+				<text><![CDATA[Project:]]></text>
 				<box leftPadding="5">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Project:]]></text>
-			</staticText>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-40" x="166" y="79" width="50" height="16" uuid="dfadf72f-ecab-4f0f-ab31-f5b860448b0f"/>
+			</element>
+			<element kind="textField" uuid="dfadf72f-ecab-4f0f-ab31-f5b860448b0f" key="textField-40" x="166" y="79" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[($F{PLANOUTSOURCED}!=null)?$P{NUMBERFORMAT}.format($F{PLANOUTSOURCED}):new String(" ")]]></expression>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PLANOUTSOURCED}!=null)?$P{NUMBERFORMAT}.format($F{PLANOUTSOURCED}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-41" style="Total_Field" x="166" y="95" width="50" height="16" uuid="7944633e-c399-4ac6-b875-6303af526e40"/>
-				<box leftPadding="5">
+			</element>
+			<element kind="textField" uuid="7944633e-c399-4ac6-b875-6303af526e40" key="textField-41" x="166" y="95" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+				<expression><![CDATA[($F{REALOUTSOURCED}!=null)?$P{NUMBERFORMAT}.format($F{REALOUTSOURCED}):new String(" ")]]></expression>
+				<box leftPadding="5" style="Total_Field">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{REALOUTSOURCED}!=null)?$P{NUMBERFORMAT}.format($F{REALOUTSOURCED}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-57" style="Detail_Header" x="166" y="62" width="50" height="16" uuid="d7ac160c-79b1-4ee7-b517-61ec7f124270"/>
-				<box leftPadding="5">
+			</element>
+			<element kind="staticText" uuid="d7ac160c-79b1-4ee7-b517-61ec7f124270" key="staticText-57" x="166" y="62" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" bold="true" hTextAlign="Right" style="Detail_Header">
+				<text><![CDATA[Outsource]]></text>
+				<box leftPadding="5" style="Detail_Header">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="7" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Outsource]]></text>
-			</staticText>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="25" splitType="Stretch">
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-36" x="486" y="5" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="448466c2-eab7-48a5-913a-3e2a6b0db577"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-37" x="387" y="5" width="95" height="19" uuid="f803e102-c2f6-4ae1-bba2-05f9d583d968"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-38" x="264" y="5" width="69" height="19" uuid="09dac470-89b8-4e58-9955-8e4750840c09"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-40" x="183" y="5" width="78" height="19" uuid="68115d45-792d-445a-be04-35db28f97ee3"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="25" splitType="Stretch">
+		<element kind="textField" uuid="448466c2-eab7-48a5-913a-3e2a6b0db577" key="textField-36" x="486" y="5" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="f803e102-c2f6-4ae1-bba2-05f9d583d968" key="textField-37" x="387" y="5" width="95" height="19" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="09dac470-89b8-4e58-9955-8e4750840c09" key="textField-38" x="264" y="5" width="69" height="19" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="68115d45-792d-445a-be04-35db28f97ee3" key="staticText-40" x="183" y="5" width="78" height="19" hTextAlign="Right">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band height="150" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-23" style="GroupHeader_DarkGray" x="0" y="24" width="535" height="24" uuid="80ac50f2-d480-445b-87d1-51a9ac6a0906"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="Bitstream Vera Sans" pdfFontName="Helvetica"/>
-				</textElement>
-				<text><![CDATA[Totals]]></text>
-			</staticText>
-			<line>
-				<reportElement key="line-82" x="0" y="148" width="535" height="1" forecolor="#555555" uuid="293a7af3-cd5e-4d88-8153-e7e95438f468"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-83" stretchType="RelativeToBandHeight" x="535" y="48" width="1" height="100" forecolor="#555555" uuid="e2884bcd-7748-45d0-8ad0-4cf1e4fe4daf"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-85" stretchType="RelativeToBandHeight" x="0" y="48" width="1" height="100" forecolor="#555555" uuid="6218dc7f-0d20-491e-b263-fc293163e03d"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-19" x="66" y="87" width="50" height="16" uuid="3e5832db-101f-4a14-93fe-62b0277e89a4"/>
-				<box topPadding="2" leftPadding="2" bottomPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{PLANREVENUETOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PLANREVENUETOTAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-20" x="116" y="87" width="50" height="16" uuid="3ff8027e-8450-411b-a5a9-58f2015ffb1d"/>
-				<box rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{PLANSERVICESTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PLANSERVICESTOTAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-21" x="216" y="87" width="50" height="16" uuid="740219d8-cc5f-4a44-aa2a-3b54eb6b699a"/>
-				<box rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{PLANREVENUETOTAL}.intValue()==0)?
+	<summary height="150" splitType="Stretch">
+		<element kind="staticText" uuid="80ac50f2-d480-445b-87d1-51a9ac6a0906" key="staticText-23" x="0" y="24" width="535" height="24" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
+			<text><![CDATA[Totals]]></text>
+			<box leftPadding="5" style="GroupHeader_DarkGray">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="293a7af3-cd5e-4d88-8153-e7e95438f468" key="line-82" x="0" y="148" width="535" height="1" forecolor="#555555">
+			<pen lineWidth="1.0" lineStyle="Solid"/>
+		</element>
+		<element kind="line" uuid="e2884bcd-7748-45d0-8ad0-4cf1e4fe4daf" key="line-83" stretchType="ContainerHeight" x="535" y="48" width="1" height="100" forecolor="#555555">
+			<pen lineWidth="1.0" lineStyle="Solid"/>
+		</element>
+		<element kind="line" uuid="6218dc7f-0d20-491e-b263-fc293163e03d" key="line-85" stretchType="ContainerHeight" x="0" y="48" width="1" height="100" forecolor="#555555">
+			<pen lineWidth="1.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="3e5832db-101f-4a14-93fe-62b0277e89a4" key="textField-19" x="66" y="87" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[($V{PLANREVENUETOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PLANREVENUETOTAL}):new String(" ")]]></expression>
+			<box topPadding="2" leftPadding="2" bottomPadding="2" rightPadding="2">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="3ff8027e-8450-411b-a5a9-58f2015ffb1d" key="textField-20" x="116" y="87" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[($V{PLANSERVICESTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PLANSERVICESTOTAL}):new String(" ")]]></expression>
+			<box rightPadding="2">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="740219d8-cc5f-4a44-aa2a-3b54eb6b699a" key="textField-21" x="216" y="87" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[($V{PLANREVENUETOTAL}.intValue()==0)?
    $P{NUMBERFORMAT}.format(new BigDecimal("0.00")):
-   $P{NUMBERFORMAT}.format($V{PLANSERNETMARGINTOTAL}.divide($V{PLANREVENUETOTAL},200,$V{PLANSERNETMARGINTOTAL}.ROUND_HALF_UP).multiply(new BigDecimal(100.0)))]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-22" x="274" y="87" width="59" height="16" uuid="102c753f-347e-4d44-8cea-745fe4e4f54b"/>
-				<box rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{PLANREINVOINCINGTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PLANREINVOINCINGTOTAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-23" x="333" y="87" width="49" height="16" uuid="0a499cc0-ab9b-451f-be4e-4085ef726f41"/>
-				<box rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{PLANEXPENSESTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PLANEXPENSESTOTAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-24" x="383" y="87" width="49" height="16" uuid="f3951fe2-4d75-4afb-8fca-b18606f3fcc0"/>
-				<box rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{PLANREINVOINCINGTOTAL}.intValue()==0)?
+   $P{NUMBERFORMAT}.format($V{PLANSERNETMARGINTOTAL}.divide($V{PLANREVENUETOTAL},200,$V{PLANSERNETMARGINTOTAL}.ROUND_HALF_UP).multiply(new BigDecimal(100.0)))]]></expression>
+			<box rightPadding="2">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="102c753f-347e-4d44-8cea-745fe4e4f54b" key="textField-22" x="274" y="87" width="59" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[($V{PLANREINVOINCINGTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PLANREINVOINCINGTOTAL}):new String(" ")]]></expression>
+			<box rightPadding="2">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="0a499cc0-ab9b-451f-be4e-4085ef726f41" key="textField-23" x="333" y="87" width="49" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[($V{PLANEXPENSESTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PLANEXPENSESTOTAL}):new String(" ")]]></expression>
+			<box rightPadding="2">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="f3951fe2-4d75-4afb-8fca-b18606f3fcc0" key="textField-24" x="383" y="87" width="49" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[($V{PLANREINVOINCINGTOTAL}.intValue()==0)?
    $P{NUMBERFORMAT}.format(new BigDecimal("0.00")):
-   $P{NUMBERFORMAT}.format($V{PLANSERNETREINVOINCINGTOTAL}.divide($V{PLANREINVOINCINGTOTAL},200,$V{PLANSERNETREINVOINCINGTOTAL}.ROUND_HALF_UP).multiply(new BigDecimal(100.0)))]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-25" x="441" y="87" width="42" height="16" uuid="b965ad1f-e042-42ca-82a4-a1aca3550515"/>
-				<box rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{PLANCROSSMARGINNETTOAL}!=null)?
+   $P{NUMBERFORMAT}.format($V{PLANSERNETREINVOINCINGTOTAL}.divide($V{PLANREINVOINCINGTOTAL},200,$V{PLANSERNETREINVOINCINGTOTAL}.ROUND_HALF_UP).multiply(new BigDecimal(100.0)))]]></expression>
+			<box rightPadding="2">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="b965ad1f-e042-42ca-82a4-a1aca3550515" key="textField-25" x="441" y="87" width="42" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[($V{PLANCROSSMARGINNETTOAL}!=null)?
 	$P{NUMBERFORMAT}.format($V{PLANCROSSMARGINNETTOAL}):
-	new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-108" x="452" y="70" width="1" height="14" uuid="5849977e-b72d-410f-84d8-d0e6ae62ab76"/>
-			</line>
-			<line>
-				<reportElement key="line-109" x="262" y="70" width="1" height="14" uuid="1d48d3e2-126d-434f-897a-392a45d9b1e9"/>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-26" x="483" y="87" width="38" height="16" uuid="6cc03b8a-114d-4775-bc75-05de8d9c3636"/>
-				<box rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{PLANTOTALREVENUETOTAL}.intValue()==0)?
+	new String(" ")]]></expression>
+			<box rightPadding="2">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+			</box>
+		</element>
+		<element kind="line" uuid="5849977e-b72d-410f-84d8-d0e6ae62ab76" key="line-108" x="452" y="70" width="1" height="14"/>
+		<element kind="line" uuid="1d48d3e2-126d-434f-897a-392a45d9b1e9" key="line-109" x="262" y="70" width="1" height="14"/>
+		<element kind="textField" uuid="6cc03b8a-114d-4775-bc75-05de8d9c3636" key="textField-26" x="483" y="87" width="38" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[($V{PLANTOTALREVENUETOTAL}.intValue()==0)?
   $P{NUMBERFORMAT}.format(new BigDecimal("0.00")):
-  $P{NUMBERFORMAT}.format($V{PLANCROSSMARGINNETTOAL}.divide($V{PLANTOTALREVENUETOTAL},200,$V{PLANCROSSMARGINNETTOAL}.ROUND_HALF_UP).multiply(new BigDecimal(100.0)))]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-27" style="Total_Field" x="66" y="103" width="50" height="16" uuid="c2977c41-dc94-437b-b0ea-05d108b4373d"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{REALREVENUETOTAL}!=null)?$P{NUMBERFORMAT}.format($V{REALREVENUETOTAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-28" style="Total_Field" x="116" y="103" width="50" height="16" uuid="c50efd7e-f809-48f9-bca3-fa838710d693"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{REALSERVICESTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{REALSERVICESTOTAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-29" style="Total_Field" x="216" y="103" width="50" height="16" uuid="fd4823f1-2b6d-4296-90e8-53a7321639c7"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{REALREVENUETOTAL}.intValue()==0)?
+  $P{NUMBERFORMAT}.format($V{PLANCROSSMARGINNETTOAL}.divide($V{PLANTOTALREVENUETOTAL},200,$V{PLANCROSSMARGINNETTOAL}.ROUND_HALF_UP).multiply(new BigDecimal(100.0)))]]></expression>
+			<box rightPadding="2">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="c2977c41-dc94-437b-b0ea-05d108b4373d" key="textField-27" x="66" y="103" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Field">
+			<expression><![CDATA[($V{REALREVENUETOTAL}!=null)?$P{NUMBERFORMAT}.format($V{REALREVENUETOTAL}):new String(" ")]]></expression>
+			<box leftPadding="5" style="Total_Field">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="c50efd7e-f809-48f9-bca3-fa838710d693" key="textField-28" x="116" y="103" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Field">
+			<expression><![CDATA[($V{REALSERVICESTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{REALSERVICESTOTAL}):new String(" ")]]></expression>
+			<box leftPadding="5" style="Total_Field">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#555555"/>
+				<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="fd4823f1-2b6d-4296-90e8-53a7321639c7" key="textField-29" x="216" y="103" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Field">
+			<expression><![CDATA[($V{REALREVENUETOTAL}.intValue()==0)?
   $P{NUMBERFORMAT}.format(new BigDecimal("0.00")):
-  $P{NUMBERFORMAT}.format($V{REALSERNETMARGINTOTAL}.divide($V{REALREVENUETOTAL},200,$V{REALSERNETMARGINTOTAL}.ROUND_HALF_UP).multiply(new BigDecimal(100.0)))]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-30" style="Total_Field" x="274" y="103" width="59" height="16" uuid="3ed0bfbe-f860-4148-af78-b7c705a479d4"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{REALREINVOINCINGTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{REALREINVOINCINGTOTAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-31" style="Total_Field" x="333" y="103" width="49" height="16" uuid="a930b918-c697-457c-9069-d49048fe0272"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{REALEXPENSESTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{REALEXPENSESTOTAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-32" style="Total_Field" x="383" y="103" width="49" height="16" uuid="372b70e5-e9df-457a-8b9c-0e6bd1cdcb38"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{REALREINVOINCINGTOTAL}.intValue()==0)?
+  $P{NUMBERFORMAT}.format($V{REALSERNETMARGINTOTAL}.divide($V{REALREVENUETOTAL},200,$V{REALSERNETMARGINTOTAL}.ROUND_HALF_UP).multiply(new BigDecimal(100.0)))]]></expression>
+			<box leftPadding="5" style="Total_Field">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#555555"/>
+				<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="3ed0bfbe-f860-4148-af78-b7c705a479d4" key="textField-30" x="274" y="103" width="59" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Field">
+			<expression><![CDATA[($V{REALREINVOINCINGTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{REALREINVOINCINGTOTAL}):new String(" ")]]></expression>
+			<box leftPadding="5" style="Total_Field">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+				<bottomPen lineWidth="0.0" lineColor="#555555"/>
+				<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="a930b918-c697-457c-9069-d49048fe0272" key="textField-31" x="333" y="103" width="49" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Field">
+			<expression><![CDATA[($V{REALEXPENSESTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{REALEXPENSESTOTAL}):new String(" ")]]></expression>
+			<box leftPadding="5" style="Total_Field">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#555555"/>
+				<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="372b70e5-e9df-457a-8b9c-0e6bd1cdcb38" key="textField-32" x="383" y="103" width="49" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Field">
+			<expression><![CDATA[($V{REALREINVOINCINGTOTAL}.intValue()==0)?
    $P{NUMBERFORMAT}.format(new BigDecimal("0.00")):
-   $P{NUMBERFORMAT}.format($V{REALSERNETREINVOINCINGTOTAL}.divide($V{REALREINVOINCINGTOTAL},200,$V{REALSERNETREINVOINCINGTOTAL}.ROUND_HALF_UP).multiply(new BigDecimal(100.0)))]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-33" style="Total_Field" x="441" y="103" width="42" height="16" uuid="8cfe96e1-e99b-4cb1-ab4d-6867356db0c6"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{REALGROSSMARGINNETTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{REALGROSSMARGINNETTOTAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-34" style="Total_Field" x="483" y="103" width="38" height="16" uuid="8cf6e323-3445-4262-8aa0-0e32bd97ef87"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{REALTOTALREVENUETOTAL}.intValue()==0)?
+   $P{NUMBERFORMAT}.format($V{REALSERNETREINVOINCINGTOTAL}.divide($V{REALREINVOINCINGTOTAL},200,$V{REALSERNETREINVOINCINGTOTAL}.ROUND_HALF_UP).multiply(new BigDecimal(100.0)))]]></expression>
+			<box leftPadding="5" style="Total_Field">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#555555"/>
+				<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="8cfe96e1-e99b-4cb1-ab4d-6867356db0c6" key="textField-33" x="441" y="103" width="42" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Field">
+			<expression><![CDATA[($V{REALGROSSMARGINNETTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{REALGROSSMARGINNETTOTAL}):new String(" ")]]></expression>
+			<box leftPadding="5" style="Total_Field">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+				<bottomPen lineWidth="0.0" lineColor="#555555"/>
+				<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="8cf6e323-3445-4262-8aa0-0e32bd97ef87" key="textField-34" x="483" y="103" width="38" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Field">
+			<expression><![CDATA[($V{REALTOTALREVENUETOTAL}.intValue()==0)?
   	$P{NUMBERFORMAT}.format(new BigDecimal(0.0)):
-	$P{NUMBERFORMAT}.format($V{REALGROSSMARGINNETTOTAL}.divide($V{REALTOTALREVENUETOTAL},200,$V{REALGROSSMARGINNETTOTAL}.ROUND_HALF_UP).multiply(new BigDecimal(100.0)))]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-35" x="66" y="119" width="50" height="16" uuid="9f8ff730-d7aa-4af0-b121-a9d8afe8ce42"/>
-				<box topPadding="2" leftPadding="2" bottomPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{COLLECTEDTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COLLECTEDTOTAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-42" style="Detail_Header" x="10" y="119" width="56" height="16" uuid="d16607cb-0d29-476f-a601-67879f430fc0"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="7" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Collected]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-43" style="Detail_Header" x="10" y="103" width="56" height="16" uuid="edd7d236-8cbc-427f-8d61-3f91fabfdb06"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement>
-					<font fontName="Bitstream Vera Sans" size="7" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Real]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-44" style="Detail_Header" x="10" y="87" width="56" height="16" uuid="0a5ea788-4df7-4f57-b6ab-315b5634a614"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement>
-					<font fontName="Bitstream Vera Sans" size="7" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Planned]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-45" style="Detail_Header" x="66" y="70" width="50" height="16" uuid="91ad3c29-f209-4757-bac8-6e1a4c19d847"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="7" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Revenue]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-46" style="Detail_Header" x="66" y="54" width="200" height="16" uuid="425e3ae2-2c29-47bd-8f74-f00193609034"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#FFFFFF"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font fontName="Bitstream Vera Sans" size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Services]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-47" style="Detail_Header" x="116" y="70" width="50" height="16" uuid="52305386-c503-4ff0-89ac-4e2df8b27bf3"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="7" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Cost]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-48" style="Detail_Header" x="216" y="70" width="50" height="16" uuid="342b8caa-7695-4e18-a061-fa1926cb3e04"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="7" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Margin %]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-49" style="Detail_Header" x="274" y="70" width="59" height="16" uuid="bfac438e-37da-46a3-8466-7b862e4d97b2"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font fontName="Bitstream Vera Sans" size="7" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Reinvoicing]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-50" style="Detail_Header" x="274" y="54" width="157" height="16" uuid="a15d0724-372a-4ddb-b974-34d13f8e5f33"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#FFFFFF"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font fontName="Bitstream Vera Sans" size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Expenses]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-51" style="Detail_Header" x="333" y="70" width="48" height="16" uuid="127ac6a4-5dc2-48ce-b576-adbe84d3baf0"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font fontName="Bitstream Vera Sans" size="7" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Expenses]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-52" style="Detail_Header" x="382" y="70" width="49" height="16" uuid="37d3511c-9b35-4bc4-ae2c-bf50d111fc1c"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="7" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Margin %]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-53" style="Detail_Header" x="441" y="70" width="82" height="16" uuid="d850f028-e1be-41b8-9f3a-d8e615e6da7f"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font fontName="Bitstream Vera Sans" size="7" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Gross margin]]></text>
-			</staticText>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-42" x="166" y="87" width="50" height="16" uuid="1ff588c2-b8d2-4162-8631-e1f88e50f295"/>
-				<box rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{PLANOUTSOURCEDTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PLANOUTSOURCEDTOTAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-43" style="Total_Field" x="166" y="103" width="50" height="16" uuid="0c63631d-a777-4b44-b6ec-d682badb37f2"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{REALOUTSOURCEDTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{REALOUTSOURCEDTOTAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-58" style="Detail_Header" x="166" y="70" width="50" height="16" uuid="53367ec0-1280-492d-a572-e29c9bc5edaa"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="7" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Outsource]]></text>
-			</staticText>
-		</band>
+	$P{NUMBERFORMAT}.format($V{REALGROSSMARGINNETTOTAL}.divide($V{REALTOTALREVENUETOTAL},200,$V{REALGROSSMARGINNETTOTAL}.ROUND_HALF_UP).multiply(new BigDecimal(100.0)))]]></expression>
+			<box leftPadding="5" style="Total_Field">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#555555"/>
+				<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="9f8ff730-d7aa-4af0-b121-a9d8afe8ce42" key="textField-35" x="66" y="119" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[($V{COLLECTEDTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COLLECTEDTOTAL}):new String(" ")]]></expression>
+			<box topPadding="2" leftPadding="2" bottomPadding="2" rightPadding="2">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#555555"/>
+				<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="d16607cb-0d29-476f-a601-67879f430fc0" key="staticText-42" x="10" y="119" width="56" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[Collected]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="edd7d236-8cbc-427f-8d61-3f91fabfdb06" key="staticText-43" x="10" y="103" width="56" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" bold="true" style="Detail_Header">
+			<text><![CDATA[Real]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="0a5ea788-4df7-4f57-b6ab-315b5634a614" key="staticText-44" x="10" y="87" width="56" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" bold="true" style="Detail_Header">
+			<text><![CDATA[Planned]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="91ad3c29-f209-4757-bac8-6e1a4c19d847" key="staticText-45" x="66" y="70" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Revenue]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="425e3ae2-2c29-47bd-8f74-f00193609034" key="staticText-46" x="66" y="54" width="200" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Services]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#FFFFFF"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="52305386-c503-4ff0-89ac-4e2df8b27bf3" key="staticText-47" x="116" y="70" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Cost]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="342b8caa-7695-4e18-a061-fa1926cb3e04" key="staticText-48" x="216" y="70" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Margin %]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="bfac438e-37da-46a3-8466-7b862e4d97b2" key="staticText-49" x="274" y="70" width="59" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" bold="true" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Reinvoicing]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="a15d0724-372a-4ddb-b974-34d13f8e5f33" key="staticText-50" x="274" y="54" width="157" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Expenses]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#FFFFFF"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="127ac6a4-5dc2-48ce-b576-adbe84d3baf0" key="staticText-51" x="333" y="70" width="48" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" bold="true" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Expenses]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="37d3511c-9b35-4bc4-ae2c-bf50d111fc1c" key="staticText-52" x="382" y="70" width="49" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" bold="true" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Margin %]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="d850f028-e1be-41b8-9f3a-d8e615e6da7f" key="staticText-53" x="441" y="70" width="82" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" bold="true" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Gross margin]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="1ff588c2-b8d2-4162-8631-e1f88e50f295" key="textField-42" x="166" y="87" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[($V{PLANOUTSOURCEDTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{PLANOUTSOURCEDTOTAL}):new String(" ")]]></expression>
+			<box rightPadding="2">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="0c63631d-a777-4b44-b6ec-d682badb37f2" key="textField-43" x="166" y="103" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Field">
+			<expression><![CDATA[($V{REALOUTSOURCEDTOTAL}!=null)?$P{NUMBERFORMAT}.format($V{REALOUTSOURCEDTOTAL}):new String(" ")]]></expression>
+			<box leftPadding="5" style="Total_Field">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#555555"/>
+				<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#555555"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="53367ec0-1280-492d-a572-e29c9bc5edaa" key="staticText-58" x="166" y="70" width="50" height="16" fontName="Bitstream Vera Sans" fontSize="7.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Outsource]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
 	</summary>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportProjectProgress.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportProjectProgress.jrxml
@@ -1,42 +1,40 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportProjectProgress" pageWidth="850" pageHeight="595" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="c1fc9d13-cc94-42ec-b54f-2cd84d921e72">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportProjectProgress" language="java" pageWidth="850" pageHeight="595" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="c1fc9d13-cc94-42ec-b54f-2cd84d921e72">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Detail_Task">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="REFERENCE_DATE" class="java.lang.String" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="REFERENCE_DATE" forPrompting="false" class="java.lang.String"/>
+	<query language="sql"><![CDATA[SELECT
 		PR.C_PROJECT_ID AS PROJECTID, PR.NAME AS PROJECTNAME, PR.DESCRIPTION AS PROJECTDESCRIPTION, PR.NOTE AS PROJECTCOMMENTS,
 		REFLISTV.NAME AS PROJECTSTATUS, BPCUSTOMER.NAME AS CUSTOMERNAME, BPRESPONSIBLE.NAME AS PERSONINCHARGE,
 		PR.STARTDATE AS STARTINGDATE, PR.DATECONTRACT AS CONTRACTDATE, PR.DATEFINISH AS ENDINGDATE,
@@ -62,8 +60,7 @@
 	    AND PR.AD_ORG_ID IN ('1')
 	    AND 1=1
 
-      ORDER BY PR.NAME, 1]]>
-	</queryString>
+      ORDER BY PR.NAME, 1]]></query>
 	<field name="projectid" class="java.lang.String"/>
 	<field name="projectname" class="java.lang.String"/>
 	<field name="projectdescription" class="java.lang.String"/>
@@ -97,103 +94,75 @@
 	<field name="taskendingdate" class="java.lang.String"/>
 	<field name="taskdaysdelayed" class="java.lang.String"/>
 	<group name="projectid">
-		<groupExpression><![CDATA[$F{projectid}]]></groupExpression>
+		<expression><![CDATA[$F{projectid}]]></expression>
 		<groupHeader>
 			<band height="182" splitType="Stretch">
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="1" y="0" width="789" height="23" forecolor="#FFFFFF" uuid="7f5bde2a-1db0-4223-badb-6f8753ef17a2"/>
-					<box leftPadding="5">
+				<element kind="textField" uuid="7f5bde2a-1db0-4223-badb-6f8753ef17a2" key="textField" x="1" y="0" width="789" height="23" forecolor="#FFFFFF" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" pattern="" blankWhenNull="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[($F{projectname}!=null)?$F{projectname}:new String(" ")]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{projectname}!=null)?$F{projectname}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="118" y="30" width="661" height="17" forecolor="#000000" uuid="14de11be-5dc7-4790-92a5-3cc81d826fe1"/>
+				</element>
+				<element kind="textField" uuid="14de11be-5dc7-4790-92a5-3cc81d826fe1" key="textField" x="118" y="30" width="661" height="17" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[($F{projectdescription}!=null)?$F{projectdescription}:new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{projectdescription}!=null)?$F{projectdescription}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText" x="6" y="30" width="112" height="17" uuid="fc11539c-f4e9-40ad-ab45-710816764181"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="fc11539c-f4e9-40ad-ab45-710816764181" key="staticText" x="6" y="30" width="112" height="17" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" vTextAlign="Middle">
 					<text><![CDATA[Description:]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="118" y="47" width="661" height="38" forecolor="#000000" uuid="d8e0540a-1ce6-4767-909f-2b69e3482063"/>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Top">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{projectcomments}!=null)?$F{projectcomments}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText" x="6" y="47" width="112" height="17" uuid="79d1300a-5138-47d8-a327-c6d63da1c049"/>
+				</element>
+				<element kind="textField" uuid="d8e0540a-1ce6-4767-909f-2b69e3482063" key="textField" x="118" y="47" width="661" height="38" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Top">
+					<expression><![CDATA[($F{projectcomments}!=null)?$F{projectcomments}:new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Top">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="79d1300a-5138-47d8-a327-c6d63da1c049" key="staticText" x="6" y="47" width="112" height="17" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" vTextAlign="Top">
 					<text><![CDATA[Comments:]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="135" y="92" width="93" height="15" forecolor="#000000" uuid="6b0c4654-3091-4bf2-b978-e725dc2f728b"/>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{projectstatus}!=null)?$F{projectstatus}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText" x="6" y="92" width="129" height="15" uuid="af0799fe-6db6-4312-b735-ffea934ec80b"/>
+				</element>
+				<element kind="textField" uuid="6b0c4654-3091-4bf2-b978-e725dc2f728b" key="textField" x="135" y="92" width="93" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[($F{projectstatus}!=null)?$F{projectstatus}:new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="af0799fe-6db6-4312-b735-ffea934ec80b" key="staticText" x="6" y="92" width="129" height="15" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" vTextAlign="Middle">
 					<text><![CDATA[Project Status:]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="340" y="92" width="173" height="15" forecolor="#000000" uuid="bce70885-4c81-4b19-ade3-18aa3eaf9fbf"/>
+					<box>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="bce70885-4c81-4b19-ade3-18aa3eaf9fbf" key="textField" x="340" y="92" width="173" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[($F{customername}!=null)?$F{customername}:new String(" ")]]></expression>
 					<box leftPadding="5">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
@@ -201,356 +170,244 @@
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{customername}!=null)?$F{customername}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText" x="235" y="92" width="105" height="15" uuid="c7073d39-4185-4544-9b89-05dba7b956e2"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="c7073d39-4185-4544-9b89-05dba7b956e2" key="staticText" x="235" y="92" width="105" height="15" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" vTextAlign="Middle">
 					<text><![CDATA[Business Partner:]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="624" y="92" width="154" height="15" forecolor="#000000" uuid="a424f30b-23fd-41ed-86da-ae6e9cb27121"/>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{personincharge}!=null)?$F{personincharge}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText" x="519" y="92" width="149" height="15" uuid="8e7e13c7-54e7-4fcb-bdf0-ca7331de0bc1"/>
+				</element>
+				<element kind="textField" uuid="a424f30b-23fd-41ed-86da-ae6e9cb27121" key="textField" x="624" y="92" width="154" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[($F{personincharge}!=null)?$F{personincharge}:new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="8e7e13c7-54e7-4fcb-bdf0-ca7331de0bc1" key="staticText" x="519" y="92" width="149" height="15" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" vTextAlign="Middle">
 					<text><![CDATA[Person in Charge:]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="135" y="114" width="93" height="15" forecolor="#000000" uuid="6e316aaa-a1b3-4c9d-bda7-5818241c6fd4"/>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{startingdate}!=null)?$F{startingdate}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText" x="6" y="114" width="129" height="15" uuid="b63b27cb-af1a-43ca-be11-1ea08511f10e"/>
+				</element>
+				<element kind="textField" uuid="6e316aaa-a1b3-4c9d-bda7-5818241c6fd4" key="textField" x="135" y="114" width="93" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[($F{startingdate}!=null)?$F{startingdate}:new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="b63b27cb-af1a-43ca-be11-1ea08511f10e" key="staticText" x="6" y="114" width="129" height="15" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" vTextAlign="Middle">
 					<text><![CDATA[Starting Date:]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="425" y="114" width="88" height="15" forecolor="#000000" uuid="3991e8e1-4192-43cb-b1eb-3375adbd8c6a"/>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{contractdate}!=null)?$F{contractdate}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText" x="235" y="114" width="190" height="15" uuid="9de9c620-495c-4fa7-9f77-0eeab43ac49c"/>
+				</element>
+				<element kind="textField" uuid="3991e8e1-4192-43cb-b1eb-3375adbd8c6a" key="textField" x="425" y="114" width="88" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[($F{contractdate}!=null)?$F{contractdate}:new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="9de9c620-495c-4fa7-9f77-0eeab43ac49c" key="staticText" x="235" y="114" width="190" height="15" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" vTextAlign="Middle">
 					<text><![CDATA[Planned End Date:]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="624" y="114" width="155" height="15" forecolor="#000000" uuid="98324fbc-a023-47c9-8312-8c3fb7958f09"/>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{endingdate}!=null)?$F{endingdate}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText" x="519" y="114" width="120" height="15" uuid="deb5fd5c-8839-403e-9f13-c30f2fcaf1c3"/>
+				</element>
+				<element kind="textField" uuid="98324fbc-a023-47c9-8312-8c3fb7958f09" key="textField" x="624" y="114" width="155" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[($F{endingdate}!=null)?$F{endingdate}:new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="deb5fd5c-8839-403e-9f13-c30f2fcaf1c3" key="staticText" x="519" y="114" width="120" height="15" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" vTextAlign="Middle">
 					<text><![CDATA[Real End Date:]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="135" y="136" width="93" height="15" forecolor="#000000" uuid="2d9adaa0-4032-4b91-b62e-8326f718f731"/>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{dayselapsed}!=null)?$F{dayselapsed}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText" x="6" y="136" width="129" height="15" uuid="109275b9-8231-479d-8835-f19b6e09ffd8"/>
+				</element>
+				<element kind="textField" uuid="2d9adaa0-4032-4b91-b62e-8326f718f731" key="textField" x="135" y="136" width="93" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[($F{dayselapsed}!=null)?$F{dayselapsed}:new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="109275b9-8231-479d-8835-f19b6e09ffd8" key="staticText" x="6" y="136" width="129" height="15" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" vTextAlign="Middle">
 					<text><![CDATA[Days elapsed:]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="425" y="136" width="88" height="15" forecolor="#000000" uuid="531ec809-f42e-4681-a17f-86f36771a408"/>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{projectcontractduration}!=null)?$F{projectcontractduration}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText" x="234" y="136" width="191" height="15" uuid="e81e664c-0e45-49e8-ab5e-ccd7d3d4afac"/>
+				</element>
+				<element kind="textField" uuid="531ec809-f42e-4681-a17f-86f36771a408" key="textField" x="425" y="136" width="88" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[($F{projectcontractduration}!=null)?$F{projectcontractduration}:new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="e81e664c-0e45-49e8-ab5e-ccd7d3d4afac" key="staticText" x="234" y="136" width="191" height="15" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" hTextAlign="Left" vTextAlign="Middle">
 					<text><![CDATA[Planned Project Duration:]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="624" y="136" width="155" height="15" forecolor="#000000" uuid="e088926f-104c-4df1-a9d3-b1bda629f8af"/>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{daysdelayed}!=null)?$F{daysdelayed}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText" x="519" y="136" width="105" height="15" uuid="33ebcd46-3e41-4e70-9634-a50226ff7275"/>
+				</element>
+				<element kind="textField" uuid="e088926f-104c-4df1-a9d3-b1bda629f8af" key="textField" x="624" y="136" width="155" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[($F{daysdelayed}!=null)?$F{daysdelayed}:new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="33ebcd46-3e41-4e70-9634-a50226ff7275" key="staticText" x="519" y="136" width="105" height="15" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" vTextAlign="Middle">
 					<text><![CDATA[Days delayed:]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="135" y="159" width="36" height="15" forecolor="#000000" uuid="c84dd17a-fc50-412a-a619-165246806daf"/>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{timeburned}!=null)?$F{timeburned}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText" x="6" y="159" width="129" height="15" uuid="56ec4f93-03a1-45eb-a28a-10b8247bea1d"/>
+				</element>
+				<element kind="textField" uuid="c84dd17a-fc50-412a-a619-165246806daf" key="textField" x="135" y="159" width="36" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[($F{timeburned}!=null)?$F{timeburned}:new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="56ec4f93-03a1-45eb-a28a-10b8247bea1d" key="staticText" x="6" y="159" width="129" height="15" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" vTextAlign="Middle">
 					<text><![CDATA[Time burned:]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="425" y="159" width="36" height="15" forecolor="#000000" uuid="175490ca-fe97-4c42-bc53-5731f6fc51a2"/>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{completionperc}!=null)?$F{completionperc}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText" x="235" y="159" width="190" height="15" uuid="d0cca87a-9a9d-4589-aee5-c4b0f2c18d03"/>
+				</element>
+				<element kind="textField" uuid="175490ca-fe97-4c42-bc53-5731f6fc51a2" key="textField" x="425" y="159" width="36" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[($F{completionperc}!=null)?$F{completionperc}:new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="d0cca87a-9a9d-4589-aee5-c4b0f2c18d03" key="staticText" x="235" y="159" width="190" height="15" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" vTextAlign="Middle">
 					<text><![CDATA[Completion percentage:]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="711" y="159" width="68" height="15" forecolor="#000000" uuid="cc5cb242-8904-462c-b4db-eeff037065ae"/>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{cumdaysdelayed}!=null)?$F{cumdaysdelayed}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText" x="519" y="159" width="192" height="15" uuid="37db073e-3d8a-4694-996e-047a1a65f712"/>
+				</element>
+				<element kind="textField" uuid="cc5cb242-8904-462c-b4db-eeff037065ae" key="textField" x="711" y="159" width="68" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[($F{cumdaysdelayed}!=null)?$F{cumdaysdelayed}:new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="37db073e-3d8a-4694-996e-047a1a65f712" key="staticText" x="519" y="159" width="192" height="15" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" vTextAlign="Middle">
 					<text><![CDATA[Cumulative days delayed:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-2" x="461" y="159" width="28" height="15" forecolor="#000000" uuid="eb43d3d0-3681-4af4-86e6-b9504675ec05"/>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="eb43d3d0-3681-4af4-86e6-b9504675ec05" key="staticText-2" x="461" y="159" width="28" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" vTextAlign="Middle">
 					<text><![CDATA[%]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-3" x="171" y="159" width="28" height="15" forecolor="#000000" uuid="87efa291-4e94-4e9e-98fc-d5fbcf45a36e"/>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="87efa291-4e94-4e9e-98fc-d5fbcf45a36e" key="staticText-3" x="171" y="159" width="28" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" vTextAlign="Middle">
 					<text><![CDATA[%]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="182" forecolor="#555555" uuid="1ea2e8ac-e1b2-4930-a0e6-0189d2916237"/>
-				</line>
-				<line>
-					<reportElement key="line-8" stretchType="RelativeToBandHeight" x="790" y="0" width="1" height="182" forecolor="#555555" uuid="6d8a2b31-8578-46ab-9d5b-3d58f449c2ac"/>
-				</line>
+					<box>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="1ea2e8ac-e1b2-4930-a0e6-0189d2916237" key="line-2" stretchType="ContainerHeight" x="0" y="0" width="1" height="182" forecolor="#555555"/>
+				<element kind="line" uuid="6d8a2b31-8578-46ab-9d5b-3d58f449c2ac" key="line-8" stretchType="ContainerHeight" x="790" y="0" width="1" height="182" forecolor="#555555"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="22" splitType="Stretch">
-				<line>
-					<reportElement key="line-4" x="1" y="6" width="789" height="1" forecolor="#555555" uuid="86d46149-e18a-4f88-8db3-926856e44ff2"/>
-				</line>
-				<line>
-					<reportElement key="line-5" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="7" forecolor="#555555" uuid="f6a2c5e1-e10f-4453-92aa-4a52ded0a046"/>
-				</line>
-				<line>
-					<reportElement key="line-16" stretchType="RelativeToBandHeight" x="790" y="0" width="1" height="7" forecolor="#555555" uuid="a36d2d39-551e-4a70-a80f-1c0a5fef5bbd"/>
-				</line>
+				<element kind="line" uuid="86d46149-e18a-4f88-8db3-926856e44ff2" key="line-4" x="1" y="6" width="789" height="1" forecolor="#555555"/>
+				<element kind="line" uuid="f6a2c5e1-e10f-4453-92aa-4a52ded0a046" key="line-5" stretchType="ContainerHeight" x="0" y="0" width="1" height="7" forecolor="#555555"/>
+				<element kind="line" uuid="a36d2d39-551e-4a70-a80f-1c0a5fef5bbd" key="line-16" stretchType="ContainerHeight" x="790" y="0" width="1" height="7" forecolor="#555555"/>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="phaseid">
-		<groupExpression><![CDATA[$F{phaseid}]]></groupExpression>
+		<expression><![CDATA[$F{phaseid}]]></expression>
 		<groupHeader>
 			<band height="48" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="7" y="3" width="186" height="15" forecolor="#FFFFFF" uuid="da709924-b463-46e8-97af-1e302fbbbb59">
-						<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				<element kind="staticText" uuid="da709924-b463-46e8-97af-1e302fbbbb59" key="staticText" x="7" y="3" width="186" height="15" forecolor="#FFFFFF" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
 					<text><![CDATA[Phase]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="7" y="18" width="186" height="15" forecolor="#000000" uuid="71796bff-1646-4aab-91f0-8648eb7af00b">
-						<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
-					</reportElement>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="71796bff-1646-4aab-91f0-8648eb7af00b" key="textField" x="7" y="18" width="186" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+					<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
+					<expression><![CDATA[($F{phasename}!=null)?$F{phasename}:new String(" ")]]></expression>
 					<box leftPadding="5">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
@@ -558,562 +415,370 @@
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{phasename}!=null)?$F{phasename}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="193" y="18" width="96" height="15" forecolor="#000000" uuid="b0b49ee5-76f5-4b8f-9d08-6d0b7a14611d">
-						<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
-					</reportElement>
+				</element>
+				<element kind="textField" uuid="b0b49ee5-76f5-4b8f-9d08-6d0b7a14611d" key="textField" x="193" y="18" width="96" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle">
+					<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
+					<expression><![CDATA[($F{phasestartingdate}!=null)?$F{phasestartingdate}:new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{phasestartingdate}!=null)?$F{phasestartingdate}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="193" y="3" width="96" height="15" forecolor="#FFFFFF" uuid="020a816e-0853-4d2d-9116-679237a3a61f">
-						<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="020a816e-0853-4d2d-9116-679237a3a61f" key="staticText" x="193" y="3" width="96" height="15" forecolor="#FFFFFF" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
 					<text><![CDATA[Starting Date]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="289" y="18" width="100" height="15" forecolor="#000000" uuid="4f40bdd8-116e-4a10-94b8-745de2251270">
-						<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
-					</reportElement>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{phasecontractdate}!=null)?$F{phasecontractdate}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="289" y="3" width="100" height="15" forecolor="#FFFFFF" uuid="00a2725c-ea56-455b-bf84-d1551422da1c">
-						<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="textField" uuid="4f40bdd8-116e-4a10-94b8-745de2251270" key="textField" x="289" y="18" width="100" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle">
+					<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
+					<expression><![CDATA[($F{phasecontractdate}!=null)?$F{phasecontractdate}:new String(" ")]]></expression>
+					<box>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="00a2725c-ea56-455b-bf84-d1551422da1c" key="staticText" x="289" y="3" width="100" height="15" forecolor="#FFFFFF" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
 					<text><![CDATA[Planned End Date]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="389" y="18" width="130" height="15" forecolor="#000000" uuid="75e8abdc-fc60-4872-866c-acd2424330a4">
-						<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
-					</reportElement>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{phasecontractduration}!=null)?$F{phasecontractduration}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="389" y="3" width="130" height="15" forecolor="#FFFFFF" uuid="ca95f519-4e3f-4fd4-9475-cc29e440b440">
-						<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="textField" uuid="75e8abdc-fc60-4872-866c-acd2424330a4" key="textField" x="389" y="18" width="130" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle">
+					<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
+					<expression><![CDATA[($F{phasecontractduration}!=null)?$F{phasecontractduration}:new String(" ")]]></expression>
+					<box>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="ca95f519-4e3f-4fd4-9475-cc29e440b440" key="staticText" x="389" y="3" width="130" height="15" forecolor="#FFFFFF" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
 					<text><![CDATA[Planned Duration]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="519" y="18" width="69" height="15" forecolor="#000000" uuid="ef3fcd8d-c64b-4b77-87c6-91690abbe68e">
-						<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
-					</reportElement>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{phasecomplete}!=null)?$F{phasecomplete}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="519" y="3" width="69" height="15" forecolor="#FFFFFF" uuid="e9d28aa0-62ab-46fb-a6b0-a3e6ed775eb8">
-						<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="textField" uuid="ef3fcd8d-c64b-4b77-87c6-91690abbe68e" key="textField" x="519" y="18" width="69" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle">
+					<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
+					<expression><![CDATA[($F{phasecomplete}!=null)?$F{phasecomplete}:new String(" ")]]></expression>
+					<box>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="e9d28aa0-62ab-46fb-a6b0-a3e6ed775eb8" key="staticText" x="519" y="3" width="69" height="15" forecolor="#FFFFFF" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
 					<text><![CDATA[Complete]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="588" y="18" width="100" height="15" forecolor="#000000" uuid="aee2e0fc-b3cf-45f6-880b-69489c581d91">
-						<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
-					</reportElement>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{phaseendingdate}!=null)?$F{phaseendingdate}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="588" y="3" width="100" height="15" forecolor="#FFFFFF" uuid="435be3b6-31cd-46c5-a335-85c5b9932c91">
-						<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="textField" uuid="aee2e0fc-b3cf-45f6-880b-69489c581d91" key="textField" x="588" y="18" width="100" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle">
+					<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
+					<expression><![CDATA[($F{phaseendingdate}!=null)?$F{phaseendingdate}:new String(" ")]]></expression>
+					<box>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="435be3b6-31cd-46c5-a335-85c5b9932c91" key="staticText" x="588" y="3" width="100" height="15" forecolor="#FFFFFF" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
 					<text><![CDATA[Real End Date]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="688" y="18" width="99" height="15" forecolor="#000000" uuid="aa6b4d96-b5d0-4737-94ba-3367187afd10">
-						<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
-					</reportElement>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="aa6b4d96-b5d0-4737-94ba-3367187afd10" key="textField" x="688" y="18" width="99" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle">
+					<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
+					<expression><![CDATA[($F{phasedaysdelayed}!=null)?$F{phasedaysdelayed}:new String(" ")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{phasedaysdelayed}!=null)?$F{phasedaysdelayed}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="688" y="3" width="99" height="15" forecolor="#FFFFFF" uuid="8ca84d6c-38e3-4088-8c69-b944a03fb9f8">
-						<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="8ca84d6c-38e3-4088-8c69-b944a03fb9f8" key="staticText" x="688" y="3" width="99" height="15" forecolor="#FFFFFF" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<printWhenExpression><![CDATA[new Boolean(($F{phasename}!=null))]]></printWhenExpression>
 					<text><![CDATA[Days delayed]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="19" y="33" width="174" height="15" forecolor="#FFFFFF" uuid="f13ee6d1-6146-410e-ad17-6289bd9a94cd">
-						<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="f13ee6d1-6146-410e-ad17-6289bd9a94cd" key="staticText" x="19" y="33" width="174" height="15" forecolor="#FFFFFF" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
 					<text><![CDATA[Task]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-5" style="GroupHeader_DarkGray" x="193" y="33" width="96" height="15" forecolor="#FFFFFF" uuid="55295281-b840-4536-8e30-0d3e63458739">
-						<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="55295281-b840-4536-8e30-0d3e63458739" key="staticText-5" x="193" y="33" width="96" height="15" forecolor="#FFFFFF" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
 					<text><![CDATA[Starting Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-6" style="GroupHeader_DarkGray" x="289" y="33" width="100" height="15" forecolor="#FFFFFF" uuid="07c70962-4f35-487e-84d3-913b6f24220e">
-						<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="07c70962-4f35-487e-84d3-913b6f24220e" key="staticText-6" x="289" y="33" width="100" height="15" forecolor="#FFFFFF" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
 					<text><![CDATA[Planned End Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-7" style="GroupHeader_DarkGray" x="389" y="33" width="130" height="15" forecolor="#FFFFFF" uuid="f5f975d7-35fe-4ec0-aec0-88cb551280a0">
-						<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="f5f975d7-35fe-4ec0-aec0-88cb551280a0" key="staticText-7" x="389" y="33" width="130" height="15" forecolor="#FFFFFF" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
 					<text><![CDATA[Planned Duration]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-8" style="GroupHeader_DarkGray" x="519" y="33" width="69" height="15" forecolor="#FFFFFF" uuid="c14181d8-fdc6-4354-9e8f-c2c500a22b06">
-						<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="c14181d8-fdc6-4354-9e8f-c2c500a22b06" key="staticText-8" x="519" y="33" width="69" height="15" forecolor="#FFFFFF" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
 					<text><![CDATA[Complete]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-9" style="GroupHeader_DarkGray" x="588" y="33" width="100" height="15" forecolor="#FFFFFF" uuid="50457a01-f5b0-4a02-8280-171ce28013bc">
-						<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="50457a01-f5b0-4a02-8280-171ce28013bc" key="staticText-9" x="588" y="33" width="100" height="15" forecolor="#FFFFFF" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
 					<text><![CDATA[Real End Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-10" style="GroupHeader_DarkGray" x="688" y="33" width="99" height="15" forecolor="#FFFFFF" uuid="62ad3f0b-4093-4202-b1a2-025ea442f6fe">
-						<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="62ad3f0b-4093-4202-b1a2-025ea442f6fe" key="staticText-10" x="688" y="33" width="99" height="15" forecolor="#FFFFFF" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
 					<text><![CDATA[Days delayed]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="48" forecolor="#555555" uuid="3b0b6829-37a3-4db5-b5e6-283cb0cd9efc"/>
-				</line>
-				<line>
-					<reportElement key="line-9" stretchType="RelativeToBandHeight" x="790" y="0" width="1" height="7" forecolor="#555555" uuid="043d7fd5-f46f-45c3-8481-3bcc30c486d5"/>
-				</line>
-				<line>
-					<reportElement key="line-10" stretchType="RelativeToBandHeight" x="790" y="0" width="1" height="48" forecolor="#555555" uuid="31735c49-9f9e-4939-afa7-27eec5aa4e62"/>
-				</line>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="3b0b6829-37a3-4db5-b5e6-283cb0cd9efc" key="line-3" stretchType="ContainerHeight" x="0" y="0" width="1" height="48" forecolor="#555555"/>
+				<element kind="line" uuid="043d7fd5-f46f-45c3-8481-3bcc30c486d5" key="line-9" stretchType="ContainerHeight" x="790" y="0" width="1" height="7" forecolor="#555555"/>
+				<element kind="line" uuid="31735c49-9f9e-4939-afa7-27eec5aa4e62" key="line-10" stretchType="ContainerHeight" x="790" y="0" width="1" height="48" forecolor="#555555"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="5" splitType="Stretch">
-				<line>
-					<reportElement key="line-7" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="5" forecolor="#555555" uuid="3356cb85-ab61-4ddc-abc1-c990b81c1541"/>
-				</line>
-				<line>
-					<reportElement key="line-17" stretchType="RelativeToBandHeight" x="790" y="0" width="1" height="5" forecolor="#555555" uuid="8ad9e1ac-b374-40cc-97ed-556a7f5894dc"/>
-				</line>
+				<element kind="line" uuid="3356cb85-ab61-4ddc-abc1-c990b81c1541" key="line-7" stretchType="ContainerHeight" x="0" y="0" width="1" height="5" forecolor="#555555"/>
+				<element kind="line" uuid="8ad9e1ac-b374-40cc-97ed-556a7f5894dc" key="line-17" stretchType="ContainerHeight" x="790" y="0" width="1" height="5" forecolor="#555555"/>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="12" splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="51" splitType="Stretch">
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" x="2" y="5" width="788" height="26" uuid="bead06c0-1d24-4d6a-a05e-6f9494ced4b0"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="18"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-1" x="162" y="34" width="127" height="17" uuid="c2265534-88fa-4240-81b3-a2e53c6fe8b0"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="12"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{REFERENCE_DATE}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" x="1" y="34" width="161" height="17" uuid="52bd2531-db04-45ae-a331-734a91d8d081"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="12" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Reference Date:]]></text>
-			</staticText>
-			<line>
-				<reportElement key="line-1" x="0" y="31" width="790" height="1" uuid="13b2deb2-71de-4e7a-8780-1fde68e40706"/>
-			</line>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="12" splitType="Stretch"/>
+	<pageHeader height="51" splitType="Stretch">
+		<element kind="textField" uuid="bead06c0-1d24-4d6a-a05e-6f9494ced4b0" key="textField" x="2" y="5" width="788" height="26" fontName="Bitstream Vera Sans" fontSize="18.0" blankWhenNull="false" vTextAlign="Middle">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="c2265534-88fa-4240-81b3-a2e53c6fe8b0" key="textField-1" x="162" y="34" width="127" height="17" fontName="Bitstream Vera Sans" fontSize="12.0" blankWhenNull="false" vTextAlign="Middle">
+			<expression><![CDATA[$P{REFERENCE_DATE}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="52bd2531-db04-45ae-a331-734a91d8d081" key="staticText-1" x="1" y="34" width="161" height="17" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true" vTextAlign="Middle">
+			<text><![CDATA[Reference Date:]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="13b2deb2-71de-4e7a-8780-1fde68e40706" key="line-1" x="0" y="31" width="790" height="1"/>
 	</pageHeader>
-	<columnHeader>
-		<band height="5" splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader height="5" splitType="Stretch"/>
 	<detail>
 		<band height="15" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Task" x="19" y="0" width="174" height="15" forecolor="#000000" uuid="c68c9635-0da2-4377-a48d-37ffa891f29f">
-					<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5">
+			<element kind="textField" uuid="c68c9635-0da2-4377-a48d-37ffa891f29f" key="textField" x="19" y="0" width="174" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Detail_Task">
+				<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
+				<expression><![CDATA[($F{taskname}!=null)?$F{taskname}:new String(" ")]]></expression>
+				<box leftPadding="5" style="Detail_Task">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{taskname}!=null)?$F{taskname}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Task" x="193" y="0" width="96" height="15" forecolor="#000000" uuid="72f5d9fb-e204-4c00-84cf-4be6d406a04e">
-					<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="textField" uuid="72f5d9fb-e204-4c00-84cf-4be6d406a04e" key="textField" x="193" y="0" width="96" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Task">
+				<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
+				<expression><![CDATA[($F{taskstartingdate}!=null)?$F{taskstartingdate}:new String(" ")]]></expression>
+				<box style="Detail_Task">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{taskstartingdate}!=null)?$F{taskstartingdate}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Task" x="289" y="0" width="100" height="15" forecolor="#000000" uuid="74457e86-64f1-4e2d-9791-e072679b2c48">
-					<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="textField" uuid="74457e86-64f1-4e2d-9791-e072679b2c48" key="textField" x="289" y="0" width="100" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Task">
+				<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
+				<expression><![CDATA[($F{taskcontractdate}!=null)?$F{taskcontractdate}:new String(" ")]]></expression>
+				<box style="Detail_Task">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{taskcontractdate}!=null)?$F{taskcontractdate}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Task" x="389" y="0" width="130" height="15" forecolor="#000000" uuid="ed937ebb-a63d-4851-8c6b-a2809159a974">
-					<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="textField" uuid="ed937ebb-a63d-4851-8c6b-a2809159a974" key="textField" x="389" y="0" width="130" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Task">
+				<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
+				<expression><![CDATA[($F{taskcontractduration}!=null)?$F{taskcontractduration}:new String(" ")]]></expression>
+				<box style="Detail_Task">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{taskcontractduration}!=null)?$F{taskcontractduration}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Task" x="519" y="0" width="69" height="15" forecolor="#000000" uuid="71c9a6a9-2ed8-4e06-be90-ca330ad5e0d8">
-					<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="textField" uuid="71c9a6a9-2ed8-4e06-be90-ca330ad5e0d8" key="textField" x="519" y="0" width="69" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Task">
+				<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
+				<expression><![CDATA[($F{taskcomplete}!=null)?$F{taskcomplete}:new String(" ")]]></expression>
+				<box style="Detail_Task">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{taskcomplete}!=null)?$F{taskcomplete}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Task" x="588" y="0" width="100" height="15" forecolor="#000000" uuid="75966724-1b26-45b9-8405-c5d1b1723601">
-					<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="textField" uuid="75966724-1b26-45b9-8405-c5d1b1723601" key="textField" x="588" y="0" width="100" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Task">
+				<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
+				<expression><![CDATA[($F{taskendingdate}!=null)?$F{taskendingdate}:new String(" ")]]></expression>
+				<box style="Detail_Task">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{taskendingdate}!=null)?$F{taskendingdate}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Task" x="688" y="0" width="99" height="15" forecolor="#000000" uuid="c3dc8601-5f83-46bc-9c71-539b2c4bdbbd">
-					<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
-				</reportElement>
-				<box>
+			</element>
+			<element kind="textField" uuid="c3dc8601-5f83-46bc-9c71-539b2c4bdbbd" key="textField" x="688" y="0" width="99" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Task">
+				<printWhenExpression><![CDATA[new Boolean(($F{taskname}!=null))]]></printWhenExpression>
+				<expression><![CDATA[($F{taskdaysdelayed}!=null)?$F{taskdaysdelayed}:new String(" ")]]></expression>
+				<box style="Detail_Task">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{taskdaysdelayed}!=null)?$F{taskdaysdelayed}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-6" style="Detail_Task" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="15" forecolor="#555555" uuid="34bd12c3-7305-4deb-a604-69a24052de1e"/>
-			</line>
-			<line>
-				<reportElement key="line-15" style="Detail_Task" stretchType="RelativeToBandHeight" x="790" y="0" width="1" height="15" forecolor="#555555" uuid="c09c3917-f52d-431a-a199-d1f53abd002c"/>
-			</line>
+			</element>
+			<element kind="line" uuid="34bd12c3-7305-4deb-a604-69a24052de1e" key="line-6" stretchType="ContainerHeight" x="0" y="0" width="1" height="15" forecolor="#555555" style="Detail_Task"/>
+			<element kind="line" uuid="c09c3917-f52d-431a-a199-d1f53abd002c" key="line-15" stretchType="ContainerHeight" x="790" y="0" width="1" height="15" forecolor="#555555" style="Detail_Task"/>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="19" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="573" y="2" width="171" height="15" forecolor="#000000" uuid="2e2caa7a-7cba-4f20-82ca-eca5bb738427"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" mode="Transparent" x="746" y="2" width="36" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="f8f8f9ff-d814-4e1b-8355-29f6047ec6b8"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Bottom">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" x="364" y="2" width="47" height="15" forecolor="#000000" uuid="3591ff70-eb87-4303-be87-d92a7cef5d8f"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Bottom">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-4" x="284" y="2" width="78" height="15" forecolor="#000000" uuid="71c77dd9-acc6-4187-8167-70bdda96b36d"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="19" splitType="Stretch">
+		<element kind="textField" uuid="2e2caa7a-7cba-4f20-82ca-eca5bb738427" key="textField" x="573" y="2" width="171" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Bottom">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="f8f8f9ff-d814-4e1b-8355-29f6047ec6b8" key="textField" mode="Transparent" x="746" y="2" width="36" height="15" forecolor="#000000" backcolor="#FFFFFF" fontName="Bitstream Vera Sans" fontSize="8.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Bottom">
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="3591ff70-eb87-4303-be87-d92a7cef5d8f" key="textField" x="364" y="2" width="47" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Left" vTextAlign="Bottom">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="71c77dd9-acc6-4187-8167-70bdda96b36d" key="staticText-4" x="284" y="2" width="78" height="15" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Right" vTextAlign="Bottom">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportPurchaseOrder.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportPurchaseOrder.jrxml
@@ -1,108 +1,104 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
-<!-- 2017-04-18T12:53:51 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportPurchaseOrder" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="d5112654-5616-45aa-ab46-4a7530b995d6">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportPurchaseOrder" language="java" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="d5112654-5616-45aa-ab46-4a7530b995d6">
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="org.openbravo.erpCommon.utility.Utility"/>
-	<import value="java.util.*"/>
-	<import value="org.openbravo.dal.core.OBContext"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="DejaVu Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="DejaVu Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>org.openbravo.erpCommon.utility.Utility</import>
+	<import>org.openbravo.dal.core.OBContext</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="DejaVu Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="DejaVu Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="DejaVu Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="DejaVu Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Data_Label" fontName="DejaVu Sans" fontSize="10" isBold="true"/>
-	<style name="Report_Data_Field" fontName="DejaVu Sans" fontSize="10" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="DejaVu Sans" fontSize="11" isBold="true">
+	<style name="Report_Data_Label" fontName="DejaVu Sans" fontSize="10.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="DejaVu Sans" fontSize="10.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="DejaVu Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="DejaVu Sans" fontSize="12" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="DejaVu Sans" fontSize="12.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Group_Data_Label" fontName="DejaVu Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="DejaVu Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="DejaVu Sans" fontSize="10" isBold="true">
+	<style name="Group_Data_Label" fontName="DejaVu Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="DejaVu Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="DejaVu Sans" fontSize="10.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="Detail_Line" fontName="DejaVu Sans" fontSize="10">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="DejaVu Sans" fontSize="10.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{DOCUMENTNO_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="DejaVu Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="DejaVu Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="DejaVu Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="DejaVu Sans" fontSize="11"/>
-	<parameter name="DateFrom" class="java.util.Date" isForPrompting="false"/>
-	<parameter name="AD_Org_ID" class="org.codehaus.jettison.json.JSONObject" isForPrompting="false">
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="DejaVu Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="DejaVu Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="DejaVu Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="DejaVu Sans" fontSize="11.0"/>
+	<parameter name="DateFrom" forPrompting="false" class="java.util.Date"/>
+	<parameter name="AD_Org_ID" forPrompting="false" class="org.codehaus.jettison.json.JSONObject">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
 	<parameter name="ChildOrgs" class="java.lang.String">
 		<defaultValueExpression><![CDATA[Utility.getInStrSet(OBContext.getOBContext().getOrganizationStructureProvider().getChildTree($P{AD_Org_ID}.getString("value"), true))]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_organization" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_organization" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{AD_Org_ID} == null || "".equals($P{AD_Org_ID}.getString("value"))) ? "" : " AND C_ORDER.AD_ORG_ID IN (" + $P{ChildOrgs} + ")"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="C_BPartner_ID" class="org.codehaus.jettison.json.JSONObject" isForPrompting="false">
+	<parameter name="C_BPartner_ID" forPrompting="false" class="org.codehaus.jettison.json.JSONObject">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_partner" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_partner" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{C_BPartner_ID} == null || "".equals($P{C_BPartner_ID}.getString("value"))) ? "" : " AND C_ORDER.C_BPARTNER_ID = '" + $P{C_BPartner_ID}.getString("value") + "'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DateTo" class="java.util.Date" isForPrompting="false"/>
-	<parameter name="M_Warehouse_ID" class="org.codehaus.jettison.json.JSONObject" isForPrompting="false">
+	<parameter name="DateTo" forPrompting="false" class="java.util.Date"/>
+	<parameter name="M_Warehouse_ID" forPrompting="false" class="org.codehaus.jettison.json.JSONObject">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_warehouse" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_warehouse" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{M_Warehouse_ID} == null || "".equals($P{M_Warehouse_ID}.getString("value"))) ? "" : " AND C_ORDER.M_WAREHOUSE_ID = '" + $P{M_Warehouse_ID}.getString("value") + "'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="C_Project_ID" class="org.codehaus.jettison.json.JSONObject" isForPrompting="false">
+	<parameter name="C_Project_ID" forPrompting="false" class="org.codehaus.jettison.json.JSONObject">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_project" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_project" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{C_Project_ID} == null || "".equals($P{C_Project_ID}.getString("value"))) ? "" : " AND C_ORDER.C_PROJECT_ID = '" + $P{C_Project_ID}.getString("value") + "'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="AMOUNTFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="QUANTITYFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="C_Currency_ID" class="org.codehaus.jettison.json.JSONObject" isForPrompting="false"/>
-	<parameter name="aux_Currency" class="java.lang.String" isForPrompting="false">
+	<parameter name="AMOUNTFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="QUANTITYFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="C_Currency_ID" forPrompting="false" class="org.codehaus.jettison.json.JSONObject"/>
+	<parameter name="aux_Currency" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{C_Currency_ID}.getString("value")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_DateFrom" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_DateFrom" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{DateFrom} == null || $P{DateFrom}.equals("")) ? "" : "AND C_ORDER.DATEORDERED >= TO_DATE('" + new java.sql.Date($P{DateFrom}.getTime()).toString() + "', 'YYYY-MM-DD')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_DateTo" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_DateTo" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{DateTo} == null || $P{DateTo}.equals("")) ? "" : "AND C_ORDER.DATEORDERED <= TO_DATE('" + new java.sql.Date($P{DateTo}.getTime()) + "', 'YYYY-MM-DD')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="Status" class="org.codehaus.jettison.json.JSONObject" isForPrompting="false">
+	<parameter name="Status" forPrompting="false" class="org.codehaus.jettison.json.JSONObject">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_Status" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_Status" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{Status} == null || $P{Status}.equals("")) ? "" : "AND C_ORDER.DOCSTATUS = '" + $P{Status}.getString("value") + "'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="Current_Client_ID" class="java.lang.String" isForPrompting="false"/>
+	<parameter name="Current_Client_ID" forPrompting="false" class="java.lang.String"/>
 	<parameter name="Readable_Organizations" class="java.lang.String">
 		<defaultValueExpression><![CDATA[]]></defaultValueExpression>
 	</parameter>
-	<parameter name="isUOMManagementEnabled" class="java.lang.Boolean" isForPrompting="false">
+	<parameter name="isUOMManagementEnabled" forPrompting="false" class="java.lang.Boolean">
 		<defaultValueExpression><![CDATA[org.openbravo.materialmgmt.UOMUtil.isUomManagementEnabled()]]></defaultValueExpression>
 	</parameter>
-	<queryString language="SQL">
-		<![CDATA[SELECT DOCUMENTNO, 
+	<query language="SQL"><![CDATA[SELECT DOCUMENTNO, 
     DATEORDERED, 
     C_BPARTNER.NAME AS CLIENT_NAME, 
     QUANTITYORDER, 
@@ -153,8 +149,7 @@
     INNER JOIN M_PRODUCT ON ZZ.PRODUCT_ID = M_PRODUCT.M_PRODUCT_ID 
     INNER JOIN C_UOM ON ZZ.OLUOMID = C_UOM.C_UOM_ID    
     LEFT JOIN C_UOM CUOM ON ZZ.C_AUM = CUOM.C_UOM_ID
-    ORDER BY CLIENT_NAME, DATEORDERED, DOCUMENTNO, PRODUCT_NAME]]>
-	</queryString>
+    ORDER BY CLIENT_NAME, DATEORDERED, DOCUMENTNO, PRODUCT_NAME]]></query>
 	<field name="DOCUMENTNO" class="java.lang.String"/>
 	<field name="DATEORDERED" class="java.util.Date"/>
 	<field name="CLIENT_NAME" class="java.lang.String"/>
@@ -171,810 +166,584 @@
 	<field name="AUMQTY" class="java.math.BigDecimal"/>
 	<field name="AUM" class="java.lang.String"/>
 	<variable name="LOCALE" class="java.util.Locale">
-		<variableExpression><![CDATA[new Locale($P{LANGUAGE}.substring(0,2),$P{LANGUAGE}.substring(3,5))]]></variableExpression>
+		<expression><![CDATA[new Locale($P{LANGUAGE}.substring(0,2),$P{LANGUAGE}.substring(3,5))]]></expression>
 	</variable>
-	<variable name="TOTAL_CLIENT" class="java.math.BigDecimal" resetType="Group" resetGroup="CLIENT_NAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVPRICELIST}]]></variableExpression>
+	<variable name="TOTAL_CLIENT" resetType="Group" calculation="Sum" resetGroup="CLIENT_NAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVPRICELIST}]]></expression>
 	</variable>
-	<variable name="TOTAL_DOCNO" class="java.math.BigDecimal" resetType="Group" resetGroup="DOCUMENTNO" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVPRICELIST}]]></variableExpression>
+	<variable name="TOTAL_DOCNO" resetType="Group" calculation="Sum" resetGroup="DOCUMENTNO" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVPRICELIST}]]></expression>
 	</variable>
 	<group name="CLIENT_NAME">
-		<groupExpression><![CDATA[$F{CLIENT_NAME}]]></groupExpression>
+		<expression><![CDATA[$F{CLIENT_NAME}]]></expression>
 		<groupHeader>
 			<band height="16" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" mode="Opaque" x="0" y="0" width="80" height="16" uuid="2cd9fc7d-bf88-47aa-990a-30504627bee9"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
+				<element kind="staticText" uuid="2cd9fc7d-bf88-47aa-990a-30504627bee9" key="staticText" mode="Opaque" x="0" y="0" width="80" height="16" style="GroupHeader_DarkGray">
 					<text><![CDATA[Customer]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" mode="Opaque" x="80" y="0" width="700" height="16" uuid="45e0985f-3d5b-41d4-ab82-dff141e2daf3">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" />
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CLIENT_NAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-7" style="Report_Footer" x="674" y="0" width="1" height="16" forecolor="#555555" uuid="623e28b5-0153-440a-ab87-49b5618777c3"/>
-				</line>
+				</element>
+				<element kind="textField" uuid="45e0985f-3d5b-41d4-ab82-dff141e2daf3" key="textField" mode="Opaque" x="80" y="0" width="700" height="16" fontName="DejaVu Sans" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Center" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{CLIENT_NAME}]]></expression>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="623e28b5-0153-440a-ab87-49b5618777c3" key="line-7" x="674" y="0" width="1" height="16" forecolor="#555555" style="Report_Footer"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="48" splitType="Stretch">
-				<textField evaluationTime="Group" evaluationGroup="CLIENT_NAME" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Total_Gray" x="677" y="1" width="79" height="16" uuid="97ed618b-09a7-4952-bf44-95a1eceb1026"/>
-					<box leftPadding="4" rightPadding="4">
+				<element kind="textField" uuid="97ed618b-09a7-4952-bf44-95a1eceb1026" key="textField" x="677" y="1" width="79" height="16" evaluationTime="Group" pattern="" evaluationGroup="CLIENT_NAME" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Gray">
+					<expression><![CDATA[($V{TOTAL_CLIENT}!=null)?$P{AMOUNTFORMAT}.format($V{TOTAL_CLIENT}):new String(" ")]]></expression>
+					<box leftPadding="4" rightPadding="4" style="Total_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[($V{TOTAL_CLIENT}!=null)?$P{AMOUNTFORMAT}.format($V{TOTAL_CLIENT}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-14" style="Report_Footer" x="779" y="0" width="1" height="21" forecolor="#555555" uuid="4fecd96d-bec0-48fa-946e-54cd0990b048">
-						<property name="local_mesure_unitx" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.x" value="px"/>
-						<property name="local_mesure_unity" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.y" value="px"/>
-						<property name="local_mesure_unitheight" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.height" value="px"/>
-					</reportElement>
-				</line>
-				<line>
-					<reportElement key="line-15" style="Report_Footer" x="0" y="0" width="1" height="20" forecolor="#555555" uuid="792a2267-c587-4d27-90c1-02574a32c179"/>
-				</line>
-				<staticText>
-					<reportElement key="staticText-2" style="Report_Footer" x="591" y="1" width="86" height="16" uuid="86aa0edc-b23f-49c3-84bc-81a1d54ab329"/>
-					<box rightPadding="4">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle"/>
+				</element>
+				<element kind="line" uuid="4fecd96d-bec0-48fa-946e-54cd0990b048" key="line-14" x="779" y="0" width="1" height="21" forecolor="#555555" style="Report_Footer">
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</element>
+				<element kind="line" uuid="792a2267-c587-4d27-90c1-02574a32c179" key="line-15" x="0" y="0" width="1" height="20" forecolor="#555555" style="Report_Footer"/>
+				<element kind="staticText" uuid="86aa0edc-b23f-49c3-84bc-81a1d54ab329" key="staticText-2" x="591" y="1" width="86" height="16" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
 					<text><![CDATA[Total Client:]]></text>
-				</staticText>
-				<textField evaluationTime="Group" evaluationGroup="DOCUMENTNO" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-12" style="Total_Gray" x="756" y="1" width="20" height="16" uuid="48a535e5-22c0-4a43-903a-4f7cf15fc8b9"/>
-					<box leftPadding="4" rightPadding="4">
+					<box rightPadding="4" style="Report_Footer">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" fontName="DejaVu Sans" />
-					</textElement>
-					<textFieldExpression><![CDATA[($V{TOTAL_CLIENT}!=null)?$F{CONVSYM}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-13" style="Report_Footer" x="0" y="20" width="779" height="1" forecolor="#555555" uuid="baf7683c-9215-475f-8a8a-8f55af033e11"/>
-				</line>
+				</element>
+				<element kind="textField" uuid="48a535e5-22c0-4a43-903a-4f7cf15fc8b9" key="textField-12" x="756" y="1" width="20" height="16" fontName="DejaVu Sans" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="DOCUMENTNO" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Total_Gray">
+					<expression><![CDATA[($V{TOTAL_CLIENT}!=null)?$F{CONVSYM}:new String(" ")]]></expression>
+					<box leftPadding="4" rightPadding="4" style="Total_Gray">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="baf7683c-9215-475f-8a8a-8f55af033e11" key="line-13" x="0" y="20" width="779" height="1" forecolor="#555555" style="Report_Footer"/>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="DOCUMENTNO">
-		<groupExpression><![CDATA[$F{DOCUMENTNO}]]></groupExpression>
+		<expression><![CDATA[$F{DOCUMENTNO}]]></expression>
 		<groupHeader>
 			<band height="48" splitType="Stretch">
-				<property name="local_mesure_unitheight" value="pixel"/>
-				<property name="com.jaspersoft.studio.unit.height" value="px"/>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-6" style="Detail_Header" x="722" y="34" width="57" height="14" uuid="879882c0-53c7-4072-b3f9-b78e485133e6">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-						<property name="local_mesure_unitx" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.x" value="px"/>
-					</reportElement>
-					<box leftPadding="5">
+				<element kind="textField" uuid="879882c0-53c7-4072-b3f9-b78e485133e6" key="textField-6" x="722" y="34" width="57" height="14" rotation="None" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-						<font size="8" fontName="DejaVu Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="10" y="10" width="110" height="14" uuid="4531472c-0832-460a-bf51-3d9cd63bd171"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
+				</element>
+				<element kind="staticText" uuid="4531472c-0832-460a-bf51-3d9cd63bd171" key="staticText" x="10" y="10" width="110" height="14" style="GroupHeader_DarkGray">
 					<text><![CDATA[Document No.]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="120" y="10" width="140" height="14" uuid="1b56a66f-200a-4bf9-b701-0e82bb5505bf"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="DejaVu Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{DOCUMENTNO}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="307" y="10" width="195" height="14" uuid="c8e0921d-29b1-43b7-936e-f6640cc0ddb7"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="1b56a66f-200a-4bf9-b701-0e82bb5505bf" key="textField" x="120" y="10" width="140" height="14" fontName="DejaVu Sans" pattern="" blankWhenNull="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{DOCUMENTNO}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{DATEORDERED}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-90" style="GroupHeader_DarkGray" x="260" y="10" width="47" height="14" uuid="8c9f4a45-12b1-4fbe-9aac-8f89d5e24a27"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="c8e0921d-29b1-43b7-936e-f6640cc0ddb7" key="textField" x="307" y="10" width="195" height="14" blankWhenNull="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{DATEORDERED}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="DejaVu Sans"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="8c9f4a45-12b1-4fbe-9aac-8f89d5e24a27" key="element-90" x="260" y="10" width="47" height="14" fontName="DejaVu Sans" style="GroupHeader_DarkGray">
 					<text><![CDATA[Date:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="20" y="34" width="160" height="14" uuid="3f645b6e-54c9-4cd0-bc0f-8dd16677e6c7"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement verticalAlignment="Middle">
-						<font size="8" fontName="DejaVu Sans"/>
-					</textElement>
-					<text><![CDATA[Product]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="180" y="34" width="53" height="14" uuid="4cd9fd06-840e-47d5-aca9-39067554a7d7">
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" fontName="DejaVu Sans"/>
-					</textElement>
-					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="233" y="34" width="42" height="14" uuid="3d6bc97b-d9db-48d2-9d3c-ff3b246b1b82">
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" fontName="DejaVu Sans"/>
-					</textElement>
-					<text><![CDATA[UOM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="380" y="34" width="100" height="14" uuid="89ac7a9c-950a-47da-b18f-df3780bc97b1"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" fontName="DejaVu Sans"/>
-					</textElement>
-					<text><![CDATA[Price]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="580" y="34" width="100" height="14" uuid="0625bfb9-8f9b-4d29-86f4-6799e3840d30"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" fontName="DejaVu Sans"/>
-					</textElement>
-					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-1" style="Report_Footer" x="0" y="0" width="1" height="48" forecolor="#555555" uuid="0d6471f0-ac8e-492c-960c-e27726efed3c"/>
-				</line>
-				<line>
-					<reportElement key="line-2" style="Report_Footer" x="10" y="24" width="1" height="24" forecolor="#555555" uuid="96396fe4-4b24-4905-929d-906b4ad96bba"/>
-				</line>
-				<staticText>
-					<reportElement key="element-93" style="GroupHeader_DarkGray" x="502" y="10" width="277" height="14" uuid="2c835da8-4a4d-4dec-8c05-e4d954166b9c">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="DejaVu Sans"/>
-					</textElement>
-					<text><![CDATA[]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-94" style="Detail_Header" x="480" y="34" width="39" height="14" uuid="e02a4193-9c6e-471d-8692-27fe306cf1d1"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8" fontName="DejaVu Sans"/>
-					</textElement>
-					<text><![CDATA[Price]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-5" style="Detail_Header" x="519" y="34" width="61" height="14" uuid="26e03595-e5c9-4612-8c76-d78993d38168"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="8" fontName="DejaVu Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="274" y="34" width="64" height="14" uuid="1eb7e742-9f3d-4bab-800b-d18f07c72a07">
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+				</element>
+				<element kind="staticText" uuid="3f645b6e-54c9-4cd0-bc0f-8dd16677e6c7" key="element-90" x="20" y="34" width="160" height="14" fontName="DejaVu Sans" fontSize="8.0" vTextAlign="Middle" style="Detail_Header">
+					<text><![CDATA[Product]]></text>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" fontName="DejaVu Sans"/>
-					</textElement>
-					<text><![CDATA[Qty in AUM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="338" y="34" width="42" height="14" uuid="f5099648-c3f1-4ce8-8e58-d60db9fafe36">
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" fontName="DejaVu Sans"/>
-					</textElement>
-					<text><![CDATA[AUM]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-6" style="Report_Footer" x="779" y="0" width="1" height="48" forecolor="#555555" uuid="2ab1091c-177a-4f9b-bdea-bf48937aa0d3"/>
-				</line>
-				<staticText>
-					<reportElement key="element-92" style="Detail_Header" mode="Opaque" x="680" y="34" width="44" height="14" uuid="cafb4457-eafc-4259-9322-7ba97aa40fac">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					</reportElement>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8" fontName="DejaVu Sans"/>
-					</textElement>
-					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="180" y="34" width="95" height="14" uuid="0548b73a-0d1c-4859-b298-7ee8a315496c">
-						<property name="local_mesure_unitx" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.x" value="px"/>
-						<property name="local_mesure_unity" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.y" value="px"/>
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" fontName="DejaVu Sans"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="4cd9fd06-840e-47d5-aca9-39067554a7d7" key="element-90" x="180" y="34" width="53" height="14" fontName="DejaVu Sans" fontSize="8.0" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="274" y="34" width="106" height="14" uuid="82b00a16-834e-42bc-a2ca-24712b240980">
-						<property name="local_mesure_unitx" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.x" value="px"/>
-						<property name="local_mesure_unity" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.y" value="px"/>
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8" fontName="DejaVu Sans"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="3d6bc97b-d9db-48d2-9d3c-ff3b246b1b82" key="element-90" x="233" y="34" width="42" height="14" fontName="DejaVu Sans" fontSize="8.0" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
 					<text><![CDATA[UOM]]></text>
-				</staticText>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="89ac7a9c-950a-47da-b18f-df3780bc97b1" key="element-90" x="380" y="34" width="100" height="14" fontName="DejaVu Sans" fontSize="8.0" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
+					<text><![CDATA[Price]]></text>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="0625bfb9-8f9b-4d29-86f4-6799e3840d30" key="element-90" x="580" y="34" width="100" height="14" fontName="DejaVu Sans" fontSize="8.0" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
+					<text><![CDATA[Amount]]></text>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="line" uuid="0d6471f0-ac8e-492c-960c-e27726efed3c" key="line-1" x="0" y="0" width="1" height="48" forecolor="#555555" style="Report_Footer"/>
+				<element kind="line" uuid="96396fe4-4b24-4905-929d-906b4ad96bba" key="line-2" x="10" y="24" width="1" height="24" forecolor="#555555" style="Report_Footer"/>
+				<element kind="staticText" uuid="2c835da8-4a4d-4dec-8c05-e4d954166b9c" key="element-93" x="502" y="10" width="277" height="14" fontName="DejaVu Sans" style="GroupHeader_DarkGray">
+					<text><![CDATA[]]></text>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="e02a4193-9c6e-471d-8692-27fe306cf1d1" key="element-94" x="480" y="34" width="39" height="14" fontName="DejaVu Sans" fontSize="8.0" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<text><![CDATA[Price]]></text>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="26e03595-e5c9-4612-8c76-d78993d38168" key="textField-5" x="519" y="34" width="61" height="14" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="1eb7e742-9f3d-4bab-800b-d18f07c72a07" key="element-90" x="274" y="34" width="64" height="14" fontName="DejaVu Sans" fontSize="8.0" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+					<text><![CDATA[Qty in AUM]]></text>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="f5099648-c3f1-4ce8-8e58-d60db9fafe36" key="element-90" x="338" y="34" width="42" height="14" fontName="DejaVu Sans" fontSize="8.0" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+					<text><![CDATA[AUM]]></text>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="line" uuid="2ab1091c-177a-4f9b-bdea-bf48937aa0d3" key="line-6" x="779" y="0" width="1" height="48" forecolor="#555555" style="Report_Footer"/>
+				<element kind="staticText" uuid="cafb4457-eafc-4259-9322-7ba97aa40fac" key="element-92" mode="Opaque" x="680" y="34" width="44" height="14" fontName="DejaVu Sans" fontSize="8.0" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
+					<text><![CDATA[Amount]]></text>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="0548b73a-0d1c-4859-b298-7ee8a315496c" key="element-90" x="180" y="34" width="95" height="14" fontName="DejaVu Sans" fontSize="8.0" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
+					<text><![CDATA[Quantity]]></text>
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="82b00a16-834e-42bc-a2ca-24712b240980" key="element-90" x="274" y="34" width="106" height="14" fontName="DejaVu Sans" fontSize="8.0" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
+					<text><![CDATA[UOM]]></text>
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<property name="local_mesure_unitheight" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.height" value="px"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="32" splitType="Stretch">
-				<line>
-					<reportElement key="line-9" style="Report_Footer" x="10" y="0" width="1" height="28" forecolor="#555555" uuid="3cf6f95e-73b6-495e-9b96-54c6bcc00acb"/>
-				</line>
-				<line>
-					<reportElement key="line-16" style="Report_Footer" x="10" y="28" width="769" height="1" forecolor="#555555" uuid="1ef3f575-64ce-4248-b75e-f4b5a22fbb9d">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-						<property name="local_mesure_unitheight" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.height" value="px"/>
-						<property name="local_mesure_unity" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.y" value="px"/>
-						<property name="local_mesure_unitx" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.x" value="px"/>
-					</reportElement>
-				</line>
-				<line>
-					<reportElement key="line-10" style="Report_Footer" x="779" y="0" width="1" height="32" forecolor="#555555" uuid="f648f7ec-8ba8-45ef-b934-b4d0c6de4039">
-						<property name="local_mesure_unitx" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.x" value="px"/>
-					</reportElement>
-				</line>
-				<line>
-					<reportElement key="line-12" style="Report_Footer" x="0" y="0" width="1" height="32" forecolor="#555555" uuid="14e2e2e5-efc6-4848-88f9-6c755c22fff3"/>
-				</line>
-				<textField evaluationTime="Group" evaluationGroup="DOCUMENTNO" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-1" style="Total_Gray" x="683" y="6" width="72" height="16" uuid="3efea6be-120f-460f-88a7-5d784d64f597"/>
-					<box leftPadding="4" rightPadding="4">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[($V{TOTAL_DOCNO}!=null)?$P{AMOUNTFORMAT}.format($V{TOTAL_DOCNO}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-1" style="Report_Footer" x="591" y="6" width="92" height="16" uuid="80f8fd76-b5a7-4466-97bf-e556d86bba6d"/>
-					<box rightPadding="4">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle"/>
-					<text><![CDATA[Total Order:]]></text>
-				</staticText>
-				<textField evaluationTime="Group" evaluationGroup="DOCUMENTNO" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-11" style="Total_Gray" x="755" y="6" width="21" height="16" uuid="2b2dbf75-a2fa-4fc5-ae04-48fd28949c4a"/>
-					<box leftPadding="4" rightPadding="4">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{TOTAL_DOCNO}!=null)?$F{CONVSYM}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-16" style="Report_Footer" x="20" y="0" width="760" height="1" forecolor="#555555" uuid="a78d1425-bbf6-4e37-abb8-fdf0f019d803">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					</reportElement>
-				</line>
-			</band>
-		</groupFooter>
-	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="24" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText" style="Report_Title" x="0" y="0" width="674" height="24" uuid="ecebaf6f-7dbb-4f76-a57b-f9a8b1cc8c74"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<text><![CDATA[Purchase Order Report]]></text>
-			</staticText>
-		</band>
-	</title>
-	<pageHeader>
-		<band height="9" splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
-	<detail>
-		<band height="14" splitType="Stretch">
-			<property name="local_mesure_unitheight" value="pixel"/>
-			<property name="com.jaspersoft.studio.unit.height" value="px"/>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="20" y="0" width="160" height="14" forecolor="#000000" uuid="e01547ef-7457-4b1e-a49f-bc8df6b82081"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8" fontName="DejaVu Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRODUCT_NAME}!=null)?$F{PRODUCT_NAME}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="180" y="0" width="53" height="14" uuid="1fbf0c3b-101b-4048-8059-f15ee922791e">
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" fontName="DejaVu Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QUANTITYORDER}!=null)?$P{QUANTITYFORMAT}.format($F{QUANTITYORDER}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="233" y="0" width="42" height="14" uuid="e1f6dfda-4efd-4908-b860-3b2a26e07ef7">
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8" fontName="DejaVu Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{UOMNAME}!=null)?$F{UOMNAME}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="380" y="0" width="79" height="14" uuid="61a17a75-4f05-4602-baa8-545698b46ea8"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" fontName="DejaVu Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRICEACTUAL}!=null)?$P{AMOUNTFORMAT}.format($F{PRICEACTUAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="580" y="0" width="79" height="14" uuid="cd89330c-7993-4c78-ab2f-445040e41316"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" fontName="DejaVu Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRICELIST}!=null)?$P{AMOUNTFORMAT}.format($F{PRICELIST}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-3" style="Report_Footer" x="10" y="0" width="1" height="14" forecolor="#555555" uuid="a9b90163-14fb-4dde-8050-5c217f4cd83d"/>
-			</line>
-			<line>
-				<reportElement key="line-4" style="Report_Footer" x="0" y="0" width="1" height="14" forecolor="#555555" uuid="0d9e6c78-ee34-4125-8d78-c6f93f02f0d5"/>
-			</line>
-			<line>
-				<reportElement key="line-5" style="Report_Footer" x="779" y="0" width="1" height="14" forecolor="#555555" uuid="c1b5662e-0b33-443e-a871-f18e9e2b72f9"/>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-3" style="Detail_Line" x="680" y="0" width="78" height="14" uuid="6024f5ab-3be8-4ed2-b315-c9d69fadfca0"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" fontName="DejaVu Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVPRICELIST}!=null)?$P{AMOUNTFORMAT}.format($F{CONVPRICELIST}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-4" style="Detail_Line" x="480" y="0" width="79" height="14" uuid="9b83be8f-2aac-47f5-b3ef-d51ccb7678d1"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" fontName="DejaVu Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVPRICEACTUAL}!=null)?$P{AMOUNTFORMAT}.format($F{CONVPRICEACTUAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-8" style="Detail_Line" x="659" y="0" width="21" height="14" uuid="631bfaf7-e534-4f25-8455-9637f346e4b3"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8" fontName="DejaVu Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{TRANSSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-10" style="Detail_Line" x="758" y="0" width="21" height="14" uuid="cf3b3515-c1a2-4a6e-8a3c-ea8fcdec14fa"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8" fontName="DejaVu Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-13" style="Detail_Line" x="559" y="0" width="21" height="14" uuid="abd797ec-1c53-4c92-bac1-638ae445f069"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8" fontName="DejaVu Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-15" style="Detail_Line" x="459" y="0" width="21" height="14" uuid="bf3121f0-3ed4-404f-a818-8b599424e91c"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8" fontName="DejaVu Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{TRANSSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="338" y="0" width="42" height="14" uuid="20a671c5-0215-446a-b9ef-7fe2f9e22ad0">
-					<property name="local_mesure_unity" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.y" value="px"/>
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8" fontName="DejaVu Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{AUM}!=null)?$F{AUM}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="275" y="0" width="63" height="14" uuid="8fc5a6a0-cadb-4454-8257-f0801dedc6d0">
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" fontName="DejaVu Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{AUMQTY}!=null)?$P{QUANTITYFORMAT}.format($F{AUMQTY}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="180" y="0" width="95" height="14" uuid="1153f63c-e2ef-4f35-8462-b1ccb00a5f90">
-					<property name="local_mesure_unitx" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.x" value="px"/>
-					<property name="local_mesure_unity" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.y" value="px"/>
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" fontName="DejaVu Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QUANTITYORDER}!=null)?$P{QUANTITYFORMAT}.format($F{QUANTITYORDER}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="275" y="0" width="105" height="14" uuid="09950aa1-a199-49c8-ba5e-7467d0d77718">
-					<property name="local_mesure_unitx" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.x" value="px"/>
-					<property name="local_mesure_unity" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.y" value="px"/>
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8" fontName="DejaVu Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{UOMNAME}!=null)?$F{UOMNAME}:new String(" ")]]></textFieldExpression>
-			</textField>
-		</band>
-	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="27" splitType="Stretch">
-			<property name="local_mesure_unitheight" value="pixel"/>
-			<property name="com.jaspersoft.studio.unit.height" value="px"/>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="566" y="7" width="170" height="19" uuid="928badd8-3058-4348-9595-6c98385b3c90"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom">
-					<font fontName="DejaVu Sans" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="740" y="7" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="2476b502-4947-4ff3-8539-ed2139e4fb83"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Bottom" rotation="None">
-					<font fontName="DejaVu Sans" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="1" width="779" height="1" forecolor="#000000" uuid="b0ed32cc-445a-4f9f-8e35-545d9b510956">
+				<element kind="line" uuid="3cf6f95e-73b6-495e-9b96-54c6bcc00acb" key="line-9" x="10" y="0" width="1" height="28" forecolor="#555555" style="Report_Footer"/>
+				<element kind="line" uuid="1ef3f575-64ce-4248-b75e-f4b5a22fbb9d" key="line-16" x="10" y="28" width="769" height="1" forecolor="#555555" style="Report_Footer">
 					<property name="local_mesure_unitwidth" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
 					<property name="local_mesure_unitheight" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
-					<property name="local_mesure_unitx" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 					<property name="local_mesure_unity" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
-				</reportElement>
-			</line>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="90" y="13" width="79" height="14" uuid="9ca676ee-7650-4466-b916-36c28866de70"/>
-				<box>
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+				</element>
+				<element kind="line" uuid="f648f7ec-8ba8-45ef-b934-b4d0c6de4039" key="line-10" x="779" y="0" width="1" height="32" forecolor="#555555" style="Report_Footer">
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+				</element>
+				<element kind="line" uuid="14e2e2e5-efc6-4848-88f9-6c755c22fff3" key="line-12" x="0" y="0" width="1" height="32" forecolor="#555555" style="Report_Footer"/>
+				<element kind="textField" uuid="3efea6be-120f-460f-88a7-5d784d64f597" key="textField-1" x="683" y="6" width="72" height="16" evaluationTime="Group" pattern="" evaluationGroup="DOCUMENTNO" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Gray">
+					<expression><![CDATA[($V{TOTAL_DOCNO}!=null)?$P{AMOUNTFORMAT}.format($V{TOTAL_DOCNO}):new String(" ")]]></expression>
+					<box leftPadding="4" rightPadding="4" style="Total_Gray">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="80f8fd76-b5a7-4466-97bf-e556d86bba6d" key="staticText-1" x="591" y="6" width="92" height="16" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
+					<text><![CDATA[Total Order:]]></text>
+					<box rightPadding="4" style="Report_Footer">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="2b2dbf75-a2fa-4fc5-ae04-48fd28949c4a" key="textField-11" x="755" y="6" width="21" height="16" fontName="DejaVu Sans" evaluationTime="Group" pattern="" evaluationGroup="DOCUMENTNO" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Total_Gray">
+					<expression><![CDATA[($V{TOTAL_DOCNO}!=null)?$F{CONVSYM}:new String(" ")]]></expression>
+					<box leftPadding="4" rightPadding="4" style="Total_Gray">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="a78d1425-bbf6-4e37-abb8-fdf0f019d803" key="line-16" x="20" y="0" width="760" height="1" forecolor="#555555" style="Report_Footer">
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</element>
+			</band>
+		</groupFooter>
+	</group>
+	<background splitType="Stretch"/>
+	<title height="24" splitType="Stretch">
+		<element kind="staticText" uuid="ecebaf6f-7dbb-4f76-a57b-f9a8b1cc8c74" key="staticText" x="0" y="0" width="674" height="24" style="Report_Title">
+			<text><![CDATA[Purchase Order Report]]></text>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+	</title>
+	<pageHeader height="9" splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
+	<detail>
+		<band height="14" splitType="Stretch">
+			<element kind="textField" uuid="e01547ef-7457-4b1e-a49f-bc8df6b82081" key="textField" x="20" y="0" width="160" height="14" forecolor="#000000" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PRODUCT_NAME}!=null)?$F{PRODUCT_NAME}:new String(" ")]]></expression>
+				<box leftPadding="5" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Bottom">
-					<font fontName="DejaVu Sans" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-3" style="default" x="10" y="13" width="78" height="14" uuid="605278db-7066-447e-82b5-84a6aeca8902"/>
-				<box topPadding="2" leftPadding="5">
+			</element>
+			<element kind="textField" uuid="1fbf0c3b-101b-4048-8059-f15ee922791e" key="textField" x="180" y="0" width="53" height="14" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+				<expression><![CDATA[($F{QUANTITYORDER}!=null)?$P{QUANTITYFORMAT}.format($F{QUANTITYORDER}):new String(" ")]]></expression>
+				<box leftPadding="5" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom">
-					<font fontName="DejaVu Sans" size="10"/>
-				</textElement>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
+			</element>
+			<element kind="textField" uuid="e1f6dfda-4efd-4908-b860-3b2a26e07ef7" key="textField" x="233" y="0" width="42" height="14" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+				<expression><![CDATA[($F{UOMNAME}!=null)?$F{UOMNAME}:new String(" ")]]></expression>
+				<box leftPadding="5" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="61a17a75-4f05-4602-baa8-545698b46ea8" key="textField" x="380" y="0" width="79" height="14" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PRICEACTUAL}!=null)?$P{AMOUNTFORMAT}.format($F{PRICEACTUAL}):new String(" ")]]></expression>
+				<box leftPadding="5" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="cd89330c-7993-4c78-ab2f-445040e41316" key="textField" x="580" y="0" width="79" height="14" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PRICELIST}!=null)?$P{AMOUNTFORMAT}.format($F{PRICELIST}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="line" uuid="a9b90163-14fb-4dde-8050-5c217f4cd83d" key="line-3" x="10" y="0" width="1" height="14" forecolor="#555555" style="Report_Footer"/>
+			<element kind="line" uuid="0d9e6c78-ee34-4125-8d78-c6f93f02f0d5" key="line-4" x="0" y="0" width="1" height="14" forecolor="#555555" style="Report_Footer"/>
+			<element kind="line" uuid="c1b5662e-0b33-443e-a871-f18e9e2b72f9" key="line-5" x="779" y="0" width="1" height="14" forecolor="#555555" style="Report_Footer"/>
+			<element kind="textField" uuid="6024f5ab-3be8-4ed2-b315-c9d69fadfca0" key="textField-3" x="680" y="0" width="78" height="14" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVPRICELIST}!=null)?$P{AMOUNTFORMAT}.format($F{CONVPRICELIST}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="9b83be8f-2aac-47f5-b3ef-d51ccb7678d1" key="textField-4" x="480" y="0" width="79" height="14" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVPRICEACTUAL}!=null)?$P{AMOUNTFORMAT}.format($F{CONVPRICEACTUAL}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="631bfaf7-e534-4f25-8455-9637f346e4b3" key="textField-8" x="659" y="0" width="21" height="14" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{TRANSSYM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="cf3b3515-c1a2-4a6e-8a3c-ea8fcdec14fa" key="textField-10" x="758" y="0" width="21" height="14" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{CONVSYM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="abd797ec-1c53-4c92-bac1-638ae445f069" key="textField-13" x="559" y="0" width="21" height="14" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{CONVSYM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="bf3121f0-3ed4-404f-a818-8b599424e91c" key="textField-15" x="459" y="0" width="21" height="14" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{TRANSSYM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="20a671c5-0215-446a-b9ef-7fe2f9e22ad0" key="textField" x="338" y="0" width="42" height="14" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+				<expression><![CDATA[($F{AUM}!=null)?$F{AUM}:new String(" ")]]></expression>
+				<property name="local_mesure_unity" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				<box leftPadding="5" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="8fc5a6a0-cadb-4454-8257-f0801dedc6d0" key="textField" x="275" y="0" width="63" height="14" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+				<expression><![CDATA[($F{AUMQTY}!=null)?$P{QUANTITYFORMAT}.format($F{AUMQTY}):new String(" ")]]></expression>
+				<box leftPadding="5" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="1153f63c-e2ef-4f35-8462-b1ccb00a5f90" key="textField" x="180" y="0" width="95" height="14" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
+				<expression><![CDATA[($F{QUANTITYORDER}!=null)?$P{QUANTITYFORMAT}.format($F{QUANTITYORDER}):new String(" ")]]></expression>
+				<property name="local_mesure_unitx" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.x" value="px"/>
+				<property name="local_mesure_unity" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				<property name="local_mesure_unitwidth" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				<box leftPadding="5" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="09950aa1-a199-49c8-ba5e-7467d0d77718" key="textField" x="275" y="0" width="105" height="14" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
+				<expression><![CDATA[($F{UOMNAME}!=null)?$F{UOMNAME}:new String(" ")]]></expression>
+				<property name="local_mesure_unitx" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.x" value="px"/>
+				<property name="local_mesure_unity" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				<property name="local_mesure_unitwidth" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				<box leftPadding="5" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<property name="local_mesure_unitheight" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
 		</band>
+	</detail>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="27" splitType="Stretch">
+		<element kind="textField" uuid="928badd8-3058-4348-9595-6c98385b3c90" key="textField" x="566" y="7" width="170" height="19" fontName="DejaVu Sans" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Bottom">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="2476b502-4947-4ff3-8539-ed2139e4fb83" key="textField" x="740" y="7" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="DejaVu Sans" fontSize="10.0" evaluationTime="Report" pattern="" blankWhenNull="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Bottom">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="b0ed32cc-445a-4f9f-8e35-545d9b510956" key="line" x="0" y="1" width="779" height="1" forecolor="#000000">
+			<property name="local_mesure_unitwidth" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.width" value="px"/>
+			<property name="local_mesure_unitheight" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<property name="local_mesure_unitx" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.x" value="px"/>
+			<property name="local_mesure_unity" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.y" value="px"/>
+		</element>
+		<element kind="textField" uuid="9ca676ee-7650-4466-b916-36c28866de70" key="textField" x="90" y="13" width="79" height="14" fontName="DejaVu Sans" fontSize="10.0" blankWhenNull="false" vTextAlign="Bottom" style="default">
+			<expression><![CDATA[new Date()]]></expression>
+			<box style="default">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="605278db-7066-447e-82b5-84a6aeca8902" key="staticText-3" x="10" y="13" width="78" height="14" fontName="DejaVu Sans" fontSize="10.0" hTextAlign="Right" vTextAlign="Bottom" style="default">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5" style="default">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<property name="local_mesure_unitheight" value="pixel"/>
+		<property name="com.jaspersoft.studio.unit.height" value="px"/>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportPurchaseOrderXLS.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportPurchaseOrderXLS.jrxml
@@ -1,111 +1,107 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
-<!-- 2017-05-25T09:44:46 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportPurchaseOrder" pageWidth="1450" pageHeight="130" orientation="Landscape" columnWidth="1450" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" whenResourceMissingType="Empty" uuid="d5112654-5616-45aa-ab46-4a7530b995d6">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportPurchaseOrder" language="java" pageWidth="1450" pageHeight="130" orientation="Landscape" columnWidth="1450" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" whenResourceMissingType="Empty" uuid="d5112654-5616-45aa-ab46-4a7530b995d6">
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
 	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="One Empty Record"/>
 	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="org.openbravo.erpCommon.utility.Utility"/>
-	<import value="java.util.*"/>
-	<import value="org.openbravo.dal.core.OBContext"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="DejaVu Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="DejaVu Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>org.openbravo.erpCommon.utility.Utility</import>
+	<import>org.openbravo.dal.core.OBContext</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="DejaVu Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="DejaVu Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="DejaVu Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="DejaVu Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Data_Label" fontName="DejaVu Sans" fontSize="10" isBold="true"/>
-	<style name="Report_Data_Field" fontName="DejaVu Sans" fontSize="10" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="DejaVu Sans" fontSize="11" isBold="true">
+	<style name="Report_Data_Label" fontName="DejaVu Sans" fontSize="10.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="DejaVu Sans" fontSize="10.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="DejaVu Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="DejaVu Sans" fontSize="12" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="DejaVu Sans" fontSize="12.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Group_Data_Label" fontName="DejaVu Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="DejaVu Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="DejaVu Sans" fontSize="10" isBold="true">
+	<style name="Group_Data_Label" fontName="DejaVu Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="DejaVu Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="DejaVu Sans" fontSize="10.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="Detail_Line" fontName="DejaVu Sans" fontSize="10">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="DejaVu Sans" fontSize="10.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{DOCUMENTNO_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="DejaVu Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="DejaVu Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="DejaVu Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="DejaVu Sans" fontSize="11"/>
-	<parameter name="DateFrom" class="java.util.Date" isForPrompting="false"/>
-	<parameter name="AD_Org_ID" class="org.codehaus.jettison.json.JSONObject" isForPrompting="false">
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="DejaVu Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="DejaVu Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="DejaVu Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="DejaVu Sans" fontSize="11.0"/>
+	<parameter name="DateFrom" forPrompting="false" class="java.util.Date"/>
+	<parameter name="AD_Org_ID" forPrompting="false" class="org.codehaus.jettison.json.JSONObject">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
 	<parameter name="ChildOrgs" class="java.lang.String">
 		<defaultValueExpression><![CDATA[Utility.getInStrSet(OBContext.getOBContext().getOrganizationStructureProvider().getChildTree($P{AD_Org_ID}.getString("value"), true))]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_organization" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_organization" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{AD_Org_ID} == null || "".equals($P{AD_Org_ID}.getString("value"))) ? "" : " AND C_ORDER.AD_ORG_ID IN (" + $P{ChildOrgs} + ")"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="C_BPartner_ID" class="org.codehaus.jettison.json.JSONObject" isForPrompting="false">
+	<parameter name="C_BPartner_ID" forPrompting="false" class="org.codehaus.jettison.json.JSONObject">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_partner" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_partner" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{C_BPartner_ID} == null || "".equals($P{C_BPartner_ID}.getString("value"))) ? "" : " AND C_ORDER.C_BPARTNER_ID = '" + $P{C_BPartner_ID}.getString("value") + "'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DateTo" class="java.util.Date" isForPrompting="false"/>
-	<parameter name="M_Warehouse_ID" class="org.codehaus.jettison.json.JSONObject" isForPrompting="false">
+	<parameter name="DateTo" forPrompting="false" class="java.util.Date"/>
+	<parameter name="M_Warehouse_ID" forPrompting="false" class="org.codehaus.jettison.json.JSONObject">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_warehouse" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_warehouse" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{M_Warehouse_ID} == null || "".equals($P{M_Warehouse_ID}.getString("value"))) ? "" : " AND C_ORDER.M_WAREHOUSE_ID = '" + $P{M_Warehouse_ID}.getString("value") + "'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="C_Project_ID" class="org.codehaus.jettison.json.JSONObject" isForPrompting="false">
+	<parameter name="C_Project_ID" forPrompting="false" class="org.codehaus.jettison.json.JSONObject">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_project" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_project" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{C_Project_ID} == null || "".equals($P{C_Project_ID}.getString("value"))) ? "" : " AND C_ORDER.C_PROJECT_ID = '" + $P{C_Project_ID}.getString("value") + "'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="AMOUNTFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="QUANTITYFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="C_Currency_ID" class="org.codehaus.jettison.json.JSONObject" isForPrompting="false"/>
-	<parameter name="aux_Currency" class="java.lang.String" isForPrompting="false">
+	<parameter name="AMOUNTFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="QUANTITYFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="C_Currency_ID" forPrompting="false" class="org.codehaus.jettison.json.JSONObject"/>
+	<parameter name="aux_Currency" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{C_Currency_ID}.getString("value")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_DateFrom" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_DateFrom" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{DateFrom} == null || $P{DateFrom}.equals("")) ? "" : "AND C_ORDER.DATEORDERED >= TO_DATE('" + new java.sql.Date($P{DateFrom}.getTime()).toString() + "', 'YYYY-MM-DD')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_DateTo" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_DateTo" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{DateTo} == null || $P{DateTo}.equals("")) ? "" : "AND C_ORDER.DATEORDERED <= TO_DATE('" + new java.sql.Date($P{DateTo}.getTime()) + "', 'YYYY-MM-DD')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="Status" class="org.codehaus.jettison.json.JSONObject" isForPrompting="false">
+	<parameter name="Status" forPrompting="false" class="org.codehaus.jettison.json.JSONObject">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_Status" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_Status" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{Status} == null || $P{Status}.equals("")) ? "" : "AND C_ORDER.DOCSTATUS = '" + $P{Status}.getString("value") + "'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="Current_Client_ID" class="java.lang.String" isForPrompting="false"/>
+	<parameter name="Current_Client_ID" forPrompting="false" class="java.lang.String"/>
 	<parameter name="Readable_Organizations" class="java.lang.String">
 		<defaultValueExpression><![CDATA[]]></defaultValueExpression>
 	</parameter>
-	<parameter name="isUOMManagementEnabled" class="java.lang.Boolean" isForPrompting="false">
+	<parameter name="isUOMManagementEnabled" forPrompting="false" class="java.lang.Boolean">
 		<defaultValueExpression><![CDATA[org.openbravo.materialmgmt.UOMUtil.isUomManagementEnabled()]]></defaultValueExpression>
 	</parameter>
-	<queryString language="SQL">
-		<![CDATA[SELECT
+	<query language="SQL"><![CDATA[SELECT
 	ZZ.DOCUMENTNO,
 	ZZ.DATEORDERED,
 	BP.NAME AS CLIENT_NAME,
@@ -190,8 +186,7 @@
     WHERE
     	RL.AD_REFERENCE_ID = '9184D71985B045E1BCF98D70D33472DE'
     ORDER BY
-    	CLIENT_NAME, DATEORDERED, DOCUMENTNO, PRODUCT_NAME]]>
-	</queryString>
+    	CLIENT_NAME, DATEORDERED, DOCUMENTNO, PRODUCT_NAME]]></query>
 	<field name="DOCUMENTNO" class="java.lang.String"/>
 	<field name="STATUS" class="java.lang.String"/>
 	<field name="DATEORDERED" class="java.util.Date"/>
@@ -213,312 +208,150 @@
 	<field name="AUMQTY" class="java.math.BigDecimal"/>
 	<field name="AUM" class="java.lang.String"/>
 	<variable name="LOCALE" class="java.util.Locale">
-		<variableExpression><![CDATA[new Locale($P{LANGUAGE}.substring(0,2),$P{LANGUAGE}.substring(3,5))]]></variableExpression>
+		<expression><![CDATA[new Locale($P{LANGUAGE}.substring(0,2),$P{LANGUAGE}.substring(3,5))]]></expression>
 	</variable>
-	<variable name="TOTAL_CLIENT" class="java.math.BigDecimal" resetType="Group" resetGroup="CLIENT_NAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVPRICELIST}]]></variableExpression>
+	<variable name="TOTAL_CLIENT" resetType="Group" calculation="Sum" resetGroup="CLIENT_NAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVPRICELIST}]]></expression>
 	</variable>
 	<group name="CLIENT_NAME">
 		<groupHeader>
 			<band height="14">
-				<staticText>
-					<reportElement mode="Opaque" x="0" y="-10" width="90" height="14" backcolor="#C0C0C0" uuid="963a2c27-e526-4f17-8e1c-02f5f2c4195b"/>
-					<textElement>
-						<font size="8"/>
-					</textElement>
+				<element kind="staticText" uuid="963a2c27-e526-4f17-8e1c-02f5f2c4195b" mode="Opaque" x="0" y="-10" width="90" height="14" backcolor="#C0C0C0" fontSize="8.0">
 					<text><![CDATA[Document No.]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="90" y="-10" width="58" height="14" backcolor="#C0C0C0" uuid="e36fce9c-f85d-4349-8f6e-7d9c724d6eb5"/>
-					<textElement>
-						<font size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="e36fce9c-f85d-4349-8f6e-7d9c724d6eb5" mode="Opaque" x="90" y="-10" width="58" height="14" backcolor="#C0C0C0" fontSize="8.0">
 					<text><![CDATA[Status]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="148" y="-10" width="168" height="14" backcolor="#C0C0C0" uuid="7f8dbe60-af50-4555-bfcb-c2895aa69608"/>
-					<textElement>
-						<font size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="7f8dbe60-af50-4555-bfcb-c2895aa69608" mode="Opaque" x="148" y="-10" width="168" height="14" backcolor="#C0C0C0" fontSize="8.0">
 					<text><![CDATA[Business Partner]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="316" y="-10" width="69" height="14" backcolor="#C0C0C0" uuid="3f1c7120-1224-43e0-9a58-77b10d13ec59"/>
-					<textElement>
-						<font size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="3f1c7120-1224-43e0-9a58-77b10d13ec59" mode="Opaque" x="316" y="-10" width="69" height="14" backcolor="#C0C0C0" fontSize="8.0">
 					<text><![CDATA[Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="385" y="-10" width="69" height="14" backcolor="#C0C0C0" uuid="10274c8e-582c-46d5-a0cb-c2797bd94e83"/>
-					<textElement>
-						<font size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="10274c8e-582c-46d5-a0cb-c2797bd94e83" mode="Opaque" x="385" y="-10" width="69" height="14" backcolor="#C0C0C0" fontSize="8.0">
 					<text><![CDATA[Need By Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="454" y="-10" width="113" height="14" backcolor="#C0C0C0" uuid="fadca79e-c532-4b84-9227-64949f99b82b"/>
-					<textElement>
-						<font size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="fadca79e-c532-4b84-9227-64949f99b82b" mode="Opaque" x="454" y="-10" width="113" height="14" backcolor="#C0C0C0" fontSize="8.0">
 					<text><![CDATA[Search Key]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="567" y="-10" width="178" height="14" backcolor="#C0C0C0" uuid="4bff7558-e45e-4926-a22f-7158a82532a1"/>
-					<textElement>
-						<font size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="4bff7558-e45e-4926-a22f-7158a82532a1" mode="Opaque" x="567" y="-10" width="178" height="14" backcolor="#C0C0C0" fontSize="8.0">
 					<text><![CDATA[Product]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="745" y="-10" width="165" height="14" backcolor="#C0C0C0" uuid="56b9099f-92b8-4b05-9c12-51a7624cfba6"/>
-					<textElement>
-						<font size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="56b9099f-92b8-4b05-9c12-51a7624cfba6" mode="Opaque" x="745" y="-10" width="165" height="14" backcolor="#C0C0C0" fontSize="8.0">
 					<text><![CDATA[UPC/EAN]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="910" y="-10" width="50" height="14" backcolor="#C0C0C0" uuid="646f6623-4180-4689-8a58-e4d2235ecfef"/>
-					<textElement>
-						<font size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="646f6623-4180-4689-8a58-e4d2235ecfef" mode="Opaque" x="910" y="-10" width="50" height="14" backcolor="#C0C0C0" fontSize="8.0">
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="960" y="-10" width="117" height="14" backcolor="#C0C0C0" uuid="3169e4a7-c48a-4189-96c2-b80171724237"/>
-					<textElement>
-						<font size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="3169e4a7-c48a-4189-96c2-b80171724237" mode="Opaque" x="960" y="-10" width="117" height="14" backcolor="#C0C0C0" fontSize="8.0">
 					<text><![CDATA[Outstanding Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="1077" y="-10" width="71" height="14" backcolor="#C0C0C0" uuid="5b19df83-18c7-422f-9601-8f57729df31f"/>
-					<textElement>
-						<font size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="5b19df83-18c7-422f-9601-8f57729df31f" mode="Opaque" x="1077" y="-10" width="71" height="14" backcolor="#C0C0C0" fontSize="8.0">
 					<text><![CDATA[UOM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="1148" y="-10" width="76" height="14" backcolor="#C0C0C0" uuid="35e504d4-b07a-4a4e-b631-f5c74391c602"/>
-					<textElement>
-						<font size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="35e504d4-b07a-4a4e-b631-f5c74391c602" mode="Opaque" x="1148" y="-10" width="76" height="14" backcolor="#C0C0C0" fontSize="8.0">
 					<text><![CDATA[Price]]></text>
-				</staticText>
-				<staticText>
-					<reportElement mode="Opaque" x="1300" y="-10" width="60" height="14" backcolor="#C0C0C0" uuid="76673677-41ed-4801-854d-f2cf0a09819f"/>
-					<textElement>
-						<font size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="76673677-41ed-4801-854d-f2cf0a09819f" mode="Opaque" x="1300" y="-10" width="60" height="14" backcolor="#C0C0C0" fontSize="8.0">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<textField>
-					<reportElement mode="Opaque" x="1360" y="-10" width="90" height="14" backcolor="#C0C0C0" uuid="2ede07c7-41fb-4c82-9966-572f58ae08c5"/>
-					<textElement>
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA["Amount " + $F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<textField>
-					<reportElement mode="Opaque" x="1224" y="-10" width="76" height="14" backcolor="#C0C0C0" uuid="8f0d33af-b6ee-47ee-b952-c18b546ca268"/>
-					<textElement>
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA["Price " + $F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="2ede07c7-41fb-4c82-9966-572f58ae08c5" mode="Opaque" x="1360" y="-10" width="90" height="14" backcolor="#C0C0C0" fontSize="8.0">
+					<expression><![CDATA["Amount " + $F{CONVISOSYM}]]></expression>
+				</element>
+				<element kind="textField" uuid="8f0d33af-b6ee-47ee-b952-c18b546ca268" mode="Opaque" x="1224" y="-10" width="76" height="14" backcolor="#C0C0C0" fontSize="8.0">
+					<expression><![CDATA["Price " + $F{CONVISOSYM}]]></expression>
+				</element>
 			</band>
 		</groupHeader>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="30" splitType="Stretch">
-			<staticText>
-				<reportElement x="0" y="0" width="1450" height="20" uuid="71002e90-edc6-4dc7-9944-81849b405e47"/>
-				<textElement>
-					<font isBold="true"/>
-				</textElement>
-				<text><![CDATA[Purchase Order Report]]></text>
-			</staticText>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="30" splitType="Stretch">
+		<element kind="staticText" uuid="71002e90-edc6-4dc7-9944-81849b405e47" x="0" y="0" width="1450" height="20" bold="true">
+			<text><![CDATA[Purchase Order Report]]></text>
+		</element>
 	</title>
-	<pageHeader>
-		<band height="80" splitType="Stretch">
-			<staticText>
-				<reportElement x="0" y="50" width="90" height="20" uuid="18d7889f-c1f9-462b-ba45-2536b7dd88c8"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Report Date:]]></text>
-			</staticText>
-			<textField>
-				<reportElement x="90" y="50" width="1360" height="20" uuid="65547b77-95bc-4097-8ab3-296260500557"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement x="0" y="30" width="90" height="20" uuid="bad268c2-db20-45e9-a444-c748ce2f8835"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Document Status: ]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="0" y="10" width="90" height="20" uuid="284a25a8-5673-42a4-866a-c57ee1a27aa3"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Secondary Filters:]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="0" y="-10" width="90" height="20" uuid="fedf1a86-534f-469e-97f8-01fa7294e72c"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Primary Filters:]]></text>
-			</staticText>
-			<textField pattern="dd-MM-yyyy" isBlankWhenNull="true">
-				<reportElement x="90" y="-10" width="1360" height="20" uuid="e1e19353-c1ac-4ed7-84b2-5f0142de3695"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[(($P{DateFrom} == null || $P{DateFrom}.equals("")) ? "" :"From "+new SimpleDateFormat("dd-MM-yyyy").format($P{DateFrom}))
-+(($P{DateTo} == null || $P{DateTo}.equals("")) ? "" : " to "+new SimpleDateFormat("dd-MM-yyyy").format($P{DateTo}))]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement x="90" y="30" width="1360" height="20" uuid="417d1e3b-0f76-42a2-83c9-5874a3bfdec5"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{Status}.getString("identifier")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement x="90" y="10" width="1360" height="20" uuid="9fbfd6ce-b233-4248-8592-8f6343f7e4d7"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($P{AD_Org_ID} == null ? "" : "Organization: " + $P{AD_Org_ID}.getString("identifier")) + ($P{AD_Org_ID} != null && !$P{C_BPartner_ID}.equals("") ? ", " : "" ) + ($P{C_BPartner_ID}.equals("") ? "" : "Business Partner: " + $F{CLIENT_NAME})]]></textFieldExpression>
-			</textField>
-		</band>
+	<pageHeader height="80" splitType="Stretch">
+		<element kind="staticText" uuid="18d7889f-c1f9-462b-ba45-2536b7dd88c8" x="0" y="50" width="90" height="20" fontSize="8.0">
+			<text><![CDATA[Report Date:]]></text>
+		</element>
+		<element kind="textField" uuid="65547b77-95bc-4097-8ab3-296260500557" x="90" y="50" width="1360" height="20" fontSize="8.0">
+			<expression><![CDATA[new Date()]]></expression>
+		</element>
+		<element kind="staticText" uuid="bad268c2-db20-45e9-a444-c748ce2f8835" x="0" y="30" width="90" height="20" fontSize="8.0">
+			<text><![CDATA[Document Status: ]]></text>
+		</element>
+		<element kind="staticText" uuid="284a25a8-5673-42a4-866a-c57ee1a27aa3" x="0" y="10" width="90" height="20" fontSize="8.0">
+			<text><![CDATA[Secondary Filters:]]></text>
+		</element>
+		<element kind="staticText" uuid="fedf1a86-534f-469e-97f8-01fa7294e72c" x="0" y="-10" width="90" height="20" fontSize="8.0">
+			<text><![CDATA[Primary Filters:]]></text>
+		</element>
+		<element kind="textField" uuid="e1e19353-c1ac-4ed7-84b2-5f0142de3695" x="90" y="-10" width="1360" height="20" fontSize="8.0" pattern="dd-MM-yyyy" blankWhenNull="true">
+			<expression><![CDATA[(($P{DateFrom} == null || $P{DateFrom}.equals("")) ? "" :"From "+new SimpleDateFormat("dd-MM-yyyy").format($P{DateFrom}))
++(($P{DateTo} == null || $P{DateTo}.equals("")) ? "" : " to "+new SimpleDateFormat("dd-MM-yyyy").format($P{DateTo}))]]></expression>
+		</element>
+		<element kind="textField" uuid="417d1e3b-0f76-42a2-83c9-5874a3bfdec5" x="90" y="30" width="1360" height="20" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true">
+			<expression><![CDATA[$P{Status}.getString("identifier")]]></expression>
+		</element>
+		<element kind="textField" uuid="9fbfd6ce-b233-4248-8592-8f6343f7e4d7" x="90" y="10" width="1360" height="20" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true">
+			<expression><![CDATA[($P{AD_Org_ID} == null ? "" : "Organization: " + $P{AD_Org_ID}.getString("identifier")) + ($P{AD_Org_ID} != null && !$P{C_BPartner_ID}.equals("") ? ", " : "" ) + ($P{C_BPartner_ID}.equals("") ? "" : "Business Partner: " + $F{CLIENT_NAME})]]></expression>
+		</element>
 	</pageHeader>
 	<detail>
 		<band height="14" splitType="Stretch">
+			<element kind="textField" uuid="6b47b056-076f-4eef-b8fd-3b9d82a88cb2" x="0" y="-10" width="90" height="14" fontSize="8.0" blankWhenNull="true">
+				<expression><![CDATA[$F{DOCUMENTNO}]]></expression>
+			</element>
+			<element kind="textField" uuid="639a9f65-fd1a-4126-abca-a70c7c45947b" x="90" y="-10" width="58" height="14" fontSize="8.0" blankWhenNull="true">
+				<expression><![CDATA[$F{STATUS}]]></expression>
+			</element>
+			<element kind="textField" uuid="331d82cf-0eb5-4c0f-beff-8327bfe2761f" x="148" y="-10" width="168" height="14" fontSize="8.0" blankWhenNull="true">
+				<expression><![CDATA[$F{CLIENT_NAME}]]></expression>
+			</element>
+			<element kind="textField" uuid="a51756f8-118e-4261-8940-06c853a6a046" x="316" y="-10" width="69" height="14" fontSize="8.0" blankWhenNull="true">
+				<expression><![CDATA[$F{DATEORDERED}]]></expression>
+			</element>
+			<element kind="textField" uuid="25276851-ceb8-4779-a9a4-575ed7c12d26" x="385" y="-10" width="69" height="14" fontSize="8.0" blankWhenNull="true">
+				<expression><![CDATA[$F{NEEDBYDATE}]]></expression>
+			</element>
+			<element kind="textField" uuid="69d0e3f3-f4bb-4a3a-9340-1e5acb8d7809" x="454" y="-10" width="113" height="14" fontSize="8.0" blankWhenNull="true">
+				<expression><![CDATA[$F{PRODUCT_CODE}]]></expression>
+			</element>
+			<element kind="textField" uuid="722a8a05-0ddb-40bc-a26c-3e4b4662fb39" x="567" y="-10" width="178" height="14" fontSize="8.0" blankWhenNull="true">
+				<expression><![CDATA[$F{PRODUCT_NAME}]]></expression>
+			</element>
+			<element kind="textField" uuid="4aaa69a4-2338-4464-86e4-c33ad3698487" x="745" y="-10" width="165" height="14" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true">
+				<expression><![CDATA[$F{BARCODE}]]></expression>
+			</element>
+			<element kind="textField" uuid="05f96c58-42b5-4a50-a2db-d2b983345d18" x="910" y="-10" width="50" height="14" fontSize="8.0" blankWhenNull="true" hTextAlign="Right">
+				<expression><![CDATA[$F{QUANTITYORDER}]]></expression>
+				<patternExpression><![CDATA[$P{QUANTITYFORMAT}.toPattern()]]></patternExpression>
+			</element>
+			<element kind="textField" uuid="99fa8175-4481-4fe6-a898-73867f82fe72" x="960" y="-10" width="117" height="14" fontSize="8.0" blankWhenNull="true" hTextAlign="Right">
+				<expression><![CDATA[$F{OUTSTANDINGQTY}]]></expression>
+				<patternExpression><![CDATA[$P{QUANTITYFORMAT}.toPattern()]]></patternExpression>
+			</element>
+			<element kind="textField" uuid="ee48d6a4-a965-432a-a856-33f356a1b43a" x="1077" y="-10" width="71" height="14" fontSize="8.0" blankWhenNull="true">
+				<expression><![CDATA[$F{UOMNAME}]]></expression>
+			</element>
+			<element kind="textField" uuid="ef1f531c-f757-4b73-a9dd-ae05e8600541" x="1148" y="-10" width="76" height="14" fontSize="8.0" blankWhenNull="true" hTextAlign="Right">
+				<expression><![CDATA[$F{PRICEACTUAL}]]></expression>
+				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
+			</element>
+			<element kind="textField" uuid="1204c703-ae80-45fd-b0d1-7b75e21ee313" x="1224" y="-10" width="76" height="14" fontSize="8.0" blankWhenNull="true" hTextAlign="Right">
+				<expression><![CDATA[$F{CONVPRICEACTUAL}]]></expression>
+				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
+			</element>
+			<element kind="textField" uuid="a42930f3-a166-4348-ba2b-f0107ee802e6" x="1360" y="-10" width="90" height="14" fontSize="8.0" blankWhenNull="true" hTextAlign="Right">
+				<expression><![CDATA[$F{CONVPRICEACTUAL}.multiply($F{QUANTITYORDER})]]></expression>
+				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
+			</element>
+			<element kind="textField" uuid="532f2787-51c1-4aef-b39a-4d731c9df441" x="1300" y="-10" width="60" height="14" fontSize="8.0" blankWhenNull="true" hTextAlign="Right">
+				<expression><![CDATA[$F{PRICEACTUAL}.multiply($F{QUANTITYORDER})]]></expression>
+				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
+			</element>
 			<property name="local_mesure_unitheight" value="pixel"/>
 			<property name="com.jaspersoft.studio.unit.height" value="px"/>
-			<textField isBlankWhenNull="true">
-				<reportElement x="0" y="-10" width="90" height="14" uuid="6b47b056-076f-4eef-b8fd-3b9d82a88cb2"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DOCUMENTNO}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="90" y="-10" width="58" height="14" uuid="639a9f65-fd1a-4126-abca-a70c7c45947b"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{STATUS}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="148" y="-10" width="168" height="14" uuid="331d82cf-0eb5-4c0f-beff-8327bfe2761f"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CLIENT_NAME}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="316" y="-10" width="69" height="14" uuid="a51756f8-118e-4261-8940-06c853a6a046"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DATEORDERED}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="385" y="-10" width="69" height="14" uuid="25276851-ceb8-4779-a9a4-575ed7c12d26"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{NEEDBYDATE}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="454" y="-10" width="113" height="14" uuid="69d0e3f3-f4bb-4a3a-9340-1e5acb8d7809"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRODUCT_CODE}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="567" y="-10" width="178" height="14" uuid="722a8a05-0ddb-40bc-a26c-3e4b4662fb39"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRODUCT_NAME}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement x="745" y="-10" width="165" height="14" uuid="4aaa69a4-2338-4464-86e4-c33ad3698487"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{BARCODE}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="910" y="-10" width="50" height="14" uuid="05f96c58-42b5-4a50-a2db-d2b983345d18"/>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{QUANTITYORDER}]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{QUANTITYFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="960" y="-10" width="117" height="14" uuid="99fa8175-4481-4fe6-a898-73867f82fe72"/>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{OUTSTANDINGQTY}]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{QUANTITYFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="1077" y="-10" width="71" height="14" uuid="ee48d6a4-a965-432a-a856-33f356a1b43a"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{UOMNAME}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="1148" y="-10" width="76" height="14" uuid="ef1f531c-f757-4b73-a9dd-ae05e8600541"/>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRICEACTUAL}]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="1224" y="-10" width="76" height="14" uuid="1204c703-ae80-45fd-b0d1-7b75e21ee313"/>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVPRICEACTUAL}]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="1360" y="-10" width="90" height="14" uuid="a42930f3-a166-4348-ba2b-f0107ee802e6"/>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVPRICEACTUAL}.multiply($F{QUANTITYORDER})]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="1300" y="-10" width="60" height="14" uuid="532f2787-51c1-4aef-b39a-4d731c9df441"/>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRICEACTUAL}.multiply($F{QUANTITYORDER})]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{AMOUNTFORMAT}.toPattern()]]></patternExpression>
-			</textField>
 		</band>
 	</detail>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportSalesOrderInvoicedJasper.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportSalesOrderInvoicedJasper.jrxml
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
-<!-- 2016-12-26T15:35:27 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportSalesOrderInvoicedJasper" pageWidth="920" pageHeight="595" orientation="Landscape" columnWidth="860" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="69316ac0-b6f7-469e-a008-b44e0006499c">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportSalesOrderInvoicedJasper" language="java" pageWidth="920" pageHeight="595" orientation="Landscape" columnWidth="860" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="69316ac0-b6f7-469e-a008-b44e0006499c">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
@@ -14,66 +12,64 @@
 	<property name="com.jaspersoft.studio.unit.rightMargin" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnWidth" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true">
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="10">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="10.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{PROJECTNAME_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
 	<parameter name="isUomManagementEnabled" class="java.lang.Boolean">
 		<defaultValueExpression><![CDATA[org.openbravo.materialmgmt.UOMUtil.isUomManagementEnabled()]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[SELECT COALESCE(CB.NAME, C_BPARTNER.NAME) AS BPARTNERNAME, C_PROJECT.VALUE||' '||C_PROJECT.NAME AS PROJECTNAME,
+	<query language="sql"><![CDATA[SELECT COALESCE(CB.NAME, C_BPARTNER.NAME) AS BPARTNERNAME, C_PROJECT.VALUE||' '||C_PROJECT.NAME AS PROJECTNAME,
       M_PRODUCT.NAME AS PRODUCTNAME, SUM(C_ORDERLINE.QTYINVOICED) AS QTYINVOICED,
       SUM(C_ORDERLINE.QTYINVOICED*C_ORDERLINE.PRICEACTUAL) AS LINENETAMT, 
       C_CURRENCY_SYMBOL(COALESCE(C_ORDERLINE.C_CURRENCY_ID, C_ORDER.C_CURRENCY_ID), C_ORDERLINE.PRICEACTUAL, 'Y') AS LINENETAMTSYM,	  
@@ -104,8 +100,7 @@
       COALESCE(C_ORDERLINE.C_CURRENCY_ID, C_ORDER.C_CURRENCY_ID), TO_DATE(COALESCE(C_ORDER.DATEORDERED, NOW())),	  
 	  C_ORDERLINE.AD_CLIENT_ID, C_ORDERLINE.AD_ORG_ID	
       HAVING SUM(C_ORDERLINE.QTYDELIVERED) > 0
-      ORDER BY COALESCE(CB.NAME, C_BPARTNER.NAME), C_PROJECT.NAME, M_PRODUCT.NAME]]>
-	</queryString>
+      ORDER BY COALESCE(CB.NAME, C_BPARTNER.NAME), C_PROJECT.NAME, M_PRODUCT.NAME]]></query>
 	<field name="BPARTNERNAME" class="java.lang.String"/>
 	<field name="PROJECTNAME" class="java.lang.String"/>
 	<field name="PRODUCTNAME" class="java.lang.String"/>
@@ -122,738 +117,508 @@
 	<field name="CONVISOSYM" class="java.lang.String"/>
 	<field name="AUMQTY" class="java.math.BigDecimal"/>
 	<field name="AUM" class="java.lang.String"/>
-	<variable name="sumTotalQty" class="java.math.BigDecimal" resetType="Group" resetGroup="PROJECTNAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYINVOICED}]]></variableExpression>
+	<variable name="sumTotalQty" resetType="Group" calculation="Sum" resetGroup="PROJECTNAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYINVOICED}]]></expression>
 	</variable>
-	<variable name="sumTotalAmount" class="java.math.BigDecimal" resetType="Group" resetGroup="PROJECTNAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVLINENETAMT}]]></variableExpression>
+	<variable name="sumTotalAmount" resetType="Group" calculation="Sum" resetGroup="PROJECTNAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVLINENETAMT}]]></expression>
 	</variable>
 	<group name="BPARTNERNAME">
-		<groupExpression><![CDATA[$F{BPARTNERNAME}]]></groupExpression>
+		<expression><![CDATA[$F{BPARTNERNAME}]]></expression>
 		<groupHeader>
 			<band height="33" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="1" y="0" width="129" height="23" uuid="a2d3266f-22f2-410c-84cd-b7cc679169e7"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
+				<element kind="staticText" uuid="a2d3266f-22f2-410c-84cd-b7cc679169e7" key="staticText" x="1" y="0" width="129" height="23" style="GroupHeader_DarkGray">
 					<text><![CDATA[PARTNER]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="130" y="0" width="729" height="23" uuid="dfc49501-a35e-4a0e-b2b3-ee16a6d25797"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{BPARTNERNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="33" forecolor="#555555" uuid="501c9663-6306-40f5-a308-74d591f5d2f0"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="859" y="0" width="1" height="33" forecolor="#555555" uuid="df6ed286-999a-4819-9fec-09b612d726a6"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				</element>
+				<element kind="textField" uuid="dfc49501-a35e-4a0e-b2b3-ee16a6d25797" key="textField" x="130" y="0" width="729" height="23" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{BPARTNERNAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="501c9663-6306-40f5-a308-74d591f5d2f0" key="line-2" stretchType="ContainerHeight" x="0" y="0" width="1" height="33" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="df6ed286-999a-4819-9fec-09b612d726a6" key="line-3" stretchType="ContainerHeight" x="859" y="0" width="1" height="33" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-32" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="10" forecolor="#555555" uuid="a133c97b-379e-49e5-896b-3b85cb2a0440"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="859" y="0" width="1" height="11" forecolor="#555555" uuid="b0dcc984-0ba0-40d2-8cc0-614766d5edf0"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-34" x="0" y="10" width="860" height="1" forecolor="#555555" uuid="0e482939-ba9b-4497-b4e5-6f496fd9d838"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="a133c97b-379e-49e5-896b-3b85cb2a0440" key="line-32" stretchType="ContainerHeight" x="0" y="0" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="b0dcc984-0ba0-40d2-8cc0-614766d5edf0" key="line-33" stretchType="ContainerHeight" x="859" y="0" width="1" height="11" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="0e482939-ba9b-4497-b4e5-6f496fd9d838" key="line-34" x="0" y="10" width="860" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="PROJECTNAME">
-		<groupExpression><![CDATA[$F{PROJECTNAME}]]></groupExpression>
+		<expression><![CDATA[$F{PROJECTNAME}]]></expression>
 		<groupHeader>
 			<band height="44" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="11" y="0" width="119" height="23" uuid="4de4ec34-8f4e-4e67-aaf8-7979a9cc3e03"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="4de4ec34-8f4e-4e67-aaf8-7979a9cc3e03" key="staticText" x="11" y="0" width="119" height="23" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[PROJECT NAME]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="130" y="0" width="729" height="23" uuid="f4fbe6fd-5ece-4582-bc26-2832c053c47a"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{PROJECTNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-4" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="44" forecolor="#555555" uuid="cc1afa9d-a407-4860-956f-27d073d476fb"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-8" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="44" forecolor="#555555" uuid="e0e41c1a-b4f4-44f3-8053-d5c8cc762009"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="20" y="28" width="158" height="16" uuid="8f8b035f-7c19-486a-8764-2ee308db0d0e"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="f4fbe6fd-5ece-4582-bc26-2832c053c47a" key="textField" x="130" y="0" width="729" height="23" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{PROJECTNAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="cc1afa9d-a407-4860-956f-27d073d476fb" key="line-4" stretchType="ContainerHeight" x="10" y="0" width="1" height="44" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="e0e41c1a-b4f4-44f3-8053-d5c8cc762009" key="line-8" stretchType="ContainerHeight" x="0" y="0" width="1" height="44" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="8f8b035f-7c19-486a-8764-2ee308db0d0e" key="element-90" x="20" y="28" width="158" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" style="Detail_Header">
 					<text><![CDATA[Product]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="178" y="28" width="82" height="16" uuid="571dc4ae-551b-40c0-b9f3-05e39e462c46">
-						<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="571dc4ae-551b-40c0-b9f3-05e39e462c46" key="element-90" x="178" y="28" width="82" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="667" y="28" width="96" height="16" uuid="0d50c6f3-6aa7-42ab-8739-c213aa63c5a7"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="0d50c6f3-6aa7-42ab-8739-c213aa63c5a7" key="element-90" x="667" y="28" width="96" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
 					<text><![CDATA[Total]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="260" y="28" width="80" height="16" uuid="39bebcc3-4f3f-4219-a1e1-d32d7524a626">
-						<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="39bebcc3-4f3f-4219-a1e1-d32d7524a626" key="element-90" x="260" y="28" width="80" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
 					<text><![CDATA[UOM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="495" y="28" width="86" height="16" uuid="f8667283-2acb-41c8-a553-b4030d57059a"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="f8667283-2acb-41c8-a553-b4030d57059a" key="element-90" x="495" y="28" width="86" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
 					<text><![CDATA[Price]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-91" style="Detail_Header" x="581" y="28" width="37" height="16" uuid="9f191819-78c9-4f1b-8bc3-b8dd91535a36">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="9f191819-78c9-4f1b-8bc3-b8dd91535a36" key="element-91" x="581" y="28" width="37" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+					<text><![CDATA[Price]]></text>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Price]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-92" style="Detail_Header" x="763" y="28" width="47" height="16" uuid="e2b9821d-d381-4fc7-9b69-0fad46128784"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="staticText" uuid="e2b9821d-d381-4fc7-9b69-0fad46128784" key="element-92" x="763" y="28" width="47" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+					<text><![CDATA[Total]]></text>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Total]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-8" style="Detail_Header" x="618" y="28" width="49" height="16" uuid="f6cd1a75-473b-4233-b729-8f0245a5d196"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="f6cd1a75-473b-4233-b729-8f0245a5d196" key="textField-8" x="618" y="28" width="49" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="415" y="28" width="80" height="16" uuid="87aa7d55-a1cc-4841-b21e-1a7c619f94c7">
-						<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="87aa7d55-a1cc-4841-b21e-1a7c619f94c7" key="element-90" x="415" y="28" width="80" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
 					<text><![CDATA[AUM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="340" y="28" width="75" height="16" uuid="e24c2f0a-00fa-42c7-b333-baf87d76f543">
-						<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="e24c2f0a-00fa-42c7-b333-baf87d76f543" key="element-90" x="340" y="28" width="75" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
 					<text><![CDATA[Qty in AUM]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-7" style="Detail_Header" x="810" y="28" width="49" height="16" uuid="eb14fedb-2b5c-4633-9144-fe35fc89c1c6"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="eb14fedb-2b5c-4633-9144-fe35fc89c1c6" key="textField-7" x="810" y="28" width="49" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#555555"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-6" stretchType="RelativeToBandHeight" x="859" y="0" width="1" height="44" forecolor="#555555" uuid="e322a663-214c-4013-a33a-2545ac32121c"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="178" y="28" width="162" height="16" uuid="77867777-7ed9-405f-8d09-8421bb39e0b9">
-						<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="e322a663-214c-4013-a33a-2545ac32121c" key="line-6" stretchType="ContainerHeight" x="859" y="0" width="1" height="44" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="77867777-7ed9-405f-8d09-8421bb39e0b9" key="element-90" x="178" y="28" width="162" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="340" y="28" width="154" height="16" uuid="e353a8c4-acd5-4755-aec2-f97f3d9c2ba3">
-						<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="e353a8c4-acd5-4755-aec2-f97f3d9c2ba3" key="element-90" x="340" y="28" width="154" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
 					<text><![CDATA[UOM]]></text>
-				</staticText>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="35" splitType="Stretch">
-				<line>
-					<reportElement key="line-28" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="35" forecolor="#555555" uuid="e3b4e0f4-47c0-4d2c-9417-d9848e4c21e6"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-29" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="9" forecolor="#555555" uuid="78d6275a-b689-4e1c-ae5b-328cb804e12c"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-30" stretchType="RelativeToBandHeight" x="859" y="0" width="1" height="35" forecolor="#555555" uuid="b5d6e85e-6a5a-40d9-ae6a-5b8b0ecc1965"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-31" x="10" y="8" width="849" height="1" forecolor="#666666" uuid="10943e96-11b1-4e6c-85d4-2a6f4e2a6332"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" mode="Opaque" x="255" y="12" width="160" height="14" backcolor="#CCCCCC" uuid="d553b975-5189-4224-8fdd-ddac005db5fe"/>
+				<element kind="line" uuid="e3b4e0f4-47c0-4d2c-9417-d9848e4c21e6" key="line-28" stretchType="ContainerHeight" x="0" y="0" width="1" height="35" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="78d6275a-b689-4e1c-ae5b-328cb804e12c" key="line-29" stretchType="ContainerHeight" x="10" y="0" width="1" height="9" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="b5d6e85e-6a5a-40d9-ae6a-5b8b0ecc1965" key="line-30" stretchType="ContainerHeight" x="859" y="0" width="1" height="35" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="10943e96-11b1-4e6c-85d4-2a6f4e2a6332" key="line-31" x="10" y="8" width="849" height="1" forecolor="#666666">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="textField" uuid="d553b975-5189-4224-8fdd-ddac005db5fe" key="textField" mode="Opaque" x="255" y="12" width="160" height="14" backcolor="#CCCCCC" fontSize="12.0" pattern="" blankWhenNull="false" hTextAlign="Right">
+					<expression><![CDATA[($V{sumTotalQty}!=null)?$P{NUMBERFORMAT}.format($V{sumTotalQty}):new String(" ")]]></expression>
 					<box leftPadding="2" rightPadding="4">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="12"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{sumTotalQty}!=null)?$P{NUMBERFORMAT}.format($V{sumTotalQty}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" mode="Opaque" x="415" y="12" width="420" height="14" backcolor="#CCCCCC" uuid="f24f7fb0-5cd3-4ca3-90c8-a2098d9fb07f"/>
+				</element>
+				<element kind="textField" uuid="f24f7fb0-5cd3-4ca3-90c8-a2098d9fb07f" key="textField" mode="Opaque" x="415" y="12" width="420" height="14" backcolor="#CCCCCC" fontSize="12.0" pattern="" blankWhenNull="false" hTextAlign="Right">
+					<expression><![CDATA[($V{sumTotalAmount}!=null)?$P{NUMBERFORMAT}.format($V{sumTotalAmount}):new String(" ")]]></expression>
 					<box rightPadding="4">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="12"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{sumTotalAmount}!=null)?$P{NUMBERFORMAT}.format($V{sumTotalAmount}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-4" x="166" y="12" width="88" height="14" uuid="2a13dfcf-1b25-431d-ab2d-6567b32653c9"/>
+				</element>
+				<element kind="staticText" uuid="2a13dfcf-1b25-431d-ab2d-6567b32653c9" key="staticText-4" x="166" y="12" width="88" height="14" fontName="Bitstream Vera Sans" fontSize="12.0" hTextAlign="Right">
+					<text><![CDATA[Total:]]></text>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font fontName="Bitstream Vera Sans" size="12"/>
-					</textElement>
-					<text><![CDATA[Total:]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-35" style="Report_Footer" x="20" y="0" width="839" height="1" forecolor="#555555" uuid="1e1c556f-da26-43eb-92f6-e96ffb34f63c"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-5" mode="Opaque" x="835" y="12" width="22" height="14" backcolor="#CCCCCC" uuid="e74040c0-4b35-438d-991b-99679cafd335"/>
+				</element>
+				<element kind="line" uuid="1e1c556f-da26-43eb-92f6-e96ffb34f63c" key="line-35" x="20" y="0" width="839" height="1" forecolor="#555555" style="Report_Footer">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="textField" uuid="e74040c0-4b35-438d-991b-99679cafd335" key="textField-5" mode="Opaque" x="835" y="12" width="22" height="14" backcolor="#CCCCCC" fontSize="12.0" pattern="" blankWhenNull="false" hTextAlign="Center">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
 					<box rightPadding="4">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="12"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="9" splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="47" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-1" style="Report_Subtitle" x="0" y="24" width="860" height="20" uuid="247fbad5-f5aa-484f-bbfd-2d1bf4536517"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_SUBTITLE}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-2" style="Report_Title" mode="Transparent" x="0" y="4" width="860" height="20" uuid="84a11df4-8625-4f0f-9f61-e9f4efd2bafa"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="9" splitType="Stretch"/>
+	<pageHeader height="47" splitType="Stretch">
+		<element kind="textField" uuid="247fbad5-f5aa-484f-bbfd-2d1bf4536517" key="textField-1" x="0" y="24" width="860" height="20" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="84a11df4-8625-4f0f-9f61-e9f4efd2bafa" key="textField-2" mode="Transparent" x="0" y="4" width="860" height="20" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band height="16" splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader height="16" splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="859" y="0" width="1" height="16" forecolor="#555555" uuid="fb5144c3-fa9e-4a99-b591-218cc5fa3f21"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="16" forecolor="#555555" uuid="682842bf-a663-4a0a-8e2b-f3625b5adade"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-18" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="16" forecolor="#555555" uuid="98053971-4d34-411c-abdb-b1275956dde9"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" x="20" y="0" width="158" height="16" uuid="27cd6901-b576-4220-ad6c-b4c38423fed6"/>
-				<box leftPadding="2" rightPadding="2">
+			<element kind="line" uuid="fb5144c3-fa9e-4a99-b591-218cc5fa3f21" key="line-16" stretchType="ContainerHeight" x="859" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="682842bf-a663-4a0a-8e2b-f3625b5adade" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="98053971-4d34-411c-abdb-b1275956dde9" key="line-18" stretchType="ContainerHeight" x="10" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="27cd6901-b576-4220-ad6c-b4c38423fed6" key="textField" x="20" y="0" width="158" height="16" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{PRODUCTNAME}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRODUCTNAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="178" y="0" width="82" height="16" uuid="7d452fdd-7dab-4415-af07-e683feb1d931">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="7d452fdd-7dab-4415-af07-e683feb1d931" key="textField" x="178" y="0" width="82" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
+				<expression><![CDATA[($F{QTYINVOICED}!=null)?$P{NUMBERFORMAT}.format($F{QTYINVOICED}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QTYINVOICED}!=null)?$P{NUMBERFORMAT}.format($F{QTYINVOICED}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="667" y="0" width="72" height="16" uuid="94d3e812-cf41-4a46-a08e-cb4909e47af9"/>
-				<box rightPadding="4">
+			</element>
+			<element kind="textField" uuid="94d3e812-cf41-4a46-a08e-cb4909e47af9" key="textField" x="667" y="0" width="72" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}):new String(" ")]]></expression>
+				<box rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" x="260" y="0" width="80" height="16" uuid="cc1dec75-609f-4ba8-a5bc-777d5a769a20">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="cc1dec75-609f-4ba8-a5bc-777d5a769a20" key="textField" x="260" y="0" width="80" height="16" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
+				<expression><![CDATA[$F{UOMNAME}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{UOMNAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="495" y="0" width="62" height="16" uuid="aa8ecd81-ca61-4518-b365-450f475e912b"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="aa8ecd81-ca61-4518-b365-450f475e912b" key="textField" x="495" y="0" width="62" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-3" style="Detail_Line" x="581" y="0" width="62" height="16" uuid="b117de0c-4545-493a-90bc-f943f0a68165"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="b117de0c-4545-493a-90bc-f943f0a68165" key="textField-3" x="581" y="0" width="62" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVPRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{CONVPRICEACTUAL}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVPRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{CONVPRICEACTUAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-4" style="Detail_Line" x="763" y="0" width="72" height="16" uuid="1b5b904f-b075-4c2c-91ea-c7306482e1a3"/>
-				<box rightPadding="4">
+			</element>
+			<element kind="textField" uuid="1b5b904f-b075-4c2c-91ea-c7306482e1a3" key="textField-4" x="763" y="0" width="72" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVLINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{CONVLINENETAMT}):new String(" ")]]></expression>
+				<box rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVLINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{CONVLINENETAMT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-6" style="Detail_Line" x="835" y="0" width="24" height="16" uuid="7121301d-9145-43a1-8688-2bafc26f35f1"/>
-				<box leftPadding="2" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="7121301d-9145-43a1-8688-2bafc26f35f1" key="textField-6" x="835" y="0" width="24" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{CONVSYM}]]></expression>
+				<box leftPadding="2" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-9" style="Detail_Line" x="643" y="0" width="24" height="16" uuid="a0538f80-3a19-4be5-8fdb-eceb126d9e9d"/>
-				<box leftPadding="2" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="a0538f80-3a19-4be5-8fdb-eceb126d9e9d" key="textField-9" x="643" y="0" width="24" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{CONVSYM}]]></expression>
+				<box leftPadding="2" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-10" style="Detail_Line" x="557" y="0" width="24" height="16" uuid="d57ecdf9-a9fe-487c-b35e-eb086d684926"/>
-				<box leftPadding="2" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="d57ecdf9-a9fe-487c-b35e-eb086d684926" key="textField-10" x="557" y="0" width="24" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{PRICEACTUALSYM}]]></expression>
+				<box leftPadding="2" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRICEACTUALSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-11" style="Detail_Line" x="739" y="0" width="24" height="16" uuid="881ecbce-9734-4f12-9830-aaa565a64ea4"/>
-				<box leftPadding="2" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="881ecbce-9734-4f12-9830-aaa565a64ea4" key="textField-11" x="739" y="0" width="24" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{LINENETAMTSYM}]]></expression>
+				<box leftPadding="2" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{LINENETAMTSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="340" y="0" width="75" height="16" uuid="02de3100-de3c-4a08-b0ce-ca74489ab0f5">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="02de3100-de3c-4a08-b0ce-ca74489ab0f5" key="textField" x="340" y="0" width="75" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
+				<expression><![CDATA[($F{AUMQTY}!=null)?$P{NUMBERFORMAT}.format($F{AUMQTY}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{AUMQTY}!=null)?$P{NUMBERFORMAT}.format($F{AUMQTY}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" x="415" y="0" width="80" height="16" uuid="144eb8aa-2621-4dd1-915d-04c8a086108a">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="144eb8aa-2621-4dd1-915d-04c8a086108a" key="textField" x="415" y="0" width="80" height="16" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
+				<expression><![CDATA[$F{AUM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AUM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="178" y="0" width="162" height="16" uuid="2524a403-3bfa-4a84-91ee-534f43659e5d">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="2524a403-3bfa-4a84-91ee-534f43659e5d" key="textField" x="178" y="0" width="162" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
+				<expression><![CDATA[($F{QTYINVOICED}!=null)?$P{NUMBERFORMAT}.format($F{QTYINVOICED}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QTYINVOICED}!=null)?$P{NUMBERFORMAT}.format($F{QTYINVOICED}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" x="340" y="0" width="154" height="16" uuid="da88e78e-1a34-4b5d-a06e-6e8eca466883">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="da88e78e-1a34-4b5d-a06e-6e8eca466883" key="textField" x="340" y="0" width="154" height="16" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
+				<expression><![CDATA[$F{UOMNAME}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{UOMNAME}]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="16" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="27" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="725" y="4" width="95" height="19" uuid="d3adb250-ca71-45e3-8601-7e33c0e4b99e"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom"/>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="824" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="47b57f2f-80f2-4d7c-9a9d-15365c3a1c1a"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Bottom" rotation="None">
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="425" y="4" width="69" height="19" uuid="a549d450-908e-469b-b0a0-5cbd8549fe4c"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Bottom"/>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" x="346" y="4" width="78" height="19" uuid="e2059d2a-6826-4a0d-88b0-3aa6ed3ff92e"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-			<line>
-				<reportElement key="line" x="0" y="1" width="860" height="1" forecolor="#000000" uuid="8fa57120-c0c6-4373-bd45-62e27a2a7810"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-		</band>
+	<columnFooter height="16" splitType="Stretch"/>
+	<pageFooter height="27" splitType="Stretch">
+		<element kind="textField" uuid="d3adb250-ca71-45e3-8601-7e33c0e4b99e" key="textField" x="725" y="4" width="95" height="19" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Bottom">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="47b57f2f-80f2-4d7c-9a9d-15365c3a1c1a" key="textField" x="824" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Bottom">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="a549d450-908e-469b-b0a0-5cbd8549fe4c" key="textField" x="425" y="4" width="69" height="19" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Bottom">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="e2059d2a-6826-4a0d-88b0-3aa6ed3ff92e" key="staticText-1" x="346" y="4" width="78" height="19" hTextAlign="Right" vTextAlign="Bottom">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="8fa57120-c0c6-4373-bd45-62e27a2a7810" key="line" x="0" y="1" width="860" height="1" forecolor="#000000">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportSalesOrderJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportSalesOrderJR.jrxml
@@ -1,73 +1,69 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
-<!-- 2016-07-12T15:15:42 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportSalesOrderJR" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="bfa4f89a-03b7-4f2e-a3be-00d6a95ae2b0">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportSalesOrderJR" language="java" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="bfa4f89a-03b7-4f2e-a3be-00d6a95ae2b0">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" isBlankWhenNull="true" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" blankWhenNull="true" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true">
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="10">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="10.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{DOCUMENTNO_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="ReportData" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="ReportData" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="isUOMManagementEnabled" class="java.lang.Boolean" isForPrompting="false">
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="isUOMManagementEnabled" forPrompting="false" class="java.lang.Boolean">
 		<defaultValueExpression><![CDATA[org.openbravo.materialmgmt.UOMUtil.isUomManagementEnabled()]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[SELECT C_ORDER.DOCUMENTNO AS DOCUMENTNO, C_ORDER.DATEORDERED AS DATEORDERED, C_BPARTNER.NAME AS CLIENT_NAME, SUM(C_ORDERLINE.QTYORDERED) AS QUANTITYORDER, 
+	<query language="sql"><![CDATA[SELECT C_ORDER.DOCUMENTNO AS DOCUMENTNO, C_ORDER.DATEORDERED AS DATEORDERED, C_BPARTNER.NAME AS CLIENT_NAME, SUM(C_ORDERLINE.QTYORDERED) AS QUANTITYORDER, 
       C_ORDERLINE.PRICEACTUAL AS PRICEACTUAL, 
       C_CURRENCY_SYMBOL (COALESCE(C_ORDERLINE.C_CURRENCY_ID, C_ORDER.C_CURRENCY_ID), C_ORDERLINE.PRICEACTUAL, 'Y') AS PRICEACTUALSYM,	  
 	  C_CURRENCY_CONVERT(C_ORDERLINE.PRICEACTUAL, COALESCE(C_ORDERLINE.C_CURRENCY_ID, C_ORDER.C_CURRENCY_ID), '102', TO_DATE(COALESCE(C_ORDER.DATEORDERED, NOW())), NULL, C_ORDERLINE.AD_CLIENT_ID, C_ORDERLINE.AD_ORG_ID) AS CONVPRICEACTUAL,      
@@ -95,8 +91,7 @@
       GROUP BY C_BPARTNER.NAME, C_ORDER.DOCUMENTNO, M_PRODUCT.NAME,C_ORDERLINE.PRICEACTUAL, C_UOM.NAME, C_ORDER.DATEORDERED,
       COALESCE(C_ORDERLINE.C_CURRENCY_ID, C_ORDER.C_CURRENCY_ID), TO_DATE(COALESCE(C_ORDER.DATEORDERED, NOW())),
 	  C_ORDERLINE.AD_CLIENT_ID, C_ORDERLINE.AD_ORG_ID
-	  ORDER BY C_BPARTNER.NAME, C_ORDER.DOCUMENTNO, M_PRODUCT.NAME,C_ORDERLINE.PRICEACTUAL, C_UOM.NAME, C_ORDER.DATEORDERED]]>
-	</queryString>
+	  ORDER BY C_BPARTNER.NAME, C_ORDER.DOCUMENTNO, M_PRODUCT.NAME,C_ORDERLINE.PRICEACTUAL, C_UOM.NAME, C_ORDER.DATEORDERED]]></query>
 	<field name="DOCUMENTNO" class="java.lang.String"/>
 	<field name="DATEORDERED" class="java.util.Date"/>
 	<field name="CLIENT_NAME" class="java.lang.String"/>
@@ -113,837 +108,616 @@
 	<field name="CONVISOSYM" class="java.lang.String"/>
 	<field name="AUM" class="java.lang.String"/>
 	<field name="AUMQTY" class="java.math.BigDecimal"/>
-	<variable name="DetailFieldTotal" class="java.math.BigDecimal" resetType="Group" resetGroup="CLIENT_NAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVPRICELIST}]]></variableExpression>
+	<variable name="DetailFieldTotal" resetType="Group" calculation="Sum" resetGroup="CLIENT_NAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVPRICELIST}]]></expression>
 	</variable>
-	<variable name="TotalQty" class="java.math.BigDecimal" resetType="Group" resetGroup="CLIENT_NAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{QUANTITYORDER}]]></variableExpression>
+	<variable name="TotalQty" resetType="Group" calculation="Sum" resetGroup="CLIENT_NAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QUANTITYORDER}]]></expression>
 	</variable>
-	<variable name="TotalQtyOrder" class="java.math.BigDecimal" resetType="Group" resetGroup="DOCUMENTNO" calculation="Sum">
-		<variableExpression><![CDATA[$F{QUANTITYORDER}]]></variableExpression>
+	<variable name="TotalQtyOrder" resetType="Group" calculation="Sum" resetGroup="DOCUMENTNO" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QUANTITYORDER}]]></expression>
 	</variable>
-	<variable name="TotalPriceOrder" class="java.math.BigDecimal" resetType="Group" resetGroup="DOCUMENTNO" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVPRICELIST}]]></variableExpression>
+	<variable name="TotalPriceOrder" resetType="Group" calculation="Sum" resetGroup="DOCUMENTNO" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVPRICELIST}]]></expression>
 	</variable>
 	<group name="CLIENT_NAME">
-		<groupExpression><![CDATA[$F{CLIENT_NAME}]]></groupExpression>
+		<expression><![CDATA[$F{CLIENT_NAME}]]></expression>
 		<groupHeader>
 			<band height="24" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText-17" style="GroupHeader_DarkGray" mode="Opaque" x="0" y="0" width="108" height="24" uuid="1aead22b-bf51-4a94-b04a-82dbb7c50797"/>
-					<box leftPadding="5">
+				<element kind="staticText" uuid="1aead22b-bf51-4a94-b04a-82dbb7c50797" key="staticText-17" mode="Opaque" x="0" y="0" width="108" height="24" style="GroupHeader_DarkGray">
+					<text><![CDATA[Client]]></text>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<text><![CDATA[Client]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-23" style="GroupHeader_DarkGray" mode="Opaque" x="108" y="0" width="673" height="24" uuid="a061dcbf-2de4-42ec-b8c6-b80f94adf0b5">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					</reportElement>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="a061dcbf-2de4-42ec-b8c6-b80f94adf0b5" key="textField-23" mode="Opaque" x="108" y="0" width="673" height="24" textAdjust="StretchHeight" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{CLIENT_NAME}]]></expression>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{CLIENT_NAME}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="33" splitType="Stretch">
-				<textField evaluationTime="Group" evaluationGroup="CLIENT_NAME" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-24" style="Total_Gray" x="240" y="1" width="514" height="16" uuid="f719fc7a-1a0e-43c7-afdb-58f954e5aa2c"/>
-					<box rightPadding="4">
+				<element kind="textField" uuid="f719fc7a-1a0e-43c7-afdb-58f954e5aa2c" key="textField-24" x="240" y="1" width="514" height="16" evaluationTime="Group" pattern="" evaluationGroup="CLIENT_NAME" blankWhenNull="false" hTextAlign="Right" style="Total_Gray">
+					<expression><![CDATA[($V{DetailFieldTotal}!=null)?$P{NUMBERFORMAT}.format($V{DetailFieldTotal}):new String(" ")]]></expression>
+					<box rightPadding="4" style="Total_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{DetailFieldTotal}!=null)?$P{NUMBERFORMAT}.format($V{DetailFieldTotal}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="CLIENT_NAME" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-25" style="Total_Gray" mode="Opaque" x="190" y="1" width="50" height="16" uuid="0c498486-909b-4828-b8e6-268ce25254d0"/>
-					<box leftPadding="5" rightPadding="4">
+				</element>
+				<element kind="textField" uuid="0c498486-909b-4828-b8e6-268ce25254d0" key="textField-25" mode="Opaque" x="190" y="1" width="50" height="16" evaluationTime="Group" pattern="" evaluationGroup="CLIENT_NAME" blankWhenNull="false" hTextAlign="Right" style="Total_Gray">
+					<expression><![CDATA[($V{TotalQty}!=null)?$P{NUMBERFORMAT}.format($V{TotalQty}):new String(" ")]]></expression>
+					<box leftPadding="5" rightPadding="4" style="Total_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{TotalQty}!=null)?$P{NUMBERFORMAT}.format($V{TotalQty}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-18" style="Group_Footer" x="10" y="1" width="180" height="16" uuid="45840fb2-c8cc-4279-9087-8785b2e9451a"/>
-					<box leftPadding="4" rightPadding="4">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Left">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="45840fb2-c8cc-4279-9087-8785b2e9451a" key="staticText-18" x="10" y="1" width="180" height="16" pdfFontName="Helvetica-Bold" hTextAlign="Left" style="Group_Footer">
 					<text><![CDATA[Total Client:]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-4" style="Report_Footer" x="0" y="0" width="1" height="24" forecolor="#555555" uuid="c2763c0b-e073-4235-80a4-4cd9eb1e2960"/>
-				</line>
-				<line>
-					<reportElement key="line-8" style="Report_Footer" x="780" y="0" width="1" height="24" forecolor="#555555" uuid="1a999846-bd48-41c4-9dbd-f79557a524a8">
-						<property name="local_mesure_unitx" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.x" value="px"/>
-					</reportElement>
-				</line>
-				<line>
-					<reportElement key="line-17" style="Report_Footer" x="0" y="24" width="781" height="1" forecolor="#555555" uuid="b2d2d496-f791-4264-8b5d-3c0c1e8c60e0">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					</reportElement>
-				</line>
-				<textField evaluationTime="Group" evaluationGroup="DOCUMENTNO" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-38" style="Total_Gray" x="754" y="1" width="24" height="16" uuid="321200f5-e449-4b5a-bce8-42ed2c4caaf0"/>
-					<box rightPadding="4">
+					<box leftPadding="4" rightPadding="4" style="Group_Footer">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="c2763c0b-e073-4235-80a4-4cd9eb1e2960" key="line-4" x="0" y="0" width="1" height="24" forecolor="#555555" style="Report_Footer"/>
+				<element kind="line" uuid="1a999846-bd48-41c4-9dbd-f79557a524a8" key="line-8" x="780" y="0" width="1" height="24" forecolor="#555555" style="Report_Footer">
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+				</element>
+				<element kind="line" uuid="b2d2d496-f791-4264-8b5d-3c0c1e8c60e0" key="line-17" x="0" y="24" width="781" height="1" forecolor="#555555" style="Report_Footer">
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</element>
+				<element kind="textField" uuid="321200f5-e449-4b5a-bce8-42ed2c4caaf0" key="textField-38" x="754" y="1" width="24" height="16" evaluationTime="Group" pattern="" evaluationGroup="DOCUMENTNO" blankWhenNull="false" hTextAlign="Center" style="Total_Gray">
+					<expression><![CDATA[($F{CONVSYM}!=null)?$F{CONVSYM}:new String(" ")]]></expression>
+					<box rightPadding="4" style="Total_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center"/>
-					<textFieldExpression><![CDATA[($F{CONVSYM}!=null)?$F{CONVSYM}:new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="DOCUMENTNO">
-		<groupExpression><![CDATA[$F{DOCUMENTNO}]]></groupExpression>
+		<expression><![CDATA[$F{DOCUMENTNO}]]></expression>
 		<groupHeader>
 			<band height="42" splitType="Stretch">
-				<property name="local_mesure_unitheight" value="pixel"/>
-				<property name="com.jaspersoft.studio.unit.height" value="px"/>
-				<staticText>
-					<reportElement key="staticText-15" style="GroupHeader_DarkGray" x="10" y="5" width="80" height="16" uuid="56ac2889-b665-4259-bc37-69c64ba714f4"/>
-					<box leftPadding="5">
+				<element kind="staticText" uuid="56ac2889-b665-4259-bc37-69c64ba714f4" key="staticText-15" x="10" y="5" width="80" height="16" style="GroupHeader_DarkGray">
+					<text><![CDATA[Order No.]]></text>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<text><![CDATA[Order No.]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField-21" style="GroupHeader_DarkGray" x="90" y="5" width="238" height="16" uuid="5a8467d2-5a7f-4971-81c2-e9cebafd0e58"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="5a8467d2-5a7f-4971-81c2-e9cebafd0e58" key="textField-21" x="90" y="5" width="238" height="16" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{DOCUMENTNO}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{DOCUMENTNO}]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-22" style="GroupHeader_DarkGray" x="418" y="5" width="362" height="16" uuid="97cadd4a-925e-4a69-b305-957147253edb">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					</reportElement>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="97cadd4a-925e-4a69-b305-957147253edb" key="textField-22" x="418" y="5" width="362" height="16" textAdjust="StretchHeight" blankWhenNull="true" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{DATEORDERED}]]></expression>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{DATEORDERED}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-1" style="Detail_Header" x="20" y="26" width="170" height="16" uuid="551814c2-9fae-484a-a66b-119254ab98af"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement>
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="551814c2-9fae-484a-a66b-119254ab98af" key="element-1" x="20" y="26" width="170" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" style="Detail_Header">
 					<text><![CDATA[Article]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-2" style="Detail_Header" x="190" y="26" width="50" height="16" uuid="437dea81-9eda-4200-9f65-fd07156e5622">
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="437dea81-9eda-4200-9f65-fd07156e5622" key="element-2" x="190" y="26" width="50" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-3" style="Detail_Header" x="240" y="26" width="49" height="16" uuid="2453eb57-32fd-4781-8eeb-9d38040f5aa7">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="2453eb57-32fd-4781-8eeb-9d38040f5aa7" key="element-3" x="240" y="26" width="49" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
 					<text><![CDATA[UOM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-16" style="GroupHeader_DarkGray" x="328" y="5" width="90" height="16" uuid="246a9c3e-08f5-4370-b54c-adcbaaeaabe8"/>
-					<box leftPadding="5">
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="246a9c3e-08f5-4370-b54c-adcbaaeaabe8" key="staticText-16" x="328" y="5" width="90" height="16" style="GroupHeader_DarkGray">
+					<text><![CDATA[Order Date:]]></text>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<text><![CDATA[Order Date:]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-2" style="Report_Footer" x="0" y="0" width="1" height="42" forecolor="#555555" uuid="9f3ce02d-7eeb-4b9d-b1aa-a137f8b0c419"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-13" style="Report_Footer" x="10" y="21" width="1" height="21" forecolor="#555555" uuid="c3fbcea5-3340-4d2a-809b-246f68619f30"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="element-6" style="Detail_Header" x="520" y="26" width="40" height="16" uuid="98f84305-2c47-4707-89bc-24551cd8426b"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="9f3ce02d-7eeb-4b9d-b1aa-a137f8b0c419" key="line-2" x="0" y="0" width="1" height="42" forecolor="#555555" style="Report_Footer">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="c3fbcea5-3340-4d2a-809b-246f68619f30" key="line-13" x="10" y="21" width="1" height="21" forecolor="#555555" style="Report_Footer">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="98f84305-2c47-4707-89bc-24551cd8426b" key="element-6" x="520" y="26" width="40" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[Price	]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-7" style="Detail_Header" x="696" y="26" width="36" height="16" uuid="9f888f82-71fa-4b9d-b1dc-647ac288fd6e"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="9f888f82-71fa-4b9d-b1dc-647ac288fd6e" key="element-7" x="696" y="26" width="36" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[Total]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-8" style="Detail_Header" x="610" y="26" width="86" height="16" uuid="a0eea037-dde0-4368-b393-7a276bb1f139"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="a0eea037-dde0-4368-b393-7a276bb1f139" key="element-8" x="610" y="26" width="86" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+					<text><![CDATA[Total]]></text>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Total]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-31" style="Detail_Header" x="560" y="26" width="50" height="16" uuid="4f2f0214-6858-48b7-be16-2bb94a8d38b7"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="4f2f0214-6858-48b7-be16-2bb94a8d38b7" key="textField-31" x="560" y="26" width="50" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[($F{CONVISOSYM}!=null)?$F{CONVISOSYM}:new String(" ")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{CONVISOSYM}!=null)?$F{CONVISOSYM}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-32" style="Detail_Header" x="732" y="26" width="48" height="16" uuid="f34d50b8-27e1-444a-9682-9ee711646d31">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-						<property name="local_mesure_unitx" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.x" value="px"/>
-					</reportElement>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="f34d50b8-27e1-444a-9682-9ee711646d31" key="textField-32" x="732" y="26" width="48" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[($F{CONVISOSYM}!=null)?$F{CONVISOSYM}:new String(" ")]]></expression>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{CONVISOSYM}!=null)?$F{CONVISOSYM}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-2" style="Detail_Header" x="289" y="26" width="90" height="16" uuid="4d79471d-c388-4a36-8628-60d0cba0d6c8">
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="4d79471d-c388-4a36-8628-60d0cba0d6c8" key="element-2" x="289" y="26" width="90" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
 					<text><![CDATA[Quantity in AUM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-4" style="Detail_Header" x="430" y="26" width="90" height="16" uuid="50059157-83b8-4081-9285-20b9359f367b"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="50059157-83b8-4081-9285-20b9359f367b" key="element-4" x="430" y="26" width="90" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
 					<text><![CDATA[Price	]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-2" style="Detail_Header" x="379" y="26" width="51" height="16" uuid="75c7c8d5-d642-4a34-86ec-f3f7ea3a7535">
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-						<paragraph tabStopWidth="40"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="75c7c8d5-d642-4a34-86ec-f3f7ea3a7535" key="element-2" x="379" y="26" width="51" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+					<paragraph tabStopWidth="40" style="Detail_Header"/>
 					<text><![CDATA[AUM]]></text>
-				</staticText>
-				<line>
-					<reportElement x="780" y="0" width="1" height="42" forecolor="#5D5D5D" uuid="c31c91f2-a8f4-4699-a4d6-e83212c47f5d">
-						<property name="local_mesure_unity" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.y" value="px"/>
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-						<property name="local_mesure_unitheight" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.height" value="px"/>
-						<property name="local_mesure_unitx" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.x" value="px"/>
-					</reportElement>
-				</line>
-				<staticText>
-					<reportElement key="element-2" style="Detail_Header" x="190" y="26" width="99" height="16" uuid="67d0ef7a-fc26-4cbb-b628-9e55345c9fa7">
-						<property name="local_mesure_unitx" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.x" value="px"/>
-						<property name="local_mesure_unity" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.y" value="px"/>
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="c31c91f2-a8f4-4699-a4d6-e83212c47f5d" x="780" y="0" width="1" height="42" forecolor="#5D5D5D">
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+				</element>
+				<element kind="staticText" uuid="67d0ef7a-fc26-4cbb-b628-9e55345c9fa7" key="element-2" x="190" y="26" width="99" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-3" style="Detail_Header" x="289" y="26" width="141" height="16" uuid="23f3bd99-f687-4a78-bd90-3229c812d4a4">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-						<property name="local_mesure_unitx" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.x" value="px"/>
-						<property name="local_mesure_unity" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.y" value="px"/>
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="23f3bd99-f687-4a78-bd90-3229c812d4a4" key="element-3" x="289" y="26" width="141" height="16" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
 					<text><![CDATA[UOM]]></text>
-				</staticText>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<property name="local_mesure_unitheight" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.height" value="px"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="32" splitType="Stretch">
-				<line>
-					<reportElement key="line-11" style="Report_Footer" x="0" y="0" width="1" height="32" forecolor="#555555" uuid="66893f04-f225-40a5-b364-10c3dd6ae298"/>
-				</line>
-				<line>
-					<reportElement key="line-12" style="Report_Footer" x="780" y="1" width="1" height="23" forecolor="#555555" uuid="a5a23c71-654f-4b75-afa0-7d893684b1e8">
-						<property name="local_mesure_unitx" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.x" value="px"/>
-					</reportElement>
-				</line>
-				<line>
-					<reportElement key="line-15" style="Report_Footer" x="10" y="0" width="1" height="24" forecolor="#555555" uuid="bdc807d9-9b78-474c-a1ee-4af0f2b1f721"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-16" style="Report_Footer" x="10" y="24" width="771" height="1" forecolor="#555555" uuid="cabeb8f0-0851-460e-a1d2-6b90ea02b4f3">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					</reportElement>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-19" style="Group_Footer" x="20" y="4" width="170" height="16" uuid="978e5784-cc97-4ad8-8006-1af8cba98b9a"/>
-					<box leftPadding="4" rightPadding="4">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Left">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				<element kind="line" uuid="66893f04-f225-40a5-b364-10c3dd6ae298" key="line-11" x="0" y="0" width="1" height="32" forecolor="#555555" style="Report_Footer"/>
+				<element kind="line" uuid="a5a23c71-654f-4b75-afa0-7d893684b1e8" key="line-12" x="780" y="1" width="1" height="23" forecolor="#555555" style="Report_Footer">
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+				</element>
+				<element kind="line" uuid="bdc807d9-9b78-474c-a1ee-4af0f2b1f721" key="line-15" x="10" y="0" width="1" height="24" forecolor="#555555" style="Report_Footer">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="cabeb8f0-0851-460e-a1d2-6b90ea02b4f3" key="line-16" x="10" y="24" width="771" height="1" forecolor="#555555" style="Report_Footer">
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="978e5784-cc97-4ad8-8006-1af8cba98b9a" key="staticText-19" x="20" y="4" width="170" height="16" pdfFontName="Helvetica-Bold" hTextAlign="Left" style="Group_Footer">
 					<text><![CDATA[Total Order:]]></text>
-				</staticText>
-				<textField evaluationTime="Group" evaluationGroup="DOCUMENTNO" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-26" style="Total_Gray" mode="Opaque" x="190" y="4" width="50" height="16" uuid="135e313e-8a84-42cd-80ce-ab391bc09028"/>
-					<box leftPadding="4" rightPadding="4">
+					<box leftPadding="4" rightPadding="4" style="Group_Footer">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{TotalQtyOrder}!=null)?$P{NUMBERFORMAT}.format($V{TotalQtyOrder}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="DOCUMENTNO" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-27" style="Total_Gray" x="240" y="4" width="514" height="16" uuid="f6d2340f-3657-4dd4-9639-9fcfe6f8c243"/>
-					<box rightPadding="4">
+				</element>
+				<element kind="textField" uuid="135e313e-8a84-42cd-80ce-ab391bc09028" key="textField-26" mode="Opaque" x="190" y="4" width="50" height="16" evaluationTime="Group" pattern="" evaluationGroup="DOCUMENTNO" blankWhenNull="false" hTextAlign="Right" style="Total_Gray">
+					<expression><![CDATA[($V{TotalQtyOrder}!=null)?$P{NUMBERFORMAT}.format($V{TotalQtyOrder}):new String(" ")]]></expression>
+					<box leftPadding="4" rightPadding="4" style="Total_Gray">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="f6d2340f-3657-4dd4-9639-9fcfe6f8c243" key="textField-27" x="240" y="4" width="514" height="16" evaluationTime="Group" pattern="" evaluationGroup="DOCUMENTNO" blankWhenNull="false" hTextAlign="Right" style="Total_Gray">
+					<expression><![CDATA[($V{TotalPriceOrder}!=null)?$P{NUMBERFORMAT}.format($V{TotalPriceOrder}):new String(" ")]]></expression>
+					<box rightPadding="4" style="Total_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{TotalPriceOrder}!=null)?$P{NUMBERFORMAT}.format($V{TotalPriceOrder}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-18" style="Report_Footer" x="20" y="0" width="760" height="1" forecolor="#555555" uuid="479e3b63-ad86-48dc-9709-6379072ba9bb">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					</reportElement>
-				</line>
-				<textField evaluationTime="Group" evaluationGroup="DOCUMENTNO" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-37" style="Total_Gray" x="754" y="4" width="24" height="16" uuid="e881503d-c03f-453b-9bed-f2153c71c5d6"/>
-					<box rightPadding="4">
+				</element>
+				<element kind="line" uuid="479e3b63-ad86-48dc-9709-6379072ba9bb" key="line-18" x="20" y="0" width="760" height="1" forecolor="#555555" style="Report_Footer">
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</element>
+				<element kind="textField" uuid="e881503d-c03f-453b-9bed-f2153c71c5d6" key="textField-37" x="754" y="4" width="24" height="16" evaluationTime="Group" pattern="" evaluationGroup="DOCUMENTNO" blankWhenNull="false" hTextAlign="Center" style="Total_Gray">
+					<expression><![CDATA[($F{CONVSYM}!=null)?$F{CONVSYM}:new String(" ")]]></expression>
+					<box rightPadding="4" style="Total_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center"/>
-					<textFieldExpression><![CDATA[($F{CONVSYM}!=null)?$F{CONVSYM}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-19" style="Report_Footer" x="780" y="25" width="1" height="7" forecolor="#555555" uuid="5582a270-8d0c-4973-a7be-cb6f1bf98e59">
-						<property name="local_mesure_unitx" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.x" value="px"/>
-					</reportElement>
-				</line>
+				</element>
+				<element kind="line" uuid="5582a270-8d0c-4973-a7be-cb6f1bf98e59" key="line-19" x="780" y="25" width="1" height="7" forecolor="#555555" style="Report_Footer">
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="20" splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="59" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Title" mode="Transparent" x="0" y="0" width="702" height="20" uuid="648d3e39-159d-401e-be6b-6036fc9add2e"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="20" width="702" height="1" uuid="3d6d5915-d32c-40ba-a7e5-12a5d1ebf6ed"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Report_Subtitle" x="0" y="20" width="702" height="20" uuid="9e5de287-6edd-43e5-a89b-0feaaa5ba680"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_SUBTITLE}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="20" splitType="Stretch"/>
+	<pageHeader height="59" splitType="Stretch">
+		<element kind="textField" uuid="648d3e39-159d-401e-be6b-6036fc9add2e" key="textField" mode="Transparent" x="0" y="0" width="702" height="20" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="3d6d5915-d32c-40ba-a7e5-12a5d1ebf6ed" key="line-1" x="0" y="20" width="702" height="1">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="9e5de287-6edd-43e5-a89b-0feaaa5ba680" key="textField" x="0" y="20" width="702" height="20" textAdjust="StretchHeight" blankWhenNull="true" style="Report_Subtitle">
+			<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band height="16" splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader height="16" splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
+			<element kind="textField" uuid="b2615b39-758e-44d5-8e63-417988ff4770" key="textField-16" x="20" y="0" width="170" height="16" fontSize="8.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PRODUCT_NAME}!=null)?$F{PRODUCT_NAME}:new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="f53335e7-982f-4aa0-ad8b-3e259daa968b" key="textField-17" x="190" y="0" width="50" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+				<expression><![CDATA[($F{QUANTITYORDER}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITYORDER}):new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="7b6e1f13-3a77-4e2f-88ff-5d1a1f7f3502" key="textField-18" x="240" y="0" width="49" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+				<expression><![CDATA[($F{UOMNAME}!=null)?$F{UOMNAME}:new String(" ")]]></expression>
+				<box leftPadding="5" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="540b6328-53aa-475e-a327-0322bf848008" key="textField-19" x="430" y="0" width="66" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="line" uuid="5132019a-aa14-4e30-8030-840c602068cd" key="line-3" x="0" y="0" width="1" height="16" forecolor="#555555" style="Report_Footer"/>
+			<element kind="line" uuid="213b497a-8251-4e56-8917-176e7210eec2" key="line-14" x="10" y="0" width="1" height="16" forecolor="#555555" style="Report_Footer">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="eb9007f5-7d55-4ff9-848b-b33a26e46e95" key="textField-28" x="520" y="0" width="66" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVPRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{CONVPRICEACTUAL}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="cc0f6a30-3268-45c8-a265-10214515af69" key="textField-29" x="696" y="0" width="61" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVPRICELIST}!=null)?$P{NUMBERFORMAT}.format($F{CONVPRICELIST}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="1de643c4-f6a2-40e4-81a5-e92b26de0415" key="textField-30" x="610" y="0" width="62" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PRICELIST}!=null)?$P{NUMBERFORMAT}.format($F{PRICELIST}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="07e0a0aa-1431-4679-9423-24a380863f19" key="textField-33" x="496" y="0" width="24" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PRICEACTUALSYM}!=null)?$F{PRICEACTUALSYM}:new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="4" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="702fb1ef-a843-4245-8faf-6512ebd038b6" key="textField-34" x="672" y="0" width="24" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PRICELISTSYM}!=null)?$F{PRICELISTSYM}:new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="4" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="1ae9a0d7-726f-4ef8-b68e-78f88487b3dd" key="textField-35" x="586" y="0" width="24" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVSYM}!=null)?$F{CONVSYM}:new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="4" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="4bdf5ac6-618c-4b6f-b5e5-b376f2dc005c" key="textField-36" x="757" y="0" width="23" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVSYM}!=null)?$F{CONVSYM}:new String(" ")]]></expression>
+				<property name="local_mesure_unitwidth" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				<box leftPadding="2" rightPadding="4" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="5c94bebe-2c1e-401b-9fd5-6b83a511471b" key="textField-18" x="379" y="0" width="51" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+				<expression><![CDATA[($F{AUM}!=null)?$F{AUM}:new String(" ")]]></expression>
+				<box leftPadding="5" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="fb9615aa-863c-4928-a146-a5b5776baba1" key="textField-17" x="289" y="0" width="90" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+				<expression><![CDATA[($F{AUMQTY}!=null)?$P{NUMBERFORMAT}.format($F{AUMQTY}):new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="50c41226-d0fe-4bc3-920e-2fec656439d8" key="textField-17" x="190" y="0" width="99" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
+				<expression><![CDATA[($F{QUANTITYORDER}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITYORDER}):new String(" ")]]></expression>
+				<property name="local_mesure_unitx" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.x" value="px"/>
+				<property name="local_mesure_unity" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				<property name="local_mesure_unitwidth" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				<box leftPadding="4" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="788b2495-0a69-440c-b5f5-cbdbb59b1210" key="textField-18" x="289" y="0" width="141" height="16" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
+				<expression><![CDATA[($F{UOMNAME}!=null)?$F{UOMNAME}:new String(" ")]]></expression>
+				<property name="local_mesure_unitx" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.x" value="px"/>
+				<property name="local_mesure_unity" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				<property name="local_mesure_unitwidth" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				<box leftPadding="5" rightPadding="2" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
+					<bottomPen lineWidth="0.0" lineColor="#555555"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
 			<property name="local_mesure_unitheight" value="pixel"/>
 			<property name="com.jaspersoft.studio.unit.height" value="px"/>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-16" style="Detail_Line" x="20" y="0" width="170" height="16" uuid="b2615b39-758e-44d5-8e63-417988ff4770"/>
-				<box leftPadding="4" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRODUCT_NAME}!=null)?$F{PRODUCT_NAME}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Detail_Line" x="190" y="0" width="50" height="16" uuid="f53335e7-982f-4aa0-ad8b-3e259daa968b">
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="4" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QUANTITYORDER}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITYORDER}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-18" style="Detail_Line" x="240" y="0" width="49" height="16" uuid="7b6e1f13-3a77-4e2f-88ff-5d1a1f7f3502">
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{UOMNAME}!=null)?$F{UOMNAME}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-19" style="Detail_Line" x="430" y="0" width="66" height="16" uuid="540b6328-53aa-475e-a327-0322bf848008"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-3" style="Report_Footer" x="0" y="0" width="1" height="16" forecolor="#555555" uuid="5132019a-aa14-4e30-8030-840c602068cd"/>
-			</line>
-			<line>
-				<reportElement key="line-14" style="Report_Footer" x="10" y="0" width="1" height="16" forecolor="#555555" uuid="213b497a-8251-4e56-8917-176e7210eec2"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-28" style="Detail_Line" x="520" y="0" width="66" height="16" uuid="eb9007f5-7d55-4ff9-848b-b33a26e46e95"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVPRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{CONVPRICEACTUAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-29" style="Detail_Line" x="696" y="0" width="61" height="16" uuid="cc0f6a30-3268-45c8-a265-10214515af69"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVPRICELIST}!=null)?$P{NUMBERFORMAT}.format($F{CONVPRICELIST}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-30" style="Detail_Line" x="610" y="0" width="62" height="16" uuid="1de643c4-f6a2-40e4-81a5-e92b26de0415"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRICELIST}!=null)?$P{NUMBERFORMAT}.format($F{PRICELIST}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-33" style="Detail_Line" x="496" y="0" width="24" height="16" uuid="07e0a0aa-1431-4679-9423-24a380863f19"/>
-				<box leftPadding="2" rightPadding="4">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRICEACTUALSYM}!=null)?$F{PRICEACTUALSYM}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-34" style="Detail_Line" x="672" y="0" width="24" height="16" uuid="702fb1ef-a843-4245-8faf-6512ebd038b6"/>
-				<box leftPadding="2" rightPadding="4">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRICELISTSYM}!=null)?$F{PRICELISTSYM}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-35" style="Detail_Line" x="586" y="0" width="24" height="16" uuid="1ae9a0d7-726f-4ef8-b68e-78f88487b3dd"/>
-				<box leftPadding="2" rightPadding="4">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVSYM}!=null)?$F{CONVSYM}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-36" style="Detail_Line" x="757" y="0" width="23" height="16" uuid="4bdf5ac6-618c-4b6f-b5e5-b376f2dc005c">
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-				</reportElement>
-				<box leftPadding="2" rightPadding="4">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVSYM}!=null)?$F{CONVSYM}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-18" style="Detail_Line" x="379" y="0" width="51" height="16" uuid="5c94bebe-2c1e-401b-9fd5-6b83a511471b">
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{AUM}!=null)?$F{AUM}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Detail_Line" x="289" y="0" width="90" height="16" uuid="fb9615aa-863c-4928-a146-a5b5776baba1">
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="4" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{AUMQTY}!=null)?$P{NUMBERFORMAT}.format($F{AUMQTY}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Detail_Line" x="190" y="0" width="99" height="16" uuid="50c41226-d0fe-4bc3-920e-2fec656439d8">
-					<property name="local_mesure_unitx" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.x" value="px"/>
-					<property name="local_mesure_unity" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.y" value="px"/>
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="4" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QUANTITYORDER}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITYORDER}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-18" style="Detail_Line" x="289" y="0" width="141" height="16" uuid="788b2495-0a69-440c-b5f5-cbdbb59b1210">
-					<property name="local_mesure_unitx" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.x" value="px"/>
-					<property name="local_mesure_unity" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.y" value="px"/>
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
-					<bottomPen lineWidth="0.0" lineColor="#555555"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{UOMNAME}!=null)?$F{UOMNAME}:new String(" ")]]></textFieldExpression>
-			</textField>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="16" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="20" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="642" y="4" width="95" height="16" uuid="f6ef6dc1-948a-419c-9ed3-8e8c2ce96755"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom"/>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="739" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="242693c8-57ea-4655-a8a2-ae73b29506d5"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Bottom" rotation="None">
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="0" width="781" height="1" forecolor="#555555" uuid="6d8f4c19-c1e7-45a0-90f2-ac8ab471ddd7">
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-				</reportElement>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="277" y="4" width="69" height="16" uuid="270efb38-74ad-4dd2-8b95-ad879999ead7"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Bottom"/>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" style="Report_Footer" x="195" y="4" width="78" height="16" uuid="3a75bb9d-4b95-4e6b-ae52-3bb13e2270ed"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="16" splitType="Stretch"/>
+	<pageFooter height="20" splitType="Stretch">
+		<element kind="textField" uuid="f6ef6dc1-948a-419c-9ed3-8e8c2ce96755" key="textField" x="642" y="4" width="95" height="16" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Bottom" style="Report_Footer">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="242693c8-57ea-4655-a8a2-ae73b29506d5" key="textField" x="739" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" rotation="None" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Bottom" style="Report_Footer">
+			<paragraph lineSpacing="Single" style="Report_Footer"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="6d8f4c19-c1e7-45a0-90f2-ac8ab471ddd7" key="line" x="0" y="0" width="781" height="1" forecolor="#555555">
+			<property name="local_mesure_unitwidth" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.width" value="px"/>
+			<pen lineWidth="1.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="270efb38-74ad-4dd2-8b95-ad879999ead7" key="textField" x="277" y="4" width="69" height="16" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Bottom" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="3a75bb9d-4b95-4e6b-ae52-3bb13e2270ed" key="staticText-1" x="195" y="4" width="78" height="16" hTextAlign="Right" vTextAlign="Bottom" style="Report_Footer">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportSalesOrderProvidedJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportSalesOrderProvidedJR.jrxml
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
-<!-- 2016-12-26T16:03:14 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportSalesOrderProvidedJR" pageWidth="920" pageHeight="595" orientation="Landscape" columnWidth="860" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="764f59d0-b626-4a6a-bf2f-036b80c04677">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportSalesOrderProvidedJR" language="java" pageWidth="920" pageHeight="595" orientation="Landscape" columnWidth="860" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="764f59d0-b626-4a6a-bf2f-036b80c04677">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
@@ -14,59 +12,57 @@
 	<property name="com.jaspersoft.studio.unit.rightMargin" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnWidth" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{PROJECTNAME_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
 	<parameter name="isUomManagementEnabled" class="java.lang.Boolean">
 		<defaultValueExpression><![CDATA[org.openbravo.materialmgmt.UOMUtil.isUomManagementEnabled()]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[SELECT C_BPARTNER.NAME AS BPARTNERNAME, C_PROJECT.VALUE||' '||C_PROJECT.NAME AS PROJECTNAME, 
+	<query language="sql"><![CDATA[SELECT C_BPARTNER.NAME AS BPARTNERNAME, C_PROJECT.VALUE||' '||C_PROJECT.NAME AS PROJECTNAME, 
       M_PRODUCT.NAME AS PRODUCTNAME, SUM(C_ORDERLINE.QTYDELIVERED) AS QTYDELIVERED, 
       SUM(C_ORDERLINE.QTYDELIVERED*C_ORDERLINE.PRICEACTUAL) AS LINENETAMT, 
       C_CURRENCY_SYMBOL (COALESCE(C_ORDERLINE.C_CURRENCY_ID, C_ORDER.C_CURRENCY_ID), C_ORDERLINE.PRICEACTUAL, 'Y') AS LINENETAMTSYM,	  
@@ -95,8 +91,7 @@
       COALESCE(C_ORDERLINE.C_CURRENCY_ID, C_ORDER.C_CURRENCY_ID), TO_DATE(COALESCE(C_ORDER.DATEORDERED, NOW())),	  
 	  C_ORDERLINE.AD_CLIENT_ID, C_ORDERLINE.AD_ORG_ID
       HAVING SUM(C_ORDERLINE.QTYDELIVERED) > 0
-      ORDER BY BPARTNERNAME, PROJECTNAME, PRODUCTNAME]]>
-	</queryString>
+      ORDER BY BPARTNERNAME, PROJECTNAME, PRODUCTNAME]]></query>
 	<field name="BPARTNERNAME" class="java.lang.String"/>
 	<field name="PROJECTNAME" class="java.lang.String"/>
 	<field name="PRODUCTNAME" class="java.lang.String"/>
@@ -113,748 +108,508 @@
 	<field name="CONVISOSYM" class="java.lang.String"/>
 	<field name="AUM" class="java.lang.String"/>
 	<field name="AUMQTY" class="java.math.BigDecimal"/>
-	<variable name="sumTotalQty" class="java.math.BigDecimal" resetType="Group" resetGroup="PROJECTNAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYDELIVERED}]]></variableExpression>
+	<variable name="sumTotalQty" resetType="Group" calculation="Sum" resetGroup="PROJECTNAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYDELIVERED}]]></expression>
 	</variable>
-	<variable name="sumTotalAmount" class="java.math.BigDecimal" resetType="Group" resetGroup="PROJECTNAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVLINENETAMT}]]></variableExpression>
+	<variable name="sumTotalAmount" resetType="Group" calculation="Sum" resetGroup="PROJECTNAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVLINENETAMT}]]></expression>
 	</variable>
 	<group name="BPARTNERNAME">
-		<groupExpression><![CDATA[$F{BPARTNERNAME}]]></groupExpression>
+		<expression><![CDATA[$F{BPARTNERNAME}]]></expression>
 		<groupHeader>
 			<band height="33" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="0" y="0" width="130" height="23" uuid="7b8f842e-902c-4883-a8d5-b3a61d27052b"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="7b8f842e-902c-4883-a8d5-b3a61d27052b" key="staticText" x="0" y="0" width="130" height="23" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[Business Partner]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="130" y="0" width="729" height="23" uuid="c366a367-b1d8-4bf5-84ce-b6a4f86effef"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{BPARTNERNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="23" width="1" height="10" forecolor="#555555" uuid="0b24a85e-2585-4323-9bf3-b8d66f88ca47"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="859" y="0" width="1" height="33" forecolor="#555555" uuid="c3232e3f-6785-4448-a71c-d67f2de63634"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				</element>
+				<element kind="textField" uuid="c366a367-b1d8-4bf5-84ce-b6a4f86effef" key="textField" x="130" y="0" width="729" height="23" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{BPARTNERNAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="0b24a85e-2585-4323-9bf3-b8d66f88ca47" key="line-2" stretchType="ContainerHeight" x="0" y="23" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="c3232e3f-6785-4448-a71c-d67f2de63634" key="line-3" stretchType="ContainerHeight" x="859" y="0" width="1" height="33" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-32" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="10" forecolor="#555555" uuid="ee639481-d6e2-45a3-b554-6bad60bc4abc"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="859" y="0" width="1" height="11" forecolor="#555555" uuid="bc1670f3-bf9f-45c0-8daf-ad7330dcdce6"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-34" x="0" y="10" width="859" height="1" forecolor="#555555" uuid="943090a0-0694-4df6-ad0e-2297be41a88c"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="ee639481-d6e2-45a3-b554-6bad60bc4abc" key="line-32" stretchType="ContainerHeight" x="0" y="0" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="bc1670f3-bf9f-45c0-8daf-ad7330dcdce6" key="line-33" stretchType="ContainerHeight" x="859" y="0" width="1" height="11" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="943090a0-0694-4df6-ad0e-2297be41a88c" key="line-34" x="0" y="10" width="859" height="1" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="PROJECTNAME">
-		<groupExpression><![CDATA[$F{PROJECTNAME}]]></groupExpression>
+		<expression><![CDATA[$F{PROJECTNAME}]]></expression>
 		<groupHeader>
 			<band height="50" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="10" y="0" width="120" height="23" uuid="52aec74f-fdc7-4322-b1e3-a76dfae8f5af"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="52aec74f-fdc7-4322-b1e3-a76dfae8f5af" key="staticText" x="10" y="0" width="120" height="23" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[PROJECT]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="130" y="0" width="729" height="23" uuid="c4064691-734e-4ef3-87ea-2806289bea88"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{PROJECTNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-4" stretchType="RelativeToBandHeight" x="10" y="23" width="1" height="27" forecolor="#555555" uuid="99b06a69-a75a-4c0a-826c-eb532d228205"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-8" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="50" forecolor="#555555" uuid="e8e5096a-fa6a-4aef-a507-a063a395f130"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="20" y="34" width="150" height="16" uuid="b3905ccc-e5b9-4b23-8345-521f99e8b486"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="c4064691-734e-4ef3-87ea-2806289bea88" key="textField" x="130" y="0" width="729" height="23" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{PROJECTNAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="99b06a69-a75a-4c0a-826c-eb532d228205" key="line-4" stretchType="ContainerHeight" x="10" y="23" width="1" height="27" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="e8e5096a-fa6a-4aef-a507-a063a395f130" key="line-8" stretchType="ContainerHeight" x="0" y="0" width="1" height="50" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="b3905ccc-e5b9-4b23-8345-521f99e8b486" key="element-90" x="20" y="34" width="150" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" style="Detail_Header">
 					<text><![CDATA[PRODUCT]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="170" y="34" width="80" height="16" uuid="9aa3857a-d879-4fbc-aa4a-0c25b1146abd">
-						<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="Bitstream Vera Sans" size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="9aa3857a-d879-4fbc-aa4a-0c25b1146abd" key="element-90" x="170" y="34" width="80" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="639" y="34" width="110" height="16" uuid="a9737d40-eb92-4587-8b83-6d7760b077a5"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="Bitstream Vera Sans" size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="a9737d40-eb92-4587-8b83-6d7760b077a5" key="element-90" x="639" y="34" width="110" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Center" style="Detail_Header">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="250" y="34" width="70" height="16" uuid="26642fda-c668-467e-bc0d-c208f8353612">
-						<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="Bitstream Vera Sans" size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="26642fda-c668-467e-bc0d-c208f8353612" key="element-90" x="250" y="34" width="70" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
 					<text><![CDATA[UOM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="459" y="34" width="90" height="16" uuid="03c00009-cf83-4448-9ca4-3bf4d946b56b"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="Bitstream Vera Sans" size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="03c00009-cf83-4448-9ca4-3bf4d946b56b" key="element-90" x="459" y="34" width="90" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Center" style="Detail_Header">
 					<text><![CDATA[Price]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-91" style="Detail_Header" x="549" y="34" width="42" height="16" uuid="2de34324-fbbb-4a73-94d5-953edba9d8fb">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="Bitstream Vera Sans" size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="2de34324-fbbb-4a73-94d5-953edba9d8fb" key="element-91" x="549" y="34" width="42" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Center" style="Detail_Header">
 					<text><![CDATA[Price]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-92" style="Detail_Header" x="749" y="34" width="62" height="16" uuid="cebae513-cc6e-474a-bac2-60217dfd98c5">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					</reportElement>
-					<box leftPadding="5" rightPadding="1">
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font fontName="Bitstream Vera Sans" size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="cebae513-cc6e-474a-bac2-60217dfd98c5" key="element-92" x="749" y="34" width="62" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-5" style="Detail_Header" x="810" y="34" width="49" height="16" uuid="30dd0906-5412-4341-b471-a78b21ab630a"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-6" style="Detail_Header" x="590" y="34" width="49" height="16" uuid="ae707067-e70d-4340-bf38-917fb798b236"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-6" stretchType="RelativeToBandHeight" x="859" y="0" width="1" height="50" forecolor="#555555" uuid="eb166890-d82b-47f3-88b5-d191c8e7b9e7"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="389" y="34" width="70" height="16" uuid="dc284b96-c397-4095-98a1-9c222afdbce1">
-						<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<box leftPadding="5" rightPadding="1" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="Bitstream Vera Sans" size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="textField" uuid="30dd0906-5412-4341-b471-a78b21ab630a" key="textField-5" x="810" y="34" width="49" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="ae707067-e70d-4340-bf38-917fb798b236" key="textField-6" x="590" y="34" width="49" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" bold="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="eb166890-d82b-47f3-88b5-d191c8e7b9e7" key="line-6" stretchType="ContainerHeight" x="859" y="0" width="1" height="50" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="dc284b96-c397-4095-98a1-9c222afdbce1" key="element-90" x="389" y="34" width="70" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
 					<text><![CDATA[AUM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="320" y="34" width="69" height="16" uuid="bcc08100-5610-4d7e-ab83-55bec7913f98">
-						<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="Bitstream Vera Sans" size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="bcc08100-5610-4d7e-ab83-55bec7913f98" key="element-90" x="320" y="34" width="69" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
 					<text><![CDATA[Qty in AUM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="170" y="34" width="150" height="16" uuid="7a837fd9-35b6-46f9-844d-78b46b1bef8d">
-						<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="Bitstream Vera Sans" size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="7a837fd9-35b6-46f9-844d-78b46b1bef8d" key="element-90" x="170" y="34" width="150" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="320" y="34" width="138" height="16" uuid="3fb4b108-9276-42d9-b850-1d23d3bba0fa">
-						<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="Bitstream Vera Sans" size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="3fb4b108-9276-42d9-b850-1d23d3bba0fa" key="element-90" x="320" y="34" width="138" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
 					<text><![CDATA[UOM]]></text>
-				</staticText>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="35" splitType="Stretch">
-				<line>
-					<reportElement key="line-28" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="35" forecolor="#555555" uuid="c5398576-5b6e-4328-8afc-ccaf06488e4e"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-29" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="8" forecolor="#555555" uuid="710204be-4c7a-41cc-9384-721bdb917a7c"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-30" stretchType="RelativeToBandHeight" x="859" y="0" width="1" height="35" forecolor="#555555" uuid="aa7389ce-2871-4e9f-98fd-8794ff6718de"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-31" x="10" y="8" width="849" height="1" forecolor="#666666" uuid="2101c733-aabd-4ece-a30a-4f9befb1398d"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" mode="Opaque" x="236" y="12" width="150" height="16" backcolor="#CCCCCC" uuid="a5fc80d1-9eab-49c3-97fc-524b60a5745f"/>
+				<element kind="line" uuid="c5398576-5b6e-4328-8afc-ccaf06488e4e" key="line-28" stretchType="ContainerHeight" x="0" y="0" width="1" height="35" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="710204be-4c7a-41cc-9384-721bdb917a7c" key="line-29" stretchType="ContainerHeight" x="10" y="0" width="1" height="8" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="aa7389ce-2871-4e9f-98fd-8794ff6718de" key="line-30" stretchType="ContainerHeight" x="859" y="0" width="1" height="35" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="2101c733-aabd-4ece-a30a-4f9befb1398d" key="line-31" x="10" y="8" width="849" height="1" forecolor="#666666">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="textField" uuid="a5fc80d1-9eab-49c3-97fc-524b60a5745f" key="textField" mode="Opaque" x="236" y="12" width="150" height="16" backcolor="#CCCCCC" fontSize="12.0" pattern="" blankWhenNull="false" hTextAlign="Right">
+					<expression><![CDATA[($V{sumTotalQty}!=null)?$P{NUMBERFORMAT}.format($V{sumTotalQty}):new String(" ")]]></expression>
 					<box rightPadding="4">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="12"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{sumTotalQty}!=null)?$P{NUMBERFORMAT}.format($V{sumTotalQty}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" mode="Opaque" x="386" y="12" width="445" height="16" backcolor="#CCCCCC" uuid="defbf150-80ce-4b6d-b888-ab17a10aa1c6"/>
+				</element>
+				<element kind="textField" uuid="defbf150-80ce-4b6d-b888-ab17a10aa1c6" key="textField" mode="Opaque" x="386" y="12" width="445" height="16" backcolor="#CCCCCC" fontSize="12.0" pattern="" blankWhenNull="false" hTextAlign="Right">
+					<expression><![CDATA[($V{sumTotalAmount}!=null)?$P{NUMBERFORMAT}.format($V{sumTotalAmount}):new String(" ")]]></expression>
 					<box rightPadding="4">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="12"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{sumTotalAmount}!=null)?$P{NUMBERFORMAT}.format($V{sumTotalAmount}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-4" x="146" y="12" width="90" height="16" uuid="1b9a1e40-fab4-47d2-94ee-eb38324f04bf"/>
+				</element>
+				<element kind="staticText" uuid="1b9a1e40-fab4-47d2-94ee-eb38324f04bf" key="staticText-4" x="146" y="12" width="90" height="16" fontName="Bitstream Vera Sans" fontSize="12.0">
+					<text><![CDATA[Total:]]></text>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" size="12"/>
-					</textElement>
-					<text><![CDATA[Total:]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-35" x="20" y="0" width="839" height="1" forecolor="#555555" uuid="7751c0ea-a0ae-43ed-b6e9-472f6a48cc2e"/>
-				</line>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-11" mode="Opaque" x="831" y="12" width="24" height="16" backcolor="#CCCCCC" uuid="34d3a322-02c9-46b5-9e89-93bac727a3b0"/>
+				</element>
+				<element kind="line" uuid="7751c0ea-a0ae-43ed-b6e9-472f6a48cc2e" key="line-35" x="20" y="0" width="839" height="1" forecolor="#555555"/>
+				<element kind="textField" uuid="34d3a322-02c9-46b5-9e89-93bac727a3b0" key="textField-11" mode="Opaque" x="831" y="12" width="24" height="16" backcolor="#CCCCCC" fontSize="12.0" pattern="" blankWhenNull="false" hTextAlign="Center">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
 					<box rightPadding="4">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="12"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="9" splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="47" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-1" style="Report_Subtitle" x="0" y="24" width="860" height="20" uuid="80b99832-9465-424c-9094-4d26713489d2"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_SUBTITLE}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-2" style="Report_Title" mode="Transparent" x="0" y="4" width="860" height="20" uuid="98ef25f3-c809-4d06-9175-7279486da318"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="9" splitType="Stretch"/>
+	<pageHeader height="47" splitType="Stretch">
+		<element kind="textField" uuid="80b99832-9465-424c-9094-4d26713489d2" key="textField-1" x="0" y="24" width="860" height="20" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="98ef25f3-c809-4d06-9175-7279486da318" key="textField-2" mode="Transparent" x="0" y="4" width="860" height="20" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band height="16" splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader height="16" splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="859" y="0" width="1" height="16" forecolor="#555555" uuid="ac5f4450-fb3b-4e89-bd1d-713ae4ecaa59"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="16" forecolor="#555555" uuid="1af2a1ec-c5a6-4015-84a0-810a5fcd55f0"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-18" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="16" forecolor="#555555" uuid="9ee3a334-542b-49f4-8577-0e873f92dd03"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="20" y="0" width="150" height="16" uuid="37344ce5-0612-4b17-8c70-7878110127b0"/>
-				<box leftPadding="2" rightPadding="2">
+			<element kind="line" uuid="ac5f4450-fb3b-4e89-bd1d-713ae4ecaa59" key="line-16" stretchType="ContainerHeight" x="859" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="1af2a1ec-c5a6-4015-84a0-810a5fcd55f0" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="9ee3a334-542b-49f4-8577-0e873f92dd03" key="line-18" stretchType="ContainerHeight" x="10" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="37344ce5-0612-4b17-8c70-7878110127b0" key="textField" x="20" y="0" width="150" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PRODUCTNAME}!=null)?$F{PRODUCTNAME}:new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRODUCTNAME}!=null)?$F{PRODUCTNAME}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="170" y="0" width="80" height="16" uuid="3a4ac233-ee2d-4639-a23b-b9385ff40566">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="3a4ac233-ee2d-4639-a23b-b9385ff40566" key="textField" x="170" y="0" width="80" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
+				<expression><![CDATA[($F{QTYDELIVERED}!=null)?$P{NUMBERFORMAT}.format($F{QTYDELIVERED}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QTYDELIVERED}!=null)?$P{NUMBERFORMAT}.format($F{QTYDELIVERED}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="639" y="0" width="86" height="16" uuid="582453b0-d162-4198-8c9a-1d0c441abe61"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="582453b0-d162-4198-8c9a-1d0c441abe61" key="textField" x="639" y="0" width="86" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="250" y="0" width="70" height="16" uuid="4c3750c7-3d14-43cb-9bee-724bb1d06076">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="4c3750c7-3d14-43cb-9bee-724bb1d06076" key="textField" x="250" y="0" width="70" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
+				<expression><![CDATA[($F{UOMNAME}!=null)?$F{UOMNAME}:new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{UOMNAME}!=null)?$F{UOMNAME}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="459" y="0" width="66" height="16" uuid="3c183f8c-3010-40b2-9212-b75b006f78e2"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="3c183f8c-3010-40b2-9212-b75b006f78e2" key="textField" x="459" y="0" width="66" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-3" style="Detail_Line" x="549" y="0" width="66" height="16" uuid="7e3a1a3c-3531-452c-8a2e-a49944503508"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="7e3a1a3c-3531-452c-8a2e-a49944503508" key="textField-3" x="549" y="0" width="66" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVPRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{CONVPRICEACTUAL}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVPRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{CONVPRICEACTUAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-4" style="Detail_Line" x="749" y="0" width="86" height="16" uuid="9f75a8d0-825c-4d2b-8848-56559265cd97"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="9f75a8d0-825c-4d2b-8848-56559265cd97" key="textField-4" x="749" y="0" width="86" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{CONVLINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{CONVLINENETAMT}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVLINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{CONVLINENETAMT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-7" style="Detail_Line" x="615" y="0" width="24" height="16" uuid="39ab0860-cc54-44d8-8bbd-5eaeb99e0e97"/>
-				<box leftPadding="2" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="39ab0860-cc54-44d8-8bbd-5eaeb99e0e97" key="textField-7" x="615" y="0" width="24" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{CONVSYM}]]></expression>
+				<box leftPadding="2" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-8" style="Detail_Line" x="835" y="0" width="24" height="16" uuid="c55bae09-947d-433a-809c-386663b35ec3"/>
-				<box leftPadding="2" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="c55bae09-947d-433a-809c-386663b35ec3" key="textField-8" x="835" y="0" width="24" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{CONVSYM}]]></expression>
+				<box leftPadding="2" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-9" style="Detail_Line" x="525" y="0" width="24" height="16" uuid="ca303a86-8977-429d-b535-9467d85d3cda"/>
-				<box leftPadding="2" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="ca303a86-8977-429d-b535-9467d85d3cda" key="textField-9" x="525" y="0" width="24" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{PRICEACTUALSYM}]]></expression>
+				<box leftPadding="2" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRICEACTUALSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-10" style="Detail_Line" x="725" y="0" width="24" height="16" uuid="91da7349-cfd9-41f0-b15b-dce80851062b"/>
-				<box leftPadding="2" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="91da7349-cfd9-41f0-b15b-dce80851062b" key="textField-10" x="725" y="0" width="24" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{LINENETAMTSYM}]]></expression>
+				<box leftPadding="2" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{LINENETAMTSYM}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="389" y="0" width="70" height="16" uuid="cd426f05-7496-4351-af39-b72dd2e606c7">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="cd426f05-7496-4351-af39-b72dd2e606c7" key="textField" x="389" y="0" width="70" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
+				<expression><![CDATA[($F{AUM}!=null)?$F{AUM}:new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{AUM}!=null)?$F{AUM}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="320" y="0" width="69" height="16" uuid="8380d5e9-5fd1-4a44-be00-efdd8db28b86">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="8380d5e9-5fd1-4a44-be00-efdd8db28b86" key="textField" x="320" y="0" width="69" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == true]]></printWhenExpression>
+				<expression><![CDATA[($F{AUMQTY}!=null)?$P{NUMBERFORMAT}.format($F{AUMQTY}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{AUMQTY}!=null)?$P{NUMBERFORMAT}.format($F{AUMQTY}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="170" y="0" width="150" height="16" uuid="c5e99b1e-6c30-4fcb-95dc-90352329d53f">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="c5e99b1e-6c30-4fcb-95dc-90352329d53f" key="textField" x="170" y="0" width="150" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
+				<expression><![CDATA[($F{QTYDELIVERED}!=null)?$P{NUMBERFORMAT}.format($F{QTYDELIVERED}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QTYDELIVERED}!=null)?$P{NUMBERFORMAT}.format($F{QTYDELIVERED}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="320" y="0" width="139" height="16" uuid="cc8b8234-4c76-4ac4-89d4-7d39a6ae82ab">
-					<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="cc8b8234-4c76-4ac4-89d4-7d39a6ae82ab" key="textField" x="320" y="0" width="139" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUomManagementEnabled} == false]]></printWhenExpression>
+				<expression><![CDATA[($F{UOMNAME}!=null)?$F{UOMNAME}:new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{UOMNAME}!=null)?$F{UOMNAME}:new String(" ")]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="16" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="27" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="595" y="4" width="95" height="19" uuid="c7fd0848-b9da-4563-aed6-8e73d0cc90ce"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom">
-					<font fontName="Bitstream Vera Sans" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="694" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="2c79627e-532d-47b9-b54d-893d105765e8"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Bottom" rotation="None">
-					<font fontName="Bitstream Vera Sans" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="1" width="860" height="1" forecolor="#000000" uuid="d0680e6e-3b29-4265-bf73-b684d6223d7c"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="277" y="4" width="69" height="19" uuid="44ce83ba-4773-4d20-a65a-21ade45483cd"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Bottom">
-					<font fontName="Bitstream Vera Sans" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" x="198" y="4" width="78" height="19" uuid="cc384752-0f64-4649-9b04-12524d73e296"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="16" splitType="Stretch"/>
+	<pageFooter height="27" splitType="Stretch">
+		<element kind="textField" uuid="c7fd0848-b9da-4563-aed6-8e73d0cc90ce" key="textField" x="595" y="4" width="95" height="19" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Bottom">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="2c79627e-532d-47b9-b54d-893d105765e8" key="textField" x="694" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Bitstream Vera Sans" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Bottom">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="d0680e6e-3b29-4265-bf73-b684d6223d7c" key="line" x="0" y="1" width="860" height="1" forecolor="#000000">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="44ce83ba-4773-4d20-a65a-21ade45483cd" key="textField" x="277" y="4" width="69" height="19" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Bottom">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="cc384752-0f64-4649-9b04-12524d73e296" key="staticText-1" x="198" y="4" width="78" height="19" fontName="Bitstream Vera Sans" hTextAlign="Right" vTextAlign="Bottom">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportSalesPartnerProduct.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportSalesPartnerProduct.jrxml
@@ -1,30 +1,29 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportSalesPartnerProduct" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="a020faf2-2e0e-4b3d-a9b3-a8d764cc9873">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportSalesPartnerProduct" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="a020faf2-2e0e-4b3d-a9b3-a8d764cc9873">
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["es_ES"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
+	<parameter name="SUBREPORT_DIR" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/home/gorkaion/openbravo/jasperreports/"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/home/iperdomo/workspace/src/openbravo/pi-libupdate/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="C_Currency_ID" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="C_Currency_ID" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["102"]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[SELECT	AD_COLUMN_IDENTIFIER(TO_CHAR('C_BPartner'),TO_CHAR(C_BPARTNER_ID),TO_CHAR($P{LANGUAGE})) AS PARTNER,
+	<query language="sql"><![CDATA[SELECT	AD_COLUMN_IDENTIFIER(TO_CHAR('C_BPartner'),TO_CHAR(C_BPARTNER_ID),TO_CHAR($P{LANGUAGE})) AS PARTNER,
 			        C_BPARTNER_ID,
 					SUM(CONVAMOUNT) AS CONVAMOUNT,
 			        SUM(GRANDTOTAL) AS GRANDTOTAL,
@@ -63,8 +62,7 @@
 			                			C_ORDER.DATEORDERED,C_ORDER.AD_CLIENT_ID,C_ORDER.AD_ORG_ID,C_ORDER.GRANDTOTAL) AA
 			        GROUP BY AA.C_BPARTNER_ID,TRCURRENCYID,TRDATE,TRCLIENTID,TRORGID) ZZ
 			GROUP BY ZZ.C_BPARTNER_ID
-			ORDER BY ORDERNO DESC]]>
-	</queryString>
+			ORDER BY ORDERNO DESC]]></query>
 	<field name="partner" class="java.lang.String"/>
 	<field name="c_bpartner_id" class="java.lang.String"/>
 	<field name="convamount" class="java.math.BigDecimal"/>
@@ -72,218 +70,147 @@
 	<field name="orderno" class="java.math.BigDecimal"/>
 	<field name="convisosym" class="java.lang.String"/>
 	<field name="convsym" class="java.lang.String"/>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="50" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText" x="25" y="5" width="480" height="40" uuid="2a83ee59-247e-4260-8c57-b0cecaba8d07"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="28" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Sales by Partner and Product]]></text>
-			</staticText>
-			<line>
-				<reportElement key="line" positionType="FixRelativeToBottom" x="0" y="48" width="534" height="1" forecolor="#000000" uuid="5ba898d3-749a-4a0a-a134-d56e1b293120"/>
-			</line>
-			<line>
-				<reportElement key="line" x="0" y="3" width="534" height="1" forecolor="#000000" uuid="236b6f0d-2d3b-4242-a603-a0629ab9ff9e"/>
-			</line>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="50" splitType="Stretch">
+		<element kind="staticText" uuid="2a83ee59-247e-4260-8c57-b0cecaba8d07" key="staticText" x="25" y="5" width="480" height="40" fontSize="28.0" bold="true" hTextAlign="Center">
+			<text><![CDATA[Sales by Partner and Product]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="5ba898d3-749a-4a0a-a134-d56e1b293120" key="line" positionType="FixRelativeToBottom" x="0" y="48" width="534" height="1" forecolor="#000000"/>
+		<element kind="line" uuid="236b6f0d-2d3b-4242-a603-a0629ab9ff9e" key="line" x="0" y="3" width="534" height="1" forecolor="#000000"/>
 	</title>
-	<pageHeader>
-		<band height="9" splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band height="20" splitType="Stretch">
-			<rectangle radius="0">
-				<reportElement key="element-22" mode="Opaque" x="1" y="1" width="534" height="17" forecolor="#000000" backcolor="#999999" uuid="3801f544-d97b-4651-9c2e-d2bc15edabb5"/>
-			</rectangle>
-			<staticText>
-				<reportElement key="element-90" x="0" y="1" width="178" height="16" forecolor="#FFFFFF" uuid="26292f40-4325-48ef-a4f8-2d8260125442"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="" size="12"/>
-				</textElement>
-				<text><![CDATA[PARTNER]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" x="178" y="1" width="103" height="16" forecolor="#FFFFFF" uuid="001265c3-ec42-4823-ad26-16234745cca8"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="" size="12"/>
-				</textElement>
-				<text><![CDATA[GRAND TOTAL]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" x="356" y="1" width="178" height="16" forecolor="#FFFFFF" uuid="71af620d-1b37-4354-ba43-e154310aa47b"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="" size="12"/>
-				</textElement>
-				<text><![CDATA[Number of Orders]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-91" x="281" y="1" width="75" height="16" forecolor="#FFFFFF" uuid="57f6f59f-07f9-4041-bdf5-4c789ca8b544"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="" size="12"/>
-				</textElement>
-				<text><![CDATA[CURRENCY]]></text>
-			</staticText>
-		</band>
+	<pageHeader height="9" splitType="Stretch"/>
+	<columnHeader height="20" splitType="Stretch">
+		<element kind="rectangle" uuid="3801f544-d97b-4651-9c2e-d2bc15edabb5" key="element-22" mode="Opaque" x="1" y="1" width="534" height="17" forecolor="#000000" backcolor="#999999" radius="0"/>
+		<element kind="staticText" uuid="26292f40-4325-48ef-a4f8-2d8260125442" key="element-90" x="0" y="1" width="178" height="16" forecolor="#FFFFFF" fontName="" fontSize="12.0">
+			<text><![CDATA[PARTNER]]></text>
+			<box leftPadding="2" rightPadding="2">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="001265c3-ec42-4823-ad26-16234745cca8" key="element-90" x="178" y="1" width="103" height="16" forecolor="#FFFFFF" fontName="" fontSize="12.0">
+			<text><![CDATA[GRAND TOTAL]]></text>
+			<box leftPadding="2" rightPadding="2">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="71af620d-1b37-4354-ba43-e154310aa47b" key="element-90" x="356" y="1" width="178" height="16" forecolor="#FFFFFF" fontName="" fontSize="12.0">
+			<text><![CDATA[Number of Orders]]></text>
+			<box leftPadding="2" rightPadding="2">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="57f6f59f-07f9-4041-bdf5-4c789ca8b544" key="element-91" x="281" y="1" width="75" height="16" forecolor="#FFFFFF" fontName="" fontSize="12.0">
+			<text><![CDATA[CURRENCY]]></text>
+			<box leftPadding="2" rightPadding="2">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</columnHeader>
 	<detail>
 		<band height="197" splitType="Stretch">
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" x="0" y="1" width="178" height="15" uuid="7599651f-5987-4e5a-a4e0-84170b0669b1"/>
+			<element kind="textField" uuid="7599651f-5987-4e5a-a4e0-84170b0669b1" key="textField" x="0" y="1" width="178" height="15" fontName="Times-Roman" fontSize="12.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true">
+				<expression><![CDATA[$F{partner}]]></expression>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font fontName="Times-Roman" size="12"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{partner}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" x="178" y="1" width="103" height="15" uuid="3aa25335-79cd-49d7-92e4-6aa0c6e6347d"/>
+			</element>
+			<element kind="textField" uuid="3aa25335-79cd-49d7-92e4-6aa0c6e6347d" key="textField" x="178" y="1" width="103" height="15" fontName="Times-Roman" fontSize="12.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left">
+				<expression><![CDATA[($F{convamount}!=null)?$P{NUMBERFORMAT}.format($F{convamount}):new String(" ")]]></expression>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left">
-					<font fontName="Times-Roman" size="12"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{convamount}!=null)?$P{NUMBERFORMAT}.format($F{convamount}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" x="356" y="1" width="178" height="15" uuid="46ab03f4-3cd2-49a6-9ee1-3b5923492a2a"/>
+			</element>
+			<element kind="textField" uuid="46ab03f4-3cd2-49a6-9ee1-3b5923492a2a" key="textField" x="356" y="1" width="178" height="15" fontName="Times-Roman" fontSize="12.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left">
+				<expression><![CDATA[($F{orderno}!=null)?$P{NUMBERFORMAT}.format($F{orderno}.intValue()):new String(" ")]]></expression>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left">
-					<font fontName="Times-Roman" size="12"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{orderno}!=null)?$P{NUMBERFORMAT}.format($F{orderno}.intValue()):new String(" ")]]></textFieldExpression>
-			</textField>
-			<subreport isUsingCache="true">
-				<reportElement key="subreport-1" x="31" y="17" width="452" height="173" uuid="c5c14ba7-53c8-408b-bad1-6cb8f2efa7a6"/>
-				<subreportParameter name="PARTNER">
-					<subreportParameterExpression><![CDATA[$F{c_bpartner_id}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[$P{NUMBERFORMAT}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LOCALE">
-					<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LANGUAGE">
-					<subreportParameterExpression><![CDATA[$P{LANGUAGE}]]></subreportParameterExpression>
-				</subreportParameter>
+			</element>
+			<element kind="subreport" uuid="c5c14ba7-53c8-408b-bad1-6cb8f2efa7a6" key="subreport-1" x="31" y="17" width="452" height="173" usingCache="true">
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{BASE_DESIGN} + "/org/openbravo/erpCommon/ad_reports/ReportSalesPartnerProduct_srpt.jasper"]]></subreportExpression>
-			</subreport>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-1" x="281" y="1" width="75" height="15" uuid="3424e71d-b75d-4900-a072-17c96f2291d4"/>
+				<expression><![CDATA[$P{BASE_DESIGN} + "/org/openbravo/erpCommon/ad_reports/ReportSalesPartnerProduct_srpt.jasper"]]></expression>
+				<parameter name="PARTNER">
+					<expression><![CDATA[$F{c_bpartner_id}]]></expression>
+				</parameter>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[$P{NUMBERFORMAT}]]></expression>
+				</parameter>
+				<parameter name="LOCALE">
+					<expression><![CDATA[$P{LOCALE}]]></expression>
+				</parameter>
+				<parameter name="LANGUAGE">
+					<expression><![CDATA[$P{LANGUAGE}]]></expression>
+				</parameter>
+			</element>
+			<element kind="textField" uuid="3424e71d-b75d-4900-a072-17c96f2291d4" key="textField-1" x="281" y="1" width="75" height="15" fontName="Times-Roman" fontSize="12.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left">
+				<expression><![CDATA[$F{convisosym}]]></expression>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left">
-					<font fontName="Times-Roman" size="12"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{convisosym}]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="27" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="325" y="4" width="170" height="19" uuid="fb9fe719-9025-4b53-bf69-f5b7d00a31f3"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="499" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="426652c3-c360-4b2d-a6e9-7e363fade132"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Top" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="1" width="535" height="1" forecolor="#000000" uuid="0cb9ced0-d4c5-49e2-b228-dc4ec143f76f"/>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="1" y="6" width="209" height="19" uuid="2c37a9eb-2ab8-4b0a-b34c-790ed2088432"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="27" splitType="Stretch">
+		<element kind="textField" uuid="fb9fe719-9025-4b53-bf69-f5b7d00a31f3" key="textField" x="325" y="4" width="170" height="19" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="426652c3-c360-4b2d-a6e9-7e363fade132" key="textField" x="499" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Top">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="0cb9ced0-d4c5-49e2-b228-dc4ec143f76f" key="line" x="0" y="1" width="535" height="1" forecolor="#000000"/>
+		<element kind="textField" uuid="2c37a9eb-2ab8-4b0a-b34c-790ed2088432" key="textField" x="1" y="6" width="209" height="19" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportSalesPartnerProduct_srpt.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportSalesPartnerProduct_srpt.jrxml
@@ -1,36 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportSalesPartnerProduct_srpt" pageWidth="452" pageHeight="233" columnWidth="452" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="513d5501-a5d0-4a7a-adb5-92caed169bf6">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportSalesPartnerProduct_srpt" language="java" pageWidth="452" pageHeight="233" columnWidth="452" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="513d5501-a5d0-4a7a-adb5-92caed169bf6">
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
 	<parameter name="PARTNER" class="java.lang.String">
 		<defaultValueExpression><![CDATA["1000004"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["es_ES"]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[SELECT C_ORDER.C_BPARTNER_ID, AD_COLUMN_IDENTIFIER(to_char('M_PRODUCT'), to_char(M_PRODUCT_ID), to_char($P{LANGUAGE})) AS PRODUCT, SUM(C_ORDERLINE.LINENETAMT) as LINENETAMT
+	<query language="sql"><![CDATA[SELECT C_ORDER.C_BPARTNER_ID, AD_COLUMN_IDENTIFIER(to_char('M_PRODUCT'), to_char(M_PRODUCT_ID), to_char($P{LANGUAGE})) AS PRODUCT, SUM(C_ORDERLINE.LINENETAMT) as LINENETAMT
 FROM C_ORDER, C_ORDERLINE
 WHERE C_ORDER.C_ORDER_ID = C_ORDERLINE.C_ORDER_ID
   AND ISSOTRX = 'Y'
   AND C_ORDER.C_BPARTNER_ID = $P{PARTNER}
 GROUP BY C_ORDERLINE.M_PRODUCT_ID, C_ORDER.C_BPARTNER_ID
-ORDER BY C_ORDER.C_BPARTNER_ID]]>
-	</queryString>
+ORDER BY C_ORDER.C_BPARTNER_ID]]></query>
 	<field name="c_bpartner_id" class="java.lang.String"/>
 	<field name="product" class="java.lang.String"/>
 	<field name="linenetamt" class="java.math.BigDecimal"/>
-	<variable name="sumlinenetamt" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{linenetamt}]]></variableExpression>
+	<variable name="sumlinenetamt" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{linenetamt}]]></expression>
 	</variable>
 	<group name="C_BPARTNER_ID">
-		<groupExpression><![CDATA[$F{c_bpartner_id}]]></groupExpression>
+		<expression><![CDATA[$F{c_bpartner_id}]]></expression>
 		<groupHeader>
 			<band/>
 		</groupHeader>
@@ -38,61 +36,38 @@ ORDER BY C_ORDER.C_BPARTNER_ID]]>
 			<band/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band splitType="Stretch"/>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band height="233" splitType="Stretch">
-			<pieChart>
-				<chart>
-					<reportElement key="element-2" x="0" y="0" width="452" height="233" uuid="483dd75c-624e-4c7b-bcb4-4bb16420820f"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<chartTitle>
-						<font size="8"/>
-					</chartTitle>
-					<chartSubtitle>
-						<font size="8"/>
-					</chartSubtitle>
-					<chartLegend textColor="#000000" backgroundColor="#FFFFFF">
-						<font size="6"/>
-					</chartLegend>
-				</chart>
-				<pieDataset>
-					<dataset resetType="Group" resetGroup="C_BPARTNER_ID"/>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary height="233" splitType="Stretch">
+		<element kind="chart" chartType="pie" uuid="483dd75c-624e-4c7b-bcb4-4bb16420820f" key="element-2" x="0" y="0" width="452" height="233" legendColor="#000000" legendBackgroundColor="#FFFFFF">
+			<titleFont fontSize="8.0"/>
+			<subtitleFont fontSize="8.0"/>
+			<legendFont fontSize="6.0"/>
+			<dataset kind="pie" resetGroup="C_BPARTNER_ID" resetType="Group">
+				<series>
 					<keyExpression><![CDATA[$F{product}]]></keyExpression>
 					<valueExpression><![CDATA[$F{linenetamt}]]></valueExpression>
 					<labelExpression><![CDATA[$F{product}]]></labelExpression>
-				</pieDataset>
-				<piePlot isCircular="true">
-					<plot/>
-					<itemLabel color="#000000" backgroundColor="#FFFFFF">
-						<font size="6"/>
-					</itemLabel>
-				</piePlot>
-			</pieChart>
-		</band>
+				</series>
+			</dataset>
+			<plot circular="true">
+				<itemLabel color="#000000" backgroundColor="#FFFFFF">
+					<font fontSize="6.0"/>
+				</itemLabel>
+			</plot>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</summary>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportShipmentEdition.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportShipmentEdition.jrxml
@@ -1,64 +1,60 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.0.0.final using JasperReports Library version 6.0.0  -->
-<!-- 2016-12-26T15:52:57 -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportShipmentEdition" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="03915ee5-7c7b-45a2-9519-6fc1230d6340">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportShipmentEdition" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="03915ee5-7c7b-45a2-9519-6fc1230d6340">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{DOCUMENTNO_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="isUOMManagementEnabled" class="java.lang.Boolean" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="isUOMManagementEnabled" forPrompting="false" class="java.lang.Boolean">
 		<defaultValueExpression><![CDATA[org.openbravo.materialmgmt.UOMUtil.isUomManagementEnabled()]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[SELECT M_INOUT.DOCUMENTNO AS DOCUMENTNO, M_INOUT.MOVEMENTDATE AS MOVEMENTDATE, C_BPARTNER.NAME AS CLIENT_NAME, M_PRODUCT.NAME AS PRODUCT_NAME, SUM(M_INOUTLINE.MOVEMENTQTY) AS QUANTITYORDER, C_UOM.NAME AS UOMNAME
+	<query language="sql"><![CDATA[SELECT M_INOUT.DOCUMENTNO AS DOCUMENTNO, M_INOUT.MOVEMENTDATE AS MOVEMENTDATE, C_BPARTNER.NAME AS CLIENT_NAME, M_PRODUCT.NAME AS PRODUCT_NAME, SUM(M_INOUTLINE.MOVEMENTQTY) AS QUANTITYORDER, C_UOM.NAME AS UOMNAME
       FROM M_INOUT, M_INOUTLINE, C_BPARTNER, M_PRODUCT, C_UOM
       WHERE M_INOUT.C_BPARTNER_ID = C_BPARTNER.C_BPARTNER_ID
       AND M_INOUT.M_INOUT_ID = M_INOUTLINE.M_INOUT_ID
@@ -69,8 +65,7 @@
       AND 1=1
       AND M_INOUT.ISSOTRX = 'Y'
       GROUP BY C_BPARTNER.NAME, M_PRODUCT.NAME, C_UOM.NAME, M_INOUT.DOCUMENTNO, M_INOUT.MOVEMENTDATE
-      ORDER BY C_BPARTNER.NAME, M_INOUT.MOVEMENTDATE]]>
-	</queryString>
+      ORDER BY C_BPARTNER.NAME, M_INOUT.MOVEMENTDATE]]></query>
 	<field name="DOCUMENTNO" class="java.lang.String"/>
 	<field name="MOVEMENTDATE" class="java.util.Date"/>
 	<field name="CLIENT_NAME" class="java.lang.String"/>
@@ -78,560 +73,410 @@
 	<field name="QUANTITYORDER" class="java.math.BigDecimal"/>
 	<field name="UOMNAME" class="java.lang.String"/>
 	<field name="AUM" class="java.lang.String">
-		<fieldDescription><![CDATA[]]></fieldDescription>
+		<description><![CDATA[]]></description>
 	</field>
 	<field name="AUMQTY" class="java.math.BigDecimal"/>
 	<group name="CLIENT_NAME">
-		<groupExpression><![CDATA[$F{CLIENT_NAME}]]></groupExpression>
+		<expression><![CDATA[$F{CLIENT_NAME}]]></expression>
 		<groupHeader>
 			<band height="33" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="0" y="0" width="120" height="23" uuid="5a856ce5-0723-4fcb-abbe-d21cade23a07"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="5a856ce5-0723-4fcb-abbe-d21cade23a07" key="staticText" x="0" y="0" width="120" height="23" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[Client:]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="120" y="0" width="415" height="23" uuid="1311e0be-3ddb-4380-9a25-d99768754857"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CLIENT_NAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="23" width="1" height="10" forecolor="#555555" uuid="1be4e0fe-4c34-47fe-bb43-04dfee54de0c"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="535" y="1" width="1" height="32" forecolor="#555555" uuid="c4ca6794-10b5-42c1-a44b-99fb04a3277c"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				</element>
+				<element kind="textField" uuid="1311e0be-3ddb-4380-9a25-d99768754857" key="textField" x="120" y="0" width="415" height="23" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{CLIENT_NAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="1be4e0fe-4c34-47fe-bb43-04dfee54de0c" key="line-2" stretchType="ContainerHeight" x="0" y="23" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="c4ca6794-10b5-42c1-a44b-99fb04a3277c" key="line-3" stretchType="ContainerHeight" x="535" y="1" width="1" height="32" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="50" splitType="Stretch">
-				<line>
-					<reportElement key="line-32" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="10" forecolor="#555555" uuid="dedcd529-aee8-4fce-9559-b732be334c03"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="10" forecolor="#555555" uuid="64739248-ba10-43a9-9abd-d07eb72f6274"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-34" x="0" y="10" width="535" height="1" forecolor="#555555" uuid="cbf32fc5-f74e-46ce-8590-e385fca9359a"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="dedcd529-aee8-4fce-9559-b732be334c03" key="line-32" stretchType="ContainerHeight" x="0" y="0" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="64739248-ba10-43a9-9abd-d07eb72f6274" key="line-33" stretchType="ContainerHeight" x="535" y="0" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="cbf32fc5-f74e-46ce-8590-e385fca9359a" key="line-34" x="0" y="10" width="535" height="1" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="DOCUMENTNO">
-		<groupExpression><![CDATA[$F{DOCUMENTNO}]]></groupExpression>
+		<expression><![CDATA[$F{DOCUMENTNO}]]></expression>
 		<groupHeader>
 			<band height="42" splitType="Stretch">
-				<property name="local_mesure_unitheight" value="pixel"/>
-				<property name="com.jaspersoft.studio.unit.height" value="px"/>
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="10" y="0" width="102" height="22" uuid="d2d1915d-e0cb-4f7a-8a0a-977716dd7073"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="d2d1915d-e0cb-4f7a-8a0a-977716dd7073" key="staticText" x="10" y="0" width="102" height="22" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[Shipment No:]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="112" y="0" width="165" height="22" uuid="fb41c56f-7362-4fd4-aab3-2ead075c9277"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{DOCUMENTNO}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-4" stretchType="RelativeToBandHeight" x="10" y="22" width="1" height="20" forecolor="#555555" uuid="7f8cae5b-8e41-493c-91bc-ef05514f9634"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-6" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="42" forecolor="#555555" uuid="f26c1577-e0b3-4458-97f7-3568d1b0ff15"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-8" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="42" forecolor="#555555" uuid="6612e852-9341-4917-a234-72277f0bda5c"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="20" y="26" width="250" height="16" uuid="dfdec30a-0bda-4929-b2a3-17cd57880c59">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					</reportElement>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="fb41c56f-7362-4fd4-aab3-2ead075c9277" key="textField" x="112" y="0" width="165" height="22" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{DOCUMENTNO}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
+				</element>
+				<element kind="line" uuid="7f8cae5b-8e41-493c-91bc-ef05514f9634" key="line-4" stretchType="ContainerHeight" x="10" y="22" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="f26c1577-e0b3-4458-97f7-3568d1b0ff15" key="line-6" stretchType="ContainerHeight" x="535" y="0" width="1" height="42" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="6612e852-9341-4917-a234-72277f0bda5c" key="line-8" stretchType="ContainerHeight" x="0" y="0" width="1" height="42" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="dfdec30a-0bda-4929-b2a3-17cd57880c59" key="element-90" x="20" y="26" width="250" height="16" style="Detail_Header">
 					<text><![CDATA[Article]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="269" y="26" width="70" height="16" uuid="9485e00d-e1c0-459d-8853-1a196700b343">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right"/>
+				</element>
+				<element kind="staticText" uuid="9485e00d-e1c0-459d-8853-1a196700b343" key="element-90" x="269" y="26" width="70" height="16" hTextAlign="Right" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="339" y="26" width="50" height="16" uuid="84b00f0d-3053-468a-8e63-09c621ea0547">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="84b00f0d-3053-468a-8e63-09c621ea0547" key="element-90" x="339" y="26" width="50" height="16" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
 					<text><![CDATA[UOM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-2" style="GroupHeader_DarkGray" x="277" y="0" width="114" height="22" uuid="87c2d1b9-1d0f-45f3-90a0-810b631ab38d"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
-					<text><![CDATA[Shipment date:]]></text>
-				</staticText>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-1" style="GroupHeader_DarkGray" x="391" y="0" width="144" height="22" uuid="11e6d934-4a09-44b7-ab2e-8f920625adba"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{MOVEMENTDATE}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="389" y="26" width="90" height="16" uuid="361563aa-82cf-4f8c-a95a-d203bf78ff12">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center"/>
+				</element>
+				<element kind="staticText" uuid="87c2d1b9-1d0f-45f3-90a0-810b631ab38d" key="staticText-2" x="277" y="0" width="114" height="22" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
+					<text><![CDATA[Shipment date:]]></text>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="11e6d934-4a09-44b7-ab2e-8f920625adba" key="textField-1" x="391" y="0" width="144" height="22" pdfFontName="Helvetica" blankWhenNull="true" bold="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{MOVEMENTDATE}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="361563aa-82cf-4f8c-a95a-d203bf78ff12" key="element-90" x="389" y="26" width="90" height="16" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
 					<text><![CDATA[Qty in AUM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="480" y="26" width="50" height="16" uuid="9353de63-a25b-4f2c-9da2-01c6f3be182a">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-						<property name="local_mesure_unitx" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.x" value="px"/>
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="9353de63-a25b-4f2c-9da2-01c6f3be182a" key="element-90" x="480" y="26" width="50" height="16" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+					<text><![CDATA[AUM]]></text>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.5" lineStyle="Solid" lineColor="#555555"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.5" lineStyle="Solid" lineColor="#555555"/>
 					</box>
-					<text><![CDATA[AUM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="269" y="26" width="120" height="16" uuid="d258366d-1094-4339-a0b2-85192b94315b">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-						<property name="local_mesure_unitx" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.x" value="px"/>
-						<property name="local_mesure_unity" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.y" value="px"/>
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center"/>
+				</element>
+				<element kind="staticText" uuid="d258366d-1094-4339-a0b2-85192b94315b" key="element-90" x="269" y="26" width="120" height="16" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="389" y="26" width="141" height="16" uuid="edec6880-0517-4ff8-8b93-4518043d378c">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-						<property name="local_mesure_unitx" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.x" value="px"/>
-						<property name="local_mesure_unity" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.y" value="px"/>
-						<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center"/>
+				</element>
+				<element kind="staticText" uuid="edec6880-0517-4ff8-8b93-4518043d378c" key="element-90" x="389" y="26" width="141" height="16" hTextAlign="Center" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
 					<text><![CDATA[UOM]]></text>
-				</staticText>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<property name="local_mesure_unitheight" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.height" value="px"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-28" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="20" forecolor="#555555" uuid="7484d6a8-f420-4547-a8ff-ee0f82189433"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-29" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="10" forecolor="#555555" uuid="e6e38614-65a3-484e-82e8-3ba9777e9b19"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-30" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="20" forecolor="#555555" uuid="01cca72d-6014-48a8-bb74-b88d36e6bc9f"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-31" x="10" y="10" width="525" height="1" forecolor="#555555" uuid="ae93db5a-0d41-416e-9d13-bfadd75aa2ae"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-35" x="20" y="0" width="510" height="1" forecolor="#555555" uuid="aa3a0ebd-75d8-4a47-aeb7-274cb2e1de78">
-						<property name="local_mesure_unitwidth" value="pixel"/>
-						<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					</reportElement>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="7484d6a8-f420-4547-a8ff-ee0f82189433" key="line-28" stretchType="ContainerHeight" x="0" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="e6e38614-65a3-484e-82e8-3ba9777e9b19" key="line-29" stretchType="ContainerHeight" x="10" y="0" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="01cca72d-6014-48a8-bb74-b88d36e6bc9f" key="line-30" stretchType="ContainerHeight" x="535" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="ae93db5a-0d41-416e-9d13-bfadd75aa2ae" key="line-31" x="10" y="10" width="525" height="1" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="aa3a0ebd-75d8-4a47-aeb7-274cb2e1de78" key="line-35" x="20" y="0" width="510" height="1" forecolor="#555555">
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="20" splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="40" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Title" mode="Transparent" x="0" y="0" width="535" height="20" uuid="ce711acf-1fbf-4fd7-9e2c-63466470732b"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="20" width="535" height="1" uuid="de855c65-36f1-4204-bede-f1bb5c43e207"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Subtitle" x="0" y="20" width="535" height="20" uuid="327e4e5b-d839-4652-926f-0b9fe4c4785e"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[($P{REPORT_SUBTITLE}!=null)?$P{REPORT_SUBTITLE}:new String(" ")]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="20" splitType="Stretch"/>
+	<pageHeader height="40" splitType="Stretch">
+		<element kind="textField" uuid="ce711acf-1fbf-4fd7-9e2c-63466470732b" key="textField" mode="Transparent" x="0" y="0" width="535" height="20" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="de855c65-36f1-4204-bede-f1bb5c43e207" key="line-1" x="0" y="20" width="535" height="1">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="327e4e5b-d839-4652-926f-0b9fe4c4785e" key="textField" x="0" y="20" width="535" height="20" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[($P{REPORT_SUBTITLE}!=null)?$P{REPORT_SUBTITLE}:new String(" ")]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band height="16" splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader height="16" splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<property name="local_mesure_unitheight" value="pixel"/>
-			<property name="com.jaspersoft.studio.unit.height" value="px"/>
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="16" forecolor="#555555" uuid="b5aa2871-1b58-4cc3-bcb5-585cce7f666c"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="16" forecolor="#555555" uuid="60ecd90a-2295-4baf-ae47-83e7726af547"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-18" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="16" forecolor="#555555" uuid="bf075cbc-e162-44fb-9b84-d8a3c35669a5"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" x="20" y="0" width="250" height="16" uuid="64136400-3677-4a8c-9d07-df781f6c294f">
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
+			<element kind="line" uuid="b5aa2871-1b58-4cc3-bcb5-585cce7f666c" key="line-16" stretchType="ContainerHeight" x="535" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="60ecd90a-2295-4baf-ae47-83e7726af547" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="bf075cbc-e162-44fb-9b84-d8a3c35669a5" key="line-18" stretchType="ContainerHeight" x="10" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="64136400-3677-4a8c-9d07-df781f6c294f" key="textField" x="20" y="0" width="250" height="16" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{PRODUCT_NAME}]]></expression>
+				<property name="local_mesure_unitwidth" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				<box leftPadding="5" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{PRODUCT_NAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="269" y="0" width="70" height="16" uuid="b1234cae-316b-406b-9396-e2f84e8f091d">
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="b1234cae-316b-406b-9396-e2f84e8f091d" key="textField" x="269" y="0" width="70" height="16" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+				<expression><![CDATA[($F{QUANTITYORDER}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITYORDER}):new String(" ")]]></expression>
+				<property name="local_mesure_unitwidth" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[($F{QUANTITYORDER}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITYORDER}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" x="339" y="0" width="50" height="16" uuid="71a74957-70fa-42ed-b354-153ba337051e">
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="71a74957-70fa-42ed-b354-153ba337051e" key="textField" x="339" y="0" width="50" height="16" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+				<expression><![CDATA[$F{UOMNAME}]]></expression>
+				<property name="local_mesure_unitwidth" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				<box leftPadding="5" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{UOMNAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="389" y="0" width="90" height="16" uuid="687f94b0-4465-4fc8-9355-84491d9330c8">
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="687f94b0-4465-4fc8-9355-84491d9330c8" key="textField" x="389" y="0" width="90" height="16" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+				<expression><![CDATA[($F{AUMQTY}!=null)?$P{NUMBERFORMAT}.format($F{AUMQTY}):new String(" ")]]></expression>
+				<property name="local_mesure_unitwidth" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[($F{AUMQTY}!=null)?$P{NUMBERFORMAT}.format($F{AUMQTY}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" x="479" y="0" width="51" height="16" uuid="f3c1061c-d45c-4e50-9d47-edf301628eed">
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="f3c1061c-d45c-4e50-9d47-edf301628eed" key="textField" x="479" y="0" width="51" height="16" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==true]]></printWhenExpression>
+				<expression><![CDATA[$F{AUM}]]></expression>
+				<property name="local_mesure_unitwidth" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				<box leftPadding="5" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{AUM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="269" y="0" width="120" height="16" uuid="779777fb-9ee5-4fe2-81d2-72e852df9f86">
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					<property name="local_mesure_unitx" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.x" value="px"/>
-					<property name="local_mesure_unity" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.y" value="px"/>
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="779777fb-9ee5-4fe2-81d2-72e852df9f86" key="textField" x="269" y="0" width="120" height="16" fontName="SansSerif" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
+				<expression><![CDATA[($F{QUANTITYORDER}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITYORDER}):new String(" ")]]></expression>
+				<property name="local_mesure_unitwidth" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				<property name="local_mesure_unitx" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.x" value="px"/>
+				<property name="local_mesure_unity" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="SansSerif"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QUANTITYORDER}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITYORDER}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" x="389" y="0" width="141" height="16" uuid="1980a3c8-2ef2-4190-8945-e10d58fd2e30">
-					<property name="local_mesure_unitwidth" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-					<property name="local_mesure_unitx" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.x" value="px"/>
-					<property name="local_mesure_unity" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.y" value="px"/>
-					<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="1980a3c8-2ef2-4190-8945-e10d58fd2e30" key="textField" x="389" y="0" width="141" height="16" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Center" vTextAlign="Middle" style="Detail_Line">
+				<printWhenExpression><![CDATA[$P{isUOMManagementEnabled}==false]]></printWhenExpression>
+				<expression><![CDATA[$F{UOMNAME}]]></expression>
+				<property name="local_mesure_unitwidth" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				<property name="local_mesure_unitx" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.x" value="px"/>
+				<property name="local_mesure_unity" value="pixel"/>
+				<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				<box leftPadding="5" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#555555"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{UOMNAME}]]></textFieldExpression>
-			</textField>
+			</element>
+			<property name="local_mesure_unitheight" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="16" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="27" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="400" y="4" width="95" height="19" uuid="0dfbf627-d23e-41fa-a345-3086c8f31163"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="499" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="29eea59c-73d1-4e49-a057-41f714c14406"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="1" width="535" height="1" forecolor="#000000" uuid="c3606d9d-5b01-417d-aace-9ab25c27f293"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="277" y="4" width="69" height="19" uuid="911a0392-ee59-464a-a650-72b9d7fe74b2"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" x="195" y="4" width="78" height="19" uuid="63ce217d-8d32-4dab-8b9d-dacb10f00786"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="16" splitType="Stretch"/>
+	<pageFooter height="27" splitType="Stretch">
+		<element kind="textField" uuid="0dfbf627-d23e-41fa-a345-3086c8f31163" key="textField" x="400" y="4" width="95" height="19" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="29eea59c-73d1-4e49-a057-41f714c14406" key="textField" x="499" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="c3606d9d-5b01-417d-aace-9ab25c27f293" key="line" x="0" y="1" width="535" height="1" forecolor="#000000">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="911a0392-ee59-464a-a650-72b9d7fe74b2" key="textField" x="277" y="4" width="69" height="19" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="63ce217d-8d32-4dab-8b9d-dacb10f00786" key="staticText-1" x="195" y="4" width="78" height="19" hTextAlign="Right" vTextAlign="Middle">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportStandardCostsJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportStandardCostsJR.jrxml
@@ -1,89 +1,87 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportStandardCostsJR" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="e22dd576-aa7d-474a-91f8-bb5d2120f249">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportStandardCostsJR" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="e22dd576-aa7d-474a-91f8-bb5d2120f249">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true">
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/usr/local/src/iReport-2.0.0/compile_dir/"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["1000000"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["0, 1000000, 1000001"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
+	<parameter name="SUBREPORT_DIR" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{BASE_DESIGN}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="MA_PROCESSPLAN_ID" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="AUX_PROCESSPLAN" class="java.lang.String" isForPrompting="false">
+	<parameter name="MA_PROCESSPLAN_ID" forPrompting="false" class="java.lang.String"/>
+	<parameter name="AUX_PROCESSPLAN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{MA_PROCESSPLAN_ID}==null||$P{MA_PROCESSPLAN_ID}.equals(""))?"":" AND MA_PROCESSPLAN.MA_PROCESSPLAN_ID = '"+$P{MA_PROCESSPLAN_ID}+"'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="SR_COST" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="SR_PRODUCED" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="MA_PROCESSPLAN_VERSION_ID" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="AUX_VERSION" class="java.lang.String" isForPrompting="false">
+	<parameter name="SR_COST" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="SR_PRODUCED" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="MA_PROCESSPLAN_VERSION_ID" forPrompting="false" class="java.lang.String"/>
+	<parameter name="AUX_VERSION" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{MA_PROCESSPLAN_VERSION_ID} == null || $P{MA_PROCESSPLAN_VERSION_ID}.equals(""))?"":" AND MA_PROCESSPLAN_VERSION.MA_PROCESSPLAN_VERSION_ID = '"+ $P{MA_PROCESSPLAN_VERSION_ID}+"'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATETO" class="java.util.Date" isForPrompting="false">
+	<parameter name="DATETO" forPrompting="false" class="java.util.Date">
 		<defaultValueExpression><![CDATA[(new SimpleDateFormat("dd-MM-yyyy")).parse("01-01-1900")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATEFROM" class="java.util.Date" isForPrompting="false">
+	<parameter name="DATEFROM" forPrompting="false" class="java.util.Date">
 		<defaultValueExpression><![CDATA[(new SimpleDateFormat("dd-MM-yyyy")).parse("31-12-3000")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="CURRENCY_ID" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_CURRENCY_ID" class="java.lang.String" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT MA_PROCESSPLAN.MA_PROCESSPLAN_ID,
+	<parameter name="CURRENCY_ID" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_CURRENCY_ID" forPrompting="false" class="java.lang.String"/>
+	<query language="sql"><![CDATA[SELECT MA_PROCESSPLAN.MA_PROCESSPLAN_ID,
        AD_COLUMN_IDENTIFIER(to_char('MA_PROCESSPLAN'), to_char(MA_PROCESSPLAN.MA_PROCESSPLAN_ID), to_char($P{LANGUAGE})) AS PROCESSPLAN,
        MA_PROCESSPLAN_VERSION.MA_PROCESSPLAN_VERSION_ID,
        MA_PROCESSPLAN_VERSION.DOCUMENTNO AS VERSION, MA_PROCESSPLAN_VERSION.DATEFROM, MA_PROCESSPLAN_VERSION.DATETO,
@@ -98,8 +96,7 @@ WHERE MA_PROCESSPLAN.MA_PROCESSPLAN_ID = MA_PROCESSPLAN_VERSION.MA_PROCESSPLAN_I
   AND MA_PROCESSPLAN_VERSION.DATEFROM <= $P{DATEFROM}
   AND MA_PROCESSPLAN_VERSION.DATETO > $P{DATETO}
   AND MA_PROCESSPLAN.AD_CLIENT_ID IN ( $P!{USER_CLIENT} ) 
-ORDER BY MA_PROCESSPLAN.MA_PROCESSPLAN_ID, MA_PROCESSPLAN_VERSION.DATEFROM, MA_SEQUENCE.SEQNO]]>
-	</queryString>
+ORDER BY MA_PROCESSPLAN.MA_PROCESSPLAN_ID, MA_PROCESSPLAN_VERSION.DATEFROM, MA_SEQUENCE.SEQNO]]></query>
 	<field name="MA_PROCESSPLAN_ID" class="java.lang.String"/>
 	<field name="PROCESSPLAN" class="java.lang.String"/>
 	<field name="MA_PROCESSPLAN_VERSION_ID" class="java.lang.String"/>
@@ -110,475 +107,353 @@ ORDER BY MA_PROCESSPLAN.MA_PROCESSPLAN_ID, MA_PROCESSPLAN_VERSION.DATEFROM, MA_S
 	<field name="SEQUENCE" class="java.lang.String"/>
 	<variable name="DetailFieldTotal" class="java.lang.String"/>
 	<group name="MA_PROCESSPLAN_ID">
-		<groupExpression><![CDATA[$F{MA_PROCESSPLAN_ID}]]></groupExpression>
+		<expression><![CDATA[$F{MA_PROCESSPLAN_ID}]]></expression>
 		<groupHeader>
 			<band height="25" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="1" y="0" width="119" height="18" uuid="f8dcdf2a-fe74-4153-b843-2de0fc0d3d75"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
+				<element kind="staticText" uuid="f8dcdf2a-fe74-4153-b843-2de0fc0d3d75" key="staticText" x="1" y="0" width="119" height="18" style="GroupHeader_DarkGray">
 					<text><![CDATA[Process Plan]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="120" y="0" width="415" height="18" uuid="58a26233-79bc-4b64-b2e5-bab6eddf06b3"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{PROCESSPLAN}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="1" width="1" height="24" forecolor="#555555" uuid="3226b10e-71f9-481f-b5e5-98d9d4b40402"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="535" y="1" width="1" height="24" forecolor="#555555" uuid="16274073-4332-402b-b5b7-e6013568f315"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				</element>
+				<element kind="textField" uuid="58a26233-79bc-4b64-b2e5-bab6eddf06b3" key="textField" x="120" y="0" width="415" height="18" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{PROCESSPLAN}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="3226b10e-71f9-481f-b5e5-98d9d4b40402" key="line-2" stretchType="ContainerHeight" x="0" y="1" width="1" height="24" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="16274073-4332-402b-b5b7-e6013568f315" key="line-3" stretchType="ContainerHeight" x="535" y="1" width="1" height="24" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-32" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="9" forecolor="#555555" uuid="300c47c2-b2d1-4e14-9bbf-67a193263ca0"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="9" forecolor="#555555" uuid="881b114a-2e97-452f-8ada-cf0324f9f44a"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-34" x="0" y="9" width="535" height="1" forecolor="#555555" uuid="afbfe19b-069d-40ca-9ab6-e91f12bbe1ca"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="300c47c2-b2d1-4e14-9bbf-67a193263ca0" key="line-32" stretchType="ContainerHeight" x="0" y="0" width="1" height="9" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="881b114a-2e97-452f-8ada-cf0324f9f44a" key="line-33" stretchType="ContainerHeight" x="535" y="0" width="1" height="9" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="afbfe19b-069d-40ca-9ab6-e91f12bbe1ca" key="line-34" x="0" y="9" width="535" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="MA_PROCESSPLAN_VERSION_ID">
-		<groupExpression><![CDATA[$F{MA_PROCESSPLAN_VERSION_ID}]]></groupExpression>
+		<expression><![CDATA[$F{MA_PROCESSPLAN_VERSION_ID}]]></expression>
 		<groupHeader>
 			<band height="40" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText-6" style="Group_Data_Label" x="20" y="20" width="78" height="16" uuid="fbabee54-30d6-4f11-820d-d3a393c98f9a"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
+				<element kind="staticText" uuid="fbabee54-30d6-4f11-820d-d3a393c98f9a" key="staticText-6" x="20" y="20" width="78" height="16" style="Group_Data_Label">
 					<text><![CDATA[Valid From]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="130" y="0" width="405" height="18" uuid="5f3a49fe-fbd0-4006-b011-5df13895764c"/>
-					<box leftPadding="5">
+					<box style="Group_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="5f3a49fe-fbd0-4006-b011-5df13895764c" key="textField" x="130" y="0" width="405" height="18" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{VERSION}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{VERSION}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-4" stretchType="RelativeToBandHeight" x="10" y="1" width="1" height="39" forecolor="#555555" uuid="a6a52670-d6b4-4fd6-8914-dce7195d8bf5"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-6" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="40" forecolor="#555555" uuid="66b1a0fd-5ebb-4c23-a3c6-468f61bab16b"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-8" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="40" forecolor="#555555" uuid="ff85a28f-6418-44c5-a302-ba1758c7bf42"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-9" style="GroupHeader_DarkGray" x="11" y="0" width="119" height="18" uuid="c2fde9cd-9d65-4331-92bd-e92c89079124"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
+				</element>
+				<element kind="line" uuid="a6a52670-d6b4-4fd6-8914-dce7195d8bf5" key="line-4" stretchType="ContainerHeight" x="10" y="1" width="1" height="39" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="66b1a0fd-5ebb-4c23-a3c6-468f61bab16b" key="line-6" stretchType="ContainerHeight" x="535" y="0" width="1" height="40" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="ff85a28f-6418-44c5-a302-ba1758c7bf42" key="line-8" stretchType="ContainerHeight" x="0" y="0" width="1" height="40" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="c2fde9cd-9d65-4331-92bd-e92c89079124" key="staticText-9" x="11" y="0" width="119" height="18" style="GroupHeader_DarkGray">
 					<text><![CDATA[Version]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField" x="98" y="20" width="107" height="16" uuid="e170d558-7ce1-4268-aac7-89c37912bbb9"/>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="e170d558-7ce1-4268-aac7-89c37912bbb9" key="textField" x="98" y="20" width="107" height="16" blankWhenNull="false">
+					<expression><![CDATA[$F{DATEFROM}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{DATEFROM}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField" x="256" y="20" width="107" height="16" uuid="a7af7472-128a-4e52-b27b-01d967136d8d"/>
+				</element>
+				<element kind="textField" uuid="a7af7472-128a-4e52-b27b-01d967136d8d" key="textField" x="256" y="20" width="107" height="16" blankWhenNull="false">
+					<expression><![CDATA[$F{DATETO}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{DATETO}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-11" style="Group_Data_Label" x="222" y="20" width="34" height="16" uuid="8ca4e707-4326-476d-819f-95ffacb8bec3"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
+				</element>
+				<element kind="staticText" uuid="8ca4e707-4326-476d-819f-95ffacb8bec3" key="staticText-11" x="222" y="20" width="34" height="16" style="Group_Data_Label">
 					<text><![CDATA[To]]></text>
-				</staticText>
+					<box style="Group_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-28" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="20" forecolor="#555555" uuid="01987e86-0c78-4dc7-a692-278033cf5b6e"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-29" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="10" forecolor="#555555" uuid="3b11e505-8aaf-47da-9fce-b4ef865e92b0"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-30" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="20" forecolor="#555555" uuid="05f8f46a-5dd3-4f9c-930f-5b07216b956b"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-31" x="10" y="10" width="525" height="1" forecolor="#555555" uuid="29eb58ee-05c6-47af-9840-cacb57af07c7"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="01987e86-0c78-4dc7-a692-278033cf5b6e" key="line-28" stretchType="ContainerHeight" x="0" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="3b11e505-8aaf-47da-9fce-b4ef865e92b0" key="line-29" stretchType="ContainerHeight" x="10" y="0" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="05f8f46a-5dd3-4f9c-930f-5b07216b956b" key="line-30" stretchType="ContainerHeight" x="535" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="29eb58ee-05c6-47af-9840-cacb57af07c7" key="line-31" x="10" y="10" width="525" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="MA_SEQUENCE_ID" minHeightToStartNewPage="150">
-		<groupExpression><![CDATA[$F{MA_SEQUENCE_ID}]]></groupExpression>
+		<expression><![CDATA[$F{MA_SEQUENCE_ID}]]></expression>
 		<groupHeader>
 			<band height="25" splitType="Stretch">
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="140" y="0" width="395" height="18" uuid="4bb3f09a-5737-42cf-89b5-51c105a49efe"/>
-					<box leftPadding="5">
+				<element kind="textField" uuid="4bb3f09a-5737-42cf-89b5-51c105a49efe" key="textField" x="140" y="0" width="395" height="18" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{SEQUENCE}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{SEQUENCE}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-5" stretchType="RelativeToBandHeight" x="20" y="1" width="1" height="24" forecolor="#555555" uuid="8385368b-f51c-4e7f-8437-8e431d433a3d"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-7" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="25" forecolor="#555555" uuid="b48f7292-c15e-4ef5-b1aa-6edf406286c8"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-9" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="25" forecolor="#555555" uuid="f96e22ac-9df6-4676-a35c-9ad2c77bc900"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-10" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="25" forecolor="#555555" uuid="d27cf788-cb8c-4510-92f5-c14c691bcc29"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-10" style="GroupHeader_DarkGray" x="21" y="0" width="119" height="18" uuid="b8c5d776-39a5-4e3d-8e3e-6ede389b2034"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
+				</element>
+				<element kind="line" uuid="8385368b-f51c-4e7f-8437-8e431d433a3d" key="line-5" stretchType="ContainerHeight" x="20" y="1" width="1" height="24" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="b48f7292-c15e-4ef5-b1aa-6edf406286c8" key="line-7" stretchType="ContainerHeight" x="535" y="0" width="1" height="25" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="f96e22ac-9df6-4676-a35c-9ad2c77bc900" key="line-9" stretchType="ContainerHeight" x="0" y="0" width="1" height="25" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="d27cf788-cb8c-4510-92f5-c14c691bcc29" key="line-10" stretchType="ContainerHeight" x="10" y="0" width="1" height="25" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="b8c5d776-39a5-4e3d-8e3e-6ede389b2034" key="staticText-10" x="21" y="0" width="119" height="18" style="GroupHeader_DarkGray">
 					<text><![CDATA[Sequence]]></text>
-				</staticText>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-23" stretchType="RelativeToBandHeight" x="20" y="0" width="1" height="10" forecolor="#555555" uuid="668f2776-3116-4aa7-8b33-dbd2de0fdf31"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-24" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="20" forecolor="#555555" uuid="3b75e4cc-ae50-4809-95ef-c50bf4c53069"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-25" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="20" forecolor="#555555" uuid="a4294dd1-84fd-45d1-9058-fbc3fe6834d4"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-26" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="20" forecolor="#555555" uuid="1ad439b8-5fa2-46ca-9cf2-3d81c46c7ab1"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-27" x="20" y="10" width="515" height="1" forecolor="#555555" uuid="0b8a681d-3084-43a5-9db6-0abc52343540"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="668f2776-3116-4aa7-8b33-dbd2de0fdf31" key="line-23" stretchType="ContainerHeight" x="20" y="0" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="3b75e4cc-ae50-4809-95ef-c50bf4c53069" key="line-24" stretchType="ContainerHeight" x="0" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="a4294dd1-84fd-45d1-9058-fbc3fe6834d4" key="line-25" stretchType="ContainerHeight" x="10" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="1ad439b8-5fa2-46ca-9cf2-3d81c46c7ab1" key="line-26" stretchType="ContainerHeight" x="535" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="0b8a681d-3084-43a5-9db6-0abc52343540" key="line-27" x="20" y="10" width="515" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="20" splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="37" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Title" mode="Transparent" x="0" y="4" width="535" height="20" uuid="1939e71e-ba6f-49f7-b6cc-c585d8a7f33c"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="24" width="535" height="1" uuid="e5d814b1-41ce-4a9b-bc8a-43c801549a6c"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="20" splitType="Stretch"/>
+	<pageHeader height="37" splitType="Stretch">
+		<element kind="textField" uuid="1939e71e-ba6f-49f7-b6cc-c585d8a7f33c" key="textField" mode="Transparent" x="0" y="4" width="535" height="20" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="e5d814b1-41ce-4a9b-bc8a-43c801549a6c" key="line-1" x="0" y="24" width="535" height="1">
+			<pen lineWidth="1.0" lineStyle="Solid"/>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="100" splitType="Stretch">
-			<line>
-				<reportElement key="line-15" stretchType="RelativeToBandHeight" x="20" y="0" width="1" height="100" forecolor="#555555" uuid="7992badb-7077-4c9f-bcfc-0783c9ed0851"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="100" forecolor="#555555" uuid="e21912c1-b35e-4221-b7c5-0f295b6dd16c"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="100" forecolor="#555555" uuid="bb27b905-c1ce-4d4a-8c47-63b598f42e70"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-18" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="100" forecolor="#555555" uuid="5374194e-554c-43e9-ac9b-80075fb1280f"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<subreport isUsingCache="true">
-				<reportElement key="subreport-1" style="Report_Footer" x="27" y="0" width="505" height="46" uuid="a5a86e85-e278-44eb-b012-573cbb2bd5ac"/>
-				<subreportParameter name="ATTACH">
-					<subreportParameterExpression><![CDATA[$P{ATTACH}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="BASE_WEB">
-					<subreportParameterExpression><![CDATA[$P{BASE_WEB}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="BASE_DESIGN">
-					<subreportParameterExpression><![CDATA[$P{BASE_DESIGN}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LANGUAGE">
-					<subreportParameterExpression><![CDATA[$P{LANGUAGE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="USER_CLIENT">
-					<subreportParameterExpression><![CDATA[$P{USER_CLIENT}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="USER_ORG">
-					<subreportParameterExpression><![CDATA[$P{USER_ORG}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[$P{NUMBERFORMAT}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="REPORT_TITLE">
-					<subreportParameterExpression><![CDATA[$P{REPORT_TITLE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="REPORT_SUBTITLE">
-					<subreportParameterExpression><![CDATA[$P{REPORT_SUBTITLE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="SUBREPORT_DIR">
-					<subreportParameterExpression><![CDATA[$P{SUBREPORT_DIR}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="CURRENCY_ID">
-					<subreportParameterExpression><![CDATA[$P{CURRENCY_ID}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="BASE_CURRENCY_ID">
-					<subreportParameterExpression><![CDATA[$P{BASE_CURRENCY_ID}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="SEQUENCE_ID">
-					<subreportParameterExpression><![CDATA[$F{MA_SEQUENCE_ID}]]></subreportParameterExpression>
-				</subreportParameter>
+			<element kind="line" uuid="7992badb-7077-4c9f-bcfc-0783c9ed0851" key="line-15" stretchType="ContainerHeight" x="20" y="0" width="1" height="100" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="e21912c1-b35e-4221-b7c5-0f295b6dd16c" key="line-16" stretchType="ContainerHeight" x="535" y="0" width="1" height="100" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="bb27b905-c1ce-4d4a-8c47-63b598f42e70" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="100" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="5374194e-554c-43e9-ac9b-80075fb1280f" key="line-18" stretchType="ContainerHeight" x="10" y="0" width="1" height="100" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="subreport" uuid="a5a86e85-e278-44eb-b012-573cbb2bd5ac" key="subreport-1" x="27" y="0" width="505" height="46" usingCache="true" style="Report_Footer">
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{SR_COST}]]></subreportExpression>
-			</subreport>
-			<subreport isUsingCache="true">
-				<reportElement key="subreport-2" style="Report_Footer" positionType="Float" x="27" y="50" width="505" height="46" uuid="104dca7b-9662-421b-813f-9186e33e318d"/>
-				<subreportParameter name="ATTACH">
-					<subreportParameterExpression><![CDATA[$P{ATTACH}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="BASE_WEB">
-					<subreportParameterExpression><![CDATA[$P{BASE_WEB}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="BASE_DESIGN">
-					<subreportParameterExpression><![CDATA[$P{BASE_DESIGN}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LANGUAGE">
-					<subreportParameterExpression><![CDATA[$P{LANGUAGE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="USER_CLIENT">
-					<subreportParameterExpression><![CDATA[$P{USER_CLIENT}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="USER_ORG">
-					<subreportParameterExpression><![CDATA[$P{USER_ORG}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[$P{NUMBERFORMAT}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="SUBREPORT_DIR">
-					<subreportParameterExpression><![CDATA[$P{SUBREPORT_DIR}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="CURRENCY_ID">
-					<subreportParameterExpression><![CDATA[$P{CURRENCY_ID}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="BASE_CURRENCY_ID">
-					<subreportParameterExpression><![CDATA[$P{BASE_CURRENCY_ID}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="SEQUENCE_ID">
-					<subreportParameterExpression><![CDATA[$F{MA_SEQUENCE_ID}]]></subreportParameterExpression>
-				</subreportParameter>
+				<expression><![CDATA[$P{SR_COST}]]></expression>
+				<parameter name="ATTACH">
+					<expression><![CDATA[$P{ATTACH}]]></expression>
+				</parameter>
+				<parameter name="BASE_WEB">
+					<expression><![CDATA[$P{BASE_WEB}]]></expression>
+				</parameter>
+				<parameter name="BASE_DESIGN">
+					<expression><![CDATA[$P{BASE_DESIGN}]]></expression>
+				</parameter>
+				<parameter name="LANGUAGE">
+					<expression><![CDATA[$P{LANGUAGE}]]></expression>
+				</parameter>
+				<parameter name="USER_CLIENT">
+					<expression><![CDATA[$P{USER_CLIENT}]]></expression>
+				</parameter>
+				<parameter name="USER_ORG">
+					<expression><![CDATA[$P{USER_ORG}]]></expression>
+				</parameter>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[$P{NUMBERFORMAT}]]></expression>
+				</parameter>
+				<parameter name="REPORT_TITLE">
+					<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+				</parameter>
+				<parameter name="REPORT_SUBTITLE">
+					<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+				</parameter>
+				<parameter name="SUBREPORT_DIR">
+					<expression><![CDATA[$P{SUBREPORT_DIR}]]></expression>
+				</parameter>
+				<parameter name="CURRENCY_ID">
+					<expression><![CDATA[$P{CURRENCY_ID}]]></expression>
+				</parameter>
+				<parameter name="BASE_CURRENCY_ID">
+					<expression><![CDATA[$P{BASE_CURRENCY_ID}]]></expression>
+				</parameter>
+				<parameter name="SEQUENCE_ID">
+					<expression><![CDATA[$F{MA_SEQUENCE_ID}]]></expression>
+				</parameter>
+			</element>
+			<element kind="subreport" uuid="104dca7b-9662-421b-813f-9186e33e318d" key="subreport-2" positionType="Float" x="27" y="50" width="505" height="46" usingCache="true" style="Report_Footer">
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{SR_PRODUCED}]]></subreportExpression>
-			</subreport>
+				<expression><![CDATA[$P{SR_PRODUCED}]]></expression>
+				<parameter name="ATTACH">
+					<expression><![CDATA[$P{ATTACH}]]></expression>
+				</parameter>
+				<parameter name="BASE_WEB">
+					<expression><![CDATA[$P{BASE_WEB}]]></expression>
+				</parameter>
+				<parameter name="BASE_DESIGN">
+					<expression><![CDATA[$P{BASE_DESIGN}]]></expression>
+				</parameter>
+				<parameter name="LANGUAGE">
+					<expression><![CDATA[$P{LANGUAGE}]]></expression>
+				</parameter>
+				<parameter name="USER_CLIENT">
+					<expression><![CDATA[$P{USER_CLIENT}]]></expression>
+				</parameter>
+				<parameter name="USER_ORG">
+					<expression><![CDATA[$P{USER_ORG}]]></expression>
+				</parameter>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[$P{NUMBERFORMAT}]]></expression>
+				</parameter>
+				<parameter name="SUBREPORT_DIR">
+					<expression><![CDATA[$P{SUBREPORT_DIR}]]></expression>
+				</parameter>
+				<parameter name="CURRENCY_ID">
+					<expression><![CDATA[$P{CURRENCY_ID}]]></expression>
+				</parameter>
+				<parameter name="BASE_CURRENCY_ID">
+					<expression><![CDATA[$P{BASE_CURRENCY_ID}]]></expression>
+				</parameter>
+				<parameter name="SEQUENCE_ID">
+					<expression><![CDATA[$F{MA_SEQUENCE_ID}]]></expression>
+				</parameter>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="16" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="20" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="402" y="4" width="95" height="16" uuid="2928ca58-716d-4f3e-afc9-ec1ef6a2960f"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="499" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="f8a72a7e-26a2-49ef-8578-dcf38ee18a45"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="1" width="535" height="1" forecolor="#000000" uuid="40a8f6b5-c5dd-4670-a13d-b1061ec97b9b"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="277" y="4" width="69" height="16" uuid="97fb5788-1fd5-4da6-96a1-aa619161fa35"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" style="Report_Footer" x="195" y="4" width="78" height="16" uuid="df69e622-0158-41f0-82bd-d8856e04a801"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="16" splitType="Stretch"/>
+	<pageFooter height="20" splitType="Stretch">
+		<element kind="textField" uuid="2928ca58-716d-4f3e-afc9-ec1ef6a2960f" key="textField" x="402" y="4" width="95" height="16" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="f8a72a7e-26a2-49ef-8578-dcf38ee18a45" key="textField" x="499" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle" style="Report_Footer">
+			<paragraph lineSpacing="Single" style="Report_Footer"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="40a8f6b5-c5dd-4670-a13d-b1061ec97b9b" key="line" x="0" y="1" width="535" height="1" forecolor="#000000">
+			<pen lineWidth="1.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="97fb5788-1fd5-4da6-96a1-aa619161fa35" key="textField" x="277" y="4" width="69" height="16" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="df69e622-0158-41f0-82bd-d8856e04a801" key="staticText-1" x="195" y="4" width="78" height="16" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportStandardCostsJR_srptcosts.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportStandardCostsJR_srptcosts.jrxml
@@ -1,69 +1,67 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportStandardCostsJR_srptcosts" pageWidth="505" pageHeight="46" orientation="Landscape" columnWidth="505" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="e57394df-d49a-40a1-bc76-39968066d58a">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportStandardCostsJR_srptcosts" language="java" pageWidth="505" pageHeight="46" orientation="Landscape" columnWidth="505" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="e57394df-d49a-40a1-bc76-39968066d58a">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true">
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="SEQUENCE_ID" class="java.lang.String" isForPrompting="false">
+	<parameter name="SEQUENCE_ID" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["1000004"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="CURRENCY_ID" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_CURRENCY_ID" class="java.lang.String" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT 1 AS LINEORDER,
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="CURRENCY_ID" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_CURRENCY_ID" forPrompting="false" class="java.lang.String"/>
+	<query language="sql"><![CDATA[SELECT 1 AS LINEORDER,
        AD_COLUMN_IDENTIFIER(to_char('M_PRODUCT'), to_char(M_PRODUCT_ID), $P{LANGUAGE}) AS CONCEPT,
        quantity*COALESCE(decrease,1)*COALESCE(rejected,1) AS QUANTITY,
        C_CURRENCY_CONVERT(COALESCE(COST, 0), $P{BASE_CURRENCY_ID}, $P{CURRENCY_ID}, TO_DATE(COALESCE(CREATED,NOW())), NULL, AD_CLIENT_ID, AD_ORG_ID) AS UNIT_COST,
@@ -122,8 +120,7 @@ FROM MA_SEQUENCE, MA_SEQUENCE_IC
 WHERE MA_SEQUENCE.MA_SEQUENCE_ID = MA_SEQUENCE_IC.MA_SEQUENCE_ID
   AND MA_SEQUENCE.MA_SEQUENCE_ID = $P{SEQUENCE_ID}
   AND MA_SEQUENCE.OUTSOURCED = 'N'
-ORDER BY LINEORDER, QUANTITY DESC, COST DESC]]>
-	</queryString>
+ORDER BY LINEORDER, QUANTITY DESC, COST DESC]]></query>
 	<field name="LINEORDER" class="java.math.BigDecimal"/>
 	<field name="CONCEPT" class="java.lang.String"/>
 	<field name="QUANTITY" class="java.math.BigDecimal"/>
@@ -132,215 +129,152 @@ ORDER BY LINEORDER, QUANTITY DESC, COST DESC]]>
 	<field name="CONVSYM" class="java.lang.String"/>
 	<field name="CONVISOSYM" class="java.lang.String"/>
 	<variable name="DetailFieldTotal" class="java.lang.String"/>
-	<variable name="COST_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{COST}]]></variableExpression>
+	<variable name="COST_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{COST}]]></expression>
 	</variable>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band height="16" splitType="Stretch">
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="0" y="0" width="175" height="16" uuid="20089ee6-f14d-426d-a402-34da9c73e10f"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<text><![CDATA[Resources]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="175" y="0" width="65" height="16" uuid="bc268675-5f9c-4281-92d7-623279966eb8"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<text><![CDATA[Quantity]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="240" y="0" width="130" height="16" uuid="4c5efe00-ded0-4de9-b64b-f4ace500749f"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Cost]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="370" y="0" width="134" height="16" uuid="8e1f0f76-4f7f-4b7b-8274-21f5b6c8fe5a"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Amount]]></text>
-			</staticText>
-		</band>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader height="16" splitType="Stretch">
+		<element kind="staticText" uuid="20089ee6-f14d-426d-a402-34da9c73e10f" key="element-90" x="0" y="0" width="175" height="16" style="Detail_Header">
+			<text><![CDATA[Resources]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="bc268675-5f9c-4281-92d7-623279966eb8" key="element-90" x="175" y="0" width="65" height="16" style="Detail_Header">
+			<text><![CDATA[Quantity]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="4c5efe00-ded0-4de9-b64b-f4ace500749f" key="element-90" x="240" y="0" width="130" height="16" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Cost]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="8e1f0f76-4f7f-4b7b-8274-21f5b6c8fe5a" key="element-90" x="370" y="0" width="134" height="16" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Amount]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
 	</columnHeader>
 	<detail>
 		<band height="14" splitType="Stretch">
-			<frame>
-				<reportElement key="frame-1" style="Detail_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="505" height="14" uuid="69b09af3-32d9-4b5d-8a67-e005454b33f4"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-1" style="default" stretchType="RelativeToBandHeight" mode="Transparent" x="370" y="0" width="118" height="14" uuid="085c3d82-d0b6-40a0-bd13-b9e894b2dfe7"/>
-					<box leftPadding="5" rightPadding="2">
+			<element kind="frame" uuid="69b09af3-32d9-4b5d-8a67-e005454b33f4" key="frame-1" stretchType="ContainerHeight" x="0" y="0" width="505" height="14" style="Detail_Line">
+				<element kind="textField" uuid="085c3d82-d0b6-40a0-bd13-b9e894b2dfe7" key="textField-1" stretchType="ContainerHeight" mode="Transparent" x="370" y="0" width="118" height="14" fontSize="9.0" blankWhenNull="false" hTextAlign="Right" style="default">
+					<expression><![CDATA[($F{COST}!=null)?$P{NUMBERFORMAT}.format($F{COST}):new String(" ")]]></expression>
+					<box leftPadding="5" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#666666"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#666666"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="9"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{COST}!=null)?$P{NUMBERFORMAT}.format($F{COST}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-2" style="default" stretchType="RelativeToBandHeight" mode="Transparent" x="240" y="0" width="114" height="14" uuid="66d31d20-6424-49f6-a0b1-8f119cdbd4cd"/>
-					<box leftPadding="5" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="66d31d20-6424-49f6-a0b1-8f119cdbd4cd" key="textField-2" stretchType="ContainerHeight" mode="Transparent" x="240" y="0" width="114" height="14" fontSize="9.0" blankWhenNull="false" hTextAlign="Right" style="default">
+					<expression><![CDATA[($F{UNIT_COST}!=null)?$P{NUMBERFORMAT}.format($F{UNIT_COST}):new String(" ")]]></expression>
+					<box leftPadding="5" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#666666"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="9"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{UNIT_COST}!=null)?$P{NUMBERFORMAT}.format($F{UNIT_COST}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-					<reportElement key="textField-3" style="default" stretchType="RelativeToBandHeight" x="175" y="0" width="65" height="14" uuid="3b99662c-1d71-45d6-9741-8e3f5ff02bac"/>
-					<box leftPadding="5" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3b99662c-1d71-45d6-9741-8e3f5ff02bac" key="textField-3" stretchType="ContainerHeight" x="175" y="0" width="65" height="14" fontSize="9.0" textAdjust="StretchHeight" blankWhenNull="false" hTextAlign="Right" style="default">
+					<expression><![CDATA[($F{QUANTITY}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITY}):new String(" ")]]></expression>
+					<box leftPadding="5" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#666666"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="9"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{QUANTITY}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITY}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-					<reportElement key="textField-4" style="default" x="0" y="0" width="175" height="14" uuid="712903b5-23bc-42ac-a533-8fcf8fa6ebcb"/>
-					<box leftPadding="5" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="712903b5-23bc-42ac-a533-8fcf8fa6ebcb" key="textField-4" x="0" y="0" width="175" height="14" fontSize="9.0" textAdjust="StretchHeight" blankWhenNull="false" style="default">
+					<expression><![CDATA[$F{CONCEPT}]]></expression>
+					<box leftPadding="5" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#666666"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="9"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONCEPT}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-5" style="Report_Footer" stretchType="RelativeToBandHeight" x="354" y="0" width="16" height="14" uuid="823ee9f8-1afc-49bd-9426-7c8dd5bdba4f"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="823ee9f8-1afc-49bd-9426-7c8dd5bdba4f" key="textField-5" stretchType="ContainerHeight" x="354" y="0" width="16" height="14" fontSize="9.0" blankWhenNull="false" underline="false" hTextAlign="Center" vTextAlign="Middle" style="Report_Footer">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Report_Footer">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="9" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-6" style="Report_Footer" stretchType="RelativeToBandHeight" x="488" y="0" width="16" height="14" uuid="e8c8b2b6-20b6-4351-bcc0-5c9fb03fca65"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="e8c8b2b6-20b6-4351-bcc0-5c9fb03fca65" key="textField-6" stretchType="ContainerHeight" x="488" y="0" width="16" height="14" fontSize="9.0" blankWhenNull="false" underline="false" hTextAlign="Center" vTextAlign="Middle" style="Report_Footer">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Report_Footer">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="9" isUnderline="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-			</frame>
+				</element>
+				<box style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="16" splitType="Stretch">
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Total_Field" x="370" y="1" width="118" height="15" uuid="2235401d-054f-4060-af6e-13f9fbf33cfd"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="9" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{COST_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COST_TOTAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" style="Report_Footer" x="220" y="1" width="150" height="15" uuid="34796178-801a-4ecf-a494-a03824a3e41e"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="10"/>
-				</textElement>
-				<text><![CDATA[Sequence Total Cost: ]]></text>
-			</staticText>
-			<line>
-				<reportElement key="line-1" style="Report_Footer" x="0" y="0" width="505" height="1" forecolor="#666666" uuid="8c4d2044-e7b9-4f8e-8e95-4d2e6a8b69bb"/>
-			</line>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-7" style="Total_Field" mode="Opaque" x="488" y="1" width="16" height="15" uuid="8fae5a69-2f19-4775-a61b-5aa38d690853"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="9" isUnderline="false" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
-		</band>
+	<columnFooter height="16" splitType="Stretch">
+		<element kind="textField" uuid="2235401d-054f-4060-af6e-13f9fbf33cfd" key="textField" x="370" y="1" width="118" height="15" fontSize="9.0" pdfFontName="Helvetica-Bold" textAdjust="StretchHeight" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+			<expression><![CDATA[($V{COST_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COST_TOTAL}):new String(" ")]]></expression>
+			<box leftPadding="5" style="Total_Field">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="34796178-801a-4ecf-a494-a03824a3e41e" key="staticText-1" x="220" y="1" width="150" height="15" fontSize="10.0" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Sequence Total Cost: ]]></text>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="8c4d2044-e7b9-4f8e-8e95-4d2e6a8b69bb" key="line-1" x="0" y="0" width="505" height="1" forecolor="#666666" style="Report_Footer"/>
+		<element kind="textField" uuid="8fae5a69-2f19-4775-a61b-5aa38d690853" key="textField-7" mode="Opaque" x="488" y="1" width="16" height="15" fontSize="9.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" underline="false" hTextAlign="Center" vTextAlign="Middle" style="Total_Field">
+			<expression><![CDATA[$F{CONVSYM}]]></expression>
+			<box leftPadding="5" style="Total_Field">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportStandardCostsJR_subreport0.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportStandardCostsJR_subreport0.jrxml
@@ -1,78 +1,76 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportStandardCostsJR_subreport0" pageWidth="505" pageHeight="46" orientation="Landscape" columnWidth="505" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="54f1ea59-9c12-430b-bc59-fa978c453b90">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportStandardCostsJR_subreport0" language="java" pageWidth="505" pageHeight="46" orientation="Landscape" columnWidth="505" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="54f1ea59-9c12-430b-bc59-fa978c453b90">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true">
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="ReportData" class="java.lang.String" isForPrompting="false">
+	<parameter name="ReportData" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="SEQUENCE_ID" class="java.lang.String" isForPrompting="false">
+	<parameter name="SEQUENCE_ID" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["1000004"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="CURRENCY_ID" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_CURRENCY_ID" class="java.lang.String" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT  MA_SEQUENCEPRODUCT.MA_SEQUENCE_ID, A.COMPONENTCOSTSUM, MA_SEQUENCEPRODUCT.COMPONENTCOST,
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="CURRENCY_ID" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_CURRENCY_ID" forPrompting="false" class="java.lang.String"/>
+	<query language="sql"><![CDATA[SELECT  MA_SEQUENCEPRODUCT.MA_SEQUENCE_ID, A.COMPONENTCOSTSUM, MA_SEQUENCEPRODUCT.COMPONENTCOST,
   AD_COLUMN_IDENTIFIER(to_char('M_PRODUCT'), to_char(M_PRODUCT_ID), $P{LANGUAGE}) AS CONCEPT,
        ROUND(quantity/CASE WHEN (decrease=0 OR rejected=0) THEN 1 ELSE COALESCE(decrease,1)*COALESCE(rejected,1) END,4) AS QUANTITY,
        C_CURRENCY_CONVERT(COALESCE(COST, 0), $P{BASE_CURRENCY_ID}, $P{CURRENCY_ID}, TO_DATE(COALESCE(MA_SEQUENCEPRODUCT.CREATED,NOW())), NULL, MA_SEQUENCEPRODUCT.AD_CLIENT_ID, MA_SEQUENCEPRODUCT.AD_ORG_ID)  AS UNIT_COST,
@@ -87,8 +85,7 @@ FROM MA_SEQUENCEPRODUCT,
      GROUP BY MA_SEQUENCE_ID) A
 WHERE MA_SEQUENCEPRODUCT.MA_SEQUENCE_ID = $P{SEQUENCE_ID}
   AND MA_SEQUENCEPRODUCT.PRODUCTIONTYPE = '+'
-  AND A.MA_SEQUENCE_ID = MA_SEQUENCEPRODUCT.MA_SEQUENCE_ID]]>
-	</queryString>
+  AND A.MA_SEQUENCE_ID = MA_SEQUENCEPRODUCT.MA_SEQUENCE_ID]]></query>
 	<field name="MA_SEQUENCE_ID" class="java.lang.String"/>
 	<field name="COMPONENTCOSTSUM" class="java.math.BigDecimal"/>
 	<field name="COMPONENTCOST" class="java.math.BigDecimal"/>
@@ -99,218 +96,152 @@ WHERE MA_SEQUENCEPRODUCT.MA_SEQUENCE_ID = $P{SEQUENCE_ID}
 	<field name="CONVSYM" class="java.lang.String"/>
 	<field name="CONVISOSYM" class="java.lang.String"/>
 	<variable name="DetailFieldTotal" class="java.lang.String"/>
-	<variable name="COST_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{COST}]]></variableExpression>
+	<variable name="COST_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{COST}]]></expression>
 	</variable>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band height="16" splitType="Stretch">
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="0" y="0" width="175" height="16" uuid="d415b472-bb84-4122-be33-67435d5f66c7"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<text><![CDATA[Produced Product]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="175" y="0" width="65" height="16" uuid="93298c05-0ad6-4fb6-b7a2-36c64124b0cb"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Quantity]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="240" y="0" width="130" height="16" uuid="98b00832-fc59-44a7-90ed-3e8c1088b60d"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Cost]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="370" y="0" width="134" height="16" uuid="99af2f6a-8974-4934-a139-dd0c454caadf"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Amount]]></text>
-			</staticText>
-		</band>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader height="16" splitType="Stretch">
+		<element kind="staticText" uuid="d415b472-bb84-4122-be33-67435d5f66c7" key="element-90" x="0" y="0" width="175" height="16" style="Detail_Header">
+			<text><![CDATA[Produced Product]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="93298c05-0ad6-4fb6-b7a2-36c64124b0cb" key="element-90" x="175" y="0" width="65" height="16" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Quantity]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="98b00832-fc59-44a7-90ed-3e8c1088b60d" key="element-90" x="240" y="0" width="130" height="16" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Cost]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="99af2f6a-8974-4934-a139-dd0c454caadf" key="element-90" x="370" y="0" width="134" height="16" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Amount]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
 	</columnHeader>
 	<detail>
 		<band height="14" splitType="Stretch">
-			<frame>
-				<reportElement key="frame-1" style="Detail_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="505" height="14" uuid="45446d8e-b989-48d6-abd9-f41c364c22a7"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-					<reportElement key="textField-1" style="default" stretchType="RelativeToBandHeight" x="0" y="0" width="175" height="14" uuid="a32a1642-1472-4127-80bd-56ccb6c19913"/>
-					<box leftPadding="3" rightPadding="2">
+			<element kind="frame" uuid="45446d8e-b989-48d6-abd9-f41c364c22a7" key="frame-1" stretchType="ContainerHeight" x="0" y="0" width="505" height="14" style="Detail_Line">
+				<element kind="textField" uuid="a32a1642-1472-4127-80bd-56ccb6c19913" key="textField-1" stretchType="ContainerHeight" x="0" y="0" width="175" height="14" fontSize="9.0" textAdjust="StretchHeight" blankWhenNull="false" style="default">
+					<expression><![CDATA[$F{CONCEPT}]]></expression>
+					<box leftPadding="3" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="9"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONCEPT}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-2" style="default" stretchType="RelativeToBandHeight" x="175" y="0" width="65" height="14" uuid="2abceda1-5f3f-46de-a29f-28f0efd0e49a"/>
-					<box leftPadding="3" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2abceda1-5f3f-46de-a29f-28f0efd0e49a" key="textField-2" stretchType="ContainerHeight" x="175" y="0" width="65" height="14" fontSize="9.0" blankWhenNull="false" hTextAlign="Right" style="default">
+					<expression><![CDATA[($F{QUANTITY}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITY}):new String(" ")]]></expression>
+					<box leftPadding="3" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="9"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{QUANTITY}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITY}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-3" style="default" stretchType="RelativeToBandHeight" x="240" y="0" width="114" height="14" uuid="b8589791-dd5d-4f41-86f1-4c075817f3a8"/>
-					<box leftPadding="3" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b8589791-dd5d-4f41-86f1-4c075817f3a8" key="textField-3" stretchType="ContainerHeight" x="240" y="0" width="114" height="14" fontSize="9.0" blankWhenNull="false" hTextAlign="Right" style="default">
+					<expression><![CDATA[($F{UNIT_COST}!=null)?$P{NUMBERFORMAT}.format($F{UNIT_COST}):new String(" ")]]></expression>
+					<box leftPadding="3" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="9"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{UNIT_COST}!=null)?$P{NUMBERFORMAT}.format($F{UNIT_COST}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-4" style="default" stretchType="RelativeToBandHeight" x="370" y="0" width="118" height="14" uuid="e40b7f7f-85ae-4592-8ca7-a207c54076a4"/>
-					<box leftPadding="3" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e40b7f7f-85ae-4592-8ca7-a207c54076a4" key="textField-4" stretchType="ContainerHeight" x="370" y="0" width="118" height="14" fontSize="9.0" blankWhenNull="false" hTextAlign="Right" style="default">
+					<expression><![CDATA[($F{COST}!=null)?$P{NUMBERFORMAT}.format($F{COST}):new String(" ")]]></expression>
+					<box leftPadding="3" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="9"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{COST}!=null)?$P{NUMBERFORMAT}.format($F{COST}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-5" style="Report_Footer" stretchType="RelativeToBandHeight" x="354" y="0" width="16" height="13" uuid="f88e7962-4e87-446a-bcda-1d95c904c99d"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="f88e7962-4e87-446a-bcda-1d95c904c99d" key="textField-5" stretchType="ContainerHeight" x="354" y="0" width="16" height="13" fontSize="9.0" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Report_Footer">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Report_Footer">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="9"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-6" style="Report_Footer" stretchType="RelativeToBandHeight" x="488" y="0" width="16" height="14" uuid="e2f2fc01-02b3-4fda-85b4-9678257bb4b1"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="e2f2fc01-02b3-4fda-85b4-9678257bb4b1" key="textField-6" stretchType="ContainerHeight" x="488" y="0" width="16" height="14" fontSize="9.0" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Report_Footer">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Report_Footer">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="9"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-			</frame>
+				</element>
+				<box style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="16" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-1" style="Report_Footer" x="270" y="1" width="100" height="15" uuid="74afcde9-1c4d-426e-9684-dc0e35e57e26"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="10"/>
-				</textElement>
-				<text><![CDATA[Total: ]]></text>
-			</staticText>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Total_Field" x="370" y="1" width="118" height="15" uuid="fda70d22-8500-4cae-8a02-2d36288ef0c4"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="9" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{COST_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COST_TOTAL}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" style="Report_Footer" x="0" y="0" width="505" height="1" forecolor="#999999" uuid="9efe61f2-0df9-41da-8c9f-d01252e82b4d"/>
-			</line>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-7" style="Total_Field" x="488" y="1" width="16" height="15" uuid="53e24970-45f9-4dae-a4a1-ab69a8be39c4"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
-		</band>
+	<columnFooter height="16" splitType="Stretch">
+		<element kind="staticText" uuid="74afcde9-1c4d-426e-9684-dc0e35e57e26" key="staticText-1" x="270" y="1" width="100" height="15" fontSize="10.0" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
+			<text><![CDATA[Total: ]]></text>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="fda70d22-8500-4cae-8a02-2d36288ef0c4" key="textField" x="370" y="1" width="118" height="15" fontSize="9.0" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Field">
+			<expression><![CDATA[($V{COST_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{COST_TOTAL}):new String(" ")]]></expression>
+			<box leftPadding="5" style="Total_Field">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="9efe61f2-0df9-41da-8c9f-d01252e82b4d" key="line-1" x="0" y="0" width="505" height="1" forecolor="#999999" style="Report_Footer"/>
+		<element kind="textField" uuid="53e24970-45f9-4dae-a4a1-ab69a8be39c4" key="textField-7" x="488" y="1" width="16" height="15" fontSize="9.0" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Total_Field">
+			<expression><![CDATA[$F{CONVSYM}]]></expression>
+			<box leftPadding="5" style="Total_Field">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportTaxInvoice.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportTaxInvoice.jrxml
@@ -1,64 +1,63 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportTaxInvoice" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="509319a5-55ea-42a3-9075-594e130174a0">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportTaxInvoice" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="509319a5-55ea-42a3-9075-594e130174a0">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="11">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="11.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/usr/local/src/AppsOpenbravo/src/"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0, 1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
 	<parameter name="SUBREPORT_DIR" class="java.lang.String">
@@ -72,99 +71,96 @@
 	</parameter>
 	<parameter name="parDateFrom" class="java.util.Date"/>
 	<parameter name="parDateTo" class="java.util.Date"/>
-	<parameter name="SALE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="PURCHASE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="SR_SALE" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="SR_SALEFOREIGN" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="SR_PURCHASE" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="SR_PURCHASEFOREIGN" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="DETAIL" class="java.lang.String" isForPrompting="false">
+	<parameter name="SALE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="PURCHASE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="SR_SALE" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="SR_SALEFOREIGN" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="SR_PURCHASE" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="SR_PURCHASEFOREIGN" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="DETAIL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Y"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="PARAM_ORG" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[select dummy from dual]]>
-	</queryString>
+	<parameter name="PARAM_ORG" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[select dummy from dual]]></query>
 	<field name="DUMMY" class="java.lang.String"/>
 	<variable name="DetailFieldTotal" class="java.lang.String"/>
 	<group name="Sales">
-		<groupExpression><![CDATA[]]></groupExpression>
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="40" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean(!$P{SALE}.equals(""))]]></printWhenExpression>
-				<subreport isUsingCache="true">
-					<reportElement key="subreport-2" style="Report_Footer" x="0" y="0" width="535" height="40" uuid="68646245-dd88-4e09-b331-e9d72d6a392c"/>
-					<subreportParameter name="ATTACH">
-						<subreportParameterExpression><![CDATA[$P{ATTACH}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="BASE_WEB">
-						<subreportParameterExpression><![CDATA[$P{BASE_WEB}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="BASE_DESIGN">
-						<subreportParameterExpression><![CDATA[$P{BASE_DESIGN}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="LANGUAGE">
-						<subreportParameterExpression><![CDATA[$P{LANGUAGE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="USER_CLIENT">
-						<subreportParameterExpression><![CDATA[$P{USER_CLIENT}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="USER_ORG">
-						<subreportParameterExpression><![CDATA[$P{PARAM_ORG}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="REPORT_TITLE">
-						<subreportParameterExpression><![CDATA[$P{REPORT_TITLE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="REPORT_SUBTITLE">
-						<subreportParameterExpression><![CDATA[$P{REPORT_SUBTITLE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SUBREPORT_DIR">
-						<subreportParameterExpression><![CDATA[$P{SUBREPORT_DIR}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="cCountryId">
-						<subreportParameterExpression><![CDATA[$P{cCountryId}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="PARAM_CURRENCY">
-						<subreportParameterExpression><![CDATA[$P{PARAM_CURRENCY}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="parDateFrom">
-						<subreportParameterExpression><![CDATA[$P{parDateFrom}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="parDateTo">
-						<subreportParameterExpression><![CDATA[$P{parDateTo}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SALE">
-						<subreportParameterExpression><![CDATA[$P{SALE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="PURCHASE">
-						<subreportParameterExpression><![CDATA[$P{PURCHASE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SR_SALE">
-						<subreportParameterExpression><![CDATA[$P{SR_SALE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SR_SALEFOREIGN">
-						<subreportParameterExpression><![CDATA[$P{SR_SALEFOREIGN}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SR_PURCHASE">
-						<subreportParameterExpression><![CDATA[$P{SR_PURCHASE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SR_PURCHASEFOREIGN">
-						<subreportParameterExpression><![CDATA[$P{SR_PURCHASEFOREIGN}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="DETAIL">
-						<subreportParameterExpression><![CDATA[$P{DETAIL}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="NUMBERFORMAT">
-						<subreportParameterExpression><![CDATA[$P{NUMBERFORMAT}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="LOCALE">
-						<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-					</subreportParameter>
+				<element kind="subreport" uuid="68646245-dd88-4e09-b331-e9d72d6a392c" key="subreport-2" x="0" y="0" width="535" height="40" usingCache="true" style="Report_Footer">
 					<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-					<subreportExpression><![CDATA[$P{SR_SALE}]]></subreportExpression>
-				</subreport>
+					<expression><![CDATA[$P{SR_SALE}]]></expression>
+					<parameter name="ATTACH">
+						<expression><![CDATA[$P{ATTACH}]]></expression>
+					</parameter>
+					<parameter name="BASE_WEB">
+						<expression><![CDATA[$P{BASE_WEB}]]></expression>
+					</parameter>
+					<parameter name="BASE_DESIGN">
+						<expression><![CDATA[$P{BASE_DESIGN}]]></expression>
+					</parameter>
+					<parameter name="LANGUAGE">
+						<expression><![CDATA[$P{LANGUAGE}]]></expression>
+					</parameter>
+					<parameter name="USER_CLIENT">
+						<expression><![CDATA[$P{USER_CLIENT}]]></expression>
+					</parameter>
+					<parameter name="USER_ORG">
+						<expression><![CDATA[$P{PARAM_ORG}]]></expression>
+					</parameter>
+					<parameter name="REPORT_TITLE">
+						<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+					</parameter>
+					<parameter name="REPORT_SUBTITLE">
+						<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+					</parameter>
+					<parameter name="SUBREPORT_DIR">
+						<expression><![CDATA[$P{SUBREPORT_DIR}]]></expression>
+					</parameter>
+					<parameter name="cCountryId">
+						<expression><![CDATA[$P{cCountryId}]]></expression>
+					</parameter>
+					<parameter name="PARAM_CURRENCY">
+						<expression><![CDATA[$P{PARAM_CURRENCY}]]></expression>
+					</parameter>
+					<parameter name="parDateFrom">
+						<expression><![CDATA[$P{parDateFrom}]]></expression>
+					</parameter>
+					<parameter name="parDateTo">
+						<expression><![CDATA[$P{parDateTo}]]></expression>
+					</parameter>
+					<parameter name="SALE">
+						<expression><![CDATA[$P{SALE}]]></expression>
+					</parameter>
+					<parameter name="PURCHASE">
+						<expression><![CDATA[$P{PURCHASE}]]></expression>
+					</parameter>
+					<parameter name="SR_SALE">
+						<expression><![CDATA[$P{SR_SALE}]]></expression>
+					</parameter>
+					<parameter name="SR_SALEFOREIGN">
+						<expression><![CDATA[$P{SR_SALEFOREIGN}]]></expression>
+					</parameter>
+					<parameter name="SR_PURCHASE">
+						<expression><![CDATA[$P{SR_PURCHASE}]]></expression>
+					</parameter>
+					<parameter name="SR_PURCHASEFOREIGN">
+						<expression><![CDATA[$P{SR_PURCHASEFOREIGN}]]></expression>
+					</parameter>
+					<parameter name="DETAIL">
+						<expression><![CDATA[$P{DETAIL}]]></expression>
+					</parameter>
+					<parameter name="NUMBERFORMAT">
+						<expression><![CDATA[$P{NUMBERFORMAT}]]></expression>
+					</parameter>
+					<parameter name="LOCALE">
+						<expression><![CDATA[$P{LOCALE}]]></expression>
+					</parameter>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -172,81 +168,80 @@
 		</groupFooter>
 	</group>
 	<group name="SalesFor">
-		<groupExpression><![CDATA[]]></groupExpression>
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="40" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean(!$P{SALE}.equals(""))]]></printWhenExpression>
-				<subreport isUsingCache="true">
-					<reportElement key="subreport-3" style="Report_Footer" x="0" y="0" width="535" height="40" uuid="7b2fe55a-fb63-4dc2-ac0c-0dce3e37a347"/>
-					<subreportParameter name="ATTACH">
-						<subreportParameterExpression><![CDATA[$P{ATTACH}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="BASE_WEB">
-						<subreportParameterExpression><![CDATA[$P{BASE_WEB}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="BASE_DESIGN">
-						<subreportParameterExpression><![CDATA[$P{BASE_DESIGN}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="LANGUAGE">
-						<subreportParameterExpression><![CDATA[$P{LANGUAGE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="USER_CLIENT">
-						<subreportParameterExpression><![CDATA[$P{USER_CLIENT}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="USER_ORG">
-						<subreportParameterExpression><![CDATA[$P{PARAM_ORG}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="REPORT_TITLE">
-						<subreportParameterExpression><![CDATA[$P{REPORT_TITLE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="REPORT_SUBTITLE">
-						<subreportParameterExpression><![CDATA[$P{REPORT_SUBTITLE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SUBREPORT_DIR">
-						<subreportParameterExpression><![CDATA[$P{SUBREPORT_DIR}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="cCountryId">
-						<subreportParameterExpression><![CDATA[$P{cCountryId}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="PARAM_CURRENCY">
-						<subreportParameterExpression><![CDATA[$P{PARAM_CURRENCY}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="parDateFrom">
-						<subreportParameterExpression><![CDATA[$P{parDateFrom}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="parDateTo">
-						<subreportParameterExpression><![CDATA[$P{parDateTo}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SALE">
-						<subreportParameterExpression><![CDATA[$P{SALE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="PURCHASE">
-						<subreportParameterExpression><![CDATA[$P{PURCHASE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SR_SALE">
-						<subreportParameterExpression><![CDATA[$P{SR_SALE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SR_SALEFOREIGN">
-						<subreportParameterExpression><![CDATA[$P{SR_SALEFOREIGN}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SR_PURCHASE">
-						<subreportParameterExpression><![CDATA[$P{SR_PURCHASE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SR_PURCHASEFOREIGN">
-						<subreportParameterExpression><![CDATA[$P{SR_PURCHASEFOREIGN}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="DETAIL">
-						<subreportParameterExpression><![CDATA[$P{DETAIL}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="NUMBERFORMAT">
-						<subreportParameterExpression><![CDATA[$P{NUMBERFORMAT}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="LOCALE">
-						<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-					</subreportParameter>
+				<element kind="subreport" uuid="7b2fe55a-fb63-4dc2-ac0c-0dce3e37a347" key="subreport-3" x="0" y="0" width="535" height="40" usingCache="true" style="Report_Footer">
 					<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-					<subreportExpression><![CDATA[$P{SR_SALEFOREIGN}]]></subreportExpression>
-				</subreport>
+					<expression><![CDATA[$P{SR_SALEFOREIGN}]]></expression>
+					<parameter name="ATTACH">
+						<expression><![CDATA[$P{ATTACH}]]></expression>
+					</parameter>
+					<parameter name="BASE_WEB">
+						<expression><![CDATA[$P{BASE_WEB}]]></expression>
+					</parameter>
+					<parameter name="BASE_DESIGN">
+						<expression><![CDATA[$P{BASE_DESIGN}]]></expression>
+					</parameter>
+					<parameter name="LANGUAGE">
+						<expression><![CDATA[$P{LANGUAGE}]]></expression>
+					</parameter>
+					<parameter name="USER_CLIENT">
+						<expression><![CDATA[$P{USER_CLIENT}]]></expression>
+					</parameter>
+					<parameter name="USER_ORG">
+						<expression><![CDATA[$P{PARAM_ORG}]]></expression>
+					</parameter>
+					<parameter name="REPORT_TITLE">
+						<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+					</parameter>
+					<parameter name="REPORT_SUBTITLE">
+						<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+					</parameter>
+					<parameter name="SUBREPORT_DIR">
+						<expression><![CDATA[$P{SUBREPORT_DIR}]]></expression>
+					</parameter>
+					<parameter name="cCountryId">
+						<expression><![CDATA[$P{cCountryId}]]></expression>
+					</parameter>
+					<parameter name="PARAM_CURRENCY">
+						<expression><![CDATA[$P{PARAM_CURRENCY}]]></expression>
+					</parameter>
+					<parameter name="parDateFrom">
+						<expression><![CDATA[$P{parDateFrom}]]></expression>
+					</parameter>
+					<parameter name="parDateTo">
+						<expression><![CDATA[$P{parDateTo}]]></expression>
+					</parameter>
+					<parameter name="SALE">
+						<expression><![CDATA[$P{SALE}]]></expression>
+					</parameter>
+					<parameter name="PURCHASE">
+						<expression><![CDATA[$P{PURCHASE}]]></expression>
+					</parameter>
+					<parameter name="SR_SALE">
+						<expression><![CDATA[$P{SR_SALE}]]></expression>
+					</parameter>
+					<parameter name="SR_SALEFOREIGN">
+						<expression><![CDATA[$P{SR_SALEFOREIGN}]]></expression>
+					</parameter>
+					<parameter name="SR_PURCHASE">
+						<expression><![CDATA[$P{SR_PURCHASE}]]></expression>
+					</parameter>
+					<parameter name="SR_PURCHASEFOREIGN">
+						<expression><![CDATA[$P{SR_PURCHASEFOREIGN}]]></expression>
+					</parameter>
+					<parameter name="DETAIL">
+						<expression><![CDATA[$P{DETAIL}]]></expression>
+					</parameter>
+					<parameter name="NUMBERFORMAT">
+						<expression><![CDATA[$P{NUMBERFORMAT}]]></expression>
+					</parameter>
+					<parameter name="LOCALE">
+						<expression><![CDATA[$P{LOCALE}]]></expression>
+					</parameter>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -254,81 +249,80 @@
 		</groupFooter>
 	</group>
 	<group name="Purchase">
-		<groupExpression><![CDATA[]]></groupExpression>
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="40" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean(!$P{PURCHASE}.equals(""))]]></printWhenExpression>
-				<subreport isUsingCache="true">
-					<reportElement key="subreport-1" style="Report_Footer" x="0" y="0" width="535" height="40" uuid="64b078cb-bd9f-47e9-afe6-ef6ff4cda767"/>
-					<subreportParameter name="ATTACH">
-						<subreportParameterExpression><![CDATA[$P{ATTACH}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="BASE_WEB">
-						<subreportParameterExpression><![CDATA[$P{BASE_WEB}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="BASE_DESIGN">
-						<subreportParameterExpression><![CDATA[$P{BASE_DESIGN}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="LANGUAGE">
-						<subreportParameterExpression><![CDATA[$P{LANGUAGE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="USER_CLIENT">
-						<subreportParameterExpression><![CDATA[$P{USER_CLIENT}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="USER_ORG">
-						<subreportParameterExpression><![CDATA[$P{PARAM_ORG}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="REPORT_TITLE">
-						<subreportParameterExpression><![CDATA[$P{REPORT_TITLE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="REPORT_SUBTITLE">
-						<subreportParameterExpression><![CDATA[$P{REPORT_SUBTITLE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SUBREPORT_DIR">
-						<subreportParameterExpression><![CDATA[$P{SUBREPORT_DIR}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="cCountryId">
-						<subreportParameterExpression><![CDATA[$P{cCountryId}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="PARAM_CURRENCY">
-						<subreportParameterExpression><![CDATA[$P{PARAM_CURRENCY}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="parDateFrom">
-						<subreportParameterExpression><![CDATA[$P{parDateFrom}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="parDateTo">
-						<subreportParameterExpression><![CDATA[$P{parDateTo}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SALE">
-						<subreportParameterExpression><![CDATA[$P{SALE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="PURCHASE">
-						<subreportParameterExpression><![CDATA[$P{PURCHASE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SR_SALE">
-						<subreportParameterExpression><![CDATA[$P{SR_SALE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SR_SALEFOREIGN">
-						<subreportParameterExpression><![CDATA[$P{SR_SALEFOREIGN}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SR_PURCHASE">
-						<subreportParameterExpression><![CDATA[$P{SR_PURCHASE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SR_PURCHASEFOREIGN">
-						<subreportParameterExpression><![CDATA[$P{SR_PURCHASEFOREIGN}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="DETAIL">
-						<subreportParameterExpression><![CDATA[$P{DETAIL}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="NUMBERFORMAT">
-						<subreportParameterExpression><![CDATA[$P{NUMBERFORMAT}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="LOCALE">
-						<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-					</subreportParameter>
+				<element kind="subreport" uuid="64b078cb-bd9f-47e9-afe6-ef6ff4cda767" key="subreport-1" x="0" y="0" width="535" height="40" usingCache="true" style="Report_Footer">
 					<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-					<subreportExpression><![CDATA[$P{SR_PURCHASE}]]></subreportExpression>
-				</subreport>
+					<expression><![CDATA[$P{SR_PURCHASE}]]></expression>
+					<parameter name="ATTACH">
+						<expression><![CDATA[$P{ATTACH}]]></expression>
+					</parameter>
+					<parameter name="BASE_WEB">
+						<expression><![CDATA[$P{BASE_WEB}]]></expression>
+					</parameter>
+					<parameter name="BASE_DESIGN">
+						<expression><![CDATA[$P{BASE_DESIGN}]]></expression>
+					</parameter>
+					<parameter name="LANGUAGE">
+						<expression><![CDATA[$P{LANGUAGE}]]></expression>
+					</parameter>
+					<parameter name="USER_CLIENT">
+						<expression><![CDATA[$P{USER_CLIENT}]]></expression>
+					</parameter>
+					<parameter name="USER_ORG">
+						<expression><![CDATA[$P{PARAM_ORG}]]></expression>
+					</parameter>
+					<parameter name="REPORT_TITLE">
+						<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+					</parameter>
+					<parameter name="REPORT_SUBTITLE">
+						<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+					</parameter>
+					<parameter name="SUBREPORT_DIR">
+						<expression><![CDATA[$P{SUBREPORT_DIR}]]></expression>
+					</parameter>
+					<parameter name="cCountryId">
+						<expression><![CDATA[$P{cCountryId}]]></expression>
+					</parameter>
+					<parameter name="PARAM_CURRENCY">
+						<expression><![CDATA[$P{PARAM_CURRENCY}]]></expression>
+					</parameter>
+					<parameter name="parDateFrom">
+						<expression><![CDATA[$P{parDateFrom}]]></expression>
+					</parameter>
+					<parameter name="parDateTo">
+						<expression><![CDATA[$P{parDateTo}]]></expression>
+					</parameter>
+					<parameter name="SALE">
+						<expression><![CDATA[$P{SALE}]]></expression>
+					</parameter>
+					<parameter name="PURCHASE">
+						<expression><![CDATA[$P{PURCHASE}]]></expression>
+					</parameter>
+					<parameter name="SR_SALE">
+						<expression><![CDATA[$P{SR_SALE}]]></expression>
+					</parameter>
+					<parameter name="SR_SALEFOREIGN">
+						<expression><![CDATA[$P{SR_SALEFOREIGN}]]></expression>
+					</parameter>
+					<parameter name="SR_PURCHASE">
+						<expression><![CDATA[$P{SR_PURCHASE}]]></expression>
+					</parameter>
+					<parameter name="SR_PURCHASEFOREIGN">
+						<expression><![CDATA[$P{SR_PURCHASEFOREIGN}]]></expression>
+					</parameter>
+					<parameter name="DETAIL">
+						<expression><![CDATA[$P{DETAIL}]]></expression>
+					</parameter>
+					<parameter name="NUMBERFORMAT">
+						<expression><![CDATA[$P{NUMBERFORMAT}]]></expression>
+					</parameter>
+					<parameter name="LOCALE">
+						<expression><![CDATA[$P{LOCALE}]]></expression>
+					</parameter>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -336,225 +330,180 @@
 		</groupFooter>
 	</group>
 	<group name="PurchaseFor">
-		<groupExpression><![CDATA[]]></groupExpression>
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="40" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean(!$P{PURCHASE}.equals(""))]]></printWhenExpression>
-				<subreport isUsingCache="true">
-					<reportElement key="subreport-4" style="Report_Footer" x="0" y="0" width="535" height="40" uuid="20e52c1d-f7ea-4827-af4b-ecf6d83645c3"/>
-					<subreportParameter name="ATTACH">
-						<subreportParameterExpression><![CDATA[$P{ATTACH}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="BASE_WEB">
-						<subreportParameterExpression><![CDATA[$P{BASE_WEB}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="BASE_DESIGN">
-						<subreportParameterExpression><![CDATA[$P{BASE_DESIGN}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="LANGUAGE">
-						<subreportParameterExpression><![CDATA[$P{LANGUAGE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="USER_CLIENT">
-						<subreportParameterExpression><![CDATA[$P{USER_CLIENT}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="USER_ORG">
-						<subreportParameterExpression><![CDATA[$P{PARAM_ORG}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="REPORT_TITLE">
-						<subreportParameterExpression><![CDATA[$P{REPORT_TITLE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="REPORT_SUBTITLE">
-						<subreportParameterExpression><![CDATA[$P{REPORT_SUBTITLE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SUBREPORT_DIR">
-						<subreportParameterExpression><![CDATA[$P{SUBREPORT_DIR}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="cCountryId">
-						<subreportParameterExpression><![CDATA[$P{cCountryId}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="PARAM_CURRENCY">
-						<subreportParameterExpression><![CDATA[$P{PARAM_CURRENCY}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="parDateFrom">
-						<subreportParameterExpression><![CDATA[$P{parDateFrom}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="parDateTo">
-						<subreportParameterExpression><![CDATA[$P{parDateTo}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SALE">
-						<subreportParameterExpression><![CDATA[$P{SALE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="PURCHASE">
-						<subreportParameterExpression><![CDATA[$P{PURCHASE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SR_SALE">
-						<subreportParameterExpression><![CDATA[$P{SR_SALE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SR_SALEFOREIGN">
-						<subreportParameterExpression><![CDATA[$P{SR_SALEFOREIGN}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SR_PURCHASE">
-						<subreportParameterExpression><![CDATA[$P{SR_PURCHASE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="SR_PURCHASEFOREIGN">
-						<subreportParameterExpression><![CDATA[$P{SR_PURCHASEFOREIGN}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="DETAIL">
-						<subreportParameterExpression><![CDATA[$P{DETAIL}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="NUMBERFORMAT">
-						<subreportParameterExpression><![CDATA[$P{NUMBERFORMAT}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="LOCALE">
-						<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-					</subreportParameter>
+				<element kind="subreport" uuid="20e52c1d-f7ea-4827-af4b-ecf6d83645c3" key="subreport-4" x="0" y="0" width="535" height="40" usingCache="true" style="Report_Footer">
 					<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-					<subreportExpression><![CDATA[$P{SR_PURCHASEFOREIGN}]]></subreportExpression>
-				</subreport>
+					<expression><![CDATA[$P{SR_PURCHASEFOREIGN}]]></expression>
+					<parameter name="ATTACH">
+						<expression><![CDATA[$P{ATTACH}]]></expression>
+					</parameter>
+					<parameter name="BASE_WEB">
+						<expression><![CDATA[$P{BASE_WEB}]]></expression>
+					</parameter>
+					<parameter name="BASE_DESIGN">
+						<expression><![CDATA[$P{BASE_DESIGN}]]></expression>
+					</parameter>
+					<parameter name="LANGUAGE">
+						<expression><![CDATA[$P{LANGUAGE}]]></expression>
+					</parameter>
+					<parameter name="USER_CLIENT">
+						<expression><![CDATA[$P{USER_CLIENT}]]></expression>
+					</parameter>
+					<parameter name="USER_ORG">
+						<expression><![CDATA[$P{PARAM_ORG}]]></expression>
+					</parameter>
+					<parameter name="REPORT_TITLE">
+						<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+					</parameter>
+					<parameter name="REPORT_SUBTITLE">
+						<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+					</parameter>
+					<parameter name="SUBREPORT_DIR">
+						<expression><![CDATA[$P{SUBREPORT_DIR}]]></expression>
+					</parameter>
+					<parameter name="cCountryId">
+						<expression><![CDATA[$P{cCountryId}]]></expression>
+					</parameter>
+					<parameter name="PARAM_CURRENCY">
+						<expression><![CDATA[$P{PARAM_CURRENCY}]]></expression>
+					</parameter>
+					<parameter name="parDateFrom">
+						<expression><![CDATA[$P{parDateFrom}]]></expression>
+					</parameter>
+					<parameter name="parDateTo">
+						<expression><![CDATA[$P{parDateTo}]]></expression>
+					</parameter>
+					<parameter name="SALE">
+						<expression><![CDATA[$P{SALE}]]></expression>
+					</parameter>
+					<parameter name="PURCHASE">
+						<expression><![CDATA[$P{PURCHASE}]]></expression>
+					</parameter>
+					<parameter name="SR_SALE">
+						<expression><![CDATA[$P{SR_SALE}]]></expression>
+					</parameter>
+					<parameter name="SR_SALEFOREIGN">
+						<expression><![CDATA[$P{SR_SALEFOREIGN}]]></expression>
+					</parameter>
+					<parameter name="SR_PURCHASE">
+						<expression><![CDATA[$P{SR_PURCHASE}]]></expression>
+					</parameter>
+					<parameter name="SR_PURCHASEFOREIGN">
+						<expression><![CDATA[$P{SR_PURCHASEFOREIGN}]]></expression>
+					</parameter>
+					<parameter name="DETAIL">
+						<expression><![CDATA[$P{DETAIL}]]></expression>
+					</parameter>
+					<parameter name="NUMBERFORMAT">
+						<expression><![CDATA[$P{NUMBERFORMAT}]]></expression>
+					</parameter>
+					<parameter name="LOCALE">
+						<expression><![CDATA[$P{LOCALE}]]></expression>
+					</parameter>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="20" splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="59" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Title" mode="Transparent" x="0" y="0" width="535" height="20" uuid="0a585cec-2b74-4c03-8e19-705db6882abb"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="20" width="535" height="1" uuid="cf99989a-3b01-4161-9045-c58e272dbc6a"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Subtitle" x="0" y="20" width="535" height="20" uuid="b04c7504-d67e-451e-b4b2-a00c65108a42"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="14"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{REPORT_SUBTITLE}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-2" style="Report_Data_Label" x="400" y="40" width="44" height="15" uuid="f75f3608-5178-4973-9bce-5fbc27fcd4fa">
-					<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
-				</reportElement>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Total:]]></text>
-			</staticText>
-			<textField evaluationTime="Report" isBlankWhenNull="false">
-				<reportElement key="textField-1" style="Total_Field" x="444" y="40" width="89" height="16" uuid="6c4d9790-409c-404b-811b-2ec0583e8547">
-					<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[($V{DetailFieldTotal}!=null)?$P{NUMBERFORMAT}.format($V{DetailFieldTotal}):new String(" ")]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="20" splitType="Stretch"/>
+	<pageHeader height="59" splitType="Stretch">
+		<element kind="textField" uuid="0a585cec-2b74-4c03-8e19-705db6882abb" key="textField" mode="Transparent" x="0" y="0" width="535" height="20" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="cf99989a-3b01-4161-9045-c58e272dbc6a" key="line-1" x="0" y="20" width="535" height="1">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="b04c7504-d67e-451e-b4b2-a00c65108a42" key="textField" x="0" y="20" width="535" height="20" fontSize="14.0" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="f75f3608-5178-4973-9bce-5fbc27fcd4fa" key="staticText-2" x="400" y="40" width="44" height="15" hTextAlign="Right" style="Report_Data_Label">
+			<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
+			<text><![CDATA[Total:]]></text>
+			<box style="Report_Data_Label">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="6c4d9790-409c-404b-811b-2ec0583e8547" key="textField-1" x="444" y="40" width="89" height="16" evaluationTime="Report" blankWhenNull="false" style="Total_Field">
+			<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
+			<expression><![CDATA[($V{DetailFieldTotal}!=null)?$P{NUMBERFORMAT}.format($V{DetailFieldTotal}):new String(" ")]]></expression>
+			<box leftPadding="5" style="Total_Field">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band splitType="Stretch"/>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="20" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="402" y="4" width="95" height="16" uuid="f48fcd73-adc9-41b9-9bbd-ea7d2210ee98"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="499" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="d06a2ea3-5cc8-4851-af3d-f8d039192ce5"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="1" width="535" height="1" forecolor="#000000" uuid="256bb4dd-1705-4f03-a3d7-d498aaea506c"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="277" y="4" width="69" height="16" uuid="3278d813-a1a6-4b3e-93f1-8d5c770672bc"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" style="Report_Footer" x="195" y="4" width="78" height="16" uuid="edb50181-1030-4faf-bd83-002a1c423f48"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="20" splitType="Stretch">
+		<element kind="textField" uuid="f48fcd73-adc9-41b9-9bbd-ea7d2210ee98" key="textField" x="402" y="4" width="95" height="16" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="d06a2ea3-5cc8-4851-af3d-f8d039192ce5" key="textField" x="499" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle" style="Report_Footer">
+			<paragraph lineSpacing="Single" style="Report_Footer"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="256bb4dd-1705-4f03-a3d7-d498aaea506c" key="line" x="0" y="1" width="535" height="1" forecolor="#000000">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="3278d813-a1a6-4b3e-93f1-8d5c770672bc" key="textField" x="277" y="4" width="69" height="16" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="edb50181-1030-4faf-bd83-002a1c423f48" key="staticText-1" x="195" y="4" width="78" height="16" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportTaxInvoicePurchase.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportTaxInvoicePurchase.jrxml
@@ -1,63 +1,62 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportTaxInvoicePurchase" pageWidth="535" pageHeight="842" columnWidth="535" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="4cdce3bc-ac34-47d4-922d-5b04e341e2ef">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportTaxInvoicePurchase" language="java" pageWidth="535" pageHeight="842" columnWidth="535" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="4cdce3bc-ac34-47d4-922d-5b04e341e2ef">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
-	<style name="Detail_Line" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9">
-		<conditionalStyle>
+	<style name="Detail_Line" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9.0">
 			<conditionExpression><![CDATA[new Boolean($V{TAXNAME_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'1000000'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'0','1000000'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Purchase"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_client" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_client" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{USER_CLIENT}.equals("") ? "" : " AND C_INVOICE.AD_CLIENT_ID IN ("+$P{USER_CLIENT}+") "]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_org" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_org" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{USER_ORG}.equals("") ? "" : " AND C_INVOICE.AD_ORG_ID IN ("+$P{USER_ORG}+") "]]></defaultValueExpression>
 	</parameter>
 	<parameter name="cCountryId" class="java.lang.String">
@@ -65,15 +64,14 @@
 	</parameter>
 	<parameter name="parDateFrom" class="java.util.Date"/>
 	<parameter name="parDateTo" class="java.util.Date"/>
-	<parameter name="PURCHASE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="DETAIL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
+	<parameter name="PURCHASE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="DETAIL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
 	<parameter name="PARAM_CURRENCY" class="java.lang.String">
 		<defaultValueExpression><![CDATA["102"]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[SELECT C_INVOICE.ISSOTRX AS SALES, 'Y' AS NATIONAL, COALESCE(C_INVOICE.POREFERENCE, C_INVOICE.DOCUMENTNO) AS REFERENCE,
+	<query language="sql"><![CDATA[SELECT C_INVOICE.ISSOTRX AS SALES, 'Y' AS NATIONAL, COALESCE(C_INVOICE.POREFERENCE, C_INVOICE.DOCUMENTNO) AS REFERENCE,
       C_INVOICE.DATEINVOICED, C_BPARTNER.NAME AS BPARTNER, LTRIM(RTRIM(C_TAX.NAME, ' '), ' ') AS TAXNAME,
       SUM(CASE WHEN DOCBASETYPE IN ('ARC','APC') THEN -1 * (C_CURRENCY_CONVERT_RATE(C_INVOICETAX.TAXBASEAMT, C_INVOICE.C_CURRENCY_ID,$P{PARAM_CURRENCY}, TO_DATE(COALESCE(C_INVOICE.DATEINVOICED, NOW())), NULL, C_INVOICETAX.AD_CLIENT_ID, C_INVOICETAX.AD_ORG_ID, ICR.RATE))
       ELSE (C_CURRENCY_CONVERT_RATE(C_INVOICETAX.TAXBASEAMT, C_INVOICE.C_CURRENCY_ID,$P{PARAM_CURRENCY}, TO_DATE(COALESCE(C_INVOICE.DATEINVOICED, NOW())), NULL, C_INVOICETAX.AD_CLIENT_ID, C_INVOICETAX.AD_ORG_ID, ICR.RATE)) END) AS TAXBASEAMT,
@@ -99,8 +97,7 @@
       AND 1=1
       GROUP BY COALESCE(C_INVOICE.POREFERENCE, C_INVOICE.DOCUMENTNO), C_INVOICE.DATEINVOICED, C_TAX.NAME, C_BPARTNER.NAME, C_INVOICE.ISSOTRX
       HAVING SUM(C_INVOICETAX.TAXBASEAMT) <> 0
-      ORDER BY C_TAX.NAME, C_INVOICE.DATEINVOICED, COALESCE(C_INVOICE.POREFERENCE,  C_INVOICE.DOCUMENTNO)]]>
-	</queryString>
+      ORDER BY C_TAX.NAME, C_INVOICE.DATEINVOICED, COALESCE(C_INVOICE.POREFERENCE,  C_INVOICE.DOCUMENTNO)]]></query>
 	<field name="SALES" class="java.lang.String"/>
 	<field name="NATIONAL" class="java.lang.String"/>
 	<field name="REFERENCE" class="java.lang.String"/>
@@ -113,302 +110,225 @@
 	<field name="CURRENCY" class="java.lang.String"/>
 	<field name="SUM_AMOUNT" class="java.lang.String"/>
 	<field name="Tax_BASE" class="java.lang.String"/>
-	<variable name="sumTaxBaseAmt" class="java.math.BigDecimal" resetType="Group" resetGroup="TAXNAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{TAXBASEAMT}]]></variableExpression>
+	<variable name="sumTaxBaseAmt" resetType="Group" calculation="Sum" resetGroup="TAXNAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{TAXBASEAMT}]]></expression>
 	</variable>
-	<variable name="sumImport" class="java.math.BigDecimal" resetType="Group" resetGroup="TAXNAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{TAXAMT}]]></variableExpression>
+	<variable name="sumImport" resetType="Group" calculation="Sum" resetGroup="TAXNAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{TAXAMT}]]></expression>
 	</variable>
 	<group name="TAXNAME">
-		<groupExpression><![CDATA[$F{TAXNAME}]]></groupExpression>
+		<expression><![CDATA[$F{TAXNAME}]]></expression>
 		<groupHeader>
 			<band height="43" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="1" y="0" width="100" height="20" uuid="7b4ec1f3-ede3-49de-b911-81a7bab5469b"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="7b4ec1f3-ede3-49de-b911-81a7bab5469b" key="staticText" x="1" y="0" width="100" height="20" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[Tax Type]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="101" y="0" width="433" height="20" uuid="977ffdfc-0370-4699-8da3-023e84fda030"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{TAXNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="1" width="1" height="42" forecolor="#555555" uuid="9d1cdc70-26e5-4bdc-a0ac-e0a5f6af75e1"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="534" y="1" width="1" height="42" forecolor="#555555" uuid="8de2e6fb-d5ca-407e-beb2-0eab2b5009a4"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="10" y="27" width="90" height="16" uuid="2d49018f-aee5-4b31-a180-e6ba498b6e2f">
-						<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="977ffdfc-0370-4699-8da3-023e84fda030" key="textField" x="101" y="0" width="433" height="20" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{TAXNAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
+				</element>
+				<element kind="line" uuid="9d1cdc70-26e5-4bdc-a0ac-e0a5f6af75e1" key="line-2" stretchType="ContainerHeight" x="0" y="1" width="1" height="42" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="8de2e6fb-d5ca-407e-beb2-0eab2b5009a4" key="line-3" stretchType="ContainerHeight" x="534" y="1" width="1" height="42" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="2d49018f-aee5-4b31-a180-e6ba498b6e2f" key="element-90" x="10" y="27" width="90" height="16" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
 					<text><![CDATA[Invoice]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="100" y="27" width="70" height="16" uuid="1977638a-45e3-416d-9ca2-d4d92671962d">
-						<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="1977638a-45e3-416d-9ca2-d4d92671962d" key="element-90" x="100" y="27" width="70" height="16" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
 					<text><![CDATA[Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="170" y="27" width="170" height="16" uuid="613e4f7a-34e8-45a9-8c0a-2523cd550b0e">
-						<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="613e4f7a-34e8-45a9-8c0a-2523cd550b0e" key="element-90" x="170" y="27" width="170" height="16" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
 					<text><![CDATA[Business Partner]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="340" y="27" width="90" height="16" uuid="8533f36a-3780-4bf6-9277-387798d84cc5"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right"/>
+				</element>
+				<element kind="staticText" uuid="8533f36a-3780-4bf6-9277-387798d84cc5" key="element-90" x="340" y="27" width="90" height="16" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[Taxable Base]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="430" y="27" width="90" height="16" uuid="383a6541-4aa6-4a75-b89b-0bd0bcd82c8d"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right"/>
+				</element>
+				<element kind="staticText" uuid="383a6541-4aa6-4a75-b89b-0bd0bcd82c8d" key="element-90" x="430" y="27" width="90" height="16" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="25" splitType="Stretch">
-				<line>
-					<reportElement key="line-32" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="19" forecolor="#555555" uuid="76700dbe-23fc-4925-9209-0003ee10dfee"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="534" y="0" width="1" height="19" forecolor="#555555" uuid="ab1040fa-1ae9-417e-a9aa-c965b9f7a934"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-34" x="0" y="19" width="535" height="1" forecolor="#555555" uuid="9d602847-5b83-41e6-8bf5-36d7f9e28eaf"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-4" style="default" x="10" y="1" width="90" height="16" uuid="d5494325-370f-4c60-8f5a-547894f46b39"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="10"/>
-					</textElement>
+				<element kind="line" uuid="76700dbe-23fc-4925-9209-0003ee10dfee" key="line-32" stretchType="ContainerHeight" x="0" y="0" width="1" height="19" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="ab1040fa-1ae9-417e-a9aa-c965b9f7a934" key="line-33" stretchType="ContainerHeight" x="534" y="0" width="1" height="19" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="9d602847-5b83-41e6-8bf5-36d7f9e28eaf" key="line-34" x="0" y="19" width="535" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="d5494325-370f-4c60-8f5a-547894f46b39" key="staticText-4" x="10" y="1" width="90" height="16" fontSize="10.0" hTextAlign="Right" style="default">
 					<text><![CDATA[Total:]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-37" x="10" y="0" width="510" height="1" forecolor="#666666" uuid="9c075a4f-9a2d-4436-9974-f6c1fabae10c"/>
-					<graphicElement>
-						<pen lineWidth="0.25" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-9" style="Total_Field" x="100" y="1" width="240" height="16" uuid="7f511bd9-e1ef-4044-9edd-63852970d594"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="9c075a4f-9a2d-4436-9974-f6c1fabae10c" key="line-37" x="10" y="0" width="510" height="1" forecolor="#666666">
+					<pen lineWidth="0.25" lineStyle="Solid"/>
+				</element>
+				<element kind="textField" uuid="7f511bd9-e1ef-4044-9edd-63852970d594" key="textField-9" x="100" y="1" width="240" height="16" blankWhenNull="false" vTextAlign="Middle" style="Total_Field">
+					<expression><![CDATA[$V{TAXNAME_COUNT}]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$V{TAXNAME_COUNT}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-12" style="Total_Field" x="430" y="1" width="90" height="16" uuid="d0020c97-e60c-4cbc-8092-c463a9c1e19e"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="d0020c97-e60c-4cbc-8092-c463a9c1e19e" key="textField-12" x="430" y="1" width="90" height="16" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{sumImport}!=null)?$P{NUMBERFORMAT}.format($V{sumImport})+$F{CURRENCY}:new String(" ")]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0"/>
 						<leftPen lineWidth="0.0"/>
 						<bottomPen lineWidth="0.0"/>
 						<rightPen lineWidth="0.0"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{sumImport}!=null)?$P{NUMBERFORMAT}.format($V{sumImport})+$F{CURRENCY}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-13" style="Total_Field" x="340" y="1" width="90" height="16" uuid="9d273afa-a443-40dd-8948-30eeefc9d66a"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="9d273afa-a443-40dd-8948-30eeefc9d66a" key="textField-13" x="340" y="1" width="90" height="16" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Field">
+					<expression><![CDATA[($V{sumTaxBaseAmt}!=null)?$P{NUMBERFORMAT}.format($V{sumTaxBaseAmt})+$F{CURRENCY}:new String(" ")]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0"/>
 						<leftPen lineWidth="0.0"/>
 						<bottomPen lineWidth="0.0"/>
 						<rightPen lineWidth="0.0"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[($V{sumTaxBaseAmt}!=null)?$P{NUMBERFORMAT}.format($V{sumTaxBaseAmt})+$F{CURRENCY}:new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="20" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Subtitle" x="0" y="0" width="535" height="20" uuid="f9dbd954-517e-4b85-a3a6-95945ccfcd22"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{PURCHASE}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader height="20" splitType="Stretch">
+		<element kind="textField" uuid="f9dbd954-517e-4b85-a3a6-95945ccfcd22" key="textField" x="0" y="0" width="535" height="20" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[$P{PURCHASE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="14" splitType="Stretch">
 			<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="534" y="0" width="1" height="14" forecolor="#555555" uuid="7af7fc3c-3922-4a5d-9108-5e649b4b3f78"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="14" forecolor="#555555" uuid="a241b1ac-046d-4789-bb55-b32a7bc5f19a"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-4" style="Detail_Line" x="10" y="0" width="90" height="14" uuid="38261e4d-ce62-44f3-b965-2efc7c39603f"/>
-				<box leftPadding="2" rightPadding="2">
+			<element kind="line" uuid="7af7fc3c-3922-4a5d-9108-5e649b4b3f78" key="line-16" stretchType="ContainerHeight" x="534" y="0" width="1" height="14" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="a241b1ac-046d-4789-bb55-b32a7bc5f19a" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="14" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="38261e4d-ce62-44f3-b965-2efc7c39603f" key="textField-4" x="10" y="0" width="90" height="14" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{REFERENCE}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{REFERENCE}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField-5" style="Detail_Line" x="100" y="0" width="70" height="14" uuid="65d8251a-0677-437c-ba2c-58c0698c2db3"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="65d8251a-0677-437c-ba2c-58c0698c2db3" key="textField-5" x="100" y="0" width="70" height="14" textAdjust="StretchHeight" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{DATEINVOICED}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{DATEINVOICED}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-6" style="Detail_Line" x="170" y="0" width="170" height="14" uuid="fb633a3e-f4a4-455c-8d6f-fa8e0d494f85"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="fb633a3e-f4a4-455c-8d6f-fa8e0d494f85" key="textField-6" x="170" y="0" width="170" height="14" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{BPARTNER}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{BPARTNER}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-7" style="Detail_Line" x="340" y="0" width="90" height="14" uuid="9e4c0531-a952-4e82-b703-7f29741654df"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="9e4c0531-a952-4e82-b703-7f29741654df" key="textField-7" x="340" y="0" width="90" height="14" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{TAXBASEAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXBASEAMT})+$F{CURRENCY}:new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[($F{TAXBASEAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXBASEAMT})+$F{CURRENCY}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-8" style="Detail_Line" x="430" y="0" width="90" height="14" uuid="703ae318-25d7-46f8-9776-3b8c4ee6e8e5"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="703ae318-25d7-46f8-9776-3b8c4ee6e8e5" key="textField-8" x="430" y="0" width="90" height="14" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{TAXAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXAMT})+$F{CURRENCY}:new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[($F{TAXAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXAMT})+$F{CURRENCY}:new String(" ")]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportTaxInvoicePurchaseForeign.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportTaxInvoicePurchaseForeign.jrxml
@@ -1,63 +1,62 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportTaxInvoicePurchaseForeign" pageWidth="535" pageHeight="842" columnWidth="535" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="ca5c867b-f5e6-4ea7-a416-fb91ed037816">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportTaxInvoicePurchaseForeign" language="java" pageWidth="535" pageHeight="842" columnWidth="535" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="ca5c867b-f5e6-4ea7-a416-fb91ed037816">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="9">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="9.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="9.0">
 			<conditionExpression><![CDATA[new Boolean($V{TAXNAME_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="9"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'1000000'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'0','1000000'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Purchase Foreign"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_client" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_client" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{USER_CLIENT}.equals("") ? "" : " AND C_INVOICE.AD_CLIENT_ID IN ("+$P{USER_CLIENT}+") "]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_org" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_org" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{USER_ORG}.equals("") ? "" : " AND C_INVOICE.AD_ORG_ID IN ("+$P{USER_ORG}+") "]]></defaultValueExpression>
 	</parameter>
 	<parameter name="cCountryId" class="java.lang.String">
@@ -65,18 +64,17 @@
 	</parameter>
 	<parameter name="parDateFrom" class="java.util.Date"/>
 	<parameter name="parDateTo" class="java.util.Date"/>
-	<parameter name="ReportData" class="java.lang.String" isForPrompting="false">
+	<parameter name="ReportData" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="PURCHASE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="DETAIL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
+	<parameter name="PURCHASE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="DETAIL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
 	<parameter name="PARAM_CURRENCY" class="java.lang.String">
 		<defaultValueExpression><![CDATA["102"]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[SELECT C_INVOICE.ISSOTRX AS SALES, 'N' AS NATIONAL, COALESCE(C_INVOICE.POREFERENCE, C_INVOICE.DOCUMENTNO) AS REFERENCE, C_INVOICE.DATEINVOICED, C_BPARTNER.NAME AS BPARTNER, LTRIM(RTRIM(C_TAX.NAME, ' '), ' ') AS TAXNAME,
+	<query language="sql"><![CDATA[SELECT C_INVOICE.ISSOTRX AS SALES, 'N' AS NATIONAL, COALESCE(C_INVOICE.POREFERENCE, C_INVOICE.DOCUMENTNO) AS REFERENCE, C_INVOICE.DATEINVOICED, C_BPARTNER.NAME AS BPARTNER, LTRIM(RTRIM(C_TAX.NAME, ' '), ' ') AS TAXNAME,
       SUM(CASE WHEN DOCBASETYPE IN ('ARC','APC') THEN -1 * (C_CURRENCY_CONVERT_RATE(C_INVOICETAX.TAXBASEAMT, C_INVOICE.C_CURRENCY_ID,$P{PARAM_CURRENCY}, TO_DATE(COALESCE(C_INVOICE.DATEINVOICED, NOW())), NULL, C_INVOICETAX.AD_CLIENT_ID, C_INVOICETAX.AD_ORG_ID, ICR.RATE))
       ELSE (C_CURRENCY_CONVERT_RATE(C_INVOICETAX.TAXBASEAMT, C_INVOICE.C_CURRENCY_ID,$P{PARAM_CURRENCY}, TO_DATE(COALESCE(C_INVOICE.DATEINVOICED, NOW())), NULL, C_INVOICETAX.AD_CLIENT_ID, C_INVOICETAX.AD_ORG_ID, ICR.RATE)) END) AS TAXBASEAMT,
       SUM(CASE WHEN DOCBASETYPE IN ('ARC','APC') THEN -1 * (C_CURRENCY_CONVERT_RATE(C_INVOICETAX.TAXAMT, C_INVOICE.C_CURRENCY_ID, $P{PARAM_CURRENCY}, TO_DATE(COALESCE(C_INVOICE.DATEINVOICED, NOW())), NULL, C_INVOICETAX.AD_CLIENT_ID, C_INVOICETAX.AD_ORG_ID, ICR.RATE))
@@ -101,8 +99,7 @@
       AND 1=1
       GROUP BY COALESCE(C_INVOICE.POREFERENCE, C_INVOICE.DOCUMENTNO), C_TAX.NAME, C_INVOICE.DATEINVOICED, C_BPARTNER.NAME, C_INVOICE.ISSOTRX
       HAVING SUM(C_INVOICETAX.TAXBASEAMT) <> 0
-      ORDER BY C_TAX.NAME, C_INVOICE.DATEINVOICED, COALESCE(C_INVOICE.POREFERENCE,  C_INVOICE.DOCUMENTNO)]]>
-	</queryString>
+      ORDER BY C_TAX.NAME, C_INVOICE.DATEINVOICED, COALESCE(C_INVOICE.POREFERENCE,  C_INVOICE.DOCUMENTNO)]]></query>
 	<field name="SALES" class="java.lang.String"/>
 	<field name="NATIONAL" class="java.lang.String"/>
 	<field name="REFERENCE" class="java.lang.String"/>
@@ -115,304 +112,225 @@
 	<field name="CURRENCY" class="java.lang.String"/>
 	<field name="SUM_AMOUNT" class="java.lang.String"/>
 	<field name="Tax_BASE" class="java.lang.String"/>
-	<variable name="sumTaxBaseAmt" class="java.math.BigDecimal" resetType="Group" resetGroup="TAXNAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{TAXBASEAMT}]]></variableExpression>
+	<variable name="sumTaxBaseAmt" resetType="Group" calculation="Sum" resetGroup="TAXNAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{TAXBASEAMT}]]></expression>
 	</variable>
-	<variable name="sumImport" class="java.math.BigDecimal" resetType="Group" resetGroup="TAXNAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{TAXAMT}]]></variableExpression>
+	<variable name="sumImport" resetType="Group" calculation="Sum" resetGroup="TAXNAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{TAXAMT}]]></expression>
 	</variable>
 	<group name="TAXNAME">
-		<groupExpression><![CDATA[$F{TAXNAME}]]></groupExpression>
+		<expression><![CDATA[$F{TAXNAME}]]></expression>
 		<groupHeader>
 			<band height="43" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="1" y="0" width="100" height="20" uuid="e26b249a-5dca-4709-a093-03e22d98bea3"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="e26b249a-5dca-4709-a093-03e22d98bea3" key="staticText" x="1" y="0" width="100" height="20" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[Tax type]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="101" y="0" width="433" height="20" uuid="9e9fa3eb-5e99-438c-b6b0-c35b6889c5cc"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{TAXNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="1" width="1" height="42" forecolor="#555555" uuid="1506911f-7c0f-44ce-bacd-c993a86cdb9f"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="534" y="1" width="1" height="42" forecolor="#555555" uuid="6dffc841-3d8f-4079-9db4-2b3ca093b19b"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="10" y="27" width="90" height="16" uuid="2122db8a-fdf4-40e2-9e1b-45c56fd3aee0">
-						<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="9e9fa3eb-5e99-438c-b6b0-c35b6889c5cc" key="textField" x="101" y="0" width="433" height="20" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{TAXNAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
+				</element>
+				<element kind="line" uuid="1506911f-7c0f-44ce-bacd-c993a86cdb9f" key="line-2" stretchType="ContainerHeight" x="0" y="1" width="1" height="42" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="6dffc841-3d8f-4079-9db4-2b3ca093b19b" key="line-3" stretchType="ContainerHeight" x="534" y="1" width="1" height="42" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="2122db8a-fdf4-40e2-9e1b-45c56fd3aee0" key="element-90" x="10" y="27" width="90" height="16" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
 					<text><![CDATA[Invoice]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="100" y="27" width="70" height="16" uuid="c14cdc48-387f-4125-8fb9-642a2bd84a55">
-						<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="c14cdc48-387f-4125-8fb9-642a2bd84a55" key="element-90" x="100" y="27" width="70" height="16" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
 					<text><![CDATA[Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="170" y="27" width="170" height="16" uuid="275428a5-ca6f-4f23-a7f3-35b9ccbdb9bc">
-						<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="275428a5-ca6f-4f23-a7f3-35b9ccbdb9bc" key="element-90" x="170" y="27" width="170" height="16" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
 					<text><![CDATA[Business Partner]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="340" y="27" width="90" height="16" uuid="b793792c-4bbb-4d2e-96e0-ec94150d7765"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right"/>
+				</element>
+				<element kind="staticText" uuid="b793792c-4bbb-4d2e-96e0-ec94150d7765" key="element-90" x="340" y="27" width="90" height="16" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[Taxable base]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="430" y="27" width="90" height="16" uuid="3fa39a1c-4bf4-4a80-97af-3d82ba9d7b69"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right"/>
+				</element>
+				<element kind="staticText" uuid="3fa39a1c-4bf4-4a80-97af-3d82ba9d7b69" key="element-90" x="430" y="27" width="90" height="16" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="27" splitType="Stretch">
-				<line>
-					<reportElement key="line-32" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="22" forecolor="#555555" uuid="f9811817-3980-4ce9-b595-58e7e30e229b"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="534" y="0" width="1" height="22" forecolor="#555555" uuid="843b480d-173e-4a68-97e6-f9cf47f39c61"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-34" x="0" y="22" width="535" height="1" forecolor="#555555" uuid="42d89b54-a689-4d2c-97ce-a43e04bbe2c0"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-4" style="default" x="10" y="1" width="90" height="16" uuid="b632f6c9-8f83-4743-bdb2-7bed07d5c25d"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
+				<element kind="line" uuid="f9811817-3980-4ce9-b595-58e7e30e229b" key="line-32" stretchType="ContainerHeight" x="0" y="0" width="1" height="22" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="843b480d-173e-4a68-97e6-f9cf47f39c61" key="line-33" stretchType="ContainerHeight" x="534" y="0" width="1" height="22" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="42d89b54-a689-4d2c-97ce-a43e04bbe2c0" key="line-34" x="0" y="22" width="535" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="b632f6c9-8f83-4743-bdb2-7bed07d5c25d" key="staticText-4" x="10" y="1" width="90" height="16" fontName="Bitstream Vera Sans" hTextAlign="Right" style="default">
 					<text><![CDATA[Total:]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-37" x="10" y="0" width="510" height="1" forecolor="#666666" uuid="49d0bbe2-29fb-4742-94ea-4b76f414cf41"/>
-					<graphicElement>
-						<pen lineWidth="0.25" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-14" style="Total_Field" x="100" y="1" width="240" height="16" uuid="aa2971fc-673e-450a-a828-2fe59754f2a3"/>
-					<box leftPadding="5">
+					<box style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="49d0bbe2-29fb-4742-94ea-4b76f414cf41" key="line-37" x="10" y="0" width="510" height="1" forecolor="#666666">
+					<pen lineWidth="0.25" lineStyle="Solid"/>
+				</element>
+				<element kind="textField" uuid="aa2971fc-673e-450a-a828-2fe59754f2a3" key="textField-14" x="100" y="1" width="240" height="16" fontName="Bitstream Vera Sans" fontSize="10.0" blankWhenNull="false" vTextAlign="Middle" style="Total_Field">
+					<expression><![CDATA[$V{TAXNAME_COUNT}]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$V{TAXNAME_COUNT}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-17" style="Total_Field" x="430" y="1" width="90" height="16" uuid="2dadab0f-45f5-46f5-99b1-47cc4e76d50e"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="2dadab0f-45f5-46f5-99b1-47cc4e76d50e" key="textField-17" x="430" y="1" width="90" height="16" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{sumImport}!=null)?$P{NUMBERFORMAT}.format($V{sumImport})+$F{CURRENCY}:new String(" ")]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0"/>
 						<leftPen lineWidth="0.0"/>
 						<bottomPen lineWidth="0.0"/>
 						<rightPen lineWidth="0.0"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{sumImport}!=null)?$P{NUMBERFORMAT}.format($V{sumImport})+$F{CURRENCY}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-18" style="Total_Field" x="340" y="1" width="90" height="16" uuid="a28b91e1-2806-45b6-80ff-b608329a7c0b"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="a28b91e1-2806-45b6-80ff-b608329a7c0b" key="textField-18" x="340" y="1" width="90" height="16" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Field">
+					<expression><![CDATA[($V{sumTaxBaseAmt}!=null)?$P{NUMBERFORMAT}.format($V{sumTaxBaseAmt})+$F{CURRENCY}:new String(" ")]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0"/>
 						<leftPen lineWidth="0.0"/>
 						<bottomPen lineWidth="0.0"/>
 						<rightPen lineWidth="0.0"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[($V{sumTaxBaseAmt}!=null)?$P{NUMBERFORMAT}.format($V{sumTaxBaseAmt})+$F{CURRENCY}:new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="20" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Subtitle" x="2" y="0" width="533" height="20" uuid="dabf7bb4-4ce2-4aa8-ab97-8fba55aaee57"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{PURCHASE}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader height="20" splitType="Stretch">
+		<element kind="textField" uuid="dabf7bb4-4ce2-4aa8-ab97-8fba55aaee57" key="textField" x="2" y="0" width="533" height="20" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[$P{PURCHASE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="14" splitType="Stretch">
 			<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="534" y="0" width="1" height="14" forecolor="#555555" uuid="97edf324-b7ea-4f83-8df3-dab57db465d2"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="14" forecolor="#555555" uuid="c4b6b0dd-e5de-43d2-96ec-c7c9586ab49f"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-9" style="Detail_Line" stretchType="RelativeToBandHeight" x="10" y="0" width="90" height="14" uuid="7cdba18e-9fff-462e-a680-98495b172192"/>
-				<box leftPadding="5" rightPadding="2">
+			<element kind="line" uuid="97edf324-b7ea-4f83-8df3-dab57db465d2" key="line-16" stretchType="ContainerHeight" x="534" y="0" width="1" height="14" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="c4b6b0dd-e5de-43d2-96ec-c7c9586ab49f" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="14" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="7cdba18e-9fff-462e-a680-98495b172192" key="textField-9" stretchType="ContainerHeight" x="10" y="0" width="90" height="14" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{REFERENCE}]]></expression>
+				<box leftPadding="5" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{REFERENCE}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField-10" style="Detail_Line" stretchType="RelativeToBandHeight" x="100" y="0" width="70" height="14" uuid="19711e69-9b59-4d6e-87e9-9cbb93e00e93"/>
-				<box leftPadding="5" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="19711e69-9b59-4d6e-87e9-9cbb93e00e93" key="textField-10" stretchType="ContainerHeight" x="100" y="0" width="70" height="14" textAdjust="StretchHeight" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{DATEINVOICED}]]></expression>
+				<box leftPadding="5" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{DATEINVOICED}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-11" style="Detail_Line" stretchType="RelativeToBandHeight" x="170" y="0" width="170" height="14" uuid="a1b2c98f-196c-4b9e-9060-0c569aef9214"/>
-				<box leftPadding="5" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="a1b2c98f-196c-4b9e-9060-0c569aef9214" key="textField-11" stretchType="ContainerHeight" x="170" y="0" width="170" height="14" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{BPARTNER}]]></expression>
+				<box leftPadding="5" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{BPARTNER}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-12" style="Detail_Line" stretchType="RelativeToBandHeight" x="340" y="0" width="90" height="14" uuid="b6d2cb13-154a-4f1d-ac5d-f199862988f5"/>
-				<box leftPadding="5" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="b6d2cb13-154a-4f1d-ac5d-f199862988f5" key="textField-12" stretchType="ContainerHeight" x="340" y="0" width="90" height="14" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{TAXBASEAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXBASEAMT})+$F{CURRENCY}:new String(" ")]]></expression>
+				<box leftPadding="5" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[($F{TAXBASEAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXBASEAMT})+$F{CURRENCY}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-13" style="Detail_Line" stretchType="RelativeToBandHeight" x="430" y="0" width="90" height="14" uuid="0a93250c-66e7-4afa-ade0-4b07bcf02e9b"/>
-				<box leftPadding="5" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="0a93250c-66e7-4afa-ade0-4b07bcf02e9b" key="textField-13" stretchType="ContainerHeight" x="430" y="0" width="90" height="14" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{TAXAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXAMT})+$F{CURRENCY}:new String(" ")]]></expression>
+				<box leftPadding="5" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[($F{TAXAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXAMT})+$F{CURRENCY}:new String(" ")]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportTaxInvoiceSale.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportTaxInvoiceSale.jrxml
@@ -1,50 +1,49 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportTaxInvoiceSale" pageWidth="535" pageHeight="842" columnWidth="535" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="58fc11f9-1212-48e2-97bf-ff1126396715">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportTaxInvoiceSale" language="java" pageWidth="535" pageHeight="842" columnWidth="535" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="58fc11f9-1212-48e2-97bf-ff1126396715">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14"/>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0"/>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="9">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="9.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="9.0">
 			<conditionExpression><![CDATA[new Boolean($V{TAXNAME_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="9"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'1000000'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'0','1000000'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Sale"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_client" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_client" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{USER_CLIENT}.equals("") ? " " : " AND C_INVOICE.AD_CLIENT_ID IN ("+$P{USER_CLIENT}+") "]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_org" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_org" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{USER_ORG}.equals("") ? " " : " AND C_INVOICE.AD_ORG_ID IN ("+$P{USER_ORG}+") "]]></defaultValueExpression>
 	</parameter>
 	<parameter name="cCountryId" class="java.lang.String">
@@ -52,18 +51,17 @@
 	</parameter>
 	<parameter name="parDateFrom" class="java.util.Date"/>
 	<parameter name="parDateTo" class="java.util.Date"/>
-	<parameter name="ReportData" class="java.lang.String" isForPrompting="false">
+	<parameter name="ReportData" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="SALE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="DETAIL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="PARAM_CURRENCY" class="java.lang.String" isForPrompting="false">
+	<parameter name="SALE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="DETAIL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="PARAM_CURRENCY" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["102"]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[SELECT C_INVOICE.ISSOTRX AS SALES, 'Y' AS NATIONAL, C_INVOICE.DOCUMENTNO AS DOCUMENTNO, C_INVOICE.DATEINVOICED, C_BPARTNER.NAME AS BPARTNER, LTRIM(RTRIM(C_TAX.NAME, ' '), ' ') AS TAXNAME,
+	<query language="sql"><![CDATA[SELECT C_INVOICE.ISSOTRX AS SALES, 'Y' AS NATIONAL, C_INVOICE.DOCUMENTNO AS DOCUMENTNO, C_INVOICE.DATEINVOICED, C_BPARTNER.NAME AS BPARTNER, LTRIM(RTRIM(C_TAX.NAME, ' '), ' ') AS TAXNAME,
       SUM(CASE WHEN DOCBASETYPE IN ('ARC','APC') THEN -1 * (C_CURRENCY_CONVERT_RATE(C_INVOICETAX.TAXBASEAMT, C_INVOICE.C_CURRENCY_ID,$P{PARAM_CURRENCY}, TO_DATE(COALESCE(C_INVOICE.DATEINVOICED, NOW())), NULL, C_INVOICETAX.AD_CLIENT_ID, C_INVOICETAX.AD_ORG_ID, ICR.RATE))
        ELSE (C_CURRENCY_CONVERT_RATE(C_INVOICETAX.TAXBASEAMT, C_INVOICE.C_CURRENCY_ID,$P{PARAM_CURRENCY}, TO_DATE(COALESCE(C_INVOICE.DATEINVOICED, NOW())), NULL, C_INVOICETAX.AD_CLIENT_ID, C_INVOICETAX.AD_ORG_ID, ICR.RATE)) END) AS TAXBASEAMT,
       SUM(CASE WHEN DOCBASETYPE IN ('ARC','APC') THEN -1 * (C_CURRENCY_CONVERT_RATE(C_INVOICETAX.TAXAMT, C_INVOICE.C_CURRENCY_ID, $P{PARAM_CURRENCY}, TO_DATE(COALESCE(C_INVOICE.DATEINVOICED, NOW())), NULL, C_INVOICETAX.AD_CLIENT_ID, C_INVOICETAX.AD_ORG_ID, ICR.RATE))
@@ -88,8 +86,7 @@ AND 1=1 $P!{aux_org}
       AND 1=1
       GROUP BY C_INVOICE.DOCUMENTNO, C_INVOICE.DATEINVOICED, C_TAX.NAME, C_BPARTNER.NAME, C_INVOICE.ISSOTRX
       HAVING SUM(C_INVOICETAX.TAXBASEAMT) <> 0
-      ORDER BY C_TAX.NAME, C_INVOICE.DATEINVOICED]]>
-	</queryString>
+      ORDER BY C_TAX.NAME, C_INVOICE.DATEINVOICED]]></query>
 	<field name="SALES" class="java.lang.String"/>
 	<field name="NATIONAL" class="java.lang.String"/>
 	<field name="DOCUMENTNO" class="java.lang.String"/>
@@ -102,293 +99,215 @@ AND 1=1 $P!{aux_org}
 	<field name="CURRENCY" class="java.lang.String"/>
 	<field name="SUM_AMOUNT" class="java.lang.String"/>
 	<field name="Tax_BASE" class="java.lang.String"/>
-	<variable name="sumTaxBaseAmt" class="java.math.BigDecimal" resetType="Group" resetGroup="TAXNAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{TAXBASEAMT}]]></variableExpression>
+	<variable name="sumTaxBaseAmt" resetType="Group" calculation="Sum" resetGroup="TAXNAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{TAXBASEAMT}]]></expression>
 	</variable>
-	<variable name="sumImport" class="java.math.BigDecimal" resetType="Group" resetGroup="TAXNAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{TAXAMT}]]></variableExpression>
+	<variable name="sumImport" resetType="Group" calculation="Sum" resetGroup="TAXNAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{TAXAMT}]]></expression>
 	</variable>
 	<variable name="sumAmount" class="java.lang.String">
-		<variableExpression><![CDATA[$V{sumImport}.toString()]]></variableExpression>
+		<expression><![CDATA[$V{sumImport}.toString()]]></expression>
 	</variable>
 	<group name="TAXNAME">
-		<groupExpression><![CDATA[$F{TAXNAME}]]></groupExpression>
+		<expression><![CDATA[$F{TAXNAME}]]></expression>
 		<groupHeader>
 			<band height="44" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="1" y="0" width="100" height="20" uuid="28c89aba-cec7-4ed7-910a-9a9f96c431bd"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="28c89aba-cec7-4ed7-910a-9a9f96c431bd" key="staticText" x="1" y="0" width="100" height="20" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[Tax Type]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="101" y="0" width="433" height="20" uuid="0ba9d2d5-2714-4e5e-945f-d9023c184ecc"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{TAXNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="1" width="1" height="43" forecolor="#555555" uuid="f925e9d3-88fb-42e6-acdb-f92d7b2a2bac"/>
-					<graphicElement>
-						<pen lineWidth="2.0"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="534" y="1" width="1" height="43" forecolor="#555555" uuid="fc79ad2f-a0a5-4565-bf11-ee9141e19989"/>
-					<graphicElement>
-						<pen lineWidth="2.0"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="10" y="28" width="90" height="16" uuid="5d191392-0e36-4218-9630-be72237027ec">
-						<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="0ba9d2d5-2714-4e5e-945f-d9023c184ecc" key="textField" x="101" y="0" width="433" height="20" pdfFontName="Helvetica" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{TAXNAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
+				</element>
+				<element kind="line" uuid="f925e9d3-88fb-42e6-acdb-f92d7b2a2bac" key="line-2" stretchType="ContainerHeight" x="0" y="1" width="1" height="43" forecolor="#555555">
+					<pen lineWidth="2.0"/>
+				</element>
+				<element kind="line" uuid="fc79ad2f-a0a5-4565-bf11-ee9141e19989" key="line-3" stretchType="ContainerHeight" x="534" y="1" width="1" height="43" forecolor="#555555">
+					<pen lineWidth="2.0"/>
+				</element>
+				<element kind="staticText" uuid="5d191392-0e36-4218-9630-be72237027ec" key="element-90" x="10" y="28" width="90" height="16" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
 					<text><![CDATA[Invoice]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="100" y="28" width="70" height="16" uuid="c959e0f5-374e-423c-bf55-0deb0fc4304c">
-						<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="c959e0f5-374e-423c-bf55-0deb0fc4304c" key="element-90" x="100" y="28" width="70" height="16" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
 					<text><![CDATA[Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="170" y="28" width="170" height="16" uuid="67f1fffb-2ef1-4a21-8d4e-1cef0684d062">
-						<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="67f1fffb-2ef1-4a21-8d4e-1cef0684d062" key="element-90" x="170" y="28" width="170" height="16" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
 					<text><![CDATA[Business Partner]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="340" y="28" width="90" height="16" uuid="5163c6e4-237c-4e15-a0eb-d75f454770c0"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
+				</element>
+				<element kind="staticText" uuid="5163c6e4-237c-4e15-a0eb-d75f454770c0" key="element-90" x="340" y="28" width="90" height="16" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[Taxable Base]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="430" y="28" width="90" height="16" uuid="a2a05adf-b648-48a2-99e4-7985efcf13de"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
+				</element>
+				<element kind="staticText" uuid="a2a05adf-b648-48a2-99e4-7985efcf13de" key="element-90" x="430" y="28" width="90" height="16" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
+					<box leftPadding="5" style="Detail_Header">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="25" splitType="Stretch">
-				<line>
-					<reportElement key="line-32" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="20" forecolor="#555555" uuid="c177c49a-984c-47e0-8f9c-2853f02f5c2d"/>
-					<graphicElement>
-						<pen lineWidth="2.0"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="534" y="0" width="1" height="20" forecolor="#555555" uuid="c70aa4b4-3cf3-4b83-9997-ffd0b1b40a31"/>
-					<graphicElement>
-						<pen lineWidth="2.0"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-34" x="0" y="20" width="535" height="1" forecolor="#555555" uuid="8a4096cf-5848-4830-8e8a-6d710daba6c4"/>
-					<graphicElement>
-						<pen lineWidth="2.0"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-4" style="default" x="10" y="1" width="90" height="16" uuid="0592f9d9-3003-4f61-9e85-6a9d178d4228"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
+				<element kind="line" uuid="c177c49a-984c-47e0-8f9c-2853f02f5c2d" key="line-32" stretchType="ContainerHeight" x="0" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0"/>
+				</element>
+				<element kind="line" uuid="c70aa4b4-3cf3-4b83-9997-ffd0b1b40a31" key="line-33" stretchType="ContainerHeight" x="534" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0"/>
+				</element>
+				<element kind="line" uuid="8a4096cf-5848-4830-8e8a-6d710daba6c4" key="line-34" x="0" y="20" width="535" height="1" forecolor="#555555">
+					<pen lineWidth="2.0"/>
+				</element>
+				<element kind="staticText" uuid="0592f9d9-3003-4f61-9e85-6a9d178d4228" key="staticText-4" x="10" y="1" width="90" height="16" fontName="Bitstream Vera Sans" hTextAlign="Right" style="default">
 					<text><![CDATA[Total:]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField" style="Total_Field" x="100" y="1" width="240" height="16" uuid="fa7b8fbb-6df6-4056-ae54-b1ebcdbc90d2"/>
-					<box leftPadding="5">
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$V{TAXNAME_COUNT}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-37" x="10" y="0" width="510" height="1" forecolor="#666666" uuid="41a238fd-693e-4dca-aa19-02e529f32b4b"/>
-				</line>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField" style="Total_Field" x="430" y="1" width="90" height="16" uuid="833af328-aa10-4f59-97f3-80bede62f7ab"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="fa7b8fbb-6df6-4056-ae54-b1ebcdbc90d2" key="textField" x="100" y="1" width="240" height="16" blankWhenNull="false" vTextAlign="Middle" style="Total_Field">
+					<expression><![CDATA[$V{TAXNAME_COUNT}]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{sumImport}!=null)?$P{NUMBERFORMAT}.format($V{sumImport})+$F{CURRENCY}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField" style="Total_Field" x="340" y="1" width="90" height="16" uuid="74378635-9c3b-47ea-a95e-913e8dc99c79"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="line" uuid="41a238fd-693e-4dca-aa19-02e529f32b4b" key="line-37" x="10" y="0" width="510" height="1" forecolor="#666666"/>
+				<element kind="textField" uuid="833af328-aa10-4f59-97f3-80bede62f7ab" key="textField" x="430" y="1" width="90" height="16" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{sumImport}!=null)?$P{NUMBERFORMAT}.format($V{sumImport})+$F{CURRENCY}:new String(" ")]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[($V{sumTaxBaseAmt}!=null)?$P{NUMBERFORMAT}.format($V{sumTaxBaseAmt})+$F{CURRENCY}:new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="74378635-9c3b-47ea-a95e-913e8dc99c79" key="textField" x="340" y="1" width="90" height="16" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Field">
+					<expression><![CDATA[($V{sumTaxBaseAmt}!=null)?$P{NUMBERFORMAT}.format($V{sumTaxBaseAmt})+$F{CURRENCY}:new String(" ")]]></expression>
+					<box leftPadding="5" style="Total_Field">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="20" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Subtitle" x="1" y="0" width="535" height="20" uuid="2c3c6613-8b9d-42e2-b405-3e878e65d7e2"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{SALE}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader height="20" splitType="Stretch">
+		<element kind="textField" uuid="2c3c6613-8b9d-42e2-b405-3e878e65d7e2" key="textField" x="1" y="0" width="535" height="20" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[$P{SALE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="14" splitType="Stretch">
 			<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="534" y="0" width="1" height="14" forecolor="#555555" uuid="7f70871f-2289-40b4-89ef-17179888020a"/>
-				<graphicElement>
-					<pen lineWidth="2.0"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="14" forecolor="#555555" uuid="972c2787-8ca5-4028-91c5-cf63ba1d8140"/>
-				<graphicElement>
-					<pen lineWidth="2.0"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" x="10" y="0" width="90" height="14" uuid="e6806501-bc38-433d-a75f-d27ef8df5684"/>
-				<box leftPadding="2" rightPadding="2">
+			<element kind="line" uuid="7f70871f-2289-40b4-89ef-17179888020a" key="line-16" stretchType="ContainerHeight" x="534" y="0" width="1" height="14" forecolor="#555555">
+				<pen lineWidth="2.0"/>
+			</element>
+			<element kind="line" uuid="972c2787-8ca5-4028-91c5-cf63ba1d8140" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="14" forecolor="#555555">
+				<pen lineWidth="2.0"/>
+			</element>
+			<element kind="textField" uuid="e6806501-bc38-433d-a75f-d27ef8df5684" key="textField" x="10" y="0" width="90" height="14" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{DOCUMENTNO}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{DOCUMENTNO}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" x="100" y="0" width="70" height="14" uuid="1c91223d-44de-4729-8fad-7850159209a2"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="1c91223d-44de-4729-8fad-7850159209a2" key="textField" x="100" y="0" width="70" height="14" textAdjust="StretchHeight" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{DATEINVOICED}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{DATEINVOICED}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" x="170" y="0" width="170" height="14" uuid="17f14d8d-a38e-41cb-9e50-4ab126356f80"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="17f14d8d-a38e-41cb-9e50-4ab126356f80" key="textField" x="170" y="0" width="170" height="14" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{BPARTNER}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{BPARTNER}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="340" y="0" width="90" height="14" uuid="ae408521-834a-43a7-8bcf-093665ec7135"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="ae408521-834a-43a7-8bcf-093665ec7135" key="textField" x="340" y="0" width="90" height="14" fontSize="9.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{TAXBASEAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXBASEAMT})+$F{CURRENCY}:new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{TAXBASEAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXBASEAMT})+$F{CURRENCY}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="430" y="0" width="90" height="14" uuid="ab32102e-81e1-4946-9bfc-5a3315375a42"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="ab32102e-81e1-4946-9bfc-5a3315375a42" key="textField" x="430" y="0" width="90" height="14" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{TAXAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXAMT})+$F{CURRENCY}:new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[($F{TAXAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXAMT})+$F{CURRENCY}:new String(" ")]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportTaxInvoiceSaleForeign.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportTaxInvoiceSaleForeign.jrxml
@@ -1,63 +1,62 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportTaxInvoiceSaleForeign" pageWidth="535" pageHeight="842" columnWidth="535" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="c5939522-8a73-4367-b4cd-43484e8ddcba">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportTaxInvoiceSaleForeign" language="java" pageWidth="535" pageHeight="842" columnWidth="535" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="c5939522-8a73-4367-b4cd-43484e8ddcba">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
-	<style name="Detail_Line" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9">
-		<conditionalStyle>
+	<style name="Detail_Line" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9.0">
 			<conditionExpression><![CDATA[new Boolean($V{TAXNAME_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'1000000'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'0','1000000'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Sale Foreign"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_client" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_client" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{USER_CLIENT}.equals("") ? "" : " AND C_INVOICE.AD_CLIENT_ID IN ("+$P{USER_CLIENT}+") "]]></defaultValueExpression>
 	</parameter>
-	<parameter name="aux_org" class="java.lang.String" isForPrompting="false">
+	<parameter name="aux_org" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{USER_ORG}.equals("") ? "" : " AND C_INVOICE.AD_ORG_ID IN ("+$P{USER_ORG}+") "]]></defaultValueExpression>
 	</parameter>
 	<parameter name="cCountryId" class="java.lang.String">
@@ -65,18 +64,17 @@
 	</parameter>
 	<parameter name="parDateFrom" class="java.util.Date"/>
 	<parameter name="parDateTo" class="java.util.Date"/>
-	<parameter name="ReportData" class="java.lang.String" isForPrompting="false">
+	<parameter name="ReportData" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="SALE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="DETAIL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
+	<parameter name="SALE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="DETAIL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
 	<parameter name="PARAM_CURRENCY" class="java.lang.String">
 		<defaultValueExpression><![CDATA["102"]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[SELECT C_INVOICE.ISSOTRX AS SALES, 'N' AS NATIONAL, C_INVOICE.DOCUMENTNO AS DOCUMENTNO, C_INVOICE.DATEINVOICED, C_BPARTNER.NAME AS BPARTNER, LTRIM(RTRIM(C_TAX.NAME, ' '), ' ') AS TAXNAME,
+	<query language="sql"><![CDATA[SELECT C_INVOICE.ISSOTRX AS SALES, 'N' AS NATIONAL, C_INVOICE.DOCUMENTNO AS DOCUMENTNO, C_INVOICE.DATEINVOICED, C_BPARTNER.NAME AS BPARTNER, LTRIM(RTRIM(C_TAX.NAME, ' '), ' ') AS TAXNAME,
       SUM(CASE WHEN DOCBASETYPE IN ('ARC','APC') THEN -1 * (C_CURRENCY_CONVERT_RATE(C_INVOICETAX.TAXBASEAMT, C_INVOICE.C_CURRENCY_ID,$P{PARAM_CURRENCY}, TO_DATE(COALESCE(C_INVOICE.DATEINVOICED, NOW())), NULL, C_INVOICETAX.AD_CLIENT_ID, C_INVOICETAX.AD_ORG_ID, ICR.RATE))
       ELSE (C_CURRENCY_CONVERT_RATE(C_INVOICETAX.TAXBASEAMT, C_INVOICE.C_CURRENCY_ID,$P{PARAM_CURRENCY}, TO_DATE(COALESCE(C_INVOICE.DATEINVOICED, NOW())), NULL, C_INVOICETAX.AD_CLIENT_ID, C_INVOICETAX.AD_ORG_ID, ICR.RATE)) END) AS TAXBASEAMT,
       SUM(CASE WHEN DOCBASETYPE IN ('ARC','APC') THEN -1 * (C_CURRENCY_CONVERT_RATE(C_INVOICETAX.TAXAMT, C_INVOICE.C_CURRENCY_ID, $P{PARAM_CURRENCY}, TO_DATE(COALESCE(C_INVOICE.DATEINVOICED, NOW())), NULL, C_INVOICETAX.AD_CLIENT_ID, C_INVOICETAX.AD_ORG_ID, ICR.RATE))
@@ -101,8 +99,7 @@
       AND 1=1
       GROUP BY C_INVOICE.DOCUMENTNO, C_TAX.NAME, C_INVOICE.DATEINVOICED, C_BPARTNER.NAME, C_INVOICE.ISSOTRX
       HAVING SUM(C_INVOICETAX.TAXBASEAMT) <> 0
-      ORDER BY C_TAX.NAME, C_INVOICE.DATEINVOICED]]>
-	</queryString>
+      ORDER BY C_TAX.NAME, C_INVOICE.DATEINVOICED]]></query>
 	<field name="SALES" class="java.lang.String"/>
 	<field name="NATIONAL" class="java.lang.String"/>
 	<field name="DOCUMENTNO" class="java.lang.String"/>
@@ -115,311 +112,225 @@
 	<field name="CURRENCY" class="java.lang.String"/>
 	<field name="SUM_AMOUNT" class="java.lang.String"/>
 	<field name="Tax_BASE" class="java.lang.String"/>
-	<variable name="sumTaxBaseAmt" class="java.math.BigDecimal" resetType="Group" resetGroup="TAXNAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{TAXBASEAMT}]]></variableExpression>
+	<variable name="sumTaxBaseAmt" resetType="Group" calculation="Sum" resetGroup="TAXNAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{TAXBASEAMT}]]></expression>
 	</variable>
-	<variable name="sumImport" class="java.math.BigDecimal" resetType="Group" resetGroup="TAXNAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{TAXAMT}]]></variableExpression>
+	<variable name="sumImport" resetType="Group" calculation="Sum" resetGroup="TAXNAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{TAXAMT}]]></expression>
 	</variable>
 	<group name="TAXNAME">
-		<groupExpression><![CDATA[$F{TAXNAME}]]></groupExpression>
+		<expression><![CDATA[$F{TAXNAME}]]></expression>
 		<groupHeader>
 			<band height="44" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="1" y="0" width="100" height="20" uuid="b11c4e80-fc6a-48dd-b0ce-a3d45b739de7"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="b11c4e80-fc6a-48dd-b0ce-a3d45b739de7" key="staticText" x="1" y="0" width="100" height="20" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[Tax type]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="101" y="0" width="433" height="20" uuid="04fef844-cf54-4db3-93f5-9723244a897d"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{TAXNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="1" width="1" height="43" forecolor="#555555" uuid="cb5a984d-7786-4ddd-a710-9ae8da40682b"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="534" y="1" width="1" height="43" forecolor="#555555" uuid="8cd7c20d-a92c-4be8-823a-5fc6a5b86095"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="10" y="28" width="90" height="16" uuid="9079ed39-3449-4a71-a475-69c6f862438c">
-						<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="04fef844-cf54-4db3-93f5-9723244a897d" key="textField" x="101" y="0" width="433" height="20" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{TAXNAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
+				</element>
+				<element kind="line" uuid="cb5a984d-7786-4ddd-a710-9ae8da40682b" key="line-2" stretchType="ContainerHeight" x="0" y="1" width="1" height="43" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="8cd7c20d-a92c-4be8-823a-5fc6a5b86095" key="line-3" stretchType="ContainerHeight" x="534" y="1" width="1" height="43" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="9079ed39-3449-4a71-a475-69c6f862438c" key="element-90" x="10" y="28" width="90" height="16" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
 					<text><![CDATA[Invoice]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="100" y="28" width="70" height="16" uuid="4ba864f4-088a-4ff7-83f7-e9dad904cd1c">
-						<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="4ba864f4-088a-4ff7-83f7-e9dad904cd1c" key="element-90" x="100" y="28" width="70" height="16" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
 					<text><![CDATA[Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="170" y="28" width="170" height="16" uuid="2ed60b11-6a9d-47e1-9b89-c6ffcc42ec17">
-						<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="2ed60b11-6a9d-47e1-9b89-c6ffcc42ec17" key="element-90" x="170" y="28" width="170" height="16" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
 					<text><![CDATA[Business Partner]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="340" y="28" width="90" height="16" uuid="877169c9-23e1-43ab-a925-2922a346e09b"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right"/>
+				</element>
+				<element kind="staticText" uuid="877169c9-23e1-43ab-a925-2922a346e09b" key="element-90" x="340" y="28" width="90" height="16" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[Taxable Base]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="430" y="28" width="90" height="16" uuid="1e976e69-4c9c-4c99-86d2-660d2894755d"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right"/>
+				</element>
+				<element kind="staticText" uuid="1e976e69-4c9c-4c99-86d2-660d2894755d" key="element-90" x="430" y="28" width="90" height="16" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="28" splitType="Stretch">
-				<line>
-					<reportElement key="line-32" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="20" forecolor="#555555" uuid="8b7c9857-22eb-4405-be4c-e47841df2b76"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="534" y="0" width="1" height="20" forecolor="#555555" uuid="58aa5ba3-e973-4d05-941b-126b317e62b4"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-34" x="0" y="20" width="535" height="1" forecolor="#555555" uuid="3e6420a9-a12b-4c1b-893f-aa26831bc1a7"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-4" style="default" x="10" y="1" width="90" height="16" uuid="df566d96-4228-4c99-8d3d-c26893a086e2"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
+				<element kind="line" uuid="8b7c9857-22eb-4405-be4c-e47841df2b76" key="line-32" stretchType="ContainerHeight" x="0" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="58aa5ba3-e973-4d05-941b-126b317e62b4" key="line-33" stretchType="ContainerHeight" x="534" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="3e6420a9-a12b-4c1b-893f-aa26831bc1a7" key="line-34" x="0" y="20" width="535" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="df566d96-4228-4c99-8d3d-c26893a086e2" key="staticText-4" x="10" y="1" width="90" height="16" fontName="Bitstream Vera Sans" hTextAlign="Right" style="default">
 					<text><![CDATA[Total:]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField" style="Total_Field" x="100" y="1" width="240" height="16" uuid="1ad38e47-0282-4aff-ba8b-e8d6cb3345d8"/>
-					<box leftPadding="5">
+					<box style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="1ad38e47-0282-4aff-ba8b-e8d6cb3345d8" key="textField" x="100" y="1" width="240" height="16" blankWhenNull="false" style="Total_Field">
+					<expression><![CDATA[$V{TAXNAME_COUNT}]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$V{TAXNAME_COUNT}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-37" x="10" y="0" width="510" height="1" forecolor="#666666" uuid="eb18c16a-7715-4e41-b6d8-53f3bc64367a"/>
-					<graphicElement>
-						<pen lineWidth="0.25" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-1" style="Total_Field" x="430" y="1" width="90" height="16" uuid="62716c1c-55d1-47e2-adc2-f1db9ef4cac5"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="line" uuid="eb18c16a-7715-4e41-b6d8-53f3bc64367a" key="line-37" x="10" y="0" width="510" height="1" forecolor="#666666">
+					<pen lineWidth="0.25" lineStyle="Solid"/>
+				</element>
+				<element kind="textField" uuid="62716c1c-55d1-47e2-adc2-f1db9ef4cac5" key="textField-1" x="430" y="1" width="90" height="16" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{sumImport}!=null)?$P{NUMBERFORMAT}.format($V{sumImport})+$F{CURRENCY}:new String(" ")]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0"/>
 						<leftPen lineWidth="0.0"/>
 						<bottomPen lineWidth="0.0"/>
 						<rightPen lineWidth="0.0"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{sumImport}!=null)?$P{NUMBERFORMAT}.format($V{sumImport})+$F{CURRENCY}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-2" style="Total_Field" x="340" y="1" width="90" height="16" uuid="da7b16db-ec05-461e-8caa-305918f55c6b"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="da7b16db-ec05-461e-8caa-305918f55c6b" key="textField-2" x="340" y="1" width="90" height="16" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Field">
+					<expression><![CDATA[($V{sumTaxBaseAmt}!=null)?$P{NUMBERFORMAT}.format($V{sumTaxBaseAmt})+$F{CURRENCY}:new String(" ")]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0"/>
 						<leftPen lineWidth="0.0"/>
 						<bottomPen lineWidth="0.0"/>
 						<rightPen lineWidth="0.0"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[($V{sumTaxBaseAmt}!=null)?$P{NUMBERFORMAT}.format($V{sumTaxBaseAmt})+$F{CURRENCY}:new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="20" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Subtitle" x="0" y="0" width="535" height="20" uuid="86de42ee-a76f-471a-9604-82230a8c5e81"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{SALE}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader height="20" splitType="Stretch">
+		<element kind="textField" uuid="86de42ee-a76f-471a-9604-82230a8c5e81" key="textField" x="0" y="0" width="535" height="20" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[$P{SALE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="14" splitType="Stretch">
 			<printWhenExpression><![CDATA[new Boolean($P{DETAIL}.equals("Y"))]]></printWhenExpression>
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="534" y="0" width="1" height="14" forecolor="#555555" uuid="b699b057-5869-4995-82b0-ef78d766c357"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="14" forecolor="#555555" uuid="9cf5ae20-4a68-4278-8bcb-b2606a1eedfd"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" x="10" y="0" width="90" height="14" uuid="dbf7a640-6150-4f82-9907-f187f7318214"/>
-				<box leftPadding="2" rightPadding="2">
+			<element kind="line" uuid="b699b057-5869-4995-82b0-ef78d766c357" key="line-16" stretchType="ContainerHeight" x="534" y="0" width="1" height="14" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="9cf5ae20-4a68-4278-8bcb-b2606a1eedfd" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="14" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="dbf7a640-6150-4f82-9907-f187f7318214" key="textField" x="10" y="0" width="90" height="14" fontName="Bitstream Vera Sans" fontSize="10.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{DOCUMENTNO}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DOCUMENTNO}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" x="100" y="0" width="70" height="14" uuid="ffa35b94-d428-4ae5-939b-83ba07475dc9"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="ffa35b94-d428-4ae5-939b-83ba07475dc9" key="textField" x="100" y="0" width="70" height="14" fontName="Times-Roman" fontSize="10.0" textAdjust="StretchHeight" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{DATEINVOICED}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DATEINVOICED}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="Detail_Line" x="170" y="0" width="170" height="14" uuid="4f468c68-51d8-4b39-aa94-0eef01afc943"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="4f468c68-51d8-4b39-aa94-0eef01afc943" key="textField" x="170" y="0" width="170" height="14" fontName="Times-Roman" fontSize="10.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{BPARTNER}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{BPARTNER}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="340" y="0" width="90" height="14" uuid="f0f61ef3-65c1-4e48-a025-c23771cf5afb"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="f0f61ef3-65c1-4e48-a025-c23771cf5afb" key="textField" x="340" y="0" width="90" height="14" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{TAXBASEAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXBASEAMT})+$F{CURRENCY}:new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{TAXBASEAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXBASEAMT})+$F{CURRENCY}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="430" y="0" width="90" height="14" uuid="64bb152f-4730-48a5-87e1-74fbe1c4c8cd"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="64bb152f-4730-48a5-87e1-74fbe1c4c8cd" key="textField" x="430" y="0" width="90" height="14" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{TAXAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXAMT})+$F{CURRENCY}:new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{TAXAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXAMT})+$F{CURRENCY}:new String(" ")]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportToInvoiceConsignmentJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportToInvoiceConsignmentJR.jrxml
@@ -1,58 +1,56 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportToInvoiceConsignmentJR" pageWidth="842" pageHeight="595" orientation="Landscape" whenNoDataType="AllSectionsNoDetail" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="a5c625d1-9d06-426a-8d36-85c089385be1">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportToInvoiceConsignmentJR" language="java" pageWidth="842" pageHeight="595" orientation="Landscape" whenNoDataType="AllSectionsNoDetail" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="a5c625d1-9d06-426a-8d36-85c089385be1">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{BPARTNERNAME_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT A.MWAREHOUSE, A.PRODUCTNAME, A.C_PROJECT_ID, SUM(A.MOVEMENTQTY) AS MOVEMENTQTY, 
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT A.MWAREHOUSE, A.PRODUCTNAME, A.C_PROJECT_ID, SUM(A.MOVEMENTQTY) AS MOVEMENTQTY, 
       SUM(A.QUANTITYORDER) AS QUANTITYORDER, A.BPARTNERNAME, A.UOMNAME1, A.UOMNAME2, A.CATEGORY,
       C_PROJECTLINE.PLANNEDPOPRICE,
 	  C_CURRENCY_CONVERT(C_PROJECTLINE.PLANNEDPOPRICE, C_PROJECT.C_CURRENCY_ID, '102', TO_DATE(COALESCE(C_PROJECT.DATECONTRACT, C_PROJECT.DATEFINISH, NOW())), NULL, C_PROJECTLINE.AD_CLIENT_ID, C_PROJECTLINE.AD_ORG_ID) AS CONVPLANNEDPOPRICE,       
@@ -106,8 +104,7 @@
       A.BPARTNERNAME, A.UOMNAME1, A.UOMNAME2, A.CATEGORY,
       C_PROJECT.C_CURRENCY_ID, C_PROJECT.DATECONTRACT, C_PROJECT.DATEFINISH, 
 	  C_PROJECTLINE.AD_CLIENT_ID, C_PROJECTLINE.AD_ORG_ID
-      ORDER BY BPARTNERNAME]]>
-	</queryString>
+      ORDER BY BPARTNERNAME]]></query>
 	<field name="PLANNEDPOPRICE" class="java.math.BigDecimal"/>
 	<field name="MWAREHOUSE" class="java.lang.String"/>
 	<field name="PRODUCTNAME" class="java.lang.String"/>
@@ -124,660 +121,450 @@
 	<field name="TRANSYM" class="java.lang.String"/>
 	<field name="CONVSYM" class="java.lang.String"/>
 	<field name="CONVISOSYM" class="java.lang.String"/>
-	<variable name="totalAmountPartner" class="java.math.BigDecimal" resetType="Group" resetGroup="BPARTNERNAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVNETAMT}]]></variableExpression>
+	<variable name="totalAmountPartner" resetType="Group" calculation="Sum" resetGroup="BPARTNERNAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVNETAMT}]]></expression>
 	</variable>
-	<variable name="totalAmountWarehouse" class="java.math.BigDecimal" resetType="Group" resetGroup="MWAREHOUSE" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVNETAMT}]]></variableExpression>
+	<variable name="totalAmountWarehouse" resetType="Group" calculation="Sum" resetGroup="MWAREHOUSE" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVNETAMT}]]></expression>
 	</variable>
 	<group name="MWAREHOUSE">
-		<groupExpression><![CDATA[$F{MWAREHOUSE}]]></groupExpression>
+		<expression><![CDATA[$F{MWAREHOUSE}]]></expression>
 		<groupHeader>
 			<band height="33" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="0" y="0" width="120" height="23" uuid="bb41bb49-c675-4159-bf4d-26e028a4150a"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="bb41bb49-c675-4159-bf4d-26e028a4150a" key="staticText" x="0" y="0" width="120" height="23" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[Warehouse]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="120" y="0" width="620" height="23" uuid="a07b2de6-6ebf-4bf1-a4be-b410cfdcac51"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{MWAREHOUSE}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="1" width="1" height="32" forecolor="#555555" uuid="f1caeff2-309c-4d5e-a9d8-eb046b3a6190"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="740" y="0" width="1" height="32" forecolor="#555555" uuid="bb9eb8f5-006d-4ab9-8c1b-7be21662498e"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				</element>
+				<element kind="textField" uuid="a07b2de6-6ebf-4bf1-a4be-b410cfdcac51" key="textField" x="120" y="0" width="620" height="23" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{MWAREHOUSE}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="f1caeff2-309c-4d5e-a9d8-eb046b3a6190" key="line-2" stretchType="ContainerHeight" x="0" y="1" width="1" height="32" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="bb9eb8f5-006d-4ab9-8c1b-7be21662498e" key="line-3" stretchType="ContainerHeight" x="740" y="0" width="1" height="32" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="35" splitType="Stretch">
-				<line>
-					<reportElement key="line-32" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="21" forecolor="#555555" uuid="2bf088a0-7ffc-479c-af54-dbeccdb34651"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="740" y="-1" width="1" height="21" forecolor="#555555" uuid="d4b93e20-7b90-452f-bc47-668e4102b00c"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-34" x="0" y="20" width="741" height="1" forecolor="#555555" uuid="11e9a68c-7547-49c6-8fb9-c3e2ef9cd24e"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-5" style="default" x="525" y="0" width="104" height="16" uuid="c8589774-7899-4ffa-933c-07c63d5b4cac">
-						<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
-					</reportElement>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
+				<element kind="line" uuid="2bf088a0-7ffc-479c-af54-dbeccdb34651" key="line-32" stretchType="ContainerHeight" x="0" y="0" width="1" height="21" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="d4b93e20-7b90-452f-bc47-668e4102b00c" key="line-33" stretchType="ContainerHeight" x="740" y="-1" width="1" height="21" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="11e9a68c-7547-49c6-8fb9-c3e2ef9cd24e" key="line-34" x="0" y="20" width="741" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="c8589774-7899-4ffa-933c-07c63d5b4cac" key="staticText-5" x="525" y="0" width="104" height="16" fontName="Bitstream Vera Sans" hTextAlign="Right" vTextAlign="Middle" style="default">
+					<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
 					<text><![CDATA[Total:]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Total_Field" x="630" y="0" width="80" height="16" uuid="692a4f00-e399-4758-a0f0-2e6c34c0e156"/>
-					<box leftPadding="5">
+					<box style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="692a4f00-e399-4758-a0f0-2e6c34c0e156" key="textField" x="630" y="0" width="80" height="16" fontName="Bitstream Vera Sans" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Field">
+					<expression><![CDATA[($V{totalAmountWarehouse}!=null)?$P{NUMBERFORMAT}.format($V{totalAmountWarehouse}):new String(" ")]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{totalAmountWarehouse}!=null)?$P{NUMBERFORMAT}.format($V{totalAmountWarehouse}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-12" style="Total_Field" x="710" y="0" width="28" height="16" uuid="2a9ca506-bda7-48c7-8cff-6d6375563254"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="2a9ca506-bda7-48c7-8cff-6d6375563254" key="textField-12" x="710" y="0" width="28" height="16" fontName="Bitstream Vera Sans" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Total_Field">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="BPARTNERNAME">
-		<groupExpression><![CDATA[$F{BPARTNERNAME}]]></groupExpression>
+		<expression><![CDATA[$F{BPARTNERNAME}]]></expression>
 		<groupHeader>
 			<band height="50" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="10" y="0" width="120" height="23" uuid="2e75e12e-2100-4a9c-a33f-f829b27d03b6"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="2e75e12e-2100-4a9c-a33f-f829b27d03b6" key="staticText" x="10" y="0" width="120" height="23" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[B.Partner]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="130" y="0" width="610" height="23" uuid="8abbbe67-8435-40b0-9854-122eee7aa914"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{BPARTNERNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-4" stretchType="RelativeToBandHeight" x="10" y="1" width="1" height="49" forecolor="#555555" uuid="793383df-7eee-400c-9680-cb2bfffe5dba"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-6" stretchType="RelativeToBandHeight" x="740" y="-1" width="1" height="50" forecolor="#555555" uuid="12632aa5-20ca-4885-9061-d3b0e135475b"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-8" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="50" forecolor="#555555" uuid="742caea9-4fce-4d31-bd72-8591d3c78a18"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="12" y="33" width="104" height="16" uuid="6c9733f5-70bf-4889-9350-bd315f9171a5"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="8abbbe67-8435-40b0-9854-122eee7aa914" key="textField" x="130" y="0" width="610" height="23" fontName="Bitstream Vera Sans" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{BPARTNERNAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="793383df-7eee-400c-9680-cb2bfffe5dba" key="line-4" stretchType="ContainerHeight" x="10" y="1" width="1" height="49" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="12632aa5-20ca-4885-9061-d3b0e135475b" key="line-6" stretchType="ContainerHeight" x="740" y="-1" width="1" height="50" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="742caea9-4fce-4d31-bd72-8591d3c78a18" key="line-8" stretchType="ContainerHeight" x="0" y="0" width="1" height="50" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="6c9733f5-70bf-4889-9350-bd315f9171a5" key="element-90" x="12" y="33" width="104" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Product]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="116" y="33" width="104" height="16" uuid="b49cf4cd-85a5-4429-a8b7-9157cb7bc10a"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="b49cf4cd-85a5-4429-a8b7-9157cb7bc10a" key="element-90" x="116" y="33" width="104" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Unit]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="220" y="33" width="104" height="16" uuid="894bbd1a-a21c-4fd9-b740-728530adeacb"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="894bbd1a-a21c-4fd9-b740-728530adeacb" key="element-90" x="220" y="33" width="104" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="324" y="33" width="104" height="16" uuid="95e31f22-fd3b-4e39-8c3d-ad9d7bae2623"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="95e31f22-fd3b-4e39-8c3d-ad9d7bae2623" key="element-90" x="324" y="33" width="104" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Price]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-92" style="Detail_Header" x="428" y="33" width="51" height="16" uuid="a2442f6d-e0fc-4adb-b083-cfa832293299"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="a2442f6d-e0fc-4adb-b083-cfa832293299" key="element-92" x="428" y="33" width="51" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Price]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-93" style="Detail_Header" x="636" y="33" width="51" height="16" uuid="f41a1d5c-b415-4b35-aed7-81443938e5a1"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="f41a1d5c-b415-4b35-aed7-81443938e5a1" key="element-93" x="636" y="33" width="51" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-94" style="Detail_Header" x="532" y="33" width="104" height="16" uuid="febdd99d-4158-4773-baef-182f1df1770d"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="febdd99d-4158-4773-baef-182f1df1770d" key="element-94" x="532" y="33" width="104" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" hTextAlign="Center" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField-9" style="Detail_Header" stretchType="RelativeToBandHeight" x="479" y="33" width="53" height="16" uuid="2a388b6d-295a-47ce-9465-d999fa25ebdb"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField-10" style="Detail_Header" stretchType="RelativeToBandHeight" x="687" y="33" width="53" height="16" uuid="0956bcd5-117d-46fb-9b4f-cf1d78c2e750"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="2a388b6d-295a-47ce-9465-d999fa25ebdb" key="textField-9" stretchType="ContainerHeight" x="479" y="33" width="53" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="0956bcd5-117d-46fb-9b4f-cf1d78c2e750" key="textField-10" stretchType="ContainerHeight" x="687" y="33" width="53" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+					<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="35" splitType="Stretch">
-				<line>
-					<reportElement key="line-28" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="35" forecolor="#555555" uuid="3f4ca406-0d02-4984-b5f9-bdf4c64726c1"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-29" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="28" forecolor="#555555" uuid="774a37c8-7ed7-4fa8-83a5-7bb5b177cc07"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-30" stretchType="RelativeToBandHeight" x="740" y="-1" width="1" height="35" forecolor="#555555" uuid="89bc3fa2-a0dc-4b32-8caa-4c38fced1c41"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-31" x="10" y="29" width="729" height="1" forecolor="#555555" uuid="220f62d6-5ae8-4ea9-a623-92482dc56d88"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-2" style="default" x="525" y="7" width="104" height="16" uuid="3cc4a241-ba03-4e39-84fc-5c24c86555c8">
-						<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
-					</reportElement>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
+				<element kind="line" uuid="3f4ca406-0d02-4984-b5f9-bdf4c64726c1" key="line-28" stretchType="ContainerHeight" x="0" y="0" width="1" height="35" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="774a37c8-7ed7-4fa8-83a5-7bb5b177cc07" key="line-29" stretchType="ContainerHeight" x="10" y="0" width="1" height="28" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="89bc3fa2-a0dc-4b32-8caa-4c38fced1c41" key="line-30" stretchType="ContainerHeight" x="740" y="-1" width="1" height="35" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="220f62d6-5ae8-4ea9-a623-92482dc56d88" key="line-31" x="10" y="29" width="729" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="3cc4a241-ba03-4e39-84fc-5c24c86555c8" key="staticText-2" x="525" y="7" width="104" height="16" fontName="Bitstream Vera Sans" hTextAlign="Right" vTextAlign="Middle" style="default">
+					<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
 					<text><![CDATA[Total:]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Total_Field" x="630" y="7" width="80" height="16" uuid="5a0ed8b0-6546-4eda-9e86-690ea4d54f60"/>
-					<box leftPadding="5">
+					<box style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="5a0ed8b0-6546-4eda-9e86-690ea4d54f60" key="textField" x="630" y="7" width="80" height="16" fontName="Bitstream Vera Sans" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Field">
+					<expression><![CDATA[($V{totalAmountPartner}!=null)?$P{NUMBERFORMAT}.format($V{totalAmountPartner}):new String(" ")]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{totalAmountPartner}!=null)?$P{NUMBERFORMAT}.format($V{totalAmountPartner}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-11" style="Total_Field" x="710" y="7" width="28" height="16" uuid="e492bc7b-2c66-48f6-ac56-11725811fad5"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="e492bc7b-2c66-48f6-ac56-11725811fad5" key="textField-11" x="710" y="7" width="28" height="16" fontName="Bitstream Vera Sans" pattern="" blankWhenNull="false" hTextAlign="Center" vTextAlign="Middle" style="Total_Field">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="20" splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="30" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Title" mode="Transparent" x="0" y="0" width="739" height="25" uuid="44cc61f7-e22f-4b57-93d6-2ecdd8005fa8"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="28" width="739" height="1" uuid="55b3bef6-3b13-4e09-921d-30a962f944c3"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="20" splitType="Stretch"/>
+	<pageHeader height="30" splitType="Stretch">
+		<element kind="textField" uuid="44cc61f7-e22f-4b57-93d6-2ecdd8005fa8" key="textField" mode="Transparent" x="0" y="0" width="739" height="25" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="55b3bef6-3b13-4e09-921d-30a962f944c3" key="line-1" x="0" y="28" width="739" height="1">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band height="16" splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader height="16" splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="740" y="-1" width="1" height="16" forecolor="#555555" uuid="de08ba5e-36ce-488e-8afc-ad4d294946f5"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="16" forecolor="#555555" uuid="f1e25dfc-462a-42de-ba56-7098735c54e4"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-18" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="16" forecolor="#555555" uuid="0f219526-3d0e-4bd3-8e79-daacf832070c"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" stretchType="RelativeToBandHeight" x="12" y="0" width="104" height="16" uuid="d3758f2f-d825-4328-9232-982c30bbca85"/>
+			<element kind="line" uuid="de08ba5e-36ce-488e-8afc-ad4d294946f5" key="line-16" stretchType="ContainerHeight" x="740" y="-1" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="f1e25dfc-462a-42de-ba56-7098735c54e4" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="0f219526-3d0e-4bd3-8e79-daacf832070c" key="line-18" stretchType="ContainerHeight" x="10" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="d3758f2f-d825-4328-9232-982c30bbca85" key="textField" stretchType="ContainerHeight" x="12" y="0" width="104" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle">
+				<expression><![CDATA[$F{PRODUCTNAME}]]></expression>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRODUCTNAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" stretchType="RelativeToBandHeight" x="116" y="0" width="74" height="16" uuid="f950b5c5-fea4-40d9-b4f4-379670dce4b8"/>
+			</element>
+			<element kind="textField" uuid="f950b5c5-fea4-40d9-b4f4-379670dce4b8" key="textField" stretchType="ContainerHeight" x="116" y="0" width="74" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{MOVEMENTQTY}!=null)?$P{NUMBERFORMAT}.format($F{MOVEMENTQTY}):new String(" ")]]></expression>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{MOVEMENTQTY}!=null)?$P{NUMBERFORMAT}.format($F{MOVEMENTQTY}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" stretchType="RelativeToBandHeight" x="324" y="0" width="75" height="16" uuid="da620d4f-e75a-4551-aeb9-56df6388e348"/>
+			</element>
+			<element kind="textField" uuid="da620d4f-e75a-4551-aeb9-56df6388e348" key="textField" stretchType="ContainerHeight" x="324" y="0" width="75" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{PLANNEDPOPRICE}!=null)?$P{NUMBERFORMAT}.format($F{PLANNEDPOPRICE}):new String(" ")]]></expression>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PLANNEDPOPRICE}!=null)?$P{NUMBERFORMAT}.format($F{PLANNEDPOPRICE}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" stretchType="RelativeToBandHeight" x="220" y="0" width="74" height="16" uuid="cc6c4f48-52ac-404b-af61-6eaf639297de"/>
+			</element>
+			<element kind="textField" uuid="cc6c4f48-52ac-404b-af61-6eaf639297de" key="textField" stretchType="ContainerHeight" x="220" y="0" width="74" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{QUANTITYORDER}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITYORDER}):new String(" ")]]></expression>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QUANTITYORDER}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITYORDER}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" stretchType="RelativeToBandHeight" x="399" y="0" width="29" height="16" uuid="833b7ba0-1a8d-4810-abe0-790815bab259"/>
+			</element>
+			<element kind="textField" uuid="833b7ba0-1a8d-4810-abe0-790815bab259" key="textField" stretchType="ContainerHeight" x="399" y="0" width="29" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Center" vTextAlign="Middle">
+				<expression><![CDATA[$F{TRANSYM}]]></expression>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{TRANSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-1" stretchType="RelativeToBandHeight" x="428" y="0" width="75" height="16" uuid="61f46251-b5ee-4f46-b723-59d041893ed3"/>
+			</element>
+			<element kind="textField" uuid="61f46251-b5ee-4f46-b723-59d041893ed3" key="textField-1" stretchType="ContainerHeight" x="428" y="0" width="75" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{CONVPLANNEDPOPRICE}!=null)?$P{NUMBERFORMAT}.format($F{CONVPLANNEDPOPRICE}):new String(" ")]]></expression>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVPLANNEDPOPRICE}!=null)?$P{NUMBERFORMAT}.format($F{CONVPLANNEDPOPRICE}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-2" stretchType="RelativeToBandHeight" x="503" y="0" width="29" height="16" uuid="76d03258-a3c0-4123-8a56-c35911040168"/>
+			</element>
+			<element kind="textField" uuid="76d03258-a3c0-4123-8a56-c35911040168" key="textField-2" stretchType="ContainerHeight" x="503" y="0" width="29" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Center" vTextAlign="Middle">
+				<expression><![CDATA[$F{CONVSYM}]]></expression>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-3" stretchType="RelativeToBandHeight" x="710" y="0" width="30" height="16" uuid="1f239589-8f22-48cb-9937-f88235b938e4"/>
+			</element>
+			<element kind="textField" uuid="1f239589-8f22-48cb-9937-f88235b938e4" key="textField-3" stretchType="ContainerHeight" x="710" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Center" vTextAlign="Middle">
+				<expression><![CDATA[$F{CONVSYM}]]></expression>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-4" stretchType="RelativeToBandHeight" x="636" y="0" width="74" height="16" uuid="ee54565b-ac4a-4601-b76e-6eb8bde0bfaa"/>
+			</element>
+			<element kind="textField" uuid="ee54565b-ac4a-4601-b76e-6eb8bde0bfaa" key="textField-4" stretchType="ContainerHeight" x="636" y="0" width="74" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{CONVNETAMT}!=null)?$P{NUMBERFORMAT}.format($F{CONVNETAMT}):new String(" ")]]></expression>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{CONVNETAMT}!=null)?$P{NUMBERFORMAT}.format($F{CONVNETAMT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-5" stretchType="RelativeToBandHeight" x="606" y="0" width="30" height="16" uuid="d0c813b8-c85e-4b98-8fb4-8c8d7b9d26b6"/>
+			</element>
+			<element kind="textField" uuid="d0c813b8-c85e-4b98-8fb4-8c8d7b9d26b6" key="textField-5" stretchType="ContainerHeight" x="606" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Center" vTextAlign="Middle">
+				<expression><![CDATA[$F{TRANSYM}]]></expression>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{TRANSYM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-6" stretchType="RelativeToBandHeight" x="532" y="0" width="74" height="16" uuid="31b98f06-5a4a-495f-9452-b47c285ef8af"/>
+			</element>
+			<element kind="textField" uuid="31b98f06-5a4a-495f-9452-b47c285ef8af" key="textField-6" stretchType="ContainerHeight" x="532" y="0" width="74" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{NETAMT}!=null)?$P{NUMBERFORMAT}.format($F{NETAMT}):new String(" ")]]></expression>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{NETAMT}!=null)?$P{NUMBERFORMAT}.format($F{NETAMT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-7" stretchType="RelativeToBandHeight" x="190" y="0" width="30" height="16" uuid="8dc2d031-f1df-4b56-9371-c4f737984b49"/>
+			</element>
+			<element kind="textField" uuid="8dc2d031-f1df-4b56-9371-c4f737984b49" key="textField-7" stretchType="ContainerHeight" x="190" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Center" vTextAlign="Middle">
+				<expression><![CDATA[($F{MOVEMENTQTY}!=null)?$F{UOMNAME2}:new String(" ")]]></expression>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{MOVEMENTQTY}!=null)?$F{UOMNAME2}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-8" stretchType="RelativeToBandHeight" x="294" y="0" width="30" height="16" uuid="494090c5-ea27-40a4-af90-913fd5c74beb"/>
+			</element>
+			<element kind="textField" uuid="494090c5-ea27-40a4-af90-913fd5c74beb" key="textField-8" stretchType="ContainerHeight" x="294" y="0" width="30" height="16" fontName="Bitstream Vera Sans" fontSize="8.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Center" vTextAlign="Middle">
+				<expression><![CDATA[($F{QUANTITYORDER}!=null)?$F{UOMNAME1}:new String(" ")]]></expression>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QUANTITYORDER}!=null)?$F{UOMNAME1}:new String(" ")]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="16" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="27" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="605" y="4" width="95" height="19" uuid="f82e029d-52de-44a8-bf16-b78abd4001bc"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="704" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="05d030dd-48ae-4793-9a25-f6f72f140134"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Bottom" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="1" width="740" height="1" forecolor="#000000" uuid="85889158-4a23-4288-ad17-f575666fac9e"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="383" y="4" width="69" height="19" uuid="add8e877-49b2-46e4-b5d1-94f5341082a8"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Bottom">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" x="300" y="4" width="78" height="19" uuid="c692c9fa-0c92-405a-a554-78ff41aeb5d3"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="16" splitType="Stretch"/>
+	<pageFooter height="27" splitType="Stretch">
+		<element kind="textField" uuid="f82e029d-52de-44a8-bf16-b78abd4001bc" key="textField" x="605" y="4" width="95" height="19" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Bottom">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="05d030dd-48ae-4793-9a25-f6f72f140134" key="textField" x="704" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Bottom">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="85889158-4a23-4288-ad17-f575666fac9e" key="line" x="0" y="1" width="740" height="1" forecolor="#000000">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="add8e877-49b2-46e4-b5d1-94f5341082a8" key="textField" x="383" y="4" width="69" height="19" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Bottom">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="c692c9fa-0c92-405a-a554-78ff41aeb5d3" key="staticText-1" x="300" y="4" width="78" height="19" hTextAlign="Right" vTextAlign="Bottom">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportTrialBalanceExcel.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportTrialBalanceExcel.jrxml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportTrialBalanceExcel" pageWidth="1430" pageHeight="842" orientation="Landscape" columnWidth="1430" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" isIgnorePagination="true" uuid="d73c9057-b2b2-4024-ad3d-89ef81bae8bf">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportTrialBalanceExcel" language="java" pageWidth="1430" pageHeight="842" orientation="Landscape" columnWidth="1430" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d73c9057-b2b2-4024-ad3d-89ef81bae8bf" ignorePagination="true">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
@@ -7,58 +7,55 @@
 	<property name="ireport.x" value="762"/>
 	<property name="ireport.y" value="0"/>
 	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="11">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="11.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat">
 		<defaultValueExpression><![CDATA[new DecimalFormat("###,##0.00", new DecimalFormatSymbols())]]></defaultValueExpression>
 	</parameter>
-	<parameter name="SHOWBPARTNER" class="java.lang.Boolean" isForPrompting="false"/>
+	<parameter name="SHOWBPARTNER" forPrompting="false" class="java.lang.Boolean"/>
 	<parameter name="SHOWPRODUCT" class="java.lang.Boolean"/>
 	<parameter name="SHOWPROJECT" class="java.lang.Boolean"/>
 	<parameter name="SHOWCOSTCENTER" class="java.lang.Boolean"/>
-	<parameter name="TOTAL" class="java.lang.String" isForPrompting="false"/>
+	<parameter name="TOTAL" forPrompting="false" class="java.lang.String"/>
 	<parameter name="DATE_FROM" class="java.lang.String"/>
 	<parameter name="DATE_TO" class="java.lang.String"/>
-	<queryString>
-		<![CDATA[]]>
-	</queryString>
+	<query language="sql"><![CDATA[]]></query>
 	<field name="ID" class="java.lang.String"/>
 	<field name="ACCOUNT_ID" class="java.lang.String"/>
 	<field name="NAME" class="java.lang.String"/>
@@ -73,391 +70,261 @@
 	<field name="PJNAME" class="java.lang.String"/>
 	<field name="PJID" class="java.lang.String"/>
 	<field name="CCNAME" class="java.lang.String"/>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="99" splitType="Stretch">
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="375" y="84" width="85" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="706b9f8e-aed0-4c06-9e4e-f7e771003983"/>
-				<box rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="10" isBold="false"/>
-				</textElement>
-				<text><![CDATA[Debit]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="460" y="84" width="85" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="0b8484a5-dc37-4a88-b334-276e9c363acd"/>
-				<box rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="10" isBold="false"/>
-				</textElement>
-				<text><![CDATA[Credit]]></text>
-			</staticText>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Subtitle" x="0" y="25" width="641" height="44" uuid="7fd0c9d4-de48-409f-8c80-b1105c95d387"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{REPORT_SUBTITLE}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="element-91" style="Detail_Header" x="641" y="84" width="189" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="98b69d95-fa41-40c1-9a3e-e3928b8a5f60">
-					<printWhenExpression><![CDATA[$P{SHOWBPARTNER}]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left">
-					<font size="10" isBold="false"/>
-				</textElement>
-				<text><![CDATA[Business Partner]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-92" style="Detail_Header" x="830" y="84" width="200" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="91384abf-f763-4e34-a5c9-b154cf3fc0e6">
-					<printWhenExpression><![CDATA[$P{SHOWPRODUCT}]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left">
-					<font size="10" isBold="false"/>
-				</textElement>
-				<text><![CDATA[Product]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-93" style="Detail_Header" x="1030" y="84" width="200" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="7e4fb08b-1d1f-4ea1-8098-71cb9f85e9cb">
-					<printWhenExpression><![CDATA[$P{SHOWPROJECT}]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left">
-					<font size="10" isBold="false"/>
-				</textElement>
-				<text><![CDATA[Project]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-94" style="Detail_Header" x="0" y="84" width="79" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="cdefdf86-109d-46b8-b5b1-f20b14687251"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left">
-					<font size="10" isBold="false"/>
-				</textElement>
-				<text><![CDATA[Account No.]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-95" style="Detail_Header" x="79" y="84" width="200" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="91d306af-d720-4542-a3f8-5cef8c84c88f"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left">
-					<font size="10" isBold="false"/>
-				</textElement>
-				<text><![CDATA[Name]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-1" style="Report_Footer" mode="Transparent" x="0" y="0" width="641" height="25" uuid="790a202e-8cc7-4473-8634-bc9b88363222"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="SansSerif" size="12" isBold="true"/>
-				</textElement>
-				<text><![CDATA[  Trial Balance]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-94" style="Detail_Header" x="0" y="69" width="279" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="67708e65-efb3-46d3-8c43-a7a89605ab7d"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="10" isBold="true"/>
-				</textElement>
-				<text><![CDATA[]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-94" style="Detail_Header" x="279" y="69" width="96" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="ea1aea6a-9d6f-4f59-9f32-ca59b1c5a033"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="10" isBold="false"/>
-				</textElement>
-				<text><![CDATA[Balance As Of]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-94" style="Detail_Header" x="375" y="69" width="170" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="0855b324-5214-410c-9aa9-8fdd21929580"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="10" isBold="false"/>
-				</textElement>
-				<text><![CDATA[Activity]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-94" style="Detail_Header" x="545" y="69" width="96" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="5c68fd39-4680-44c8-a7b0-1a39a7aa72dd"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="10" isBold="false"/>
-				</textElement>
-				<text><![CDATA[Balance As Of]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-94" style="Detail_Header" x="641" y="69" width="589" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="495a3698-1f60-4e1c-b164-18505792fe03"/>
-				<box leftPadding="5" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="10" isBold="false"/>
-				</textElement>
-				<text><![CDATA[]]></text>
-			</staticText>
-			<textField>
-				<reportElement mode="Opaque" x="545" y="84" width="96" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="635c7994-6b22-4775-983f-e6b564459e3d"/>
-				<textElement textAlignment="Center" verticalAlignment="Middle" rotation="None" markup="none">
-					<font fontName="Bitstream Vera Sans" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{DATE_TO}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement mode="Opaque" x="290" y="84" width="85" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="f1e80c42-eb88-4f1b-8b61-1a2d85b15dd1"/>
-				<textElement textAlignment="Center" verticalAlignment="Middle" rotation="None" markup="none">
-					<font fontName="Bitstream Vera Sans" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{DATE_FROM}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="element-93" style="Detail_Header" x="1230" y="84" width="200" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="7e4fb08b-1d1f-4ea1-8098-71cb9f85e9cb">
-					<printWhenExpression><![CDATA[$P{SHOWCOSTCENTER}]]></printWhenExpression>
-				</reportElement>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left">
-					<font size="10" isBold="false"/>
-				</textElement>
-				<text><![CDATA[Cost Center]]></text>
-			</staticText>
-		</band>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader height="99" splitType="Stretch">
+		<element kind="staticText" uuid="706b9f8e-aed0-4c06-9e4e-f7e771003983" key="element-90" x="375" y="84" width="85" height="15" forecolor="#000000" backcolor="#FFFFFF" fontSize="10.0" bold="false" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Debit]]></text>
+			<box rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="0b8484a5-dc37-4a88-b334-276e9c363acd" key="element-90" x="460" y="84" width="85" height="15" forecolor="#000000" backcolor="#FFFFFF" fontSize="10.0" bold="false" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Credit]]></text>
+			<box rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="7fd0c9d4-de48-409f-8c80-b1105c95d387" key="textField" x="0" y="25" width="641" height="44" fontSize="10.0" pattern="" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="98b69d95-fa41-40c1-9a3e-e3928b8a5f60" key="element-91" x="641" y="84" width="189" height="15" forecolor="#000000" backcolor="#FFFFFF" fontSize="10.0" bold="false" hTextAlign="Left" style="Detail_Header">
+			<printWhenExpression><![CDATA[$P{SHOWBPARTNER}]]></printWhenExpression>
+			<text><![CDATA[Business Partner]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="91384abf-f763-4e34-a5c9-b154cf3fc0e6" key="element-92" x="830" y="84" width="200" height="15" forecolor="#000000" backcolor="#FFFFFF" fontSize="10.0" bold="false" hTextAlign="Left" style="Detail_Header">
+			<printWhenExpression><![CDATA[$P{SHOWPRODUCT}]]></printWhenExpression>
+			<text><![CDATA[Product]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="7e4fb08b-1d1f-4ea1-8098-71cb9f85e9cb" key="element-93" x="1030" y="84" width="200" height="15" forecolor="#000000" backcolor="#FFFFFF" fontSize="10.0" bold="false" hTextAlign="Left" style="Detail_Header">
+			<printWhenExpression><![CDATA[$P{SHOWPROJECT}]]></printWhenExpression>
+			<text><![CDATA[Project]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="cdefdf86-109d-46b8-b5b1-f20b14687251" key="element-94" x="0" y="84" width="79" height="15" forecolor="#000000" backcolor="#FFFFFF" fontSize="10.0" bold="false" hTextAlign="Left" style="Detail_Header">
+			<text><![CDATA[Account No.]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="91d306af-d720-4542-a3f8-5cef8c84c88f" key="element-95" x="79" y="84" width="200" height="15" forecolor="#000000" backcolor="#FFFFFF" fontSize="10.0" bold="false" hTextAlign="Left" style="Detail_Header">
+			<text><![CDATA[Name]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="790a202e-8cc7-4473-8634-bc9b88363222" key="staticText-1" mode="Transparent" x="0" y="0" width="641" height="25" fontName="SansSerif" fontSize="12.0" bold="true" style="Report_Footer">
+			<text><![CDATA[  Trial Balance]]></text>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="67708e65-efb3-46d3-8c43-a7a89605ab7d" key="element-94" x="0" y="69" width="279" height="15" forecolor="#000000" backcolor="#FFFFFF" fontSize="10.0" bold="true" style="Detail_Header">
+			<text><![CDATA[]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="ea1aea6a-9d6f-4f59-9f32-ca59b1c5a033" key="element-94" x="279" y="69" width="96" height="15" forecolor="#000000" backcolor="#FFFFFF" fontSize="10.0" bold="false" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Balance As Of]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="0855b324-5214-410c-9aa9-8fdd21929580" key="element-94" x="375" y="69" width="170" height="15" forecolor="#000000" backcolor="#FFFFFF" fontSize="10.0" bold="false" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Activity]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="5c68fd39-4680-44c8-a7b0-1a39a7aa72dd" key="element-94" x="545" y="69" width="96" height="15" forecolor="#000000" backcolor="#FFFFFF" fontSize="10.0" bold="false" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Balance As Of]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="495a3698-1f60-4e1c-b164-18505792fe03" key="element-94" x="641" y="69" width="589" height="15" forecolor="#000000" backcolor="#FFFFFF" fontSize="10.0" bold="false" style="Detail_Header">
+			<text><![CDATA[]]></text>
+			<box leftPadding="5" rightPadding="2" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="635c7994-6b22-4775-983f-e6b564459e3d" mode="Opaque" x="545" y="84" width="96" height="15" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="Bitstream Vera Sans" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Center" vTextAlign="Middle">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA[$P{DATE_TO}]]></expression>
+		</element>
+		<element kind="textField" uuid="f1e80c42-eb88-4f1b-8b61-1a2d85b15dd1" mode="Opaque" x="290" y="84" width="85" height="15" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="Bitstream Vera Sans" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Center" vTextAlign="Middle">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA[$P{DATE_FROM}]]></expression>
+		</element>
+		<element kind="staticText" uuid="7e4fb08b-1d1f-4ea1-8098-71cb9f85e9cb" key="element-93" x="1230" y="84" width="200" height="15" forecolor="#000000" backcolor="#FFFFFF" fontSize="10.0" bold="false" hTextAlign="Left" style="Detail_Header">
+			<printWhenExpression><![CDATA[$P{SHOWCOSTCENTER}]]></printWhenExpression>
+			<text><![CDATA[Cost Center]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="13" splitType="Stretch">
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" stretchType="RelativeToBandHeight" x="0" y="0" width="79" height="13" uuid="561a03a6-ef38-455a-9010-2df856ebf833"/>
+			<element kind="textField" uuid="561a03a6-ef38-455a-9010-2df856ebf833" key="textField" stretchType="ContainerHeight" x="0" y="0" width="79" height="13" fontSize="10.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false">
+				<expression><![CDATA[$F{ACCOUNT_ID}]]></expression>
 				<box topPadding="2" leftPadding="5">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="10" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{ACCOUNT_ID}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" x="79" y="0" width="200" height="13" uuid="be3921ce-7e22-4d09-8c22-31dfcdd87347"/>
+			</element>
+			<element kind="textField" uuid="be3921ce-7e22-4d09-8c22-31dfcdd87347" key="textField" stretchType="ElementGroupHeight" x="79" y="0" width="200" height="13" fontSize="10.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" bold="false">
+				<expression><![CDATA[$F{NAME}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="10" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{NAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-18" stretchType="RelativeToBandHeight" x="545" y="0" width="96" height="13" uuid="3083c6e2-ff96-4bd8-8aa5-f648a05f351b"/>
+			</element>
+			<element kind="textField" uuid="3083c6e2-ff96-4bd8-8aa5-f648a05f351b" key="textField-18" stretchType="ContainerHeight" x="545" y="0" width="96" height="13" fontSize="10.0" pattern="" blankWhenNull="true" hTextAlign="Right">
+				<expression><![CDATA[$F{SALDO_FINAL}]]></expression>
+				<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{SALDO_FINAL}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="ece58c00-da3b-409b-b21e-ef1e34ac0039" key="textField-20" stretchType="ContainerHeight" x="460" y="0" width="85" height="13" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[$F{AMTACCTCR}]]></expression>
 				<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-20" stretchType="RelativeToBandHeight" x="460" y="0" width="85" height="13" uuid="ece58c00-da3b-409b-b21e-ef1e34ac0039"/>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AMTACCTCR}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="66e1e5da-791a-421e-a4d7-bb3987eba601" key="textField-21" stretchType="ContainerHeight" x="375" y="0" width="85" height="13" fontSize="10.0" pattern="" blankWhenNull="true" hTextAlign="Right">
+				<expression><![CDATA[$F{AMTACCTDR}]]></expression>
 				<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-21" stretchType="RelativeToBandHeight" x="375" y="0" width="85" height="13" uuid="66e1e5da-791a-421e-a4d7-bb3987eba601"/>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{AMTACCTDR}]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="9fead840-b567-4904-925a-e1264cef905a" key="textField-22" stretchType="ContainerHeight" x="279" y="0" width="96" height="13" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[$F{SALDO_INICIAL}]]></expression>
 				<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-22" stretchType="RelativeToBandHeight" x="279" y="0" width="96" height="13" uuid="9fead840-b567-4904-925a-e1264cef905a"/>
 				<box rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{SALDO_INICIAL}]]></textFieldExpression>
-				<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" x="641" y="0" width="189" height="13" uuid="9b147e4b-23d1-4eb4-9e35-ee119ae34967">
-					<printWhenExpression><![CDATA[$P{SHOWBPARTNER}]]></printWhenExpression>
-				</reportElement>
+			</element>
+			<element kind="textField" uuid="9b147e4b-23d1-4eb4-9e35-ee119ae34967" key="textField" stretchType="ElementGroupHeight" x="641" y="0" width="189" height="13" fontSize="10.0" textAdjust="StretchHeight" blankWhenNull="true">
+				<printWhenExpression><![CDATA[$P{SHOWBPARTNER}]]></printWhenExpression>
+				<expression><![CDATA[$F{BPNAME}]]></expression>
 				<box leftPadding="5">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{BPNAME}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" x="830" y="0" width="200" height="13" uuid="10b853a4-cb37-4021-b744-b9bf92f7c6ce">
-					<printWhenExpression><![CDATA[$P{SHOWPRODUCT}]]></printWhenExpression>
-				</reportElement>
+			</element>
+			<element kind="textField" uuid="10b853a4-cb37-4021-b744-b9bf92f7c6ce" key="textField" stretchType="ElementGroupHeight" x="830" y="0" width="200" height="13" fontSize="10.0" textAdjust="StretchHeight" blankWhenNull="true">
+				<printWhenExpression><![CDATA[$P{SHOWPRODUCT}]]></printWhenExpression>
+				<expression><![CDATA[$F{PDNAME}]]></expression>
 				<box leftPadding="5">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PDNAME}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" x="1030" y="0" width="200" height="13" uuid="6721adb6-7645-4598-8a4b-4c65196d1e5d">
-					<printWhenExpression><![CDATA[$P{SHOWPROJECT}]]></printWhenExpression>
-				</reportElement>
+			</element>
+			<element kind="textField" uuid="6721adb6-7645-4598-8a4b-4c65196d1e5d" key="textField" stretchType="ElementGroupHeight" x="1030" y="0" width="200" height="13" fontSize="10.0" textAdjust="StretchHeight" blankWhenNull="true">
+				<printWhenExpression><![CDATA[$P{SHOWPROJECT}]]></printWhenExpression>
+				<expression><![CDATA[$F{PJNAME}]]></expression>
 				<box leftPadding="5">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PJNAME}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" stretchType="RelativeToTallestObject" x="1230" y="0" width="200" height="13" uuid="6721adb6-7645-4598-8a4b-4c65196d1e5d">
-					<printWhenExpression><![CDATA[$P{SHOWCOSTCENTER}]]></printWhenExpression>
-				</reportElement>
+			</element>
+			<element kind="textField" uuid="6721adb6-7645-4598-8a4b-4c65196d1e5d" key="textField" stretchType="ElementGroupHeight" x="1230" y="0" width="200" height="13" fontSize="10.0" textAdjust="StretchHeight" blankWhenNull="true">
+				<printWhenExpression><![CDATA[$P{SHOWCOSTCENTER}]]></printWhenExpression>
+				<expression><![CDATA[$F{CCNAME}]]></expression>
 				<box leftPadding="5">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CCNAME}]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportTrialBalancePDF.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportTrialBalancePDF.jrxml
@@ -1,64 +1,61 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportTrialBalancePDF" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="94f73212-0a4e-4d01-a77d-7c1011919e14">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportTrialBalancePDF" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="94f73212-0a4e-4d01-a77d-7c1011919e14">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="7.59499667166483"/>
 	<property name="ireport.x" value="3206"/>
 	<property name="ireport.y" value="1488"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="11">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="11.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{AccountGroup_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="TOTAL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="SUBACCOUNTVIEW" class="java.lang.Boolean" isForPrompting="false"/>
-	<parameter name="DEFAULTVIEW" class="java.lang.Boolean" isForPrompting="false"/>
-	<parameter name="DUMMY" class="java.lang.Boolean" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="TOTAL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="SUBACCOUNTVIEW" forPrompting="false" class="java.lang.Boolean"/>
+	<parameter name="DEFAULTVIEW" forPrompting="false" class="java.lang.Boolean"/>
+	<parameter name="DUMMY" forPrompting="false" class="java.lang.Boolean">
 		<defaultValueExpression><![CDATA[Boolean.TRUE]]></defaultValueExpression>
 	</parameter>
-	<parameter name="PageNo" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="DATE_FROM" class="java.lang.String" isForPrompting="false"/>
+	<parameter name="PageNo" forPrompting="false" class="java.lang.String"/>
+	<parameter name="DATE_FROM" forPrompting="false" class="java.lang.String"/>
 	<parameter name="DATE_TO" class="java.lang.String"/>
 	<parameter name="PAGEOF" class="java.lang.String"/>
-	<queryString>
-		<![CDATA[]]>
-	</queryString>
+	<query language="sql"><![CDATA[]]></query>
 	<field name="ID" class="java.lang.String"/>
 	<field name="ACCOUNT_ID" class="java.lang.String"/>
 	<field name="NAME" class="java.lang.String"/>
@@ -68,127 +65,104 @@
 	<field name="SALDO_FINAL" class="java.math.BigDecimal"/>
 	<field name="GROUPBYID" class="java.lang.String"/>
 	<field name="GROUPBYNAME" class="java.lang.String"/>
-	<variable name="TOTAL_INITIAL_BALANCE" class="java.math.BigDecimal" resetType="Group" resetGroup="AccountGroup" calculation="Sum">
-		<variableExpression><![CDATA[$F{SALDO_INICIAL}]]></variableExpression>
+	<variable name="TOTAL_INITIAL_BALANCE" resetType="Group" calculation="Sum" resetGroup="AccountGroup" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{SALDO_INICIAL}]]></expression>
 	</variable>
-	<variable name="TOTAL_DEBIT" class="java.math.BigDecimal" resetType="Group" resetGroup="AccountGroup" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMTACCTDR}]]></variableExpression>
+	<variable name="TOTAL_DEBIT" resetType="Group" calculation="Sum" resetGroup="AccountGroup" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMTACCTDR}]]></expression>
 	</variable>
-	<variable name="TOTAL_CREDIT" class="java.math.BigDecimal" resetType="Group" resetGroup="AccountGroup" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMTACCTCR}]]></variableExpression>
+	<variable name="TOTAL_CREDIT" resetType="Group" calculation="Sum" resetGroup="AccountGroup" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMTACCTCR}]]></expression>
 	</variable>
-	<variable name="TOTAL_FINAL_BALANCE" class="java.math.BigDecimal" resetType="Group" resetGroup="AccountGroup" calculation="Sum">
-		<variableExpression><![CDATA[$F{SALDO_FINAL}]]></variableExpression>
+	<variable name="TOTAL_FINAL_BALANCE" resetType="Group" calculation="Sum" resetGroup="AccountGroup" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{SALDO_FINAL}]]></expression>
 	</variable>
-	<variable name="TOTAL2_DEBIT" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMTACCTDR}]]></variableExpression>
+	<variable name="TOTAL2_DEBIT" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMTACCTDR}]]></expression>
 	</variable>
-	<variable name="TOTAL2_INITIAL_BALANCE" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{SALDO_INICIAL}]]></variableExpression>
+	<variable name="TOTAL2_INITIAL_BALANCE" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{SALDO_INICIAL}]]></expression>
 	</variable>
-	<variable name="TOTAL2_CREDIT" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMTACCTCR}]]></variableExpression>
+	<variable name="TOTAL2_CREDIT" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMTACCTCR}]]></expression>
 	</variable>
-	<variable name="TOTAL2_FINAL_BALANCE" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{SALDO_FINAL}]]></variableExpression>
+	<variable name="TOTAL2_FINAL_BALANCE" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{SALDO_FINAL}]]></expression>
 	</variable>
 	<group name="aux">
-		<groupExpression><![CDATA[$P{DUMMY}]]></groupExpression>
+		<expression><![CDATA[$P{DUMMY}]]></expression>
 		<groupHeader>
 			<band splitType="Stretch"/>
 		</groupHeader>
 		<groupFooter>
 			<band height="19" splitType="Stretch">
 				<printWhenExpression><![CDATA[$P{DEFAULTVIEW}]]></printWhenExpression>
-				<frame>
-					<reportElement key="frame-5" style="Total_Gray" x="0" y="2" width="535" height="17" isRemoveLineWhenBlank="true" backcolor="#FFFFFF" uuid="7f569287-1d6d-4423-ad30-abf387535736"/>
-					<box>
+				<element kind="frame" uuid="7f569287-1d6d-4423-ad30-abf387535736" key="frame-5" x="0" y="2" width="535" height="17" backcolor="#FFFFFF" removeLineWhenBlank="true" style="Total_Gray">
+					<element kind="textField" uuid="48afd15c-b9bf-4638-b506-9ea2db863cf0" key="textField-31" mode="Transparent" x="310" y="3" width="75" height="12" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="8.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" evaluationTime="Group" pattern="" evaluationGroup="AccountGroup" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Top">
+						<paragraph lineSpacing="Single"/>
+						<expression><![CDATA[($V{TOTAL2_DEBIT}!=null) ? $P{NUMBERFORMAT}.format($V{TOTAL2_DEBIT}).toString() : new String(" ")]]></expression>
+						<box topPadding="1" rightPadding="3">
+							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+							<bottomPen lineWidth="0.0" lineColor="#000000"/>
+							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						</box>
+					</element>
+					<element kind="textField" uuid="4b9e0d14-2f02-49ad-80f9-96eeed60972a" key="textField-32" mode="Transparent" x="234" y="3" width="75" height="12" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="8.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" evaluationTime="Group" pattern="" evaluationGroup="AccountGroup" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Top">
+						<paragraph lineSpacing="Single"/>
+						<expression><![CDATA[($V{TOTAL2_INITIAL_BALANCE}!=null) ? $P{NUMBERFORMAT}.format($V{TOTAL2_INITIAL_BALANCE}).toString() : new String(" ")]]></expression>
+						<box topPadding="1" rightPadding="3">
+							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+							<bottomPen lineWidth="0.0" lineColor="#000000"/>
+							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						</box>
+					</element>
+					<element kind="textField" uuid="83834fd9-99ec-4c0b-812f-0417c4bc3213" key="textField-33" mode="Transparent" x="384" y="3" width="75" height="12" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="8.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" evaluationTime="Group" pattern="" evaluationGroup="AccountGroup" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Top">
+						<paragraph lineSpacing="Single"/>
+						<expression><![CDATA[($V{TOTAL2_CREDIT}!=null) ? $P{NUMBERFORMAT}.format($V{TOTAL2_CREDIT}).toString() : new String(" ")]]></expression>
+						<box topPadding="1" rightPadding="3">
+							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+							<bottomPen lineWidth="0.0" lineColor="#000000"/>
+							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						</box>
+					</element>
+					<element kind="textField" uuid="c336e057-95cb-426a-a970-7ec0128f2863" key="textField-34" mode="Transparent" x="460" y="3" width="75" height="12" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="8.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" evaluationTime="Group" pattern="" evaluationGroup="AccountGroup" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Top">
+						<paragraph lineSpacing="Single"/>
+						<expression><![CDATA[($V{TOTAL2_FINAL_BALANCE}!=null) ? $P{NUMBERFORMAT}.format($V{TOTAL2_FINAL_BALANCE}).toString() : new String(" ")]]></expression>
+						<box topPadding="1" rightPadding="3">
+							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+							<bottomPen lineWidth="0.0" lineColor="#000000"/>
+							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						</box>
+					</element>
+					<element kind="textField" uuid="e37478b3-fb55-40e4-833c-565e7a1d2573" key="textField-30" mode="Opaque" x="73" y="3" width="146" height="12" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="8.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle">
+						<paragraph lineSpacing="Single"/>
+						<expression><![CDATA[$P{TOTAL}]]></expression>
+						<box topPadding="1" rightPadding="3">
+							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+							<bottomPen lineWidth="0.0" lineColor="#000000"/>
+							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						</box>
+					</element>
+					<element kind="line" uuid="ebb42346-82e5-4c51-a151-1adfde42dfd9" key="line-15" x="0" y="0" width="535" height="1" forecolor="#555555" style="Report_Footer">
+						<printWhenExpression><![CDATA[$P{DEFAULTVIEW}]]></printWhenExpression>
+					</element>
+					<box style="Total_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textField evaluationTime="Group" evaluationGroup="AccountGroup" pattern="" isBlankWhenNull="false">
-						<reportElement key="textField-31" mode="Transparent" x="310" y="3" width="75" height="12" forecolor="#000000" backcolor="#FFFFFF" uuid="48afd15c-b9bf-4638-b506-9ea2db863cf0"/>
-						<box topPadding="1" rightPadding="3">
-							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-							<bottomPen lineWidth="0.0" lineColor="#000000"/>
-							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						</box>
-						<textElement textAlignment="Right" verticalAlignment="Top" rotation="None" markup="none">
-							<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-							<paragraph lineSpacing="Single"/>
-						</textElement>
-						<textFieldExpression><![CDATA[($V{TOTAL2_DEBIT}!=null) ? $P{NUMBERFORMAT}.format($V{TOTAL2_DEBIT}).toString() : new String(" ")]]></textFieldExpression>
-					</textField>
-					<textField evaluationTime="Group" evaluationGroup="AccountGroup" pattern="" isBlankWhenNull="false">
-						<reportElement key="textField-32" mode="Transparent" x="234" y="3" width="75" height="12" forecolor="#000000" backcolor="#FFFFFF" uuid="4b9e0d14-2f02-49ad-80f9-96eeed60972a"/>
-						<box topPadding="1" rightPadding="3">
-							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-							<bottomPen lineWidth="0.0" lineColor="#000000"/>
-							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						</box>
-						<textElement textAlignment="Right" verticalAlignment="Top" rotation="None" markup="none">
-							<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-							<paragraph lineSpacing="Single"/>
-						</textElement>
-						<textFieldExpression><![CDATA[($V{TOTAL2_INITIAL_BALANCE}!=null) ? $P{NUMBERFORMAT}.format($V{TOTAL2_INITIAL_BALANCE}).toString() : new String(" ")]]></textFieldExpression>
-					</textField>
-					<textField evaluationTime="Group" evaluationGroup="AccountGroup" pattern="" isBlankWhenNull="false">
-						<reportElement key="textField-33" mode="Transparent" x="384" y="3" width="75" height="12" forecolor="#000000" backcolor="#FFFFFF" uuid="83834fd9-99ec-4c0b-812f-0417c4bc3213"/>
-						<box topPadding="1" rightPadding="3">
-							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-							<bottomPen lineWidth="0.0" lineColor="#000000"/>
-							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						</box>
-						<textElement textAlignment="Right" verticalAlignment="Top" rotation="None" markup="none">
-							<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-							<paragraph lineSpacing="Single"/>
-						</textElement>
-						<textFieldExpression><![CDATA[($V{TOTAL2_CREDIT}!=null) ? $P{NUMBERFORMAT}.format($V{TOTAL2_CREDIT}).toString() : new String(" ")]]></textFieldExpression>
-					</textField>
-					<textField evaluationTime="Group" evaluationGroup="AccountGroup" pattern="" isBlankWhenNull="false">
-						<reportElement key="textField-34" mode="Transparent" x="460" y="3" width="75" height="12" forecolor="#000000" backcolor="#FFFFFF" uuid="c336e057-95cb-426a-a970-7ec0128f2863"/>
-						<box topPadding="1" rightPadding="3">
-							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-							<bottomPen lineWidth="0.0" lineColor="#000000"/>
-							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						</box>
-						<textElement textAlignment="Right" verticalAlignment="Top" rotation="None" markup="none">
-							<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-							<paragraph lineSpacing="Single"/>
-						</textElement>
-						<textFieldExpression><![CDATA[($V{TOTAL2_FINAL_BALANCE}!=null) ? $P{NUMBERFORMAT}.format($V{TOTAL2_FINAL_BALANCE}).toString() : new String(" ")]]></textFieldExpression>
-					</textField>
-					<textField isBlankWhenNull="false">
-						<reportElement key="textField-30" mode="Opaque" x="73" y="3" width="146" height="12" forecolor="#000000" backcolor="#FFFFFF" uuid="e37478b3-fb55-40e4-833c-565e7a1d2573"/>
-						<box topPadding="1" rightPadding="3">
-							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-							<bottomPen lineWidth="0.0" lineColor="#000000"/>
-							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						</box>
-						<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None" markup="none">
-							<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-							<paragraph lineSpacing="Single"/>
-						</textElement>
-						<textFieldExpression><![CDATA[$P{TOTAL}]]></textFieldExpression>
-					</textField>
-					<line>
-						<reportElement key="line-15" style="Report_Footer" x="0" y="0" width="535" height="1" forecolor="#555555" uuid="ebb42346-82e5-4c51-a151-1adfde42dfd9">
-							<printWhenExpression><![CDATA[$P{DEFAULTVIEW}]]></printWhenExpression>
-						</reportElement>
-					</line>
-				</frame>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="AccountGroup" minHeightToStartNewPage="55">
-		<groupExpression><![CDATA[$F{ID}]]></groupExpression>
+		<expression><![CDATA[$F{ID}]]></expression>
 		<groupHeader>
 			<band splitType="Stretch">
 				<printWhenExpression><![CDATA[$P{SUBACCOUNTVIEW}]]></printWhenExpression>
@@ -197,537 +171,357 @@
 		<groupFooter>
 			<band height="24" splitType="Stretch">
 				<printWhenExpression><![CDATA[$P{SUBACCOUNTVIEW}]]></printWhenExpression>
-				<line>
-					<reportElement key="line-1" x="237" y="2" width="70" height="1" forecolor="#555555" uuid="00aa65ac-071d-448f-8bd6-3a6c525cd88e"/>
-				</line>
-				<line>
-					<reportElement key="line-1" x="312" y="2" width="70" height="1" forecolor="#555555" uuid="f18b9437-7ade-42c1-80e5-24ea626f9dbd"/>
-				</line>
-				<line>
-					<reportElement key="line-1" x="387" y="2" width="70" height="1" forecolor="#555555" uuid="025c70c2-66c0-4e2c-9830-3d2d36ca9254"/>
-				</line>
-				<line>
-					<reportElement key="line-1" x="462" y="2" width="70" height="1" forecolor="#555555" uuid="25a9a063-e07d-4549-a11f-be012b41bfa0"/>
-				</line>
-				<textField evaluationTime="Group" evaluationGroup="AccountGroup" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-9" mode="Opaque" x="460" y="4" width="75" height="12" forecolor="#000000" backcolor="#FFFFFF" uuid="0b927f06-09a7-4ec1-86ac-62f320463499"/>
+				<element kind="line" uuid="00aa65ac-071d-448f-8bd6-3a6c525cd88e" key="line-1" x="237" y="2" width="70" height="1" forecolor="#555555"/>
+				<element kind="line" uuid="f18b9437-7ade-42c1-80e5-24ea626f9dbd" key="line-1" x="312" y="2" width="70" height="1" forecolor="#555555"/>
+				<element kind="line" uuid="025c70c2-66c0-4e2c-9830-3d2d36ca9254" key="line-1" x="387" y="2" width="70" height="1" forecolor="#555555"/>
+				<element kind="line" uuid="25a9a063-e07d-4549-a11f-be012b41bfa0" key="line-1" x="462" y="2" width="70" height="1" forecolor="#555555"/>
+				<element kind="textField" uuid="0b927f06-09a7-4ec1-86ac-62f320463499" key="textField-9" mode="Opaque" x="460" y="4" width="75" height="12" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="8.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" evaluationTime="Group" pattern="" evaluationGroup="AccountGroup" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Top">
+					<paragraph lineSpacing="Single"/>
+					<expression><![CDATA[($V{TOTAL_FINAL_BALANCE}!=null) ? $P{NUMBERFORMAT}.format($V{TOTAL_FINAL_BALANCE}).toString() : new String(" ")]]></expression>
 					<box topPadding="2" rightPadding="3">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Top" rotation="None" markup="none">
-						<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-						<paragraph lineSpacing="Single"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{TOTAL_FINAL_BALANCE}!=null) ? $P{NUMBERFORMAT}.format($V{TOTAL_FINAL_BALANCE}).toString() : new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="AccountGroup" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-10" mode="Opaque" x="234" y="4" width="75" height="12" forecolor="#000000" backcolor="#FFFFFF" uuid="49b561d0-8a9f-4f31-a286-1a251b50e4c5"/>
+				</element>
+				<element kind="textField" uuid="49b561d0-8a9f-4f31-a286-1a251b50e4c5" key="textField-10" mode="Opaque" x="234" y="4" width="75" height="12" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="8.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" evaluationTime="Group" pattern="" evaluationGroup="AccountGroup" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Top">
+					<paragraph lineSpacing="Single"/>
+					<expression><![CDATA[($V{TOTAL_INITIAL_BALANCE}!=null) ? $P{NUMBERFORMAT}.format($V{TOTAL_INITIAL_BALANCE}).toString() : new String(" ")]]></expression>
 					<box topPadding="2" rightPadding="3">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Top" rotation="None" markup="none">
-						<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-						<paragraph lineSpacing="Single"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{TOTAL_INITIAL_BALANCE}!=null) ? $P{NUMBERFORMAT}.format($V{TOTAL_INITIAL_BALANCE}).toString() : new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="AccountGroup" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-12" mode="Opaque" x="384" y="4" width="75" height="12" forecolor="#000000" backcolor="#FFFFFF" uuid="1dc11373-3e56-4434-89f6-83b7f6489cde"/>
+				</element>
+				<element kind="textField" uuid="1dc11373-3e56-4434-89f6-83b7f6489cde" key="textField-12" mode="Opaque" x="384" y="4" width="75" height="12" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="8.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" evaluationTime="Group" pattern="" evaluationGroup="AccountGroup" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Top">
+					<paragraph lineSpacing="Single"/>
+					<expression><![CDATA[($V{TOTAL_CREDIT}!=null) ? $P{NUMBERFORMAT}.format($V{TOTAL_CREDIT}).toString() : new String(" ")]]></expression>
 					<box topPadding="2" rightPadding="3">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Top" rotation="None" markup="none">
-						<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-						<paragraph lineSpacing="Single"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{TOTAL_CREDIT}!=null) ? $P{NUMBERFORMAT}.format($V{TOTAL_CREDIT}).toString() : new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-23" style="Total_Gray" x="67" y="4" width="166" height="12" backcolor="#FFFFFF" uuid="70fc905c-45ab-4850-b9f3-fab55161e8bb"/>
-					<box topPadding="2" leftPadding="5">
+				</element>
+				<element kind="textField" uuid="70fc905c-45ab-4850-b9f3-fab55161e8bb" key="textField-23" x="67" y="4" width="166" height="12" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="8.0" pdfFontName="Helvetica" blankWhenNull="false" bold="false" style="Total_Gray">
+					<expression><![CDATA[$F{NAME}]]></expression>
+					<box topPadding="2" leftPadding="5" style="Total_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="DejaVu Sans" size="8" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NAME}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-23" style="Total_Gray" x="1" y="4" width="67" height="12" backcolor="#FFFFFF" uuid="a3c5827d-8d85-4b01-b7ce-70d0c93aa79d"/>
-					<box topPadding="2" leftPadding="5">
+				</element>
+				<element kind="textField" uuid="a3c5827d-8d85-4b01-b7ce-70d0c93aa79d" key="textField-23" x="1" y="4" width="67" height="12" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="8.0" pdfFontName="Helvetica" blankWhenNull="false" bold="false" style="Total_Gray">
+					<expression><![CDATA[$F{ACCOUNT_ID}]]></expression>
+					<box topPadding="2" leftPadding="5" style="Total_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="DejaVu Sans" size="8" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{ACCOUNT_ID}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="AccountGroup" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-10" mode="Opaque" x="310" y="4" width="75" height="12" forecolor="#000000" backcolor="#FFFFFF" uuid="ee6a7b9d-3b9a-4948-b5bc-06805848fda9"/>
+				</element>
+				<element kind="textField" uuid="ee6a7b9d-3b9a-4948-b5bc-06805848fda9" key="textField-10" mode="Opaque" x="310" y="4" width="75" height="12" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="8.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" evaluationTime="Group" pattern="" evaluationGroup="AccountGroup" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Top">
+					<paragraph lineSpacing="Single"/>
+					<expression><![CDATA[($V{TOTAL_DEBIT}!=null) ? $P{NUMBERFORMAT}.format($V{TOTAL_DEBIT}).toString() : new String(" ")]]></expression>
 					<box topPadding="2" rightPadding="3">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Top" rotation="None" markup="none">
-						<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-						<paragraph lineSpacing="Single"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{TOTAL_DEBIT}!=null) ? $P{NUMBERFORMAT}.format($V{TOTAL_DEBIT}).toString() : new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="18" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-15" style="Report_Footer" x="1" y="0" width="535" height="18" uuid="ae98033a-2b02-4fc0-888c-b190e352f11d"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left">
-					<font fontName="DejaVu Sans" size="12" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[ Trial Balance]]></text>
-			</staticText>
-			<line>
-				<reportElement key="line-1" x="2" y="15" width="532" height="1" uuid="a1f682e5-9793-4692-8c8f-93d89c161597"/>
-			</line>
-			<staticText>
-				<reportElement key="staticText-8" style="Report_Footer" x="429" y="0" width="53" height="16" uuid="91ffcdd2-e7d6-41c1-bdd5-bd29727aea33"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<text><![CDATA[Printed on]]></text>
-			</staticText>
-			<textField pattern="dd/MM/yyyy" isBlankWhenNull="false">
-				<reportElement key="textField-15" style="Report_Footer" x="484" y="1" width="52" height="16" uuid="43c21cda-6c2f-43a3-b9f1-b514c53ff820"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="18" splitType="Stretch">
+		<element kind="staticText" uuid="ae98033a-2b02-4fc0-888c-b190e352f11d" key="staticText-15" x="1" y="0" width="535" height="18" fontName="DejaVu Sans" fontSize="12.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left" style="Report_Footer">
+			<text><![CDATA[ Trial Balance]]></text>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="a1f682e5-9793-4692-8c8f-93d89c161597" key="line-1" x="2" y="15" width="532" height="1"/>
+		<element kind="staticText" uuid="91ffcdd2-e7d6-41c1-bdd5-bd29727aea33" key="staticText-8" x="429" y="0" width="53" height="16" fontName="DejaVu Sans" fontSize="8.0" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
+			<text><![CDATA[Printed on]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="43c21cda-6c2f-43a3-b9f1-b514c53ff820" key="textField-15" x="484" y="1" width="52" height="16" fontName="DejaVu Sans" fontSize="8.0" pattern="dd/MM/yyyy" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</title>
-	<pageHeader>
-		<band height="96" splitType="Stretch">
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-2" style="Report_Subtitle" x="2" y="0" width="535" height="56" forecolor="#000000" uuid="861b20a3-6c52-4a98-ad80-40f6065cafb9"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="DejaVu Sans" size="12"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{REPORT_SUBTITLE}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-14" style="GroupHeader_DarkGray" x="68" y="79" width="168" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="220518dc-9a27-4b12-bed2-4e248b308aab"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="DejaVu Sans" size="10" isBold="false"/>
-				</textElement>
-				<text><![CDATA[Name]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-14" style="GroupHeader_DarkGray" x="1" y="64" width="235" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="199dded3-c9f8-4755-9ad6-f63958ce40c6"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="SansSerif" size="10"/>
-				</textElement>
-				<text><![CDATA[]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-14" style="GroupHeader_DarkGray" x="231" y="64" width="76" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="05151da0-ab15-4afd-8ee1-c95dde06bb54"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font fontName="DejaVu Sans" size="10" isBold="false"/>
-				</textElement>
-				<text><![CDATA[Balance As Of]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-14" style="GroupHeader_DarkGray" x="310" y="63" width="150" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="e26c8107-6e97-4545-b1af-eacaca026e50"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font fontName="DejaVu Sans" size="10" isBold="false"/>
-				</textElement>
-				<text><![CDATA[Activity]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-14" style="GroupHeader_DarkGray" x="458" y="63" width="76" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="4f966c57-45a7-48a9-b8cd-74e8e583f189"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font fontName="DejaVu Sans" size="10" isBold="false"/>
-				</textElement>
-				<text><![CDATA[Balance As Of]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-10" style="GroupHeader_DarkGray" x="385" y="79" width="75" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="d1b16e60-acc9-40d5-aec4-480fffb64de4"/>
-				<box leftPadding="5" rightPadding="3">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font fontName="DejaVu Sans" size="10" isBold="false"/>
-				</textElement>
-				<text><![CDATA[Credit]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-11" style="GroupHeader_DarkGray" x="310" y="79" width="75" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="61d34191-b2a6-4268-8e2f-ebe43855a52e"/>
-				<box leftPadding="5" rightPadding="3">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font fontName="DejaVu Sans" size="10" isBold="false"/>
-				</textElement>
-				<text><![CDATA[Debit]]></text>
-			</staticText>
-			<textField>
-				<reportElement mode="Opaque" x="232" y="79" width="75" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="62eaaa51-c45c-423a-ba6b-52997d6b74ef"/>
-				<textElement textAlignment="Center" verticalAlignment="Middle" rotation="None" markup="none">
-					<font fontName="DejaVu Sans" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{DATE_FROM}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement mode="Opaque" x="459" y="79" width="77" height="15" forecolor="#000000" backcolor="#FFFFFF" uuid="49e6402f-ac21-4a8e-859c-0ed69027e204"/>
-				<textElement textAlignment="Center" verticalAlignment="Middle" rotation="None" markup="none">
-					<font fontName="DejaVu Sans" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{DATE_TO}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="3" y="59" width="531" height="1" forecolor="#555555" uuid="d21f46b0-d48d-449f-8d10-d79ed6f19a36"/>
-			</line>
-			<line>
-				<reportElement key="line-1" x="316" y="79" width="140" height="1" forecolor="#555555" uuid="406692f7-5592-4dc0-bc07-722bf3818fbb"/>
-			</line>
-			<line>
-				<reportElement key="line-1" x="2" y="95" width="532" height="1" forecolor="#555555" uuid="8d5b2165-7cb3-465f-b9fd-dbdcf8db86b3"/>
-			</line>
-			<staticText>
-				<reportElement key="staticText-14" style="GroupHeader_DarkGray" stretchType="RelativeToTallestObject" x="0" y="79" width="72" height="15" isPrintWhenDetailOverflows="true" forecolor="#000000" backcolor="#FFFFFF" uuid="9b5ad912-d21e-4c19-a306-330d05f4e614"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="DejaVu Sans" size="10" isBold="false"/>
-				</textElement>
-				<text><![CDATA[Account No.]]></text>
-			</staticText>
-		</band>
+	<pageHeader height="96" splitType="Stretch">
+		<element kind="textField" uuid="861b20a3-6c52-4a98-ad80-40f6065cafb9" key="textField-2" x="2" y="0" width="535" height="56" forecolor="#000000" fontName="DejaVu Sans" fontSize="12.0" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="220518dc-9a27-4b12-bed2-4e248b308aab" key="staticText-14" x="68" y="79" width="168" height="15" forecolor="#000000" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="10.0" bold="false" style="GroupHeader_DarkGray">
+			<text><![CDATA[Name]]></text>
+			<box leftPadding="5" style="GroupHeader_DarkGray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="199dded3-c9f8-4755-9ad6-f63958ce40c6" key="staticText-14" x="1" y="64" width="235" height="15" forecolor="#000000" backcolor="#FFFFFF" fontName="SansSerif" fontSize="10.0" style="GroupHeader_DarkGray">
+			<text><![CDATA[]]></text>
+			<box leftPadding="5" style="GroupHeader_DarkGray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="05151da0-ab15-4afd-8ee1-c95dde06bb54" key="staticText-14" x="231" y="64" width="76" height="15" forecolor="#000000" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="10.0" bold="false" hTextAlign="Center" style="GroupHeader_DarkGray">
+			<text><![CDATA[Balance As Of]]></text>
+			<box leftPadding="5" style="GroupHeader_DarkGray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="e26c8107-6e97-4545-b1af-eacaca026e50" key="staticText-14" x="310" y="63" width="150" height="15" forecolor="#000000" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="10.0" bold="false" hTextAlign="Center" style="GroupHeader_DarkGray">
+			<text><![CDATA[Activity]]></text>
+			<box leftPadding="5" style="GroupHeader_DarkGray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="4f966c57-45a7-48a9-b8cd-74e8e583f189" key="staticText-14" x="458" y="63" width="76" height="15" forecolor="#000000" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="10.0" bold="false" hTextAlign="Center" style="GroupHeader_DarkGray">
+			<text><![CDATA[Balance As Of]]></text>
+			<box leftPadding="5" style="GroupHeader_DarkGray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="d1b16e60-acc9-40d5-aec4-480fffb64de4" key="staticText-10" x="385" y="79" width="75" height="15" forecolor="#000000" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="10.0" bold="false" hTextAlign="Center" style="GroupHeader_DarkGray">
+			<text><![CDATA[Credit]]></text>
+			<box leftPadding="5" rightPadding="3" style="GroupHeader_DarkGray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="61d34191-b2a6-4268-8e2f-ebe43855a52e" key="staticText-11" x="310" y="79" width="75" height="15" forecolor="#000000" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="10.0" bold="false" hTextAlign="Center" style="GroupHeader_DarkGray">
+			<text><![CDATA[Debit]]></text>
+			<box leftPadding="5" rightPadding="3" style="GroupHeader_DarkGray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="62eaaa51-c45c-423a-ba6b-52997d6b74ef" mode="Opaque" x="232" y="79" width="75" height="15" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Center" vTextAlign="Middle">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA[$P{DATE_FROM}]]></expression>
+		</element>
+		<element kind="textField" uuid="49e6402f-ac21-4a8e-859c-0ed69027e204" mode="Opaque" x="459" y="79" width="77" height="15" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Center" vTextAlign="Middle">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA[$P{DATE_TO}]]></expression>
+		</element>
+		<element kind="line" uuid="d21f46b0-d48d-449f-8d10-d79ed6f19a36" key="line-1" x="3" y="59" width="531" height="1" forecolor="#555555"/>
+		<element kind="line" uuid="406692f7-5592-4dc0-bc07-722bf3818fbb" key="line-1" x="316" y="79" width="140" height="1" forecolor="#555555"/>
+		<element kind="line" uuid="8d5b2165-7cb3-465f-b9fd-dbdcf8db86b3" key="line-1" x="2" y="95" width="532" height="1" forecolor="#555555"/>
+		<element kind="staticText" uuid="9b5ad912-d21e-4c19-a306-330d05f4e614" key="staticText-14" stretchType="ElementGroupHeight" x="0" y="79" width="72" height="15" forecolor="#000000" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="10.0" printWhenDetailOverflows="true" bold="false" style="GroupHeader_DarkGray">
+			<text><![CDATA[Account No.]]></text>
+			<box leftPadding="5" style="GroupHeader_DarkGray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="26" splitType="Stretch">
-			<frame>
-				<reportElement key="frame-2" style="Report_Footer" x="0" y="0" width="535" height="14" isRemoveLineWhenBlank="true" uuid="e3802ec3-df4e-4c6d-9d5c-e19917e3ec7d">
+			<element kind="frame" uuid="e3802ec3-df4e-4c6d-9d5c-e19917e3ec7d" key="frame-2" x="0" y="0" width="535" height="14" removeLineWhenBlank="true" style="Report_Footer">
+				<printWhenExpression><![CDATA[$P{SUBACCOUNTVIEW}]]></printWhenExpression>
+				<element kind="textField" uuid="2172066b-7713-4b98-a364-cebcb50b2400" key="textField-17" x="14" y="4" width="217" height="10" fontName="DejaVu Sans" fontSize="8.0" evaluationTime="Band" blankWhenNull="false" style="Report_Footer">
 					<printWhenExpression><![CDATA[$P{SUBACCOUNTVIEW}]]></printWhenExpression>
-				</reportElement>
-				<box>
+					<expression><![CDATA[($F{GROUPBYNAME}==null) ? new String("") : $F{GROUPBYNAME}]]></expression>
+					<box leftPadding="5" style="Report_Footer">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="b1061066-16f8-4106-99b8-ce033bf08ee1" key="textField-18" x="234" y="4" width="75" height="10" fontName="DejaVu Sans" fontSize="8.0" evaluationTime="Band" blankWhenNull="false" hTextAlign="Right" style="Report_Footer">
+					<printWhenExpression><![CDATA[$P{SUBACCOUNTVIEW}]]></printWhenExpression>
+					<expression><![CDATA[($F{SALDO_INICIAL}!=null) ? $P{NUMBERFORMAT}.format($F{SALDO_INICIAL}).toString() : new String(" ")]]></expression>
+					<box rightPadding="3" style="Report_Footer">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="d250f6d2-8cf5-43f9-b0b1-079596be3603" key="textField-19" x="310" y="4" width="75" height="10" fontName="DejaVu Sans" fontSize="8.0" evaluationTime="Band" blankWhenNull="false" hTextAlign="Right" style="Report_Footer">
+					<printWhenExpression><![CDATA[$P{SUBACCOUNTVIEW}]]></printWhenExpression>
+					<expression><![CDATA[($F{AMTACCTDR}!=null) ? $P{NUMBERFORMAT}.format($F{AMTACCTDR}).toString() : new String(" ")]]></expression>
+					<box rightPadding="3" style="Report_Footer">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="325bd0ff-436d-4a0b-bcb1-86409989182f" key="textField-20" x="384" y="4" width="75" height="10" fontName="DejaVu Sans" fontSize="8.0" evaluationTime="Band" blankWhenNull="false" hTextAlign="Right" style="Report_Footer">
+					<printWhenExpression><![CDATA[$P{SUBACCOUNTVIEW}]]></printWhenExpression>
+					<expression><![CDATA[($F{AMTACCTCR}!=null) ? $P{NUMBERFORMAT}.format($F{AMTACCTCR}).toString() : new String(" ")]]></expression>
+					<box rightPadding="3" style="Report_Footer">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="f740d65f-3563-4760-8909-fc8d73df7d80" key="textField-21" x="460" y="4" width="75" height="10" fontName="DejaVu Sans" fontSize="8.0" evaluationTime="Band" blankWhenNull="false" hTextAlign="Right" style="Report_Footer">
+					<printWhenExpression><![CDATA[$P{SUBACCOUNTVIEW}]]></printWhenExpression>
+					<expression><![CDATA[($F{SALDO_FINAL}!=null) ? $P{NUMBERFORMAT}.format($F{SALDO_FINAL}).toString() : new String(" ")]]></expression>
+					<box rightPadding="3" style="Report_Footer">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<box style="Report_Footer">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textField evaluationTime="Band" isBlankWhenNull="false">
-					<reportElement key="textField-17" style="Report_Footer" x="14" y="4" width="217" height="10" uuid="2172066b-7713-4b98-a364-cebcb50b2400">
-						<printWhenExpression><![CDATA[$P{SUBACCOUNTVIEW}]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+			</element>
+			<element kind="frame" uuid="1c207ecd-174c-4c1c-90aa-70b193d5cf62" key="frame-4" x="-1" y="14" width="536" height="12" removeLineWhenBlank="true" style="Report_Footer">
+				<printWhenExpression><![CDATA[$P{DEFAULTVIEW}]]></printWhenExpression>
+				<element kind="textField" uuid="59b61a56-6ae0-44ec-a7de-2517e1a930a9" key="textField-24" x="234" y="0" width="75" height="12" fontName="DejaVu Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Right" style="Report_Footer">
+					<expression><![CDATA[($F{SALDO_INICIAL}!=null) ? $P{NUMBERFORMAT}.format($F{SALDO_INICIAL}).toString() : new String(" ")]]></expression>
+					<box topPadding="1" rightPadding="3" style="Report_Footer">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{GROUPBYNAME}==null) ? new String("") : $F{GROUPBYNAME}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Band" isBlankWhenNull="false">
-					<reportElement key="textField-18" style="Report_Footer" x="234" y="4" width="75" height="10" uuid="b1061066-16f8-4106-99b8-ce033bf08ee1">
-						<printWhenExpression><![CDATA[$P{SUBACCOUNTVIEW}]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="9329abcb-5ef4-42a5-a4b2-6a4102874fe3" key="textField-28" x="66" y="0" width="166" height="12" fontName="DejaVu Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Left" style="Report_Footer">
+					<expression><![CDATA[$F{NAME}]]></expression>
+					<box topPadding="1" leftPadding="5" style="Report_Footer">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{SALDO_INICIAL}!=null) ? $P{NUMBERFORMAT}.format($F{SALDO_INICIAL}).toString() : new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Band" isBlankWhenNull="false">
-					<reportElement key="textField-19" style="Report_Footer" x="310" y="4" width="75" height="10" uuid="d250f6d2-8cf5-43f9-b0b1-079596be3603">
-						<printWhenExpression><![CDATA[$P{SUBACCOUNTVIEW}]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="4bd27895-c30a-433a-b664-988d911e83a5" key="textField-25" x="309" y="0" width="75" height="12" fontName="DejaVu Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Right" style="Report_Footer">
+					<expression><![CDATA[($F{AMTACCTDR}!=null) ? $P{NUMBERFORMAT}.format($F{AMTACCTDR}).toString() : new String(" ")]]></expression>
+					<box topPadding="1" rightPadding="3" style="Report_Footer">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{AMTACCTDR}!=null) ? $P{NUMBERFORMAT}.format($F{AMTACCTDR}).toString() : new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Band" isBlankWhenNull="false">
-					<reportElement key="textField-20" style="Report_Footer" x="384" y="4" width="75" height="10" uuid="325bd0ff-436d-4a0b-bcb1-86409989182f">
-						<printWhenExpression><![CDATA[$P{SUBACCOUNTVIEW}]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="84d5d253-4904-4557-8c39-fad6224ad346" key="textField-26" x="384" y="0" width="75" height="12" fontName="DejaVu Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Right" style="Report_Footer">
+					<expression><![CDATA[($F{AMTACCTCR}!=null) ? $P{NUMBERFORMAT}.format($F{AMTACCTCR}).toString() : new String(" ")]]></expression>
+					<box topPadding="1" rightPadding="3" style="Report_Footer">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{AMTACCTCR}!=null) ? $P{NUMBERFORMAT}.format($F{AMTACCTCR}).toString() : new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Band" isBlankWhenNull="false">
-					<reportElement key="textField-21" style="Report_Footer" x="460" y="4" width="75" height="10" uuid="f740d65f-3563-4760-8909-fc8d73df7d80">
-						<printWhenExpression><![CDATA[$P{SUBACCOUNTVIEW}]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="6faaa4cb-8b89-4b79-a5c2-198211d7f682" key="textField-27" x="460" y="0" width="75" height="12" fontName="DejaVu Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Right" style="Report_Footer">
+					<expression><![CDATA[($F{SALDO_FINAL}!=null) ? $P{NUMBERFORMAT}.format($F{SALDO_FINAL}).toString() : new String(" ")]]></expression>
+					<box topPadding="1" rightPadding="3" style="Report_Footer">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{SALDO_FINAL}!=null) ? $P{NUMBERFORMAT}.format($F{SALDO_FINAL}).toString() : new String(" ")]]></textFieldExpression>
-				</textField>
-			</frame>
-			<frame>
-				<reportElement key="frame-4" style="Report_Footer" x="-1" y="14" width="536" height="12" isRemoveLineWhenBlank="true" uuid="1c207ecd-174c-4c1c-90aa-70b193d5cf62">
-					<printWhenExpression><![CDATA[$P{DEFAULTVIEW}]]></printWhenExpression>
-				</reportElement>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-24" style="Report_Footer" x="234" y="0" width="75" height="12" uuid="59b61a56-6ae0-44ec-a7de-2517e1a930a9"/>
-					<box topPadding="1" rightPadding="3">
+				</element>
+				<element kind="textField" uuid="19ebdee3-379d-4a23-b0d5-c9e3d5825d47" key="textField-28" x="1" y="0" width="67" height="12" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="false" hTextAlign="Left" style="Report_Footer">
+					<expression><![CDATA[$F{ACCOUNT_ID}]]></expression>
+					<box topPadding="1" leftPadding="5" style="Report_Footer">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{SALDO_INICIAL}!=null) ? $P{NUMBERFORMAT}.format($F{SALDO_INICIAL}).toString() : new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-28" style="Report_Footer" x="66" y="0" width="166" height="12" uuid="9329abcb-5ef4-42a5-a4b2-6a4102874fe3"/>
-					<box topPadding="1" leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Left">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NAME}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-25" style="Report_Footer" x="309" y="0" width="75" height="12" uuid="4bd27895-c30a-433a-b664-988d911e83a5"/>
-					<box topPadding="1" rightPadding="3">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{AMTACCTDR}!=null) ? $P{NUMBERFORMAT}.format($F{AMTACCTDR}).toString() : new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-26" style="Report_Footer" x="384" y="0" width="75" height="12" uuid="84d5d253-4904-4557-8c39-fad6224ad346"/>
-					<box topPadding="1" rightPadding="3">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{AMTACCTCR}!=null) ? $P{NUMBERFORMAT}.format($F{AMTACCTCR}).toString() : new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-27" style="Report_Footer" x="460" y="0" width="75" height="12" uuid="6faaa4cb-8b89-4b79-a5c2-198211d7f682"/>
-					<box topPadding="1" rightPadding="3">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{SALDO_FINAL}!=null) ? $P{NUMBERFORMAT}.format($F{SALDO_FINAL}).toString() : new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-					<reportElement key="textField-28" style="Report_Footer" x="1" y="0" width="67" height="12" uuid="19ebdee3-379d-4a23-b0d5-c9e3d5825d47"/>
-					<box topPadding="1" leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Left">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{ACCOUNT_ID}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="AccountGroup" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-11" mode="Opaque" x="310" y="0" width="75" height="12" forecolor="#000000" backcolor="#FFFFFF" uuid="b49bda0a-3eed-4b77-b416-34bb3d0e58d1"/>
+				</element>
+				<element kind="textField" uuid="b49bda0a-3eed-4b77-b416-34bb3d0e58d1" key="textField-11" mode="Opaque" x="310" y="0" width="75" height="12" forecolor="#000000" backcolor="#FFFFFF" rotation="None" markup="none" fontName="DejaVu Sans" fontSize="8.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" evaluationTime="Group" pattern="" evaluationGroup="AccountGroup" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Top">
+					<paragraph lineSpacing="Single"/>
+					<expression><![CDATA[($V{TOTAL_DEBIT}!=null) ? $P{NUMBERFORMAT}.format($V{TOTAL_DEBIT}).toString() : new String(" ")]]></expression>
 					<box topPadding="2" rightPadding="3">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Top" rotation="None" markup="none">
-						<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="Cp1252" isPdfEmbedded="false"/>
-						<paragraph lineSpacing="Single"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{TOTAL_DEBIT}!=null) ? $P{NUMBERFORMAT}.format($V{TOTAL_DEBIT}).toString() : new String(" ")]]></textFieldExpression>
-				</textField>
-			</frame>
+				</element>
+				<box style="Report_Footer">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="40" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-7" style="Report_Footer" x="0" y="0" width="140" height="16" uuid="94ae928d-ce31-40c0-8c94-ff9681716f6e">
-					<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
-				</reportElement>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<text><![CDATA[other footer data]]></text>
-			</staticText>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-35" style="Report_Footer" x="245" y="15" width="257" height="16" uuid="6f2f170e-da87-436c-af00-9ce6ed41bb16"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{PAGEOF}.replace("{P}",(new java.lang.Integer(($V{PAGE_NUMBER}.intValue()) +(Integer.parseInt($P{PageNo}))-(1) )).toString())]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report">
-				<reportElement key="" x="504" y="16" width="28" height="16" uuid="e87f71a1-f1ff-4d58-8f3e-2bda39976992"/>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[(new java.lang.Integer($V{PAGE_NUMBER})).toString()]]></textFieldExpression>
-			</textField>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="40" splitType="Stretch">
+		<element kind="staticText" uuid="94ae928d-ce31-40c0-8c94-ff9681716f6e" key="staticText-7" x="0" y="0" width="140" height="16" fontName="DejaVu Sans" fontSize="8.0" style="Report_Footer">
+			<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
+			<text><![CDATA[other footer data]]></text>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="6f2f170e-da87-436c-af00-9ce6ed41bb16" key="textField-35" x="245" y="15" width="257" height="16" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[$P{PAGEOF}.replace("{P}",(new java.lang.Integer(($V{PAGE_NUMBER}.intValue()) +(Integer.parseInt($P{PageNo}))-(1) )).toString())]]></expression>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="e87f71a1-f1ff-4d58-8f3e-2bda39976992" key="" x="504" y="16" width="28" height="16" fontName="DejaVu Sans" fontSize="8.0" evaluationTime="Report" hTextAlign="Left" vTextAlign="Middle">
+			<expression><![CDATA[(new java.lang.Integer($V{PAGE_NUMBER})).toString()]]></expression>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportWarehousePartnerJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportWarehousePartnerJR.jrxml
@@ -1,70 +1,68 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportWarehousePartnerJR" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="7761643a-888d-4085-bd65-842b0ef65ab1">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportWarehousePartnerJR" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="7761643a-888d-4085-bd65-842b0ef65ab1">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
-	<style name="Detail_Line" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<style name="Detail_Line" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0">
 			<conditionExpression><![CDATA[new Boolean($V{CATEGORYNAME_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" isDefault="true" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" default="true" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="ReportData" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="ReportData" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT M_PRODUCT_CATEGORY.NAME AS CATEGORYNAME, M_PRODUCT.VALUE||'-'||M_PRODUCT.NAME AS NAME, SUM(MOVEMENTQTY) AS MOVEMENTQTY, M_LOCATOR.X, M_LOCATOR.Y, 
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT M_PRODUCT_CATEGORY.NAME AS CATEGORYNAME, M_PRODUCT.VALUE||'-'||M_PRODUCT.NAME AS NAME, SUM(MOVEMENTQTY) AS MOVEMENTQTY, M_LOCATOR.X, M_LOCATOR.Y, 
       AD_COLUMN_IDENTIFIER('M_WAREHOUSE', to_char(M_LOCATOR.M_WAREHOUSE_ID), 'es_ES') AS WAREHOUSE,
       M_LOCATOR.Z, C1.NAME AS UOMMOVEMENTQTY, M_ATTRIBUTESETINSTANCE.M_ATTRIBUTESETINSTANCE_ID, M_ATTRIBUTESETINSTANCE.DESCRIPTION,
       (CASE WHEN M_TRANSACTION.M_PRODUCT_UOM_ID IS NULL THEN (CASE M_PRODUCT.WEIGHT*SUM(M_TRANSACTION.MOVEMENTQTY) WHEN 0 THEN NULL ELSE M_PRODUCT.WEIGHT*SUM(M_TRANSACTION.MOVEMENTQTY) END) ELSE SUM(M_TRANSACTION.QUANTITYORDER) END) AS WEIGHT, 
@@ -80,8 +78,7 @@
       AND 1=1
       GROUP BY M_PRODUCT_CATEGORY.NAME,M_PRODUCT.VALUE, M_PRODUCT.NAME, M_ATTRIBUTESETINSTANCE.M_ATTRIBUTESETINSTANCE_ID, M_ATTRIBUTESETINSTANCE.DESCRIPTION, M_LOCATOR.M_LOCATOR_ID, M_LOCATOR.X, M_LOCATOR.Y, M_LOCATOR.Z, C1.NAME, M_PRODUCT.WEIGHT, C1.C_UOM_ID, M_TRANSACTION.M_PRODUCT_UOM_ID, C2.NAME, M_LOCATOR.M_WAREHOUSE_ID
       HAVING SUM(MOVEMENTQTY) > 0
-      ORDER BY  M_PRODUCT_CATEGORY.NAME,M_PRODUCT.VALUE, M_PRODUCT.NAME, M_ATTRIBUTESETINSTANCE.DESCRIPTION,M_LOCATOR.X, M_LOCATOR.Y, M_LOCATOR.Z]]>
-	</queryString>
+      ORDER BY  M_PRODUCT_CATEGORY.NAME,M_PRODUCT.VALUE, M_PRODUCT.NAME, M_ATTRIBUTESETINSTANCE.DESCRIPTION,M_LOCATOR.X, M_LOCATOR.Y, M_LOCATOR.Z]]></query>
 	<field name="CATEGORYNAME" class="java.lang.String"/>
 	<field name="NAME" class="java.lang.String"/>
 	<field name="MOVEMENTQTY" class="java.math.BigDecimal"/>
@@ -97,394 +94,296 @@
 	<field name="ID" class="java.lang.String"/>
 	<variable name="DetailFieldTotal" class="java.lang.String"/>
 	<group name="CATEGORYNAME">
-		<groupExpression><![CDATA[$F{CATEGORYNAME}]]></groupExpression>
+		<expression><![CDATA[$F{CATEGORYNAME}]]></expression>
 		<groupHeader>
 			<band height="44" splitType="Stretch">
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="0" y="0" width="535" height="23" uuid="e9b85e2d-640f-4e60-a4b2-53927616e3e2"/>
-					<box leftPadding="5">
+				<element kind="textField" uuid="e9b85e2d-640f-4e60-a4b2-53927616e3e2" key="textField" x="0" y="0" width="535" height="23" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{CATEGORYNAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{CATEGORYNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="44" forecolor="#555555" uuid="f81fc0e4-25e2-4fd2-8835-641ab909737e"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="10" y="28" width="139" height="16" uuid="4b302104-cdaa-4b94-b93f-48f50ead4fce"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
+				</element>
+				<element kind="line" uuid="f81fc0e4-25e2-4fd2-8835-641ab909737e" key="line-3" stretchType="ContainerHeight" x="535" y="0" width="1" height="44" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="4b302104-cdaa-4b94-b93f-48f50ead4fce" key="element-90" x="10" y="28" width="139" height="16" style="Detail_Header">
 					<text><![CDATA[Article]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="149" y="28" width="64" height="16" uuid="60459cc7-cb54-4cc8-a74e-8fcc48eff5c6"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="60459cc7-cb54-4cc8-a74e-8fcc48eff5c6" key="element-90" x="149" y="28" width="64" height="16" style="Detail_Header">
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="314" y="28" width="12" height="16" uuid="0020041b-4279-44c8-9383-247b18cc202d"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="0020041b-4279-44c8-9383-247b18cc202d" key="element-90" x="314" y="28" width="12" height="16" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
 					<text><![CDATA[X]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="326" y="28" width="12" height="16" uuid="74a85381-eae7-4544-af43-6e5a5d51c35f"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="74a85381-eae7-4544-af43-6e5a5d51c35f" key="element-90" x="326" y="28" width="12" height="16" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
 					<text><![CDATA[Y]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="417" y="28" width="116" height="16" uuid="ad7d58f8-f407-4216-9cae-282292af864f"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="ad7d58f8-f407-4216-9cae-282292af864f" key="element-90" x="417" y="28" width="116" height="16" style="Detail_Header">
 					<text><![CDATA[Warehouse]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="338" y="28" width="12" height="16" uuid="23ca49c4-df67-4767-80cb-f1587e96a43a"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="23ca49c4-df67-4767-80cb-f1587e96a43a" key="element-90" x="338" y="28" width="12" height="16" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
 					<text><![CDATA[Z]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="213" y="28" width="37" height="16" uuid="fb99cf48-8b90-446c-a8cc-e75f0d686e03"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="fb99cf48-8b90-446c-a8cc-e75f0d686e03" key="element-90" x="213" y="28" width="37" height="16" style="Detail_Header">
 					<text><![CDATA[Unit]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="250" y="28" width="64" height="16" uuid="368fac87-ad56-419c-9fd8-8e3dd59df724"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="368fac87-ad56-419c-9fd8-8e3dd59df724" key="element-90" x="250" y="28" width="64" height="16" style="Detail_Header">
 					<text><![CDATA[Attribute]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="350" y="28" width="67" height="16" uuid="f5364d19-b0a3-4790-8955-e421ecc2cb37"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="f5364d19-b0a3-4790-8955-e421ecc2cb37" key="element-90" x="350" y="28" width="67" height="16" style="Detail_Header">
 					<text><![CDATA[Other unit]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-37" stretchType="RelativeToBandHeight" x="1" y="23" width="1" height="21" forecolor="#555555" uuid="c369d377-4090-481d-a310-5cabb3178e9c"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="line" uuid="c369d377-4090-481d-a310-5cabb3178e9c" key="line-37" stretchType="ContainerHeight" x="1" y="23" width="1" height="21" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="15" forecolor="#555555" uuid="8c1e276d-a12f-47e2-b183-a062c6f752fb"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-34" x="1" y="14" width="534" height="1" forecolor="#555555" uuid="704a11c0-e049-4f07-8918-8337e862be93"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-36" mode="Opaque" x="11" y="0" width="522" height="1" forecolor="#666666" uuid="9038eadc-9312-4f2e-81e7-7d04e7460733"/>
-					<graphicElement>
-						<pen lineWidth="0.25" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-39" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="14" forecolor="#555555" uuid="e6e2f452-2f5b-49bc-a062-929758a7b460"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="8c1e276d-a12f-47e2-b183-a062c6f752fb" key="line-33" stretchType="ContainerHeight" x="535" y="0" width="1" height="15" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="704a11c0-e049-4f07-8918-8337e862be93" key="line-34" x="1" y="14" width="534" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="9038eadc-9312-4f2e-81e7-7d04e7460733" key="line-36" mode="Opaque" x="11" y="0" width="522" height="1" forecolor="#666666">
+					<pen lineWidth="0.25" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="e6e2f452-2f5b-49bc-a062-929758a7b460" key="line-39" stretchType="ContainerHeight" x="1" y="0" width="1" height="14" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="46" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Title" mode="Transparent" x="0" y="0" width="535" height="20" uuid="aa628db4-8bef-4028-8377-144e1b9cb07e"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-35" x="0" y="27" width="535" height="1" uuid="b9233759-fce9-4ff6-8f46-399a8adfa0cf"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-		</band>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader height="46" splitType="Stretch">
+		<element kind="textField" uuid="aa628db4-8bef-4028-8377-144e1b9cb07e" key="textField" mode="Transparent" x="0" y="0" width="535" height="20" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="b9233759-fce9-4ff6-8f46-399a8adfa0cf" key="line-35" x="0" y="27" width="535" height="1">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="16" forecolor="#555555" uuid="4b276c5c-e93d-4b13-99c7-c709d798d9f5"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-1" style="Detail_Line" stretchType="RelativeToBandHeight" x="10" y="0" width="139" height="16" uuid="9649c031-de81-4495-98e0-3cff0e428da0"/>
-				<box leftPadding="1" rightPadding="1">
+			<element kind="line" uuid="4b276c5c-e93d-4b13-99c7-c709d798d9f5" key="line-16" stretchType="ContainerHeight" x="535" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="9649c031-de81-4495-98e0-3cff0e428da0" key="textField-1" stretchType="ContainerHeight" x="10" y="0" width="139" height="16" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{NAME}]]></expression>
+				<box leftPadding="1" rightPadding="1" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{NAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-2" style="Detail_Line" stretchType="RelativeToBandHeight" x="149" y="0" width="64" height="16" uuid="a59426ac-ef33-4fb4-b402-57c2ebfe322e"/>
-				<box leftPadding="1" rightPadding="1">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[($F{MOVEMENTQTY}!=null)?$F{MOVEMENTQTY}:BigDecimal.ZERO]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="a59426ac-ef33-4fb4-b402-57c2ebfe322e" key="textField-2" stretchType="ContainerHeight" x="149" y="0" width="64" height="16" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{MOVEMENTQTY}!=null)?$F{MOVEMENTQTY}:BigDecimal.ZERO]]></expression>
 				<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-3" style="Detail_Line" stretchType="RelativeToBandHeight" x="213" y="0" width="37" height="16" uuid="4250c75d-2558-4b47-a8c7-87583022251f"/>
-				<box leftPadding="1" rightPadding="1">
+				<box leftPadding="1" rightPadding="1" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{UOMMOVEMENTQTY}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-4" style="Detail_Line" stretchType="RelativeToBandHeight" x="250" y="0" width="64" height="16" uuid="c258e713-674a-4a84-82fe-5a69c3f15f37"/>
-				<box leftPadding="1" rightPadding="1">
+			</element>
+			<element kind="textField" uuid="4250c75d-2558-4b47-a8c7-87583022251f" key="textField-3" stretchType="ContainerHeight" x="213" y="0" width="37" height="16" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{UOMMOVEMENTQTY}]]></expression>
+				<box leftPadding="1" rightPadding="1" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[($F{DESCRIPTION}==null)?new String("  "):$F{DESCRIPTION}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-5" style="Detail_Line" stretchType="RelativeToBandHeight" x="314" y="0" width="12" height="16" uuid="152d12a8-9fc7-4e5a-885b-07fff41947df"/>
-				<box leftPadding="1" rightPadding="1">
+			</element>
+			<element kind="textField" uuid="c258e713-674a-4a84-82fe-5a69c3f15f37" key="textField-4" stretchType="ContainerHeight" x="250" y="0" width="64" height="16" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{DESCRIPTION}==null)?new String("  "):$F{DESCRIPTION}]]></expression>
+				<box leftPadding="1" rightPadding="1" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{X}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-6" style="Detail_Line" stretchType="RelativeToBandHeight" x="326" y="0" width="12" height="16" uuid="24b7690b-1fb0-4cdd-8162-4f92236416cc"/>
-				<box leftPadding="1" rightPadding="1">
+			</element>
+			<element kind="textField" uuid="152d12a8-9fc7-4e5a-885b-07fff41947df" key="textField-5" stretchType="ContainerHeight" x="314" y="0" width="12" height="16" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{X}]]></expression>
+				<box leftPadding="1" rightPadding="1" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{Y}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-7" style="Detail_Line" stretchType="RelativeToBandHeight" x="338" y="0" width="12" height="16" uuid="13831f7e-8f5f-425b-82ac-d80098510a05"/>
-				<box leftPadding="1" rightPadding="1">
+			</element>
+			<element kind="textField" uuid="24b7690b-1fb0-4cdd-8162-4f92236416cc" key="textField-6" stretchType="ContainerHeight" x="326" y="0" width="12" height="16" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{Y}]]></expression>
+				<box leftPadding="1" rightPadding="1" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{Z}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-8" style="Detail_Line" stretchType="RelativeToBandHeight" x="350" y="0" width="45" height="16" uuid="a2454f2f-3922-4085-a080-4f22a79a05a4"/>
-				<box leftPadding="1" rightPadding="1">
+			</element>
+			<element kind="textField" uuid="13831f7e-8f5f-425b-82ac-d80098510a05" key="textField-7" stretchType="ContainerHeight" x="338" y="0" width="12" height="16" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{Z}]]></expression>
+				<box leftPadding="1" rightPadding="1" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[($F{WEIGHT}!=null)?$F{WEIGHT}:BigDecimal.ZERO]]></textFieldExpression>
+			</element>
+			<element kind="textField" uuid="a2454f2f-3922-4085-a080-4f22a79a05a4" key="textField-8" stretchType="ContainerHeight" x="350" y="0" width="45" height="16" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{WEIGHT}!=null)?$F{WEIGHT}:BigDecimal.ZERO]]></expression>
 				<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-9" style="Detail_Line" stretchType="RelativeToBandHeight" x="395" y="0" width="22" height="16" uuid="6059b44e-4351-4224-b3ea-01f292055faa"/>
-				<box leftPadding="1" rightPadding="1">
+				<box leftPadding="1" rightPadding="1" style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="6059b44e-4351-4224-b3ea-01f292055faa" key="textField-9" stretchType="ContainerHeight" x="395" y="0" width="22" height="16" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[($F{UOMWEIGHT}==null)?new String("  "):$F{UOMWEIGHT}]]></expression>
+				<box leftPadding="1" rightPadding="1" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 				</box>
-				<textElement verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[($F{UOMWEIGHT}==null)?new String("  "):$F{UOMWEIGHT}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-10" style="Detail_Line" stretchType="RelativeToBandHeight" x="417" y="0" width="116" height="16" uuid="21c43f78-6a8c-47fe-944e-6d52a4df06dd"/>
-				<box leftPadding="1" rightPadding="1">
+			</element>
+			<element kind="textField" uuid="21c43f78-6a8c-47fe-944e-6d52a4df06dd" key="textField-10" stretchType="ContainerHeight" x="417" y="0" width="116" height="16" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Detail_Line">
+				<expression><![CDATA[$F{WAREHOUSE}]]></expression>
+				<box leftPadding="1" rightPadding="1" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 				</box>
-				<textElement verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$F{WAREHOUSE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-38" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="16" forecolor="#555555" uuid="f192a64a-6306-4ce6-8933-c32f13d4d801"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
+			</element>
+			<element kind="line" uuid="f192a64a-6306-4ce6-8933-c32f13d4d801" key="line-38" stretchType="ContainerHeight" x="1" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="20" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="402" y="4" width="95" height="16" uuid="e5e524e2-4c6b-4277-87b3-876172aaebcd"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="499" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="99190e75-1708-49ef-a080-9018c739ba34"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="1" width="535" height="1" forecolor="#000000" uuid="bb586828-c1d0-4f88-b578-55cf01d1ce9d"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="277" y="4" width="69" height="16" uuid="2353447f-a61d-43cb-8282-181b09af6544"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" style="Report_Footer" x="195" y="4" width="78" height="16" uuid="63d5df6d-664e-4124-9619-45398c9bde11"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="20" splitType="Stretch">
+		<element kind="textField" uuid="e5e524e2-4c6b-4277-87b3-876172aaebcd" key="textField" x="402" y="4" width="95" height="16" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="99190e75-1708-49ef-a080-9018c739ba34" key="textField" x="499" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle" style="Report_Footer">
+			<paragraph lineSpacing="Single" style="Report_Footer"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="bb586828-c1d0-4f88-b578-55cf01d1ce9d" key="line" x="0" y="1" width="535" height="1" forecolor="#000000">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="2353447f-a61d-43cb-8282-181b09af6544" key="textField" x="277" y="4" width="69" height="16" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="63d5df6d-664e-4124-9619-45398c9bde11" key="staticText-1" x="195" y="4" width="78" height="16" hTextAlign="Right" style="Report_Footer">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportWorkRequirementDailyEdit.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportWorkRequirementDailyEdit.jrxml
@@ -1,47 +1,45 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportWorkRequirementDailyEdit" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="cbbcad5d-b527-4b67-9019-9bad04e9ae3d">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportWorkRequirementDailyEdit" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="cbbcad5d-b527-4b67-9019-9bad04e9ae3d">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14"/>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0"/>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{PHASE_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="PRODUCTS" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="PRODUCTS2" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT wr.MA_WorkRequirement_ID AS wrid, pp.NAME AS processplan, wr.STARTDATE AS startdate, wr.ENDDATE AS enddate, 
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="PRODUCTS" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="PRODUCTS2" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<query language="sql"><![CDATA[SELECT wr.MA_WorkRequirement_ID AS wrid, pp.NAME AS processplan, wr.STARTDATE AS startdate, wr.ENDDATE AS enddate, 
       wrp.MA_WRPhase_ID AS wrpid, ps.NAME AS process, wrp.DONEQUANTITY AS quantity, 
       COALESCE(wr.SECONDARYQTY*s.MULTIPLIER,wrp.QUANTITY) AS needqty, 
         wrpp.M_PRODUCT_ID AS productid, pd.NAME AS product, wrpp.MOVEMENTQTY AS needed, wrp.SeqNO, 'Bordes' AS negative,
@@ -61,8 +59,7 @@
         AND wrp.CLOSED = 'N'
         AND wrpp.PRODUCTIONTYPE = '-'
         AND wrpp.ConsumeRM = 'N'
-      ORDER BY enddate, wr.DocumentNo, wrp.SeqNo]]>
-	</queryString>
+      ORDER BY enddate, wr.DocumentNo, wrp.SeqNo]]></query>
 	<field name="WRID" class="java.lang.String"/>
 	<field name="PROCESSPLAN" class="java.lang.String"/>
 	<field name="STARTDATE" class="java.sql.Timestamp"/>
@@ -80,296 +77,222 @@
 	<field name="DOCNO" class="java.lang.String"/>
 	<field name="WRNAME" class="java.lang.String"/>
 	<group name="DOCNO">
-		<groupExpression><![CDATA[$F{DOCNO}]]></groupExpression>
+		<expression><![CDATA[$F{DOCNO}]]></expression>
 		<groupHeader>
 			<band height="31" splitType="Stretch">
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="1" width="1" height="30" forecolor="#555555" uuid="ce0d309f-db8c-4204-93f9-aa118aa984af"/>
-				</line>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="535" y="1" width="1" height="30" forecolor="#555555" uuid="2955af44-05be-48f7-8220-a94a6677b311"/>
-				</line>
-				<staticText>
-					<reportElement key="staticText-4" style="GroupHeader_DarkGray" x="1" y="0" width="224" height="24" uuid="9cf77539-9cd6-43d0-b913-8217e2f1df53"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
+				<element kind="line" uuid="ce0d309f-db8c-4204-93f9-aa118aa984af" key="line-2" stretchType="ContainerHeight" x="0" y="1" width="1" height="30" forecolor="#555555"/>
+				<element kind="line" uuid="2955af44-05be-48f7-8220-a94a6677b311" key="line-3" stretchType="ContainerHeight" x="535" y="1" width="1" height="30" forecolor="#555555"/>
+				<element kind="staticText" uuid="9cf77539-9cd6-43d0-b913-8217e2f1df53" key="staticText-4" x="1" y="0" width="224" height="24" style="GroupHeader_DarkGray">
 					<text><![CDATA[Work requirement]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="291" y="0" width="244" height="24" uuid="a47c1cc7-d244-4475-a5e7-f5c1913e3a69"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{WRNAME}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-6" style="GroupHeader_DarkGray" x="225" y="0" width="66" height="24" uuid="57567015-0337-41e9-866c-af923678d011"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="a47c1cc7-d244-4475-a5e7-f5c1913e3a69" key="textField" x="291" y="0" width="244" height="24" blankWhenNull="false" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{WRNAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="57567015-0337-41e9-866c-af923678d011" key="staticText-6" x="225" y="0" width="66" height="24" style="GroupHeader_DarkGray">
 					<text><![CDATA[Doc. No.]]></text>
-				</staticText>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="16" splitType="Stretch">
-				<line>
-					<reportElement key="line-34" x="0" y="0" width="535" height="1" forecolor="#555555" uuid="ad811597-23ce-4941-a59b-5b7b71c7e17d"/>
-				</line>
+				<element kind="line" uuid="ad811597-23ce-4941-a59b-5b7b71c7e17d" key="line-34" x="0" y="0" width="535" height="1" forecolor="#555555"/>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="PHASE">
-		<groupExpression><![CDATA[$F{WRPID}]]></groupExpression>
+		<expression><![CDATA[$F{WRPID}]]></expression>
 		<groupHeader>
 			<band splitType="Stretch"/>
 		</groupHeader>
 		<groupFooter>
 			<band height="16" splitType="Stretch">
-				<line>
-					<reportElement key="line-38" x="11" y="0" width="524" height="1" forecolor="#555555" uuid="9a03c9ba-543b-49e7-82af-3981a0b95dfe"/>
-				</line>
-				<line>
-					<reportElement key="line-44" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="16" forecolor="#555555" uuid="9f0a673c-3654-4a79-9eef-153fe1bc4922"/>
-				</line>
-				<line>
-					<reportElement key="line-45" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="16" forecolor="#555555" uuid="134ee2ea-9889-4673-86e8-5d8f81547632"/>
-				</line>
+				<element kind="line" uuid="9a03c9ba-543b-49e7-82af-3981a0b95dfe" key="line-38" x="11" y="0" width="524" height="1" forecolor="#555555"/>
+				<element kind="line" uuid="9f0a673c-3654-4a79-9eef-153fe1bc4922" key="line-44" stretchType="ContainerHeight" x="0" y="0" width="1" height="16" forecolor="#555555"/>
+				<element kind="line" uuid="134ee2ea-9889-4673-86e8-5d8f81547632" key="line-45" stretchType="ContainerHeight" x="535" y="0" width="1" height="16" forecolor="#555555"/>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="20" splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="42" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Title" mode="Transparent" x="0" y="0" width="535" height="20" uuid="b68215ec-1bb5-4f68-85fd-bd9f7cdd1ff7"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="20" width="535" height="1" uuid="70c0a88a-c5d8-4b16-bbcc-c53c4cf90572"/>
-			</line>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="20" splitType="Stretch"/>
+	<pageHeader height="42" splitType="Stretch">
+		<element kind="textField" uuid="b68215ec-1bb5-4f68-85fd-bd9f7cdd1ff7" key="textField" mode="Transparent" x="0" y="0" width="535" height="20" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="70c0a88a-c5d8-4b16-bbcc-c53c4cf90572" key="line-1" x="0" y="20" width="535" height="1"/>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="298" splitType="Stretch">
-			<line>
-				<reportElement key="line-6" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="298" forecolor="#555555" uuid="5ea8ed36-1d09-4366-b13f-56f3545263c4"/>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="85" y="23" width="92" height="16" uuid="d5f7432f-f0b4-4dcc-939e-beecab22575c"/>
-				<box leftPadding="5" rightPadding="2">
+			<element kind="line" uuid="5ea8ed36-1d09-4366-b13f-56f3545263c4" key="line-6" stretchType="ContainerHeight" x="535" y="0" width="1" height="298" forecolor="#555555"/>
+			<element kind="textField" uuid="d5f7432f-f0b4-4dcc-939e-beecab22575c" key="textField" x="85" y="23" width="92" height="16" pattern="" blankWhenNull="false" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{NEEDQTY}!=null)?$P{NUMBERFORMAT}.format($F{NEEDQTY}):new String(" ")]]></expression>
+				<box leftPadding="5" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[($F{NEEDQTY}!=null)?$P{NUMBERFORMAT}.format($F{NEEDQTY}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="element-90" style="default" x="24" y="23" width="55" height="16" uuid="fa98d613-20e8-45e7-bfc6-996133880b4f"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
+			</element>
+			<element kind="staticText" uuid="fa98d613-20e8-45e7-bfc6-996133880b4f" key="element-90" x="24" y="23" width="55" height="16" pdfFontName="Helvetica-Bold" bold="true" style="default">
 				<text><![CDATA[Quantity]]></text>
-			</staticText>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="GroupHeader_DarkGray" x="97" y="0" width="438" height="18" uuid="65fae4b2-f4f0-4415-8485-160187d7fce2"/>
-				<box leftPadding="5">
+				<box style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$F{SEQNO}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-5" style="GroupHeader_DarkGray" x="11" y="0" width="86" height="18" uuid="c45d32d8-21cb-4c70-9e30-21d40a365e06"/>
-				<box leftPadding="5">
+			</element>
+			<element kind="textField" uuid="65fae4b2-f4f0-4415-8485-160187d7fce2" key="textField" x="97" y="0" width="438" height="18" pattern="" blankWhenNull="false" style="GroupHeader_DarkGray">
+				<expression><![CDATA[$F{SEQNO}]]></expression>
+				<box leftPadding="5" style="GroupHeader_DarkGray">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
+			</element>
+			<element kind="staticText" uuid="c45d32d8-21cb-4c70-9e30-21d40a365e06" key="staticText-5" x="11" y="0" width="86" height="18" style="GroupHeader_DarkGray">
 				<text><![CDATA[Phase]]></text>
-			</staticText>
-			<line>
-				<reportElement key="line-35" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="298" forecolor="#555555" uuid="d7584640-cdf4-4759-ab27-32eba428f9e8"/>
-			</line>
-			<line>
-				<reportElement key="line-43" stretchType="RelativeToBandHeight" x="10" y="1" width="1" height="297" forecolor="#555555" uuid="4bace6d8-c1b9-4431-b6ab-eef371154176"/>
-			</line>
-			<subreport isUsingCache="true">
-				<reportElement key="subreport-1" x="24" y="47" width="507" height="30" uuid="85809fb4-2bc3-4090-b451-5c7bdf0f0f63"/>
-				<subreportParameter name="WRPID">
-					<subreportParameterExpression><![CDATA[$F{WRPID}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[$P{NUMBERFORMAT}]]></subreportParameterExpression>
-				</subreportParameter>
+				<box leftPadding="5" style="GroupHeader_DarkGray">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="line" uuid="d7584640-cdf4-4759-ab27-32eba428f9e8" key="line-35" stretchType="ContainerHeight" x="0" y="0" width="1" height="298" forecolor="#555555"/>
+			<element kind="line" uuid="4bace6d8-c1b9-4431-b6ab-eef371154176" key="line-43" stretchType="ContainerHeight" x="10" y="1" width="1" height="297" forecolor="#555555"/>
+			<element kind="subreport" uuid="85809fb4-2bc3-4090-b451-5c7bdf0f0f63" key="subreport-1" x="24" y="47" width="507" height="30" usingCache="true">
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{PRODUCTS}]]></subreportExpression>
-			</subreport>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField" x="24" y="161" width="499" height="111" uuid="3cb61610-bfd0-4771-9d58-4b4db2531b83"/>
+				<expression><![CDATA[$P{PRODUCTS}]]></expression>
+				<parameter name="WRPID">
+					<expression><![CDATA[$F{WRPID}]]></expression>
+				</parameter>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[$P{NUMBERFORMAT}]]></expression>
+				</parameter>
+			</element>
+			<element kind="textField" uuid="3cb61610-bfd0-4771-9d58-4b4db2531b83" key="textField" x="24" y="161" width="499" height="111" blankWhenNull="true">
+				<expression><![CDATA[$F{DESCRIPTION}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$F{DESCRIPTION}]]></textFieldExpression>
-			</textField>
-			<subreport isUsingCache="true">
-				<reportElement key="subreport-2" x="24" y="111" width="507" height="30" uuid="241b6ae1-cc31-46fd-bd9c-f3275210bab3"/>
-				<subreportParameter name="WRPID">
-					<subreportParameterExpression><![CDATA[$F{WRPID}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[$P{NUMBERFORMAT}]]></subreportParameterExpression>
-				</subreportParameter>
+			</element>
+			<element kind="subreport" uuid="241b6ae1-cc31-46fd-bd9c-f3275210bab3" key="subreport-2" x="24" y="111" width="507" height="30" usingCache="true">
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{PRODUCTS2}]]></subreportExpression>
-			</subreport>
-			<staticText>
-				<reportElement key="staticText-9" style="GroupHeader_Gray" x="24" y="95" width="337" height="15" uuid="22c784b8-6fe7-41ac-a1a1-09f611b6c95f"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
+				<expression><![CDATA[$P{PRODUCTS2}]]></expression>
+				<parameter name="WRPID">
+					<expression><![CDATA[$F{WRPID}]]></expression>
+				</parameter>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[$P{NUMBERFORMAT}]]></expression>
+				</parameter>
+			</element>
+			<element kind="staticText" uuid="22c784b8-6fe7-41ac-a1a1-09f611b6c95f" key="staticText-9" x="24" y="95" width="337" height="15" style="GroupHeader_Gray">
 				<text><![CDATA[Product]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-91" style="GroupHeader_Gray" x="361" y="95" width="170" height="15" uuid="bacb2842-1be3-4631-8d88-0a37b6ed1620"/>
-				<box>
+				<box topPadding="2" leftPadding="5" style="GroupHeader_Gray">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font pdfFontName="Helvetica-Bold"/>
-				</textElement>
+			</element>
+			<element kind="staticText" uuid="bacb2842-1be3-4631-8d88-0a37b6ed1620" key="element-91" x="361" y="95" width="170" height="15" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="GroupHeader_Gray">
 				<text><![CDATA[Required qty.]]></text>
-			</staticText>
+				<box style="GroupHeader_Gray">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="27" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="471" y="4" width="10" height="19" isPrintWhenDetailOverflows="true" uuid="c7834f34-fc9e-4ba3-83b4-c4ec9a258e51"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Bottom">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="509" y="4" width="22" height="19" isPrintWhenDetailOverflows="true" forecolor="#000000" backcolor="#FFFFFF" uuid="f965e3d5-80ab-4452-99f0-7c77f5e9543a"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Bottom" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="1" width="535" height="1" forecolor="#000000" uuid="fead8a48-e2b9-45df-a2db-ca976042b7a0"/>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="277" y="4" width="69" height="19" uuid="69b63298-4a91-4de8-8418-bf0fb1292e30"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Bottom">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" x="195" y="4" width="78" height="19" uuid="0e93caa7-a060-4ec8-b947-b5dba378aa88"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-7" x="481" y="4" width="26" height="19" uuid="63173725-7c1b-4bd7-a418-6c92658c42e2"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center" verticalAlignment="Bottom"/>
-				<text><![CDATA[of]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-8" x="390" y="4" width="69" height="19" uuid="b906bd92-6dc3-47b4-843d-0703d9732754"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom"/>
-				<text><![CDATA[Page]]></text>
-			</staticText>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="27" splitType="Stretch">
+		<element kind="textField" uuid="c7834f34-fc9e-4ba3-83b4-c4ec9a258e51" key="textField" x="471" y="4" width="10" height="19" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" printWhenDetailOverflows="true" hTextAlign="Center" vTextAlign="Bottom">
+			<expression><![CDATA[$V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="f965e3d5-80ab-4452-99f0-7c77f5e9543a" key="textField" x="509" y="4" width="22" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" printWhenDetailOverflows="true" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Center" vTextAlign="Bottom">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA[$V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="fead8a48-e2b9-45df-a2db-ca976042b7a0" key="line" x="0" y="1" width="535" height="1" forecolor="#000000"/>
+		<element kind="textField" uuid="69b63298-4a91-4de8-8418-bf0fb1292e30" key="textField" x="277" y="4" width="69" height="19" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Bottom">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="0e93caa7-a060-4ec8-b947-b5dba378aa88" key="staticText-1" x="195" y="4" width="78" height="19" hTextAlign="Right" vTextAlign="Bottom">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="63173725-7c1b-4bd7-a418-6c92658c42e2" key="staticText-7" x="481" y="4" width="26" height="19" hTextAlign="Center" vTextAlign="Bottom">
+			<text><![CDATA[of]]></text>
+			<box topPadding="2" leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="b906bd92-6dc3-47b4-843d-0703d9732754" key="staticText-8" x="390" y="4" width="69" height="19" hTextAlign="Right" vTextAlign="Bottom">
+			<text><![CDATA[Page]]></text>
+			<box topPadding="2" leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/ReportWorkRequirementJR.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/ReportWorkRequirementJR.jrxml
@@ -1,74 +1,71 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportWorkRequirementJR" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="66e7cffd-a0f8-4b81-a5dc-7105fb95028b">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportWorkRequirementJR" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="66e7cffd-a0f8-4b81-a5dc-7105fb95028b">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Group_Data_Label" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true">
+	<style name="Group_Data_Label" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="Detail_Line" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9">
-		<conditionalStyle>
+	<style name="Detail_Line" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9.0">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Red" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9">
-		<conditionalStyle>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Red" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9.0">
+		<conditionalStyle forecolor="#FF0000" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9.0">
 			<conditionExpression><![CDATA[new Boolean($F{NEEDED}.compareTo($F{STOCK}.add($F{INPROCESS}))>1)]]></conditionExpression>
-			<style forecolor="#FF0000" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9"/>
 		</conditionalStyle>
 	</style>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["('1000000')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["('0')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Pending Work Requirement"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="ReportData" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="ReportData" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT wr.MA_WorkRequirement_ID AS wrid, AD_COLUMN_IDENTIFIER('MA_WorkRequirement', wr.MA_WORKREQUIREMENT_ID, 'es_ES') AS wrname, 
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT wr.MA_WorkRequirement_ID AS wrid, AD_COLUMN_IDENTIFIER('MA_WorkRequirement', wr.MA_WORKREQUIREMENT_ID, 'es_ES') AS wrname, 
        AD_COLUMN_IDENTIFIER('MA_ProcessPlan', pp.MA_ProcessPlan_ID, 'es_ES') AS processplan, 
        wr.STARTDATE AS startdate, wr.ENDDATE AS enddate, wrp.SeqNO,
        AD_COLUMN_IDENTIFIER('MA_WRPhase', wrp.MA_WRPhase_ID, 'es_ES') AS wrpname, 
@@ -88,8 +85,7 @@ AND wrp.CLOSED = 'N'
 AND wrpp.PRODUCTIONTYPE = '-'
 GROUP BY wr.MA_WorkRequirement_ID, wrp.MA_WRPHASE_ID, wr.DOCUMENTNO, pp.MA_ProcessPlan_ID, wr.STARTDATE, wr.ENDDATE,
          ps.MA_Process_ID, wrp.DONEQUANTITY, wrp.QUANTITY, pd.M_PRODUCT_ID, wrpp.MOVEMENTQTY, wrp.SeqNo, wrpp.M_PRODUCT_ID
-ORDER BY enddate, wr.MA_WorkRequirement_ID, wrp.SeqNo, wrp.MA_WRPHASE_ID]]>
-	</queryString>
+ORDER BY enddate, wr.MA_WorkRequirement_ID, wrp.SeqNo, wrp.MA_WRPHASE_ID]]></query>
 	<field name="WRID" class="java.lang.String"/>
 	<field name="WRNAME" class="java.lang.String"/>
 	<field name="PROCESSPLAN" class="java.lang.String"/>
@@ -109,479 +105,353 @@ ORDER BY enddate, wr.MA_WorkRequirement_ID, wrp.SeqNo, wrp.MA_WRPHASE_ID]]>
 	<field name="WRPID" class="java.lang.String"/>
 	<variable name="DetailFieldTotal" class="java.lang.String"/>
 	<group name="WRID">
-		<groupExpression><![CDATA[$F{WRID}]]></groupExpression>
+		<expression><![CDATA[$F{WRID}]]></expression>
 		<groupHeader>
 			<band height="68" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="1" y="0" width="169" height="23" uuid="1548acd7-1c46-431c-b15d-7f6c4777b2da"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="1548acd7-1c46-431c-b15d-7f6c4777b2da" key="staticText" x="1" y="0" width="169" height="23" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[Work Requirement:]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="170" y="0" width="365" height="23" uuid="ae4d91ee-0612-4b54-815a-20f0a9fc4f8f"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{WRNAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="1" width="1" height="67" forecolor="#555555" uuid="93d8491d-9e2c-4dc5-b946-bb7d5449a819"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="535" y="1" width="1" height="67" forecolor="#555555" uuid="db21821f-9bbf-46eb-b528-59df39dab068"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="Group_Data_Field" x="146" y="48" width="296" height="18" uuid="db7998eb-eaf0-4d43-bdba-d49bd7391bbf"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ae4d91ee-0612-4b54-815a-20f0a9fc4f8f" key="textField" x="170" y="0" width="365" height="23" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{WRNAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{PROCESSPLAN}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="Group_Data_Field" x="126" y="28" width="121" height="18" uuid="aee28497-ef4d-45c5-94f8-e4b205fb677d"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="line" uuid="93d8491d-9e2c-4dc5-b946-bb7d5449a819" key="line-2" stretchType="ContainerHeight" x="0" y="1" width="1" height="67" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="db21821f-9bbf-46eb-b528-59df39dab068" key="line-3" stretchType="ContainerHeight" x="535" y="1" width="1" height="67" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="textField" uuid="db7998eb-eaf0-4d43-bdba-d49bd7391bbf" key="textField" x="146" y="48" width="296" height="18" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Group_Data_Field">
+					<expression><![CDATA[$F{PROCESSPLAN}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="Group_Data_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{STARTDATE}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-90" style="Group_Data_Label" x="10" y="28" width="115" height="18" uuid="51969616-1b41-49d5-a1a2-2021c2d79ac6"/>
-					<box leftPadding="5" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="aee28497-ef4d-45c5-94f8-e4b205fb677d" key="textField" x="126" y="28" width="121" height="18" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Group_Data_Field">
+					<expression><![CDATA[$F{STARTDATE}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="Group_Data_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="51969616-1b41-49d5-a1a2-2021c2d79ac6" key="element-90" x="10" y="28" width="115" height="18" style="Group_Data_Label">
 					<text><![CDATA[Starting Date:]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="Group_Data_Field" x="376" y="28" width="103" height="18" uuid="aa92da87-6ded-4f08-9185-6a233efbf5f2"/>
-					<box leftPadding="2" rightPadding="2">
+					<box leftPadding="5" rightPadding="2" style="Group_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="aa92da87-6ded-4f08-9185-6a233efbf5f2" key="textField" x="376" y="28" width="103" height="18" pattern="" blankWhenNull="true" vTextAlign="Middle" style="Group_Data_Field">
+					<expression><![CDATA[$F{ENDDATE}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="Group_Data_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{ENDDATE}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-90" style="Group_Data_Label" x="260" y="28" width="116" height="18" uuid="14f2f590-6109-4407-a77f-2f2be65b7dee"/>
-					<box leftPadding="5" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
+				</element>
+				<element kind="staticText" uuid="14f2f590-6109-4407-a77f-2f2be65b7dee" key="element-90" x="260" y="28" width="116" height="18" style="Group_Data_Label">
 					<text><![CDATA[Ending Date:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Group_Data_Label" x="10" y="48" width="136" height="18" uuid="b953817e-36b4-4e8f-9b8b-c5e83be67c4b"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" rightPadding="2" style="Group_Data_Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="b953817e-36b4-4e8f-9b8b-c5e83be67c4b" key="element-90" x="10" y="48" width="136" height="18" style="Group_Data_Label">
 					<text><![CDATA[Production Plan:]]></text>
-				</staticText>
+					<box leftPadding="5" rightPadding="2" style="Group_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-32" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="14" forecolor="#555555" uuid="3ac3b5cc-13f4-4f35-b3b5-901d29b15fa4"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="14" forecolor="#555555" uuid="d55bd349-6cf1-43e3-afe2-2712b8faee35"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-34" x="0" y="14" width="535" height="1" forecolor="#555555" uuid="ecbc2a08-ffcb-44c3-88f8-6f0c4f6ffa72"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="3ac3b5cc-13f4-4f35-b3b5-901d29b15fa4" key="line-32" stretchType="ContainerHeight" x="0" y="0" width="1" height="14" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="d55bd349-6cf1-43e3-afe2-2712b8faee35" key="line-33" stretchType="ContainerHeight" x="535" y="0" width="1" height="14" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="ecbc2a08-ffcb-44c3-88f8-6f0c4f6ffa72" key="line-34" x="0" y="14" width="535" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="WRPID">
-		<groupExpression><![CDATA[$F{WRPID}]]></groupExpression>
+		<expression><![CDATA[$F{WRPID}]]></expression>
 		<groupHeader>
 			<band height="63" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="11" y="0" width="65" height="23" uuid="81a09dda-074b-48d3-ac7b-d05a0ae3ce35"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="81a09dda-074b-48d3-ac7b-d05a0ae3ce35" key="staticText" x="11" y="0" width="65" height="23" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
 					<text><![CDATA[Phase:]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="76" y="0" width="459" height="23" uuid="1a0db58e-e83b-41f8-b93e-a97d52402acd"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{SEQNO}.toPlainString() + " - " + $F{PROCESS}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-4" stretchType="RelativeToBandHeight" x="10" y="1" width="1" height="62" forecolor="#555555" uuid="4a41373d-73df-4d54-9d7a-c772272d0a7d"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-6" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="63" forecolor="#555555" uuid="1bd71ee3-bcd0-41b0-a815-fbfd692ab903"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-8" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="63" forecolor="#555555" uuid="c43c4895-826f-406c-a051-5d00459a048b"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Group_Data_Field" x="340" y="25" width="100" height="18" uuid="cf74db92-d1da-45c0-9660-1738c443f273"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1a0db58e-e83b-41f8-b93e-a97d52402acd" key="textField" x="76" y="0" width="459" height="23" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{SEQNO}.toPlainString() + " - " + $F{PROCESS}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[($F{QUANTITY}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITY}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-90" style="Group_Data_Label" x="19" y="25" width="82" height="18" uuid="0be143c0-d39b-4125-ba5c-484e4852fa64"/>
-					<box leftPadding="5" rightPadding="2">
+				</element>
+				<element kind="line" uuid="4a41373d-73df-4d54-9d7a-c772272d0a7d" key="line-4" stretchType="ContainerHeight" x="10" y="1" width="1" height="62" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="1bd71ee3-bcd0-41b0-a815-fbfd692ab903" key="line-6" stretchType="ContainerHeight" x="535" y="0" width="1" height="63" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="c43c4895-826f-406c-a051-5d00459a048b" key="line-8" stretchType="ContainerHeight" x="0" y="0" width="1" height="63" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="textField" uuid="cf74db92-d1da-45c0-9660-1738c443f273" key="textField" x="340" y="25" width="100" height="18" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Group_Data_Field">
+					<expression><![CDATA[($F{QUANTITY}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITY}):new String(" ")]]></expression>
+					<box leftPadding="2" rightPadding="2" style="Group_Data_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="0be143c0-d39b-4125-ba5c-484e4852fa64" key="element-90" x="19" y="25" width="82" height="18" style="Group_Data_Label">
 					<text><![CDATA[Quantity:]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Group_Data_Field" x="101" y="25" width="100" height="18" uuid="7febfe9b-e016-4234-bf5f-ae939cd6fea9"/>
-					<box leftPadding="2" rightPadding="2">
+					<box leftPadding="5" rightPadding="2" style="Group_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="7febfe9b-e016-4234-bf5f-ae939cd6fea9" key="textField" x="101" y="25" width="100" height="18" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Group_Data_Field">
+					<expression><![CDATA[($F{NEEDQTY}!=null)?$P{NUMBERFORMAT}.format($F{NEEDQTY}):new String(" ")]]></expression>
+					<box leftPadding="2" rightPadding="2" style="Group_Data_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[($F{NEEDQTY}!=null)?$P{NUMBERFORMAT}.format($F{NEEDQTY}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-90" style="Group_Data_Label" x="233" y="25" width="107" height="18" uuid="27f29cf2-0082-4604-b25a-800b36b55796"/>
-					<box leftPadding="5" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
+				</element>
+				<element kind="staticText" uuid="27f29cf2-0082-4604-b25a-800b36b55796" key="element-90" x="233" y="25" width="107" height="18" style="Group_Data_Label">
 					<text><![CDATA[Done:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="18" y="47" width="276" height="16" uuid="2b3444d8-bbe1-40a8-89d3-1fb6bd0aa36c"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
+					<box leftPadding="5" rightPadding="2" style="Group_Data_Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="2b3444d8-bbe1-40a8-89d3-1fb6bd0aa36c" key="element-90" x="18" y="47" width="276" height="16" style="Detail_Header">
 					<text><![CDATA[PRODUCT]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="374" y="47" width="80" height="16" uuid="429bf200-c0be-4aa7-926a-b98799943a1d"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="429bf200-c0be-4aa7-926a-b98799943a1d" key="element-90" x="374" y="47" width="80" height="16" style="Detail_Header">
 					<text><![CDATA[Available]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="294" y="47" width="80" height="16" uuid="8a150ac3-1c51-488e-b1af-a38ec2c73b7a"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="8a150ac3-1c51-488e-b1af-a38ec2c73b7a" key="element-90" x="294" y="47" width="80" height="16" style="Detail_Header">
 					<text><![CDATA[Required]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="454" y="47" width="80" height="16" uuid="c05fd726-8982-44c1-9a35-aae0ce8eb9c3"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="c05fd726-8982-44c1-9a35-aae0ce8eb9c3" key="element-90" x="454" y="47" width="80" height="16" style="Detail_Header">
 					<text><![CDATA[On hand]]></text>
-				</staticText>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-28" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="20" forecolor="#555555" uuid="db2645c4-898a-4796-bdd4-afff5dcd5863"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-29" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="10" forecolor="#555555" uuid="656536c4-92f2-48ca-bae0-b508f4612e5e"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-30" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="20" forecolor="#555555" uuid="d19b2276-0667-41fe-bad3-20b86a64fcb8"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-31" x="10" y="10" width="525" height="1" forecolor="#555555" uuid="f42975fb-2cca-496b-896b-a76e13ba7e0a"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-35" x="19" y="0" width="516" height="1" forecolor="#555555" uuid="e5fd0283-9d99-4367-9beb-43304e71c136"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="db2645c4-898a-4796-bdd4-afff5dcd5863" key="line-28" stretchType="ContainerHeight" x="0" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="656536c4-92f2-48ca-bae0-b508f4612e5e" key="line-29" stretchType="ContainerHeight" x="10" y="0" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="d19b2276-0667-41fe-bad3-20b86a64fcb8" key="line-30" stretchType="ContainerHeight" x="535" y="0" width="1" height="20" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="f42975fb-2cca-496b-896b-a76e13ba7e0a" key="line-31" x="10" y="10" width="525" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="e5fd0283-9d99-4367-9beb-43304e71c136" key="line-35" x="19" y="0" width="516" height="1" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="20" splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="35" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Title" mode="Transparent" x="0" y="0" width="535" height="25" uuid="5e9808f5-81b4-40c6-a45a-f8a18c4f2323"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="26" width="535" height="1" uuid="bb185b88-abe0-4936-bb59-c5d09f354b2f"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="20" splitType="Stretch"/>
+	<pageHeader height="35" splitType="Stretch">
+		<element kind="textField" uuid="5e9808f5-81b4-40c6-a45a-f8a18c4f2323" key="textField" mode="Transparent" x="0" y="0" width="535" height="25" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="bb185b88-abe0-4936-bb59-c5d09f354b2f" key="line-1" x="0" y="26" width="535" height="1">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band height="16" splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader height="16" splitType="Stretch"/>
 	<detail>
 		<band height="14" splitType="Stretch">
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="14" forecolor="#555555" uuid="da5f9638-392e-4206-95d1-46cd7c32075f"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="14" forecolor="#555555" uuid="4072fa5d-a68e-492c-809a-10788c4c38f5"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-18" stretchType="RelativeToBandHeight" x="10" y="0" width="1" height="14" forecolor="#555555" uuid="32e8a312-a9a9-4302-97b7-260566f0982a"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<frame>
-				<reportElement key="frame-1" style="Detail_Line" x="18" y="0" width="517" height="14" uuid="6fd96a96-ad3b-4e4d-8e07-3e99c9ab184b"/>
-				<box>
+			<element kind="line" uuid="da5f9638-392e-4206-95d1-46cd7c32075f" key="line-16" stretchType="ContainerHeight" x="535" y="0" width="1" height="14" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="4072fa5d-a68e-492c-809a-10788c4c38f5" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="14" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="32e8a312-a9a9-4302-97b7-260566f0982a" key="line-18" stretchType="ContainerHeight" x="10" y="0" width="1" height="14" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="frame" uuid="6fd96a96-ad3b-4e4d-8e07-3e99c9ab184b" key="frame-1" x="18" y="0" width="517" height="14" style="Detail_Line">
+				<element kind="textField" uuid="3a8b7828-a36b-496b-a271-522017120686" key="textField-4" x="1" y="0" width="271" height="14" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="Detail_Red">
+					<expression><![CDATA[$F{PRODUCT}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="Detail_Red">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#666666"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#666666"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="e724b406-b8b8-4b92-81d2-49b142541084" key="textField-5" x="272" y="0" width="80" height="14" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" hTextAlign="Right" style="Detail_Red">
+					<expression><![CDATA[($F{NEEDED}!=null)?$P{NUMBERFORMAT}.format($F{NEEDED}):new String(" ")]]></expression>
+					<box leftPadding="2" rightPadding="2" style="Detail_Red">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#666666"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#666666"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="f392fa4e-3d99-4b0a-b138-9c0b7ddfa026" key="textField-6" x="355" y="0" width="80" height="14" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" hTextAlign="Right" style="Detail_Red">
+					<expression><![CDATA[($F{STOCK}!=null)?$P{NUMBERFORMAT}.format($F{STOCK}):new String(" ")]]></expression>
+					<box leftPadding="2" rightPadding="2" style="Detail_Red">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#666666"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#666666"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="c422d2ab-95de-4c85-80fb-8f94fed49afa" key="textField-7" x="436" y="0" width="80" height="14" pdfFontName="Helvetica-Bold" pattern="" blankWhenNull="false" hTextAlign="Right" style="Detail_Red">
+					<expression><![CDATA[($F{INPROCESS}!=null)?$P{NUMBERFORMAT}.format($F{INPROCESS}):new String(" ")]]></expression>
+					<box leftPadding="2" rightPadding="2" style="Detail_Red">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#666666"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#666666"/>
+					</box>
+				</element>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField-4" style="Detail_Red" x="1" y="0" width="271" height="14" uuid="3a8b7828-a36b-496b-a271-522017120686"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#666666"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#666666"/>
-					</box>
-					<textFieldExpression><![CDATA[$F{PRODUCT}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-5" style="Detail_Red" x="272" y="0" width="80" height="14" uuid="e724b406-b8b8-4b92-81d2-49b142541084"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#666666"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#666666"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{NEEDED}!=null)?$P{NUMBERFORMAT}.format($F{NEEDED}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-6" style="Detail_Red" x="355" y="0" width="80" height="14" uuid="f392fa4e-3d99-4b0a-b138-9c0b7ddfa026"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#666666"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#666666"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{STOCK}!=null)?$P{NUMBERFORMAT}.format($F{STOCK}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-7" style="Detail_Red" x="436" y="0" width="80" height="14" uuid="c422d2ab-95de-4c85-80fb-8f94fed49afa"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#666666"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#666666"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{INPROCESS}!=null)?$P{NUMBERFORMAT}.format($F{INPROCESS}):new String(" ")]]></textFieldExpression>
-				</textField>
-			</frame>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="4" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="20" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="402" y="4" width="95" height="16" uuid="0069d106-87fd-4477-9547-5a382b6814ba"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="499" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="18a745ff-7da9-4d83-8972-12e7e18be062"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="1" width="535" height="1" forecolor="#000000" uuid="9b8b0a55-d119-4ca7-9df6-18ed50fa7408"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="277" y="4" width="69" height="16" uuid="52b536d8-b9f3-4252-a922-f4d15a216316"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" style="Report_Footer" x="195" y="4" width="78" height="16" uuid="091e14eb-9823-4074-85df-1dd48393ccae"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="4" splitType="Stretch"/>
+	<pageFooter height="20" splitType="Stretch">
+		<element kind="textField" uuid="0069d106-87fd-4477-9547-5a382b6814ba" key="textField" x="402" y="4" width="95" height="16" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="18a745ff-7da9-4d83-8972-12e7e18be062" key="textField" x="499" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle" style="Report_Footer">
+			<paragraph lineSpacing="Single" style="Report_Footer"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="9b8b0a55-d119-4ca7-9df6-18ed50fa7408" key="line" x="0" y="1" width="535" height="1" forecolor="#000000">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="52b536d8-b9f3-4252-a922-f4d15a216316" key="textField" x="277" y="4" width="69" height="16" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="091e14eb-9823-4074-85df-1dd48393ccae" key="staticText-1" x="195" y="4" width="78" height="16" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/SimpleDimensionalComparative.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/SimpleDimensionalComparative.jrxml
@@ -1,90 +1,79 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="SimpleDimensionalComparative" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="730" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="998085fe-979c-4a42-ad9f-592a626f2da5">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="SimpleDimensionalComparative" language="java" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="730" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="998085fe-979c-4a42-ad9f-592a626f2da5">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Data_Label" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true">
+	<style name="Report_Data_Label" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8" isBold="true">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0" bold="true">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level1_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="true">
-		<conditionalStyle>
+	<style name="Level1_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="true">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==1)&&($V{NIVEL1_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==1)&&($V{NIVEL1_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level2_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="true">
-		<conditionalStyle>
+	<style name="Level2_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="true">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==2)&&($V{NIVEL1_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==2)&&($V{NIVEL1_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level3_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="true">
-		<conditionalStyle>
+	<style name="Level3_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="true">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==3)&&($V{NIVEL2_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==3)&&($V{NIVEL2_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level4_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="true">
-		<conditionalStyle>
+	<style name="Level4_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="true">
+		<conditionalStyle backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==4)&&($V{NIVEL3_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==4)&&($V{NIVEL3_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level5_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="true">
-		<conditionalStyle>
+	<style name="Level5_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="true">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==5)&&($V{NIVEL4_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==5)&&($V{NIVEL4_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level6_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="true"/>
-	<style name="Level7_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="true"/>
-	<style name="Level8_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="true"/>
-	<style name="Level9_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8" isBold="true"/>
-	<style name="Report_Footer" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
+	<style name="Level6_Line" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="true"/>
+	<style name="Level7_Line" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="true"/>
+	<style name="Level8_Line" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="true"/>
+	<style name="Level9_Line" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0" bold="true"/>
+	<style name="Report_Footer" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
 	<style name="Detail_Border" forecolor="#8A8A8A">
 		<pen lineWidth="0.25" lineStyle="Solid"/>
 		<box>
@@ -95,92 +84,91 @@
 			<rightPen lineWidth="0.0" lineStyle="Solid"/>
 		</box>
 	</style>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["0,1000000"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["0,1000000"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATEFROM" class="java.util.Date" isForPrompting="false">
+	<parameter name="DATEFROM" forPrompting="false" class="java.util.Date">
 		<defaultValueExpression><![CDATA[(new SimpleDateFormat("dd-MM-yyyy")).parse("01-01-1900")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATETO" class="java.util.Date" isForPrompting="false">
+	<parameter name="DATETO" forPrompting="false" class="java.util.Date">
 		<defaultValueExpression><![CDATA[(new SimpleDateFormat("dd-MM-yyyy")).parse("31-12-3000")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="cBpGroupId" class="java.lang.String" isForPrompting="false">
+	<parameter name="cBpGroupId" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="cBpGroupId_Aux" class="java.lang.String" isForPrompting="false">
+	<parameter name="cBpGroupId_Aux" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{cBpGroupId}.equals("") ? " " : (" AND C_BP_Group.C_BP_Group_ID = " + $P{cBpGroupId})]]></defaultValueExpression>
 	</parameter>
-	<parameter name="cBpartnerId" class="java.lang.String" isForPrompting="false">
+	<parameter name="cBpartnerId" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="cBpartnerId_Aux" class="java.lang.String" isForPrompting="false">
+	<parameter name="cBpartnerId_Aux" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{cBpartnerId}.equals(""))?"  ":" AND C_BPartner.C_BPartner_ID IN " + $P{cBpartnerId}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="mProductCategoryId" class="java.lang.String" isForPrompting="false">
+	<parameter name="mProductCategoryId" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="mProductCategoryId_Aux" class="java.lang.String" isForPrompting="false">
+	<parameter name="mProductCategoryId_Aux" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{mProductCategoryId}.equals(""))?"  ":" AND M_Product_Category.M_Product_Category_Id = " + $P{mProductCategoryId}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="mProductId" class="java.lang.String" isForPrompting="false">
+	<parameter name="mProductId" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="mProductId_Aux" class="java.lang.String" isForPrompting="false">
+	<parameter name="mProductId_Aux" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{mProductId}.equals(""))?" ":" AND M_Product.M_Product_ID IN " + $P{mProductId}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="orderBy" class="java.lang.String" isForPrompting="false">
+	<parameter name="orderBy" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[" ORDER BY 1 "]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Purchase Orders Report"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="PRODUCT_LEVEL" class="java.lang.Integer" isForPrompting="false">
+	<parameter name="PRODUCT_LEVEL" forPrompting="false" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[new Integer(3)]]></defaultValueExpression>
 	</parameter>
-	<parameter name="THEME" class="java.lang.String" isForPrompting="false">
+	<parameter name="THEME" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Default"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false">
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/var/lib/tomcat-5.5/webapps/alerts/web"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL1_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL1_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Partner Group"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL2_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL2_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Product Category"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL3_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL3_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Product"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL4_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL4_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Partner"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL5_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL6_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL7_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL8_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL9_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="DIMENSIONS" class="java.lang.Integer" isForPrompting="false">
+	<parameter name="LEVEL5_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL6_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL7_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL8_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL9_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="DIMENSIONS" forPrompting="false" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[new Integer(2)]]></defaultValueExpression>
 	</parameter>
-	<parameter name="GROUP_LEVEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="GROUP_LEVEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["1.- Group1, 2.- Group2, 3.- Group3"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["1.- "+$P{LEVEL1_LABEL}
 +($P{LEVEL2_LABEL}==""?"":", 2.- "+$P{LEVEL2_LABEL})
 +($P{LEVEL3_LABEL}==""?"":", 3.- "+$P{LEVEL3_LABEL})
 +($P{LEVEL4_LABEL}==""?"":", 4.- "+$P{LEVEL4_LABEL})
 +($P{LEVEL5_LABEL}==""?"":", 5.- "+$P{LEVEL5_LABEL})]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5,
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5,
       SUM(AMOUNT) AS AMOUNT, SUM(QTY) AS QTY,
       SUM(AMOUNTREF) AS AMOUNTREF, SUM(QTYREF) AS QTYREF, UOMSYMBOL,
       SUM(CONVAMOUNT) AS CONVAMOUNT,           	        	  
@@ -233,8 +221,7 @@
       AND C_ORDER.AD_CLIENT_ID IN('12')
       AND 2=2) AA
       GROUP BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, UOMSYMBOL, TRCURRENCYID, TRDATE, TRCLIENTID, TRORGID) ZZ
-      GROUP BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, UOMSYMBOL, CONVSYM, CONVISOSYM, 1]]>
-	</queryString>
+      GROUP BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, UOMSYMBOL, CONVSYM, CONVISOSYM, 1]]></query>
 	<field name="NIVEL1" class="java.lang.String"/>
 	<field name="NIVEL2" class="java.lang.String"/>
 	<field name="NIVEL3" class="java.lang.String"/>
@@ -252,465 +239,375 @@
 	<field name="AMOUNTSYM" class="java.lang.String"/>
 	<field name="CONVSYM" class="java.lang.String"/>
 	<field name="CONVISOSYM" class="java.lang.String"/>
-	<variable name="QTY_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="QTY_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="QTYREF_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="AMOUNT_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNTREF}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNTREF_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="CONVAMOUNTREF_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNTREF_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="CONVAMOUNTREF_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNTREF_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="CONVAMOUNTREF_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNTREF_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="CONVAMOUNTREF_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNTREF_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="CONVAMOUNTREF_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNTREF_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="CONVAMOUNTREF_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMT_PCT_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM1}.equals(new BigDecimal(0.0)))?null:$V{AMOUNT_SUM1}.subtract( $V{AMOUNTREF_SUM1} ).multiply(new BigDecimal(100.0)).divide( $V{AMOUNTREF_SUM1}, 6)]]></variableExpression>
+	<variable name="AMT_PCT_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM1}.equals(new BigDecimal(0.0)))?null:$V{AMOUNT_SUM1}.subtract( $V{AMOUNTREF_SUM1} ).multiply(new BigDecimal(100.0)).divide( $V{AMOUNTREF_SUM1}, 6)]]></expression>
 	</variable>
-	<variable name="AMT_PCT_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM2}.equals(new BigDecimal(0.0)))?null:$V{AMOUNT_SUM2}.subtract( $V{AMOUNTREF_SUM2} ).multiply(new BigDecimal(100.0)).divide( $V{AMOUNTREF_SUM2}, 6)]]></variableExpression>
+	<variable name="AMT_PCT_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM2}.equals(new BigDecimal(0.0)))?null:$V{AMOUNT_SUM2}.subtract( $V{AMOUNTREF_SUM2} ).multiply(new BigDecimal(100.0)).divide( $V{AMOUNTREF_SUM2}, 6)]]></expression>
 	</variable>
-	<variable name="AMT_PCT_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM3}.equals(new BigDecimal(0.0)))?null:$V{AMOUNT_SUM3}.subtract( $V{AMOUNTREF_SUM3} ).multiply(new BigDecimal(100.0)).divide( $V{AMOUNTREF_SUM3}, 6)]]></variableExpression>
+	<variable name="AMT_PCT_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM3}.equals(new BigDecimal(0.0)))?null:$V{AMOUNT_SUM3}.subtract( $V{AMOUNTREF_SUM3} ).multiply(new BigDecimal(100.0)).divide( $V{AMOUNTREF_SUM3}, 6)]]></expression>
 	</variable>
-	<variable name="AMT_PCT_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM4}.equals(new BigDecimal(0.0)))?null:$V{AMOUNT_SUM4}.subtract( $V{AMOUNTREF_SUM4} ).multiply(new BigDecimal(100.0)).divide( $V{AMOUNTREF_SUM4}, 6)]]></variableExpression>
+	<variable name="AMT_PCT_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM4}.equals(new BigDecimal(0.0)))?null:$V{AMOUNT_SUM4}.subtract( $V{AMOUNTREF_SUM4} ).multiply(new BigDecimal(100.0)).divide( $V{AMOUNTREF_SUM4}, 6)]]></expression>
 	</variable>
-	<variable name="AMT_PCT_5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM5}.equals(new BigDecimal(0.0)))?null:$V{AMOUNT_SUM5}.subtract( $V{AMOUNTREF_SUM5} ).multiply(new BigDecimal(100.0)).divide( $V{AMOUNTREF_SUM5}, 6)]]></variableExpression>
+	<variable name="AMT_PCT_5" resetType="Group" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM5}.equals(new BigDecimal(0.0)))?null:$V{AMOUNT_SUM5}.subtract( $V{AMOUNTREF_SUM5} ).multiply(new BigDecimal(100.0)).divide( $V{AMOUNTREF_SUM5}, 6)]]></expression>
 	</variable>
 	<variable name="AMT_PCT_T" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[($V{CONVAMOUNTREF_TOTAL}.equals(new BigDecimal(0.0)))?null:$V{CONVAMOUNT_TOTAL}.subtract( $V{CONVAMOUNTREF_TOTAL} ).multiply(new BigDecimal(100.0)).divide( $V{CONVAMOUNTREF_TOTAL}, 6)]]></variableExpression>
+		<expression><![CDATA[($V{CONVAMOUNTREF_TOTAL}.equals(new BigDecimal(0.0)))?null:$V{CONVAMOUNT_TOTAL}.subtract( $V{CONVAMOUNTREF_TOTAL} ).multiply(new BigDecimal(100.0)).divide( $V{CONVAMOUNTREF_TOTAL}, 6)]]></expression>
 	</variable>
-	<variable name="CONVAMT_PCT_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{CONVAMOUNTREF_SUM1}.equals(new BigDecimal(0.0)))?null:$V{CONVAMOUNT_SUM1}.subtract( $V{CONVAMOUNTREF_SUM1} ).multiply(new BigDecimal(100.0)).divide( $V{CONVAMOUNTREF_SUM1}, 6)]]></variableExpression>
+	<variable name="CONVAMT_PCT_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{CONVAMOUNTREF_SUM1}.equals(new BigDecimal(0.0)))?null:$V{CONVAMOUNT_SUM1}.subtract( $V{CONVAMOUNTREF_SUM1} ).multiply(new BigDecimal(100.0)).divide( $V{CONVAMOUNTREF_SUM1}, 6)]]></expression>
 	</variable>
-	<variable name="CONVAMT_PCT_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{CONVAMOUNTREF_SUM2}.equals(new BigDecimal(0.0)))?null:$V{CONVAMOUNT_SUM2}.subtract( $V{CONVAMOUNTREF_SUM2} ).multiply(new BigDecimal(100.0)).divide( $V{CONVAMOUNTREF_SUM2}, 6)]]></variableExpression>
+	<variable name="CONVAMT_PCT_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{CONVAMOUNTREF_SUM2}.equals(new BigDecimal(0.0)))?null:$V{CONVAMOUNT_SUM2}.subtract( $V{CONVAMOUNTREF_SUM2} ).multiply(new BigDecimal(100.0)).divide( $V{CONVAMOUNTREF_SUM2}, 6)]]></expression>
 	</variable>
-	<variable name="CONVAMT_PCT_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{CONVAMOUNTREF_SUM3}.equals(new BigDecimal(0.0)))?null:$V{CONVAMOUNT_SUM3}.subtract( $V{CONVAMOUNTREF_SUM3} ).multiply(new BigDecimal(100.0)).divide( $V{CONVAMOUNTREF_SUM3}, 6)]]></variableExpression>
+	<variable name="CONVAMT_PCT_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{CONVAMOUNTREF_SUM3}.equals(new BigDecimal(0.0)))?null:$V{CONVAMOUNT_SUM3}.subtract( $V{CONVAMOUNTREF_SUM3} ).multiply(new BigDecimal(100.0)).divide( $V{CONVAMOUNTREF_SUM3}, 6)]]></expression>
 	</variable>
-	<variable name="CONVAMT_PCT_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{CONVAMOUNTREF_SUM4}.equals(new BigDecimal(0.0)))?null:$V{CONVAMOUNT_SUM4}.subtract( $V{CONVAMOUNTREF_SUM4} ).multiply(new BigDecimal(100.0)).divide( $V{CONVAMOUNTREF_SUM4}, 6)]]></variableExpression>
+	<variable name="CONVAMT_PCT_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{CONVAMOUNTREF_SUM4}.equals(new BigDecimal(0.0)))?null:$V{CONVAMOUNT_SUM4}.subtract( $V{CONVAMOUNTREF_SUM4} ).multiply(new BigDecimal(100.0)).divide( $V{CONVAMOUNTREF_SUM4}, 6)]]></expression>
 	</variable>
-	<variable name="CONVAMT_PCT_5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5">
-		<variableExpression><![CDATA[($V{CONVAMOUNTREF_SUM5}.equals(new BigDecimal(0.0)))?null:$V{CONVAMOUNT_SUM5}.subtract( $V{CONVAMOUNTREF_SUM5} ).multiply(new BigDecimal(100.0)).divide( $V{CONVAMOUNTREF_SUM5}, 6)]]></variableExpression>
+	<variable name="CONVAMT_PCT_5" resetType="Group" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{CONVAMOUNTREF_SUM5}.equals(new BigDecimal(0.0)))?null:$V{CONVAMOUNT_SUM5}.subtract( $V{CONVAMOUNTREF_SUM5} ).multiply(new BigDecimal(100.0)).divide( $V{CONVAMOUNTREF_SUM5}, 6)]]></expression>
 	</variable>
 	<variable name="CONVAMT_PCT_T" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[($V{CONVAMOUNTREF_TOTAL}.equals(new BigDecimal(0.0)))?null:$V{CONVAMOUNT_TOTAL}.subtract( $V{CONVAMOUNTREF_TOTAL} ).multiply(new BigDecimal(100.0)).divide( $V{CONVAMOUNTREF_TOTAL}, 6)]]></variableExpression>
+		<expression><![CDATA[($V{CONVAMOUNTREF_TOTAL}.equals(new BigDecimal(0.0)))?null:$V{CONVAMOUNT_TOTAL}.subtract( $V{CONVAMOUNTREF_TOTAL} ).multiply(new BigDecimal(100.0)).divide( $V{CONVAMOUNTREF_TOTAL}, 6)]]></expression>
 	</variable>
-	<variable name="QTY_PCT_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{QTYREF_SUM1}.equals(new BigDecimal(0.0)))?null:$V{QTY_SUM1}.subtract( $V{QTYREF_SUM1} ).multiply(new BigDecimal(100.0)).divide( $V{QTYREF_SUM1}, 2, 6)]]></variableExpression>
+	<variable name="QTY_PCT_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM1}.equals(new BigDecimal(0.0)))?null:$V{QTY_SUM1}.subtract( $V{QTYREF_SUM1} ).multiply(new BigDecimal(100.0)).divide( $V{QTYREF_SUM1}, 2, 6)]]></expression>
 	</variable>
-	<variable name="QTY_PCT_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{QTYREF_SUM2}.equals(new BigDecimal(0.0)))?null:$V{QTY_SUM2}.subtract( $V{QTYREF_SUM2} ).multiply(new BigDecimal(100.0)).divide( $V{QTYREF_SUM2}, 2, 6)]]></variableExpression>
+	<variable name="QTY_PCT_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM2}.equals(new BigDecimal(0.0)))?null:$V{QTY_SUM2}.subtract( $V{QTYREF_SUM2} ).multiply(new BigDecimal(100.0)).divide( $V{QTYREF_SUM2}, 2, 6)]]></expression>
 	</variable>
-	<variable name="QTY_PCT_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{QTYREF_SUM3}.equals(new BigDecimal(0.0)))?null:$V{QTY_SUM3}.subtract( $V{QTYREF_SUM3} ).multiply(new BigDecimal(100.0)).divide( $V{QTYREF_SUM3}, 2, 6)]]></variableExpression>
+	<variable name="QTY_PCT_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM3}.equals(new BigDecimal(0.0)))?null:$V{QTY_SUM3}.subtract( $V{QTYREF_SUM3} ).multiply(new BigDecimal(100.0)).divide( $V{QTYREF_SUM3}, 2, 6)]]></expression>
 	</variable>
-	<variable name="QTY_PCT_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{QTYREF_SUM4}.equals(new BigDecimal(0.0)))?null:$V{QTY_SUM4}.subtract( $V{QTYREF_SUM4} ).multiply(new BigDecimal(100.0)).divide( $V{QTYREF_SUM4}, 2, 6)]]></variableExpression>
+	<variable name="QTY_PCT_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM4}.equals(new BigDecimal(0.0)))?null:$V{QTY_SUM4}.subtract( $V{QTYREF_SUM4} ).multiply(new BigDecimal(100.0)).divide( $V{QTYREF_SUM4}, 2, 6)]]></expression>
 	</variable>
-	<variable name="QTY_PCT_5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5">
-		<variableExpression><![CDATA[($V{QTYREF_SUM5}.equals(new BigDecimal(0.0)))?null:$V{QTY_SUM5}.subtract( $V{QTYREF_SUM5} ).multiply(new BigDecimal(100.0)).divide( $V{QTYREF_SUM5}, 2, 6)]]></variableExpression>
+	<variable name="QTY_PCT_5" resetType="Group" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM5}.equals(new BigDecimal(0.0)))?null:$V{QTY_SUM5}.subtract( $V{QTYREF_SUM5} ).multiply(new BigDecimal(100.0)).divide( $V{QTYREF_SUM5}, 2, 6)]]></expression>
 	</variable>
 	<group name="TOTALIZE">
-		<groupExpression><![CDATA[]]></groupExpression>
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band splitType="Stretch"/>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<textField evaluationTime="Report" isBlankWhenNull="false">
-					<reportElement key="textField-36" style="Total_Field" x="307" y="2" width="64" height="17" uuid="ba5d68ec-2f83-477d-b91c-3360b7449efb"/>
-					<box leftPadding="5">
+				<element kind="textField" uuid="ba5d68ec-2f83-477d-b91c-3360b7449efb" key="textField-36" x="307" y="2" width="64" height="17" fontSize="8.0" evaluationTime="Report" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{CONVAMOUNT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-18" style="Report_Data_Label" x="255" y="2" width="52" height="17" uuid="d93f9f9c-8e88-4aa4-9abe-d55b8df43fcc"/>
-					<box leftPadding="5" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="d93f9f9c-8e88-4aa4-9abe-d55b8df43fcc" key="staticText-18" x="255" y="2" width="52" height="17" fontSize="8.0" hTextAlign="Right" vTextAlign="Middle" style="Report_Data_Label">
 					<text><![CDATA[Totals]]></text>
-				</staticText>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-37" style="Total_Field" x="390" y="2" width="64" height="17" uuid="7549a292-4de5-4556-8c7c-a040b8c79685"/>
-					<box leftPadding="5">
+					<box leftPadding="5" rightPadding="2" style="Report_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="7549a292-4de5-4556-8c7c-a040b8c79685" key="textField-37" x="390" y="2" width="64" height="17" fontSize="8.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{CONVAMOUNTREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNTREF_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNTREF_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNTREF_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-38" style="Total_Field" x="473" y="2" width="47" height="17" uuid="85cfa867-f2db-457d-bc04-146ecd2040db"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="85cfa867-f2db-457d-bc04-146ecd2040db" key="textField-38" x="473" y="2" width="47" height="17" fontSize="8.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{CONVAMT_PCT_T}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMT_PCT_T}):new String(" ")]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMT_PCT_T}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMT_PCT_T}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-5" x="0" y="1" width="730" height="1" uuid="d3ee56a2-04e1-45dc-9904-ff6b6451c314"/>
-				</line>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-39" style="Detail_Header" mode="Opaque" x="15" y="2" width="15" height="17" uuid="4ab290be-8e87-4396-a3f9-0f94caa4efb6">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+				</element>
+				<element kind="line" uuid="d3ee56a2-04e1-45dc-9904-ff6b6451c314" key="line-5" x="0" y="1" width="730" height="1"/>
+				<element kind="textField" uuid="4ab290be-8e87-4396-a3f9-0f94caa4efb6" key="textField-39" mode="Opaque" x="15" y="2" width="15" height="17" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-40" style="Detail_Header" mode="Opaque" x="0" y="2" width="15" height="17" uuid="15a3266a-9194-4af3-80b0-71cfbe22b6ec">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="15a3266a-9194-4af3-80b0-71cfbe22b6ec" key="textField-40" mode="Opaque" x="0" y="2" width="15" height="17" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-41" style="Detail_Header" mode="Opaque" x="30" y="2" width="15" height="17" uuid="85e91a01-118f-4b30-93b7-0160b5369327">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="85e91a01-118f-4b30-93b7-0160b5369327" key="textField-41" mode="Opaque" x="30" y="2" width="15" height="17" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-42" style="Detail_Header" mode="Opaque" x="45" y="2" width="15" height="17" uuid="f6a5b0a2-ebe5-43c0-beca-7846f6bd2abe">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="f6a5b0a2-ebe5-43c0-beca-7846f6bd2abe" key="textField-42" mode="Opaque" x="45" y="2" width="15" height="17" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-43" style="Detail_Header" mode="Opaque" x="60" y="2" width="15" height="17" uuid="14f0b0f7-2df7-4600-9ed1-5f2fa43ed056">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="14f0b0f7-2df7-4600-9ed1-5f2fa43ed056" key="textField-43" mode="Opaque" x="60" y="2" width="15" height="17" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":" ")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-55" style="Total_Field" x="371" y="2" width="19" height="17" uuid="bcd4a7c0-0e5c-48c7-8af9-95247faecf4d"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="bcd4a7c0-0e5c-48c7-8af9-95247faecf4d" key="textField-55" x="371" y="2" width="19" height="17" fontSize="8.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Center" style="Total_Field">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-56" style="Total_Field" x="454" y="2" width="19" height="17" uuid="c6fccc5e-eea4-4133-8b42-4a243b6eb5d9"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="c6fccc5e-eea4-4133-8b42-4a243b6eb5d9" key="textField-56" x="454" y="2" width="19" height="17" fontSize="8.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Center" style="Total_Field">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="NIVEL1">
-		<groupExpression><![CDATA[$F{NIVEL1}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL1}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="307" height="18" uuid="fe196a82-5d32-4c1e-8e3a-7da1a3329b0f"/>
-					<box rightPadding="2">
+				<element kind="textField" uuid="fe196a82-5d32-4c1e-8e3a-7da1a3329b0f" key="textField" stretchType="ContainerHeight" x="0" y="0" width="307" height="18" textAdjust="StretchHeight" blankWhenNull="true" bold="true" style="Level1_Line">
+					<expression><![CDATA[$F{NIVEL1}]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement>
-						<font isBold="true"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL1}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" x="520" y="0" width="80" height="18" uuid="c9e623a2-f464-4172-8aa4-5a1b93e5ee18">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c9e623a2-f464-4172-8aa4-5a1b93e5ee18" key="textField" stretchType="ContainerHeight" x="520" y="0" width="80" height="18" evaluationTime="Group" evaluationGroup="NIVEL1" blankWhenNull="false" bold="true" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="true"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" x="307" y="0" width="64" height="18" uuid="34296123-5e91-479b-bced-ab6905d26809"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="34296123-5e91-479b-bced-ab6905d26809" key="textField" stretchType="ContainerHeight" x="307" y="0" width="64" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" bold="true" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="true"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" x="390" y="0" width="64" height="18" uuid="c6b4423b-3254-4fb8-a57e-afd1660a9504"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c6b4423b-3254-4fb8-a57e-afd1660a9504" key="textField" stretchType="ContainerHeight" x="390" y="0" width="64" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" bold="true" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{CONVAMOUNTREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNTREF_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="true"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNTREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNTREF_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" x="600" y="0" width="80" height="18" uuid="84f83947-0b6b-4283-8d74-f078701cb7a4">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="84f83947-0b6b-4283-8d74-f078701cb7a4" key="textField" stretchType="ContainerHeight" x="600" y="0" width="80" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" bold="true" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="true"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-9" style="Level1_Line" stretchType="RelativeToBandHeight" x="473" y="0" width="47" height="18" uuid="74816e37-cc33-4373-93d9-89fe8da63ee4"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="74816e37-cc33-4373-93d9-89fe8da63ee4" key="textField-9" stretchType="ContainerHeight" x="473" y="0" width="47" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" bold="true" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{CONVAMT_PCT_1}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMT_PCT_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="true"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMT_PCT_1}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMT_PCT_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" x="680" y="0" width="50" height="18" uuid="722c83ce-f16b-4b96-88e8-037ac713e88c">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="722c83ce-f16b-4b96-88e8-037ac713e88c" key="textField" stretchType="ContainerHeight" x="680" y="0" width="50" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" bold="true" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PCT_1}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PCT_1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="true"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PCT_1}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PCT_1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-45" style="Level1_Line" stretchType="RelativeToBandHeight" x="371" y="0" width="19" height="18" uuid="2f7725d4-7b54-4a6d-9368-78241bf739f5"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="2f7725d4-7b54-4a6d-9368-78241bf739f5" key="textField-45" stretchType="ContainerHeight" x="371" y="0" width="19" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" bold="true" hTextAlign="Center" style="Level1_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font isBold="true"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-46" style="Level1_Line" stretchType="RelativeToBandHeight" x="454" y="0" width="19" height="18" uuid="9163567b-c9fa-4746-af8b-7e2ea120d6f7"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="9163567b-c9fa-4746-af8b-7e2ea120d6f7" key="textField-46" stretchType="ContainerHeight" x="454" y="0" width="19" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" bold="true" hTextAlign="Center" style="Level1_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font isBold="true"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -720,141 +617,103 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL2">
-		<groupExpression><![CDATA[$F{NIVEL2}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL2}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="292" height="18" uuid="0cc5e6aa-0785-41ef-9a76-61ffc9a2a8ae"/>
-					<box rightPadding="2">
+				<element kind="textField" uuid="0cc5e6aa-0785-41ef-9a76-61ffc9a2a8ae" key="textField" stretchType="ContainerHeight" x="15" y="0" width="292" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[$F{NIVEL2}]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL2}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" x="520" y="0" width="80" height="18" uuid="b2897d80-83ff-4f6f-95e3-b1d7a1694b71">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="b2897d80-83ff-4f6f-95e3-b1d7a1694b71" key="textField" stretchType="ContainerHeight" x="520" y="0" width="80" height="18" evaluationTime="Group" evaluationGroup="NIVEL2" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" x="307" y="0" width="64" height="18" uuid="3cea65aa-fc3f-4fca-adba-6e93583cbe4f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3cea65aa-fc3f-4fca-adba-6e93583cbe4f" key="textField" stretchType="ContainerHeight" x="307" y="0" width="64" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" x="390" y="0" width="64" height="18" uuid="4dbb6556-2e1f-4ab1-b34b-27e791e925b0"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4dbb6556-2e1f-4ab1-b34b-27e791e925b0" key="textField" stretchType="ContainerHeight" x="390" y="0" width="64" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{CONVAMOUNTREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNTREF_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNTREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNTREF_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" x="600" y="0" width="80" height="18" uuid="65878d31-33ab-415a-9659-507216d3fb93">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="65878d31-33ab-415a-9659-507216d3fb93" key="textField" stretchType="ContainerHeight" x="600" y="0" width="80" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-8" style="Level2_Line" stretchType="RelativeToBandHeight" x="473" y="0" width="47" height="18" uuid="8aba79ca-52b4-49c6-8deb-957d258a77e6"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="8aba79ca-52b4-49c6-8deb-957d258a77e6" key="textField-8" stretchType="ContainerHeight" x="473" y="0" width="47" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{CONVAMT_PCT_2}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMT_PCT_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMT_PCT_2}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMT_PCT_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" x="680" y="0" width="50" height="18" uuid="1163f5ea-eeae-4433-bc8d-3d4f63b7aeb9">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="1163f5ea-eeae-4433-bc8d-3d4f63b7aeb9" key="textField" stretchType="ContainerHeight" x="680" y="0" width="50" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PCT_2}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PCT_2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PCT_2}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PCT_2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-26" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="1bcf5abe-3cbc-448b-a22b-1869e50941c6"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="1bcf5abe-3cbc-448b-a22b-1869e50941c6" key="textField-26" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="None" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-51" style="Level2_Line" stretchType="RelativeToBandHeight" x="371" y="0" width="19" height="18" uuid="0bd77696-2643-4a05-a015-f7c85fb393c0"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="0bd77696-2643-4a05-a015-f7c85fb393c0" key="textField-51" stretchType="ContainerHeight" x="371" y="0" width="19" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level2_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-52" style="Level2_Line" stretchType="RelativeToBandHeight" x="454" y="0" width="19" height="18" uuid="dcd53b05-d199-4e92-af73-72cf98871196"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="dcd53b05-d199-4e92-af73-72cf98871196" key="textField-52" stretchType="ContainerHeight" x="454" y="0" width="19" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level2_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -864,152 +723,112 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL3">
-		<groupExpression><![CDATA[$F{NIVEL3}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL3}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="277" height="18" uuid="16794fd4-dc26-4ad0-b270-29b90aabaab5"/>
-					<box rightPadding="2">
+				<element kind="textField" uuid="16794fd4-dc26-4ad0-b270-29b90aabaab5" key="textField" stretchType="ContainerHeight" x="30" y="0" width="277" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[$F{NIVEL3}]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL3}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" x="520" y="0" width="80" height="18" uuid="83708134-4172-4771-afb0-4345378a4d03">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="83708134-4172-4771-afb0-4345378a4d03" key="textField" stretchType="ContainerHeight" x="520" y="0" width="80" height="18" evaluationTime="Group" evaluationGroup="NIVEL3" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" x="307" y="0" width="64" height="18" uuid="04013fa6-4875-40be-bed7-190b55b32fc9"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="04013fa6-4875-40be-bed7-190b55b32fc9" key="textField" stretchType="ContainerHeight" x="307" y="0" width="64" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" x="390" y="0" width="64" height="18" uuid="6a96a8ab-332f-4a17-b333-ed9eaa956f56"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="6a96a8ab-332f-4a17-b333-ed9eaa956f56" key="textField" stretchType="ContainerHeight" x="390" y="0" width="64" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{CONVAMOUNTREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNTREF_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNTREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNTREF_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" x="600" y="0" width="80" height="18" uuid="2440a4b7-c69a-4128-90c2-3daba316d0d5">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2440a4b7-c69a-4128-90c2-3daba316d0d5" key="textField" stretchType="ContainerHeight" x="600" y="0" width="80" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-7" style="Level3_Line" stretchType="RelativeToBandHeight" x="473" y="0" width="47" height="18" uuid="5a798240-3e6d-43fa-b669-12b156efc532"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5a798240-3e6d-43fa-b669-12b156efc532" key="textField-7" stretchType="ContainerHeight" x="473" y="0" width="47" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{CONVAMT_PCT_3}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMT_PCT_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMT_PCT_3}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMT_PCT_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" x="680" y="0" width="50" height="18" uuid="ad53f35f-0879-4178-9b60-2c699a863890">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ad53f35f-0879-4178-9b60-2c699a863890" key="textField" stretchType="ContainerHeight" x="680" y="0" width="50" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PCT_3}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PCT_3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PCT_3}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PCT_3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-27" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="ce5a6756-da97-4e4b-8119-31d7c1c8dfeb"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="ce5a6756-da97-4e4b-8119-31d7c1c8dfeb" key="textField-27" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="None" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-32" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="00aefd19-1a2e-4bcd-a5d7-fde320f50de7"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="00aefd19-1a2e-4bcd-a5d7-fde320f50de7" key="textField-32" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="None" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-47" style="Level3_Line" stretchType="RelativeToBandHeight" x="454" y="0" width="19" height="18" uuid="afd51ccd-4209-422a-9049-d39a6bf1cea7"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="afd51ccd-4209-422a-9049-d39a6bf1cea7" key="textField-47" stretchType="ContainerHeight" x="454" y="0" width="19" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level3_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-48" style="Level3_Line" stretchType="RelativeToBandHeight" x="371" y="0" width="19" height="18" uuid="7c39dc55-ac3b-4eab-ab3d-681ef6b16078"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="7c39dc55-ac3b-4eab-ab3d-681ef6b16078" key="textField-48" stretchType="ContainerHeight" x="371" y="0" width="19" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level3_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -1019,163 +838,121 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL4">
-		<groupExpression><![CDATA[$F{NIVEL4}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL4}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="262" height="18" uuid="694917c2-fffc-4e66-83bc-0452c09770e7"/>
-					<box rightPadding="2">
+				<element kind="textField" uuid="694917c2-fffc-4e66-83bc-0452c09770e7" key="textField" stretchType="ContainerHeight" x="45" y="0" width="262" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[$F{NIVEL4}]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL4}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" x="520" y="0" width="80" height="18" uuid="82af8a9e-40ed-4b9c-927b-3da22ac27860">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="82af8a9e-40ed-4b9c-927b-3da22ac27860" key="textField" stretchType="ContainerHeight" x="520" y="0" width="80" height="18" evaluationTime="Group" evaluationGroup="NIVEL4" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" x="307" y="0" width="64" height="18" uuid="7a08e1b5-5262-4278-87eb-b29af57fb245"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="7a08e1b5-5262-4278-87eb-b29af57fb245" key="textField" stretchType="ContainerHeight" x="307" y="0" width="64" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" x="390" y="0" width="64" height="18" uuid="13b844f6-5ce5-4c2c-b711-d2934c4a1511"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="13b844f6-5ce5-4c2c-b711-d2934c4a1511" key="textField" stretchType="ContainerHeight" x="390" y="0" width="64" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{CONVAMOUNTREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNTREF_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNTREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNTREF_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" x="600" y="0" width="80" height="18" uuid="616e845b-07d6-4e34-8d30-069fefe44f62">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="616e845b-07d6-4e34-8d30-069fefe44f62" key="textField" stretchType="ContainerHeight" x="600" y="0" width="80" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-10" style="Level4_Line" stretchType="RelativeToBandHeight" x="473" y="0" width="47" height="18" uuid="f4e76c04-3697-40c0-a97e-9013500b5654"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f4e76c04-3697-40c0-a97e-9013500b5654" key="textField-10" stretchType="ContainerHeight" x="473" y="0" width="47" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{CONVAMT_PCT_4}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMT_PCT_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMT_PCT_4}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMT_PCT_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" x="680" y="0" width="50" height="18" uuid="ca8a2e31-b3b9-4b75-ad6e-7c93941fdaaa">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ca8a2e31-b3b9-4b75-ad6e-7c93941fdaaa" key="textField" stretchType="ContainerHeight" x="680" y="0" width="50" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PCT_4}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PCT_4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PCT_4}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PCT_4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-28" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="6935ddd0-7ce8-4a48-be4e-81f63574e3e6"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="6935ddd0-7ce8-4a48-be4e-81f63574e3e6" key="textField-28" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="None" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-30" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="a48d009f-caa5-47ad-b7bc-dfc043447c40"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="a48d009f-caa5-47ad-b7bc-dfc043447c40" key="textField-30" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="None" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-33" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="3302ebf7-ebe0-4687-b247-f48ef16385d2"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="3302ebf7-ebe0-4687-b247-f48ef16385d2" key="textField-33" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="None" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-53" style="Level4_Line" stretchType="RelativeToBandHeight" x="371" y="0" width="19" height="18" uuid="bdd5c215-e319-4e44-833d-e34b07729989"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="bdd5c215-e319-4e44-833d-e34b07729989" key="textField-53" stretchType="ContainerHeight" x="371" y="0" width="19" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level4_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-54" style="Level4_Line" stretchType="RelativeToBandHeight" x="454" y="0" width="19" height="18" uuid="eae3d791-019e-4f77-b310-44d894d917e6"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="eae3d791-019e-4f77-b310-44d894d917e6" key="textField-54" stretchType="ContainerHeight" x="454" y="0" width="19" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level4_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -1185,174 +962,130 @@
 		</groupFooter>
 	</group>
 	<group name="LEVEL5">
-		<groupExpression><![CDATA[$F{NIVEL5}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL5}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="247" height="18" uuid="de16bf52-82be-41f4-bfd3-5d5529b60cf6"/>
-					<box rightPadding="2">
+				<element kind="textField" uuid="de16bf52-82be-41f4-bfd3-5d5529b60cf6" key="textField" stretchType="ContainerHeight" x="60" y="0" width="247" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[$F{NIVEL5}]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL5}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" x="520" y="0" width="80" height="18" uuid="c56fcd77-d473-4a35-a03c-fce8057388fd">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c56fcd77-d473-4a35-a03c-fce8057388fd" key="textField" stretchType="ContainerHeight" x="520" y="0" width="80" height="18" evaluationTime="Group" evaluationGroup="LEVEL5" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" x="307" y="0" width="64" height="18" uuid="9a9c385a-97eb-494c-bcf0-d4ce1cd247e7"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9a9c385a-97eb-494c-bcf0-d4ce1cd247e7" key="textField" stretchType="ContainerHeight" x="307" y="0" width="64" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" x="390" y="0" width="64" height="18" uuid="c8b9c371-dde1-4ed0-95cf-8a1b4e6094a8"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c8b9c371-dde1-4ed0-95cf-8a1b4e6094a8" key="textField" stretchType="ContainerHeight" x="390" y="0" width="64" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{CONVAMOUNTREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNTREF_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNTREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNTREF_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" x="600" y="0" width="80" height="18" uuid="e1c763c2-e76f-4cc4-a6b0-7f1e24a0b132">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e1c763c2-e76f-4cc4-a6b0-7f1e24a0b132" key="textField" stretchType="ContainerHeight" x="600" y="0" width="80" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTYREF_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" x="473" y="0" width="47" height="18" uuid="9611da66-e1fd-42a3-8d58-f21daebd7623"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9611da66-e1fd-42a3-8d58-f21daebd7623" key="textField" stretchType="ContainerHeight" x="473" y="0" width="47" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{CONVAMT_PCT_5}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMT_PCT_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMT_PCT_5}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMT_PCT_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" x="680" y="0" width="50" height="18" uuid="9fa873dc-bbb4-4854-9a46-12362ded355f">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9fa873dc-bbb4-4854-9a46-12362ded355f" key="textField" stretchType="ContainerHeight" x="680" y="0" width="50" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PCT_5}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PCT_5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PCT_5}!=null)?$P{NUMBERFORMAT}.format($V{QTY_PCT_5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-29" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="1871335d-6d8d-47f7-8810-e496e4b2a5bd"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="1871335d-6d8d-47f7-8810-e496e4b2a5bd" key="textField-29" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="None" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-31" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="b712c411-dbc2-4ee5-9653-04d26188042c"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="b712c411-dbc2-4ee5-9653-04d26188042c" key="textField-31" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="None" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-34" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="658b0053-c7dd-4a2e-a349-e4fe48f7430d"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="658b0053-c7dd-4a2e-a349-e4fe48f7430d" key="textField-34" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="None" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-35" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="58f749cd-c32f-4e4a-8ec6-2bda61817a95"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="58f749cd-c32f-4e4a-8ec6-2bda61817a95" key="textField-35" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="None" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-49" style="Level5_Line" stretchType="RelativeToBandHeight" x="454" y="0" width="19" height="18" uuid="005c8798-61f4-4041-894f-39312126dca0"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="005c8798-61f4-4041-894f-39312126dca0" key="textField-49" stretchType="ContainerHeight" x="454" y="0" width="19" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level5_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-50" style="Level5_Line" stretchType="RelativeToBandHeight" x="371" y="0" width="19" height="18" uuid="1bbe9773-10cd-4873-88f7-c9a8798593df"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="1bbe9773-10cd-4873-88f7-c9a8798593df" key="textField-50" stretchType="ContainerHeight" x="371" y="0" width="19" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level5_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -1361,304 +1094,222 @@
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band height="11" splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="109" splitType="Stretch">
-			<frame>
-				<reportElement key="frame-1" mode="Opaque" x="0" y="90" width="730" height="19" backcolor="#5D5D5D" uuid="9a2e9015-c26d-48f3-aab4-7f587a6a1322"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-18" style="Detail_Header" mode="Transparent" x="0" y="0" width="15" height="19" uuid="02862fff-e197-4f40-99a3-ff3a0f7a36f0"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-19" style="Detail_Header" mode="Transparent" x="15" y="0" width="15" height="19" uuid="bab058da-df69-4704-8aa5-67bf17197a9b"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-20" style="Detail_Header" mode="Transparent" x="30" y="0" width="15" height="19" uuid="722708ac-b007-4202-a8c5-67b67f22c133"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-21" style="Detail_Header" mode="Transparent" x="45" y="0" width="15" height="19" uuid="f29e4c35-fe1e-428e-a3b2-3682cc363870"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-22" style="Detail_Header" mode="Transparent" x="60" y="0" width="15" height="19" uuid="2308e83b-0ab4-4005-88ec-68eab03c29b2"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":"")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-10" style="Detail_Header" mode="Opaque" x="307" y="0" width="83" height="19" uuid="1f92206f-0551-4831-bb4d-118007dbac53"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-11" style="Detail_Header" mode="Opaque" x="390" y="0" width="80" height="19" uuid="a3f7ed52-3bcd-40d5-b850-b14c64c1cc6c"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Amt. Ref.]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-12" style="Detail_Header" mode="Opaque" x="472" y="0" width="48" height="19" uuid="51468281-4f10-4f83-9c1d-ca14af2b256d"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[A %]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-13" style="Detail_Header" mode="Opaque" x="520" y="0" width="80" height="19" uuid="efea0807-facc-4834-8b10-dc3a46fe5561"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-14" style="Detail_Header" mode="Opaque" x="600" y="0" width="80" height="19" uuid="19697bc6-35a3-4e4a-8cd2-42be906eee93"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Qty. Ref.]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-15" style="Detail_Header" mode="Opaque" x="680" y="0" width="50" height="19" uuid="52381915-d783-4cc1-8495-506e7c374330"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Q %]]></text>
-				</staticText>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-44" style="Detail_Header" positionType="FixRelativeToBottom" x="258" y="0" width="49" height="19" uuid="6a45ef86-8390-41c9-bf53-1e29a67dbf2a"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-			</frame>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Report_Title" x="0" y="0" width="730" height="26" uuid="c764c6f7-d8c5-4c88-b5fe-20be97341c33"/>
-				<box leftPadding="5">
+	<background height="11" splitType="Stretch"/>
+	<title height="109" splitType="Stretch">
+		<element kind="frame" uuid="9a2e9015-c26d-48f3-aab4-7f587a6a1322" key="frame-1" mode="Opaque" x="0" y="90" width="730" height="19" backcolor="#5D5D5D">
+			<element kind="textField" uuid="02862fff-e197-4f40-99a3-ff3a0f7a36f0" key="textField-18" mode="Transparent" x="0" y="0" width="15" height="19" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></expression>
+				<box leftPadding="5" style="Detail_Header">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Subtitle" x="0" y="31" width="730" height="18" uuid="013d6551-a60c-427e-a5ac-7a1bf22a98a3"/>
-				<box leftPadding="5">
+			</element>
+			<element kind="textField" uuid="bab058da-df69-4704-8aa5-67bf17197a9b" key="textField-19" mode="Transparent" x="15" y="0" width="15" height="19" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></expression>
+				<box leftPadding="5" style="Detail_Header">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_SUBTITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="26" width="730" height="1" uuid="36e567f3-cc29-4932-9c38-c4259c23b8c7"/>
-			</line>
-			<line>
-				<reportElement key="line-2" x="0" y="49" width="730" height="1" uuid="611f4c6d-20c9-429f-a807-2a3b314c5f78"/>
-			</line>
-			<staticText>
-				<reportElement key="staticText-9" style="Report_Data_Label" x="0" y="54" width="114" height="16" uuid="2769bcd6-425f-437a-9cd0-3c44e5dd60a3"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="722708ac-b007-4202-a8c5-67b67f22c133" key="textField-20" mode="Transparent" x="30" y="0" width="15" height="19" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></expression>
+				<box leftPadding="5" style="Detail_Header">
+					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<text><![CDATA[Grouping Levels:]]></text>
-			</staticText>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-12" style="Report_Data_Field" x="114" y="54" width="616" height="16" uuid="27d789ab-6a5d-462d-a6d7-7515e77ec840"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="f29e4c35-fe1e-428e-a3b2-3682cc363870" key="textField-21" mode="Transparent" x="45" y="0" width="15" height="19" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></expression>
+				<box leftPadding="5" style="Detail_Header">
+					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<textFieldExpression><![CDATA[$P{LEVEL_LABEL}]]></textFieldExpression>
-			</textField>
-		</band>
+			</element>
+			<element kind="textField" uuid="2308e83b-0ab4-4005-88ec-68eab03c29b2" key="textField-22" mode="Transparent" x="60" y="0" width="15" height="19" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":"")]]></expression>
+				<box leftPadding="5" style="Detail_Header">
+					<pen lineWidth="0.0"/>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="1f92206f-0551-4831-bb4d-118007dbac53" key="staticText-10" mode="Opaque" x="307" y="0" width="83" height="19" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+				<text><![CDATA[Amount]]></text>
+				<box leftPadding="5" style="Detail_Header">
+					<pen lineWidth="0.0"/>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="a3f7ed52-3bcd-40d5-b850-b14c64c1cc6c" key="staticText-11" mode="Opaque" x="390" y="0" width="80" height="19" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+				<text><![CDATA[Amt. Ref.]]></text>
+				<box leftPadding="5" style="Detail_Header">
+					<pen lineWidth="0.0"/>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="51468281-4f10-4f83-9c1d-ca14af2b256d" key="staticText-12" mode="Opaque" x="472" y="0" width="48" height="19" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+				<text><![CDATA[A %]]></text>
+				<box leftPadding="5" style="Detail_Header">
+					<pen lineWidth="0.0"/>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="efea0807-facc-4834-8b10-dc3a46fe5561" key="staticText-13" mode="Opaque" x="520" y="0" width="80" height="19" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+				<text><![CDATA[Quantity]]></text>
+				<box leftPadding="5" style="Detail_Header">
+					<pen lineWidth="0.0"/>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="19697bc6-35a3-4e4a-8cd2-42be906eee93" key="staticText-14" mode="Opaque" x="600" y="0" width="80" height="19" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+				<text><![CDATA[Qty. Ref.]]></text>
+				<box leftPadding="5" style="Detail_Header">
+					<pen lineWidth="0.0"/>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="52381915-d783-4cc1-8495-506e7c374330" key="staticText-15" mode="Opaque" x="680" y="0" width="50" height="19" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+				<text><![CDATA[Q %]]></text>
+				<box leftPadding="5" style="Detail_Header">
+					<pen lineWidth="0.0"/>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="6a45ef86-8390-41c9-bf53-1e29a67dbf2a" key="textField-44" positionType="FixRelativeToBottom" x="258" y="0" width="49" height="19" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+				<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+				<box leftPadding="5" style="Detail_Header">
+					<pen lineWidth="0.0"/>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				</box>
+			</element>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="c764c6f7-d8c5-4c88-b5fe-20be97341c33" key="textField" x="0" y="0" width="730" height="26" textAdjust="StretchHeight" blankWhenNull="true" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="013d6551-a60c-427e-a5ac-7a1bf22a98a3" key="textField" x="0" y="31" width="730" height="18" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="36e567f3-cc29-4932-9c38-c4259c23b8c7" key="line-1" x="0" y="26" width="730" height="1"/>
+		<element kind="line" uuid="611f4c6d-20c9-429f-a807-2a3b314c5f78" key="line-2" x="0" y="49" width="730" height="1"/>
+		<element kind="staticText" uuid="2769bcd6-425f-437a-9cd0-3c44e5dd60a3" key="staticText-9" x="0" y="54" width="114" height="16" style="Report_Data_Label">
+			<text><![CDATA[Grouping Levels:]]></text>
+			<box style="Report_Data_Label">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="27d789ab-6a5d-462d-a6d7-7515e77ec840" key="textField-12" x="114" y="54" width="616" height="16" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Data_Field">
+			<expression><![CDATA[$P{LEVEL_LABEL}]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band splitType="Stretch"/>
 	</detail>
-	<columnFooter>
-		<band height="1" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="20" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-17" style="Report_Footer" x="282" y="3" width="78" height="16" uuid="be45b461-34c7-4bb2-a81c-de8fb34850bb"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom"/>
-				<text><![CDATA[Generated on ]]></text>
-			</staticText>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-23" style="Report_Footer" x="597" y="4" width="95" height="16" uuid="316e4ae4-cd4f-47b6-a980-cdb184ef3113"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom"/>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-24" style="Report_Footer" x="694" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="9060a12f-b0af-47c9-be4d-0c31731a9a62"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Bottom" rotation="None">
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-25" style="Report_Footer" x="371" y="3" width="90" height="16" uuid="75789202-b0bb-4de2-91e8-612d2e3cedf9"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Bottom"/>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-4" x="0" y="1" width="730" height="1" uuid="d7856d05-6380-4608-baab-6cdc355c8b37"/>
-			</line>
-		</band>
+	<columnFooter height="1" splitType="Stretch"/>
+	<pageFooter height="20" splitType="Stretch">
+		<element kind="staticText" uuid="be45b461-34c7-4bb2-a81c-de8fb34850bb" key="staticText-17" x="282" y="3" width="78" height="16" hTextAlign="Right" vTextAlign="Bottom" style="Report_Footer">
+			<text><![CDATA[Generated on ]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="316e4ae4-cd4f-47b6-a980-cdb184ef3113" key="textField-23" x="597" y="4" width="95" height="16" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Bottom" style="Report_Footer">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="9060a12f-b0af-47c9-be4d-0c31731a9a62" key="textField-24" x="694" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" rotation="None" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Bottom" style="Report_Footer">
+			<paragraph lineSpacing="Single" style="Report_Footer"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="75789202-b0bb-4de2-91e8-612d2e3cedf9" key="textField-25" x="371" y="3" width="90" height="16" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Bottom" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="d7856d05-6380-4608-baab-6cdc355c8b37" key="line-4" x="0" y="1" width="730" height="1"/>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/SimpleDimensionalNoComparative.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/SimpleDimensionalNoComparative.jrxml
@@ -1,176 +1,164 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="SimpleDimensionalNoComparative" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="561cda02-49ee-459a-9225-b5d1e5db8cbb">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="SimpleDimensionalNoComparative" language="java" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="561cda02-49ee-459a-9225-b5d1e5db8cbb">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" isDefault="true" vAlign="Middle" fontName="SansSerif" fontSize="11"/>
-	<style name="Report_Title" fontName="SansSerif" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="11.0"/>
+	<style name="Report_Title" fontName="SansSerif" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="SansSerif" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="SansSerif" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Data_Label" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
-	<style name="Report_Data_Field" fontName="SansSerif" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="10" isBold="false">
+	<style name="Report_Data_Label" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="11.0" bold="false"/>
+	<style name="Report_Data_Field" fontName="SansSerif" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="10.0" bold="false">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="SansSerif" fontSize="10" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="10.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="Detail_Line" fontName="SansSerif" fontSize="8" isBold="true">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="SansSerif" fontSize="8.0" bold="true">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level1_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="true">
-		<conditionalStyle>
+	<style name="Level1_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="true">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==1)&&($V{NIVEL1_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==1)&&($V{NIVEL1_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level2_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="true">
-		<conditionalStyle>
+	<style name="Level2_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="true">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==2)&&($V{NIVEL1_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==2)&&($V{NIVEL1_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level3_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="true">
-		<conditionalStyle>
+	<style name="Level3_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="true">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==3)&&($V{NIVEL2_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==3)&&($V{NIVEL2_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level4_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="true">
-		<conditionalStyle>
+	<style name="Level4_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="true">
+		<conditionalStyle backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==4)&&($V{NIVEL3_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==4)&&($V{NIVEL3_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level5_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="true">
-		<conditionalStyle>
+	<style name="Level5_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="true">
+		<conditionalStyle mode="Opaque" backcolor="#FFFFFF" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==5)&&($V{NIVEL4_COUNT}.intValue()%2==0))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#FFFFFF" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="false">
 			<conditionExpression><![CDATA[new Boolean(($P{DIMENSIONS}.intValue()==5)&&($V{NIVEL4_COUNT}.intValue()%2==1))]]></conditionExpression>
-			<style mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="false"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level6_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="true"/>
-	<style name="Level7_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="true"/>
-	<style name="Level8_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="true"/>
-	<style name="Level9_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="8" isBold="true"/>
-	<style name="Report_Footer" vAlign="Middle" fontName="SansSerif" fontSize="11"/>
+	<style name="Level6_Line" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="true"/>
+	<style name="Level7_Line" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="true"/>
+	<style name="Level8_Line" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="true"/>
+	<style name="Level9_Line" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="8.0" bold="true"/>
+	<style name="Report_Footer" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="11.0"/>
 	<style name="Detail_Border" forecolor="#8A8A8A">
 		<pen lineWidth="0.25" lineStyle="Solid"/>
 	</style>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["0,1000000"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["0,1000000"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATEFROM" class="java.util.Date" isForPrompting="false">
+	<parameter name="DATEFROM" forPrompting="false" class="java.util.Date">
 		<defaultValueExpression><![CDATA[(new SimpleDateFormat("dd-MM-yyyy")).parse("01-01-1900")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATETO" class="java.util.Date" isForPrompting="false">
+	<parameter name="DATETO" forPrompting="false" class="java.util.Date">
 		<defaultValueExpression><![CDATA[(new SimpleDateFormat("dd-MM-yyyy")).parse("31-12-3000")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="cBpGroupId" class="java.lang.String" isForPrompting="false">
+	<parameter name="cBpGroupId" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="cBpGroupId_Aux" class="java.lang.String" isForPrompting="false">
+	<parameter name="cBpGroupId_Aux" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{cBpGroupId}.equals("") ? " " : (" AND C_BP_Group.C_BP_Group_ID = " + $P{cBpGroupId})]]></defaultValueExpression>
 	</parameter>
-	<parameter name="cBpartnerId" class="java.lang.String" isForPrompting="false">
+	<parameter name="cBpartnerId" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="cBpartnerId_Aux" class="java.lang.String" isForPrompting="false">
+	<parameter name="cBpartnerId_Aux" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{cBpartnerId}.equals(""))?"  ":" AND C_BPartner.C_BPartner_ID IN " + $P{cBpartnerId}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="mProductCategoryId" class="java.lang.String" isForPrompting="false">
+	<parameter name="mProductCategoryId" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="mProductCategoryId_Aux" class="java.lang.String" isForPrompting="false">
+	<parameter name="mProductCategoryId_Aux" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{mProductCategoryId}.equals(""))?"  ":" AND M_Product_Category.M_Product_Category_Id = " + $P{mProductCategoryId}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="mProductId" class="java.lang.String" isForPrompting="false">
+	<parameter name="mProductId" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="mProductId_Aux" class="java.lang.String" isForPrompting="false">
+	<parameter name="mProductId_Aux" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{mProductId}.equals(""))?" ":" AND M_Product.M_Product_ID IN " + $P{mProductId}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="orderBy" class="java.lang.String" isForPrompting="false">
+	<parameter name="orderBy" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[" ORDER BY 1 "]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Purchase Orders Report"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="PRODUCT_LEVEL" class="java.lang.Integer" isForPrompting="false">
+	<parameter name="PRODUCT_LEVEL" forPrompting="false" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[new Integer(3)]]></defaultValueExpression>
 	</parameter>
-	<parameter name="THEME" class="java.lang.String" isForPrompting="false">
+	<parameter name="THEME" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Default"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false">
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/var/lib/tomcat-5.5/webapps/alerts/web"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL1_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL1_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Partner Group"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL2_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL2_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Product Category"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL3_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL3_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Product"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL4_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL4_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Partner"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL5_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL6_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL7_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL8_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL9_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="DIMENSIONS" class="java.lang.Integer" isForPrompting="false">
+	<parameter name="LEVEL5_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL6_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL7_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL8_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL9_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="DIMENSIONS" forPrompting="false" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[new Integer(4)]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["1.- "+$P{LEVEL1_LABEL}
 +($P{LEVEL2_LABEL}==""?"":", 2.- "+$P{LEVEL2_LABEL})
 +($P{LEVEL3_LABEL}==""?"":", 3.- "+$P{LEVEL3_LABEL})
 +($P{LEVEL4_LABEL}==""?"":", 4.- "+$P{LEVEL4_LABEL})
 +($P{LEVEL5_LABEL}==""?"":", 5.- "+$P{LEVEL5_LABEL})]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5,
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5,
       SUM(AMOUNT) AS AMOUNT, SUM(QTY) AS QTY,
       SUM(AMOUNTREF) AS AMOUNTREF, SUM(QTYREF) AS QTYREF, UOMSYMBOL,
       SUM(CONVAMOUNT) AS CONVAMOUNT,           
@@ -203,8 +191,7 @@
       AND C_ORDER.AD_CLIENT_ID IN ('6')
       AND 1=1) AA
       GROUP BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, UOMSYMBOL, TRCURRENCYID, TRDATE, TRCLIENTID, TRORGID) ZZ
-      GROUP BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, UOMSYMBOL, CONVSYM, CONVISOSYM, 1]]>
-	</queryString>
+      GROUP BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, UOMSYMBOL, CONVSYM, CONVISOSYM, 1]]></query>
 	<field name="NIVEL1" class="java.lang.String"/>
 	<field name="NIVEL2" class="java.lang.String"/>
 	<field name="NIVEL3" class="java.lang.String"/>
@@ -218,251 +205,195 @@
 	<field name="UOMSYMBOL" class="java.lang.String"/>
 	<field name="CONVSYM" class="java.lang.String"/>
 	<field name="CONVISOSYM" class="java.lang.String"/>
-	<variable name="QTY_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="QTY_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="AMOUNT_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
 	<group name="TOTALIZE">
-		<groupExpression><![CDATA[]]></groupExpression>
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band splitType="Stretch"/>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-21" style="Total_Field" x="327" y="2" width="68" height="16" uuid="4a6c8cf8-4f01-4e8c-b07b-a8e2cff554f5"/>
-					<box leftPadding="5">
+				<element kind="textField" uuid="4a6c8cf8-4f01-4e8c-b07b-a8e2cff554f5" key="textField-21" x="327" y="2" width="68" height="16" fontSize="8.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{CONVAMOUNT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_TOTAL}):new String(" ")]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_TOTAL}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_TOTAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-8" style="Report_Data_Label" x="233" y="2" width="94" height="16" uuid="ab2525b0-7f69-4152-a228-5254841f0e18"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="ab2525b0-7f69-4152-a228-5254841f0e18" key="staticText-8" x="233" y="2" width="94" height="16" fontSize="8.0" hTextAlign="Right" vTextAlign="Middle" style="Report_Data_Label">
 					<text><![CDATA[Total:]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-3" x="0" y="1" width="483" height="1" uuid="663a807c-bcc6-469f-a424-c45411ea1e2b"/>
-				</line>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-23" style="Detail_Header" mode="Opaque" x="15" y="2" width="15" height="16" uuid="477e894c-6fb0-449d-a9c7-d5c64b3d7450">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Report_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="663a807c-bcc6-469f-a424-c45411ea1e2b" key="line-3" x="0" y="1" width="483" height="1"/>
+				<element kind="textField" uuid="477e894c-6fb0-449d-a9c7-d5c64b3d7450" key="textField-23" mode="Opaque" x="15" y="2" width="15" height="16" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" evaluationTime="Report" pattern="##0.00" isBlankWhenNull="true">
-					<reportElement key="textField-22" style="Detail_Header" x="0" y="2" width="15" height="16" uuid="071a4e90-dda9-4aba-b158-8a86df90ea92">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="071a4e90-dda9-4aba-b158-8a86df90ea92" key="textField-22" x="0" y="2" width="15" height="16" rotation="None" fontSize="8.0" textAdjust="StretchHeight" evaluationTime="Report" pattern="##0.00" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-24" style="Detail_Header" mode="Opaque" x="30" y="2" width="15" height="16" uuid="f23e5d31-fe65-4713-bfe8-cd67ccdbde94">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="f23e5d31-fe65-4713-bfe8-cd67ccdbde94" key="textField-24" mode="Opaque" x="30" y="2" width="15" height="16" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-25" style="Detail_Header" mode="Opaque" x="45" y="2" width="15" height="16" uuid="2b9be694-ca70-434f-b145-dfd7b2648ed0">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="2b9be694-ca70-434f-b145-dfd7b2648ed0" key="textField-25" mode="Opaque" x="45" y="2" width="15" height="16" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-26" style="Detail_Header" mode="Opaque" x="60" y="2" width="15" height="16" uuid="f3f6c93e-a245-48b1-99b9-785f355a4a67">
-						<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="f3f6c93e-a245-48b1-99b9-785f355a4a67" key="textField-26" mode="Opaque" x="60" y="2" width="15" height="16" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+					<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":" ")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-81" style="Total_Field" x="395" y="2" width="19" height="16" uuid="f3ec2043-ce86-4dbf-965e-b0b916c04f6c"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="f3ec2043-ce86-4dbf-965e-b0b916c04f6c" key="textField-81" x="395" y="2" width="19" height="16" fontSize="8.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Center" style="Total_Field">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="NIVEL1">
-		<groupExpression><![CDATA[$F{NIVEL1}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL1}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="327" height="18" uuid="03f79728-5d84-4b8f-9c9f-1ea288453980"/>
-					<box rightPadding="2">
+				<element kind="textField" uuid="03f79728-5d84-4b8f-9c9f-1ea288453980" key="textField" stretchType="ContainerHeight" x="0" y="0" width="327" height="18" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[$F{NIVEL1}]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement>
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL1}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" x="414" y="0" width="69" height="18" uuid="ee17b8da-2945-427f-83e9-07728e3b34e1">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="5" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="ee17b8da-2945-427f-83e9-07728e3b34e1" key="textField" stretchType="ContainerHeight" x="414" y="0" width="69" height="18" evaluationTime="Group" evaluationGroup="NIVEL1" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM1}):new String(" ")]]></expression>
+					<box leftPadding="5" rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" x="327" y="0" width="68" height="18" uuid="0b4aa785-738b-4d0f-a85b-afd3280d7da4"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0b4aa785-738b-4d0f-a85b-afd3280d7da4" key="textField" stretchType="ContainerHeight" x="327" y="0" width="68" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_SUM1}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM1}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_SUM1}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-66" style="Level1_Line" stretchType="RelativeToBandHeight" x="395" y="0" width="19" height="18" uuid="29d3e5fb-f828-464c-b2fc-34e4dc7c5071"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="29d3e5fb-f828-464c-b2fc-34e4dc7c5071" key="textField-66" stretchType="ContainerHeight" x="395" y="0" width="19" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level1_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -472,72 +403,56 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL2">
-		<groupExpression><![CDATA[$F{NIVEL2}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL2}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="312" height="18" uuid="bf4f4e8a-1d89-4beb-892f-51012ce35580"/>
-					<box rightPadding="2">
+				<element kind="textField" uuid="bf4f4e8a-1d89-4beb-892f-51012ce35580" key="textField" stretchType="ContainerHeight" x="15" y="0" width="312" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[$F{NIVEL2}]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL2}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" x="414" y="0" width="69" height="18" uuid="330d90b1-63f7-4358-81ff-f2d6fbbc2ac0">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="330d90b1-63f7-4358-81ff-f2d6fbbc2ac0" key="textField" stretchType="ContainerHeight" x="414" y="0" width="69" height="18" evaluationTime="Group" evaluationGroup="NIVEL2" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" x="327" y="0" width="68" height="18" uuid="9224e922-0b61-42bc-b1bb-6edb08cca58b"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9224e922-0b61-42bc-b1bb-6edb08cca58b" key="textField" stretchType="ContainerHeight" x="327" y="0" width="68" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_SUM2}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM2}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_SUM2}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-2" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="4944bc78-e150-45d3-b2f6-49564aa6633a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4944bc78-e150-45d3-b2f6-49564aa6633a" key="textField-2" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-67" style="Level2_Line" stretchType="RelativeToBandHeight" x="395" y="0" width="19" height="18" uuid="cca72bb7-90bd-4f34-9827-5a45575431c4"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="cca72bb7-90bd-4f34-9827-5a45575431c4" key="textField-67" stretchType="ContainerHeight" x="395" y="0" width="19" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level2_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -547,83 +462,65 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL3">
-		<groupExpression><![CDATA[$F{NIVEL3}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL3}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="297" height="18" uuid="16b9904a-b742-40d8-bdbe-5295028251f0"/>
-					<box rightPadding="2">
+				<element kind="textField" uuid="16b9904a-b742-40d8-bdbe-5295028251f0" key="textField" stretchType="ContainerHeight" x="30" y="0" width="297" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[$F{NIVEL3}]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL3}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" x="414" y="0" width="69" height="18" uuid="0ee12426-ede3-4cf8-9262-4a82eb5b5249">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0ee12426-ede3-4cf8-9262-4a82eb5b5249" key="textField" stretchType="ContainerHeight" x="414" y="0" width="69" height="18" evaluationTime="Group" evaluationGroup="NIVEL3" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" x="327" y="0" width="68" height="18" uuid="93782ee4-ad3c-41c2-8c53-025a7510b003"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="93782ee4-ad3c-41c2-8c53-025a7510b003" key="textField" stretchType="ContainerHeight" x="327" y="0" width="68" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_SUM3}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM3}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_SUM3}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-3" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="2254a5f6-cbae-4a57-aa24-96d4ac7d6134"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2254a5f6-cbae-4a57-aa24-96d4ac7d6134" key="textField-3" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-8" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="73033cea-51ea-4a44-b8bd-ca3bdf0a8d9a"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="73033cea-51ea-4a44-b8bd-ca3bdf0a8d9a" key="textField-8" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-68" style="Level3_Line" stretchType="RelativeToBandHeight" x="395" y="0" width="19" height="18" uuid="d94e61e5-9e21-4f84-90cc-04b8b176af82"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="d94e61e5-9e21-4f84-90cc-04b8b176af82" key="textField-68" stretchType="ContainerHeight" x="395" y="0" width="19" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level3_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -633,94 +530,74 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL4">
-		<groupExpression><![CDATA[$F{NIVEL4}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL4}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="282" height="18" uuid="4482e29c-49e7-4edb-9454-d7f44068045f"/>
-					<box rightPadding="2">
+				<element kind="textField" uuid="4482e29c-49e7-4edb-9454-d7f44068045f" key="textField" stretchType="ContainerHeight" x="45" y="0" width="282" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[$F{NIVEL4}]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL4}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" x="414" y="0" width="69" height="18" uuid="c6ce865b-8c6d-4de4-97d4-5f0fddb76255">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="c6ce865b-8c6d-4de4-97d4-5f0fddb76255" key="textField" stretchType="ContainerHeight" x="414" y="0" width="69" height="18" evaluationTime="Group" evaluationGroup="NIVEL4" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" x="327" y="0" width="68" height="18" uuid="8a2f3da9-6411-43f2-8c11-7472d2b1531f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="8a2f3da9-6411-43f2-8c11-7472d2b1531f" key="textField" stretchType="ContainerHeight" x="327" y="0" width="68" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_SUM4}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM4}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_SUM4}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-4" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="d14b8f82-c239-4b49-afee-6964b29922a3"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="d14b8f82-c239-4b49-afee-6964b29922a3" key="textField-4" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-6" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="efc879d0-9101-47b0-b1d2-52a20095b18c"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="efc879d0-9101-47b0-b1d2-52a20095b18c" key="textField-6" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-9" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="43ab8586-99d6-46b7-a540-7406f1bb5c77"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="43ab8586-99d6-46b7-a540-7406f1bb5c77" key="textField-9" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-69" style="Level4_Line" stretchType="RelativeToBandHeight" x="395" y="0" width="19" height="18" uuid="f4f6fa60-67a4-4fff-849b-693d8419c7c9"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="f4f6fa60-67a4-4fff-849b-693d8419c7c9" key="textField-69" stretchType="ContainerHeight" x="395" y="0" width="19" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level4_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -730,105 +607,83 @@
 		</groupFooter>
 	</group>
 	<group name="LEVEL5">
-		<groupExpression><![CDATA[$F{NIVEL5}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL5}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" x="60" y="0" width="267" height="18" uuid="72445be2-5478-40e8-a72a-d6ef5ae078b2"/>
-					<box rightPadding="2">
+				<element kind="textField" uuid="72445be2-5478-40e8-a72a-d6ef5ae078b2" key="textField" stretchType="ContainerHeight" x="60" y="0" width="267" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[$F{NIVEL5}]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL5}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" x="414" y="0" width="69" height="18" uuid="33fc32bc-f2e1-40f2-a438-decf345d8093">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="33fc32bc-f2e1-40f2-a438-decf345d8093" key="textField" stretchType="ContainerHeight" x="414" y="0" width="69" height="18" evaluationTime="Group" evaluationGroup="LEVEL5" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{QTY_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" x="327" y="0" width="68" height="18" uuid="596fb919-6575-43e2-b3e0-34dcfff15548"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="596fb919-6575-43e2-b3e0-34dcfff15548" key="textField" stretchType="ContainerHeight" x="327" y="0" width="68" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_SUM5}):new String(" ")]]></expression>
+					<box rightPadding="2" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM5}!=null)?$P{NUMBERFORMAT}.format($V{CONVAMOUNT_SUM5}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-5" style="Level1_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="15" height="18" uuid="30bd4eb8-bf2d-43dd-bf11-c50e2ee3686f"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="30bd4eb8-bf2d-43dd-bf11-c50e2ee3686f" key="textField-5" stretchType="ContainerHeight" x="0" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box rightPadding="2" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-7" style="Level3_Line" stretchType="RelativeToBandHeight" x="30" y="0" width="15" height="18" uuid="0977bc74-2c5b-4512-aed2-85964f7c9ef6"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="0977bc74-2c5b-4512-aed2-85964f7c9ef6" key="textField-7" stretchType="ContainerHeight" x="30" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box rightPadding="2" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-10" style="Level2_Line" stretchType="RelativeToBandHeight" x="15" y="0" width="15" height="18" uuid="5e674faa-d2fd-4802-9f91-20a8676ffb33"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="5e674faa-d2fd-4802-9f91-20a8676ffb33" key="textField-10" stretchType="ContainerHeight" x="15" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box rightPadding="2" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-11" style="Level4_Line" stretchType="RelativeToBandHeight" x="45" y="0" width="15" height="18" uuid="9c2a5bc3-41fe-4a9c-b32f-5f6989555f52"/>
-					<box rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9c2a5bc3-41fe-4a9c-b32f-5f6989555f52" key="textField-11" stretchType="ContainerHeight" x="45" y="0" width="15" height="18" rotation="Left" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box rightPadding="2" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-70" style="Level5_Line" stretchType="RelativeToBandHeight" x="395" y="0" width="19" height="18" uuid="e18c8dd9-8bd8-4389-899f-8473951fdc63"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="e18c8dd9-8bd8-4389-899f-8473951fdc63" key="textField-70" stretchType="ContainerHeight" x="395" y="0" width="19" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level5_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#999999"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -837,248 +692,182 @@
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band height="11" splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="104" splitType="Stretch">
-			<frame>
-				<reportElement key="frame-1" mode="Opaque" x="0" y="85" width="483" height="19" backcolor="#5D5D5D" uuid="9e8a3913-9ead-4a01-b13b-ddfa3335dd47"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-61" style="Detail_Header" x="0" y="1" width="15" height="17" uuid="51a8625d-60d3-4a08-a881-e90a37f6371b"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-62" style="Detail_Header" x="15" y="1" width="15" height="17" uuid="7a33bd80-ef45-4261-aeaa-a19f19cbb5c9"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-63" style="Detail_Header" x="30" y="1" width="15" height="17" uuid="bdbd6ccf-3025-4965-a7b0-f5ce373cc27e"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-64" style="Detail_Header" x="45" y="1" width="15" height="17" uuid="122c6e9f-8c2b-4053-8d6f-bd8fd162334f"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-65" style="Detail_Header" x="60" y="1" width="15" height="17" uuid="7598ecd4-9dee-4f9a-bd04-bad18a90c8ac"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":"")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-9" style="Detail_Header" mode="Opaque" x="327" y="1" width="42" height="17" uuid="95019775-ad6c-440e-a0e7-4b759552dd11"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Amount]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-10" style="Detail_Header" mode="Opaque" x="414" y="1" width="69" height="17" uuid="25f6f682-66c5-4200-8c9b-e13c7a59a906"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Center">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-82" style="Detail_Header" positionType="FixRelativeToBottom" x="369" y="1" width="45" height="17" uuid="83857200-e7b1-4482-af5a-34e22da15e51"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="8" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-				</textField>
-			</frame>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Report_Title" x="0" y="0" width="482" height="26" uuid="1651fc77-1e47-4251-879d-a35bc772aadb"/>
-				<box leftPadding="5">
+	<background height="11" splitType="Stretch"/>
+	<title height="104" splitType="Stretch">
+		<element kind="frame" uuid="9e8a3913-9ead-4a01-b13b-ddfa3335dd47" key="frame-1" mode="Opaque" x="0" y="85" width="483" height="19" backcolor="#5D5D5D">
+			<element kind="textField" uuid="51a8625d-60d3-4a08-a881-e90a37f6371b" key="textField-61" x="0" y="1" width="15" height="17" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></expression>
+				<box leftPadding="5" style="Detail_Header">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Subtitle" x="0" y="31" width="483" height="18" uuid="bf6079e0-c28b-4083-9073-821ce9955a8c"/>
-				<box leftPadding="5">
+			</element>
+			<element kind="textField" uuid="7a33bd80-ef45-4261-aeaa-a19f19cbb5c9" key="textField-62" x="15" y="1" width="15" height="17" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></expression>
+				<box leftPadding="5" style="Detail_Header">
 					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_SUBTITLE}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-5" style="Report_Data_Label" x="0" y="56" width="114" height="16" uuid="9413c214-2f4f-4384-b3b9-2f188fcf815e"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="bdbd6ccf-3025-4965-a7b0-f5ce373cc27e" key="textField-63" x="30" y="1" width="15" height="17" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></expression>
+				<box leftPadding="5" style="Detail_Header">
+					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<text><![CDATA[Grouping Levels:]]></text>
-			</staticText>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-17" style="Report_Data_Field" x="114" y="56" width="369" height="16" uuid="9f3db144-35be-4ff4-af6f-a245e6972403"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="122c6e9f-8c2b-4053-8d6f-bd8fd162334f" key="textField-64" x="45" y="1" width="15" height="17" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></expression>
+				<box leftPadding="5" style="Detail_Header">
+					<pen lineWidth="0.0"/>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 				</box>
-				<textFieldExpression><![CDATA[$P{LEVEL_LABEL}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="26" width="483" height="1" uuid="f1b5eaf3-2ab2-4a2c-9638-45ff5fed808e"/>
-			</line>
-			<line>
-				<reportElement key="line-2" x="0" y="49" width="483" height="1" uuid="0ef9bee3-8868-433d-aac3-6408e0fcf367"/>
-			</line>
-		</band>
+			</element>
+			<element kind="textField" uuid="7598ecd4-9dee-4f9a-bd04-bad18a90c8ac" key="textField-65" x="60" y="1" width="15" height="17" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+				<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":"")]]></expression>
+				<box leftPadding="5" style="Detail_Header">
+					<pen lineWidth="0.0"/>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="95019775-ad6c-440e-a0e7-4b759552dd11" key="staticText-9" mode="Opaque" x="327" y="1" width="42" height="17" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+				<text><![CDATA[Amount]]></text>
+				<box leftPadding="5" style="Detail_Header">
+					<pen lineWidth="0.0"/>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				</box>
+			</element>
+			<element kind="staticText" uuid="25f6f682-66c5-4200-8c9b-e13c7a59a906" key="staticText-10" mode="Opaque" x="414" y="1" width="69" height="17" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+				<text><![CDATA[Quantity]]></text>
+				<box leftPadding="5" style="Detail_Header">
+					<pen lineWidth="0.0"/>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="83857200-e7b1-4482-af5a-34e22da15e51" key="textField-82" positionType="FixRelativeToBottom" x="369" y="1" width="45" height="17" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="true" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+				<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+				<box leftPadding="5" style="Detail_Header">
+					<pen lineWidth="0.0"/>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				</box>
+			</element>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="1651fc77-1e47-4251-879d-a35bc772aadb" key="textField" x="0" y="0" width="482" height="26" textAdjust="StretchHeight" blankWhenNull="true" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="bf6079e0-c28b-4083-9073-821ce9955a8c" key="textField" x="0" y="31" width="483" height="18" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="9413c214-2f4f-4384-b3b9-2f188fcf815e" key="staticText-5" x="0" y="56" width="114" height="16" style="Report_Data_Label">
+			<text><![CDATA[Grouping Levels:]]></text>
+			<box style="Report_Data_Label">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="9f3db144-35be-4ff4-af6f-a245e6972403" key="textField-17" x="114" y="56" width="369" height="16" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Data_Field">
+			<expression><![CDATA[$P{LEVEL_LABEL}]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="f1b5eaf3-2ab2-4a2c-9638-45ff5fed808e" key="line-1" x="0" y="26" width="483" height="1"/>
+		<element kind="line" uuid="0ef9bee3-8868-433d-aac3-6408e0fcf367" key="line-2" x="0" y="49" width="483" height="1"/>
 	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band splitType="Stretch"/>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="20" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-7" style="Report_Footer" x="156" y="3" width="78" height="16" uuid="4df50366-d521-4ee3-a46f-4985a5d8d77f"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom"/>
-				<text><![CDATA[Generated on ]]></text>
-			</staticText>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-18" style="Report_Footer" x="237" y="3" width="90" height="16" uuid="f86eb7a9-88e6-42a5-8229-06bfa6896a5f"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Bottom"/>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-19" style="Report_Footer" x="350" y="3" width="95" height="16" uuid="2043b131-3d17-4c5f-86d3-69ffe36b22bb"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Bottom"/>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-20" style="Report_Footer" x="447" y="3" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="bb4eed15-3588-4a72-a8a0-ef98f1d6e7c5"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Bottom" rotation="None">
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-4" style="Report_Footer" x="0" y="2" width="483" height="1" uuid="33d25c1e-eabc-4ffb-bf07-674b413b60d2"/>
-			</line>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="20" splitType="Stretch">
+		<element kind="staticText" uuid="4df50366-d521-4ee3-a46f-4985a5d8d77f" key="staticText-7" x="156" y="3" width="78" height="16" hTextAlign="Right" vTextAlign="Bottom" style="Report_Footer">
+			<text><![CDATA[Generated on ]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="f86eb7a9-88e6-42a5-8229-06bfa6896a5f" key="textField-18" x="237" y="3" width="90" height="16" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Bottom" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="2043b131-3d17-4c5f-86d3-69ffe36b22bb" key="textField-19" x="350" y="3" width="95" height="16" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Bottom" style="Report_Footer">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="bb4eed15-3588-4a72-a8a0-ef98f1d6e7c5" key="textField-20" x="447" y="3" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" rotation="None" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Bottom" style="Report_Footer">
+			<paragraph lineSpacing="Single" style="Report_Footer"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="33d25c1e-eabc-4ffb-bf07-674b413b60d2" key="line-4" x="0" y="2" width="483" height="1" style="Report_Footer"/>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/SubreportWorkRequirementDaily.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/SubreportWorkRequirementDaily.jrxml
@@ -1,96 +1,69 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="SubreportWorkRequirementDaily" pageWidth="421" pageHeight="595" columnWidth="361" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="93cd12be-f396-4bf9-accc-8e150eb954b4">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="SubreportWorkRequirementDaily" language="java" pageWidth="421" pageHeight="595" columnWidth="361" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="93cd12be-f396-4bf9-accc-8e150eb954b4">
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="WRPID" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT M_PRODUCT.NAME AS PRODUCT_NAME, MA_WRPHASEPRODUCT.MOVEMENTQTY
+	<parameter name="WRPID" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT M_PRODUCT.NAME AS PRODUCT_NAME, MA_WRPHASEPRODUCT.MOVEMENTQTY
 FROM M_PRODUCT, MA_WRPHASEPRODUCT
 WHERE MA_WRPHASEPRODUCT.MA_WRPHASE_ID = '$P!{WRPID}'
 AND M_PRODUCT.M_PRODUCT_ID = MA_WRPHASEPRODUCT.M_PRODUCT_ID
-AND MA_WRPHASEPRODUCT.PRODUCTIONTYPE = '+']]>
-	</queryString>
+AND MA_WRPHASEPRODUCT.PRODUCTIONTYPE = '+']]></query>
 	<field name="product_name" class="java.lang.String"/>
 	<field name="movementqty" class="java.math.BigDecimal"/>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band height="20" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-1" x="0" y="0" width="200" height="20" uuid="dbba8d70-4e8c-473b-af58-b79ebb7bb635"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Product]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-2" x="200" y="0" width="130" height="20" uuid="0ab7c765-ff93-47d4-9e70-a12a64cc5edf"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Produced qty.]]></text>
-			</staticText>
-		</band>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader height="20" splitType="Stretch">
+		<element kind="staticText" uuid="dbba8d70-4e8c-473b-af58-b79ebb7bb635" key="staticText-1" x="0" y="0" width="200" height="20" pdfFontName="Helvetica-Bold" bold="true">
+			<text><![CDATA[Product]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="0ab7c765-ff93-47d4-9e70-a12a64cc5edf" key="staticText-2" x="200" y="0" width="130" height="20" pdfFontName="Helvetica-Bold" bold="true">
+			<text><![CDATA[Produced qty.]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</columnHeader>
 	<detail>
 		<band height="18" splitType="Stretch">
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-1" x="0" y="0" width="200" height="18" uuid="fee5fb4c-038f-46df-b50e-bb2392aad13b"/>
+			<element kind="textField" uuid="fee5fb4c-038f-46df-b50e-bb2392aad13b" key="textField-1" x="0" y="0" width="200" height="18" blankWhenNull="false">
+				<expression><![CDATA[$F{product_name}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$F{product_name}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-2" x="200" y="0" width="130" height="18" uuid="14bc74f6-05e3-4139-8fd3-e37c4e14e8b1"/>
+			</element>
+			<element kind="textField" uuid="14bc74f6-05e3-4139-8fd3-e37c4e14e8b1" key="textField-2" x="200" y="0" width="130" height="18" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[($F{movementqty}!=null)?$P{NUMBERFORMAT}.format($F{movementqty}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA[($F{movementqty}!=null)?$P{NUMBERFORMAT}.format($F{movementqty}):new String(" ")]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/SubreportWorkRequirementDaily2.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/SubreportWorkRequirementDaily2.jrxml
@@ -1,69 +1,50 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="SubreportWorkRequirementDaily2" pageWidth="506" pageHeight="200" orientation="Landscape" columnWidth="506" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="5ca7e2de-24bb-469b-a8db-82e35bb6a962">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="SubreportWorkRequirementDaily2" language="java" pageWidth="506" pageHeight="200" orientation="Landscape" columnWidth="506" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="5ca7e2de-24bb-469b-a8db-82e35bb6a962">
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="WRPID" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT M_PRODUCT.NAME AS PRODUCT_NAME, MA_WRPHASEPRODUCT.MOVEMENTQTY
+	<parameter name="WRPID" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT M_PRODUCT.NAME AS PRODUCT_NAME, MA_WRPHASEPRODUCT.MOVEMENTQTY
 FROM M_PRODUCT, MA_WRPHASEPRODUCT
 WHERE MA_WRPHASEPRODUCT.MA_WRPHASE_ID = '$P!{WRPID}'
 AND M_PRODUCT.M_PRODUCT_ID = MA_WRPHASEPRODUCT.M_PRODUCT_ID
-AND MA_WRPHASEPRODUCT.PRODUCTIONTYPE = '-']]>
-	</queryString>
+AND MA_WRPHASEPRODUCT.PRODUCTIONTYPE = '-']]></query>
 	<field name="product_name" class="java.lang.String"/>
 	<field name="movementqty" class="java.math.BigDecimal"/>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="18" splitType="Stretch">
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-1" x="8" y="0" width="326" height="18" uuid="64501b2b-db09-43c0-9066-ad5d7586f37c"/>
+			<element kind="textField" uuid="64501b2b-db09-43c0-9066-ad5d7586f37c" key="textField-1" x="8" y="0" width="326" height="18" blankWhenNull="false">
+				<expression><![CDATA[$F{product_name}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$F{product_name}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-2" x="334" y="0" width="163" height="18" uuid="ffd6b921-2698-43e1-a3c0-a64283ecb1cd"/>
+			</element>
+			<element kind="textField" uuid="ffd6b921-2698-43e1-a3c0-a64283ecb1cd" key="textField-2" x="334" y="0" width="163" height="18" blankWhenNull="false" hTextAlign="Right">
+				<expression><![CDATA[($F{movementqty}!=null)?$P{NUMBERFORMAT}.format($F{movementqty}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA[($F{movementqty}!=null)?$P{NUMBERFORMAT}.format($F{movementqty}):new String(" ")]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/WeightDimensionalComparative.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/WeightDimensionalComparative.jrxml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="WeightDimensionalComparative" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="730" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="c336158b-5039-4b91-a548-7d71b338fad6">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="WeightDimensionalComparative" language="java" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="730" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="c336158b-5039-4b91-a548-7d71b338fad6">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
@@ -7,126 +7,124 @@
 	<property name="ireport.x" value="1671"/>
 	<property name="ireport.y" value="105"/>
 	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="10" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="10.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8" isBold="true">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0" bold="true">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level1_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Level2_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Level3_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Level4_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Level5_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Level6_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Level7_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Level8_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Level9_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Level10_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Level11_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<style name="Level1_Line" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Level2_Line" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Level3_Line" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Level4_Line" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Level5_Line" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Level6_Line" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Level7_Line" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Level8_Line" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Level9_Line" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Level10_Line" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Level11_Line" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["0,1000000"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["0,1000000"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATEFROM" class="java.util.Date" isForPrompting="false">
+	<parameter name="DATEFROM" forPrompting="false" class="java.util.Date">
 		<defaultValueExpression><![CDATA[(new SimpleDateFormat("dd-MM-yyyy")).parse("01-01-1900")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATETO" class="java.util.Date" isForPrompting="false">
+	<parameter name="DATETO" forPrompting="false" class="java.util.Date">
 		<defaultValueExpression><![CDATA[(new SimpleDateFormat("dd-MM-yyyy")).parse("31-12-3000")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="cBpGroupId" class="java.lang.String" isForPrompting="false">
+	<parameter name="cBpGroupId" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="cBpGroupId_Aux" class="java.lang.String" isForPrompting="false">
+	<parameter name="cBpGroupId_Aux" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{cBpGroupId}.equals("") ? " " : (" AND C_BP_Group.C_BP_Group_ID = " + $P{cBpGroupId})]]></defaultValueExpression>
 	</parameter>
-	<parameter name="cBpartnerId" class="java.lang.String" isForPrompting="false">
+	<parameter name="cBpartnerId" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="cBpartnerId_Aux" class="java.lang.String" isForPrompting="false">
+	<parameter name="cBpartnerId_Aux" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{cBpartnerId}.equals(""))?"  ":" AND C_BPartner.C_BPartner_ID IN " + $P{cBpartnerId}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="mProductCategoryId" class="java.lang.String" isForPrompting="false">
+	<parameter name="mProductCategoryId" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="mProductCategoryId_Aux" class="java.lang.String" isForPrompting="false">
+	<parameter name="mProductCategoryId_Aux" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{mProductCategoryId}.equals(""))?"  ":" AND M_Product_Category.M_Product_Category_Id = " + $P{mProductCategoryId}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="mProductId" class="java.lang.String" isForPrompting="false">
+	<parameter name="mProductId" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="mProductId_Aux" class="java.lang.String" isForPrompting="false">
+	<parameter name="mProductId_Aux" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{mProductId}.equals(""))?" ":" AND M_Product.M_Product_ID IN " + $P{mProductId}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="orderBy" class="java.lang.String" isForPrompting="false">
+	<parameter name="orderBy" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[" ORDER BY 1 "]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Purchase Orders Report"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="PRODUCT_LEVEL" class="java.lang.Integer" isForPrompting="false">
+	<parameter name="PRODUCT_LEVEL" forPrompting="false" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[new Integer(3)]]></defaultValueExpression>
 	</parameter>
-	<parameter name="THEME" class="java.lang.String" isForPrompting="false">
+	<parameter name="THEME" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Default"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false">
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/var/lib/tomcat-5.5/webapps/alerts/web"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL1_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL1_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Partner Group"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL2_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL2_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Product Category"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL3_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL3_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Product"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL4_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL4_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Partner"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL5_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL6_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL7_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL8_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL9_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL10_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL11_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="DIMENSIONS" class="java.lang.Integer" isForPrompting="false">
+	<parameter name="LEVEL5_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL6_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL7_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL8_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL9_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL10_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL11_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="DIMENSIONS" forPrompting="false" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[new Integer(4)]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["1.- "+$P{LEVEL1_LABEL}+($P{LEVEL2_LABEL}==""?"":", 2.- "+$P{LEVEL2_LABEL})+($P{LEVEL3_LABEL}==""?"":", 3.- "+$P{LEVEL3_LABEL})+($P{LEVEL4_LABEL}==""?"":", 4.- "+$P{LEVEL4_LABEL})+($P{LEVEL5_LABEL}==""?"":", 5.- "+$P{LEVEL5_LABEL})+($P{LEVEL5_LABEL}==""?"":", 6.- "+$P{LEVEL6_LABEL})+($P{LEVEL7_LABEL}==""?"":", 7.- "+$P{LEVEL7_LABEL})+($P{LEVEL8_LABEL}==""?"":", 8.- "+$P{LEVEL8_LABEL})+($P{LEVEL9_LABEL}==""?"":", 9.- "+$P{LEVEL9_LABEL})+($P{LEVEL10_LABEL}==""?"":", 10.- "+$P{LEVEL10_LABEL})+($P{LEVEL11_LABEL}==""?"":", 11.- "+$P{LEVEL11_LABEL})]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10, NIVEL11, 
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10, NIVEL11, 
 	  SUM(AMOUNT) AS AMOUNT, SUM(QTY) AS QTY, SUM(WEIGHT) AS WEIGHT,
 	  SUM(AMOUNTREF) AS AMOUNTREF, SUM(QTYREF) AS QTYREF, SUM(WEIGHTREF) AS WEIGHTREF, UOMSYMBOL,
 	  SUM(CONVAMOUNT) AS CONVAMOUNT,
@@ -187,8 +185,7 @@
       AND C_ORDER.AD_CLIENT_ID IN('16')
       AND 2=2) AA
       GROUP BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10, NIVEL11, UOMSYMBOL, TRCURRENCYID, TRDATE, TRCLIENTID, TRORGID) ZZ
-	  GROUP BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10, NIVEL11, UOMSYMBOL, CONVSYM, CONVISOSYM, 1]]>
-	</queryString>
+	  GROUP BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10, NIVEL11, UOMSYMBOL, CONVSYM, CONVISOSYM, 1]]></query>
 	<field name="NIVEL1" class="java.lang.String"/>
 	<field name="NIVEL2" class="java.lang.String"/>
 	<field name="NIVEL3" class="java.lang.String"/>
@@ -212,868 +209,735 @@
 	<field name="CONVAMOUNT" class="java.math.BigDecimal"/>
 	<field name="CONVAMOUNTREF" class="java.math.BigDecimal"/>
 	<field name="WSYMBOL" class="java.lang.String"/>
-	<variable name="WEIGHT_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM11" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL11" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM11" resetType="Group" calculation="Sum" resetGroup="LEVEL11" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="WEIGHT_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM10" resetType="Group" calculation="Sum" resetGroup="LEVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="WEIGHT_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM9" resetType="Group" calculation="Sum" resetGroup="LEVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="WEIGHT_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM8" resetType="Group" calculation="Sum" resetGroup="LEVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="WEIGHT_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM7" resetType="Group" calculation="Sum" resetGroup="LEVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="WEIGHT_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM6" resetType="Group" calculation="Sum" resetGroup="LEVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="WEIGHT_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="WEIGHT_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM11" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL11" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM11" resetType="Group" calculation="Sum" resetGroup="LEVEL11" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM10" resetType="Group" calculation="Sum" resetGroup="LEVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM9" resetType="Group" calculation="Sum" resetGroup="LEVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM8" resetType="Group" calculation="Sum" resetGroup="LEVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM7" resetType="Group" calculation="Sum" resetGroup="LEVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM6" resetType="Group" calculation="Sum" resetGroup="LEVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="WEIGHTREF_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHTREF}]]></variableExpression>
+	<variable name="WEIGHTREF_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHTREF}]]></expression>
 	</variable>
-	<variable name="QTY_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM11" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL11" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM11" resetType="Group" calculation="Sum" resetGroup="LEVEL11" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="QTY_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM10" resetType="Group" calculation="Sum" resetGroup="LEVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="QTY_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM9" resetType="Group" calculation="Sum" resetGroup="LEVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="QTY_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM8" resetType="Group" calculation="Sum" resetGroup="LEVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="QTY_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM7" resetType="Group" calculation="Sum" resetGroup="LEVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="QTY_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM6" resetType="Group" calculation="Sum" resetGroup="LEVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="QTY_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="QTY_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTYREF_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM11" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL11" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM11" resetType="Group" calculation="Sum" resetGroup="LEVEL11" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM10" resetType="Group" calculation="Sum" resetGroup="LEVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM9" resetType="Group" calculation="Sum" resetGroup="LEVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM8" resetType="Group" calculation="Sum" resetGroup="LEVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM7" resetType="Group" calculation="Sum" resetGroup="LEVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM6" resetType="Group" calculation="Sum" resetGroup="LEVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="QTYREF_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTYREF}]]></variableExpression>
+	<variable name="QTYREF_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTYREF}]]></expression>
 	</variable>
-	<variable name="AMOUNT_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM6" resetType="Group" calculation="Sum" resetGroup="LEVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM7" resetType="Group" calculation="Sum" resetGroup="LEVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM8" resetType="Group" calculation="Sum" resetGroup="LEVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM9" resetType="Group" calculation="Sum" resetGroup="LEVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM6" resetType="Group" calculation="Sum" resetGroup="LEVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM7" resetType="Group" calculation="Sum" resetGroup="LEVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM8" resetType="Group" calculation="Sum" resetGroup="LEVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMOUNTREF_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNTREF}]]></variableExpression>
+	<variable name="AMOUNTREF_SUM9" resetType="Group" calculation="Sum" resetGroup="LEVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNTREF}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM6" resetType="Group" calculation="Sum" resetGroup="LEVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM7" resetType="Group" calculation="Sum" resetGroup="LEVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM8" resetType="Group" calculation="Sum" resetGroup="LEVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM9" resetType="Group" calculation="Sum" resetGroup="LEVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM10" resetType="Group" calculation="Sum" resetGroup="LEVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM11" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL11" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM11" resetType="Group" calculation="Sum" resetGroup="LEVEL11" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNTREF_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="CONVAMOUNTREF_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNTREF_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="CONVAMOUNTREF_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNTREF_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="CONVAMOUNTREF_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNTREF_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="CONVAMOUNTREF_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNTREF_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="CONVAMOUNTREF_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNTREF_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="CONVAMOUNTREF_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNTREF_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="CONVAMOUNTREF_SUM6" resetType="Group" calculation="Sum" resetGroup="LEVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNTREF_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="CONVAMOUNTREF_SUM7" resetType="Group" calculation="Sum" resetGroup="LEVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNTREF_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="CONVAMOUNTREF_SUM8" resetType="Group" calculation="Sum" resetGroup="LEVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNTREF_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="CONVAMOUNTREF_SUM9" resetType="Group" calculation="Sum" resetGroup="LEVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNTREF_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="CONVAMOUNTREF_SUM10" resetType="Group" calculation="Sum" resetGroup="LEVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNTREF_SUM11" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL11" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNTREF}]]></variableExpression>
+	<variable name="CONVAMOUNTREF_SUM11" resetType="Group" calculation="Sum" resetGroup="LEVEL11" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNTREF}]]></expression>
 	</variable>
-	<variable name="AMT_PCT_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM1}.signum()==0)?null:$V{AMOUNT_SUM1}.subtract( $V{AMOUNTREF_SUM1} ).divide( $V{AMOUNTREF_SUM1}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="AMT_PCT_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM1}.signum()==0)?null:$V{AMOUNT_SUM1}.subtract( $V{AMOUNTREF_SUM1} ).divide( $V{AMOUNTREF_SUM1}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="AMT_PCT_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM2}.signum()==0)?null:$V{AMOUNT_SUM2}.subtract( $V{AMOUNTREF_SUM2} ).divide( $V{AMOUNTREF_SUM2}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="AMT_PCT_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM2}.signum()==0)?null:$V{AMOUNT_SUM2}.subtract( $V{AMOUNTREF_SUM2} ).divide( $V{AMOUNTREF_SUM2}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="AMT_PCT_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM3}.signum()==0)?null:$V{AMOUNT_SUM3}.subtract( $V{AMOUNTREF_SUM3} ).divide( $V{AMOUNTREF_SUM3}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="AMT_PCT_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM3}.signum()==0)?null:$V{AMOUNT_SUM3}.subtract( $V{AMOUNTREF_SUM3} ).divide( $V{AMOUNTREF_SUM3}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="AMT_PCT_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM4}.signum()==0)?null:$V{AMOUNT_SUM4}.subtract( $V{AMOUNTREF_SUM4} ).divide( $V{AMOUNTREF_SUM4}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="AMT_PCT_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM4}.signum()==0)?null:$V{AMOUNT_SUM4}.subtract( $V{AMOUNTREF_SUM4} ).divide( $V{AMOUNTREF_SUM4}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="AMT_PCT_5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM5}.signum()==0)?null:$V{AMOUNT_SUM5}.subtract( $V{AMOUNTREF_SUM5} ).divide( $V{AMOUNTREF_SUM5}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="AMT_PCT_5" resetType="Group" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM5}.signum()==0)?null:$V{AMOUNT_SUM5}.subtract( $V{AMOUNTREF_SUM5} ).divide( $V{AMOUNTREF_SUM5}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="AMT_PCT_6" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL6">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM6}.signum()==0)?null:$V{AMOUNT_SUM6}.subtract( $V{AMOUNTREF_SUM6} ).divide( $V{AMOUNTREF_SUM6}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="AMT_PCT_6" resetType="Group" resetGroup="LEVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM6}.signum()==0)?null:$V{AMOUNT_SUM6}.subtract( $V{AMOUNTREF_SUM6} ).divide( $V{AMOUNTREF_SUM6}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="AMT_PCT_7" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL7">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM7}.signum()==0)?null:$V{AMOUNT_SUM7}.subtract( $V{AMOUNTREF_SUM7} ).divide( $V{AMOUNTREF_SUM7}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="AMT_PCT_7" resetType="Group" resetGroup="LEVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM7}.signum()==0)?null:$V{AMOUNT_SUM7}.subtract( $V{AMOUNTREF_SUM7} ).divide( $V{AMOUNTREF_SUM7}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="AMT_PCT_8" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL8">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM8}.signum()==0)?null:$V{AMOUNT_SUM8}.subtract( $V{AMOUNTREF_SUM8} ).divide( $V{AMOUNTREF_SUM8}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="AMT_PCT_8" resetType="Group" resetGroup="LEVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM8}.signum()==0)?null:$V{AMOUNT_SUM8}.subtract( $V{AMOUNTREF_SUM8} ).divide( $V{AMOUNTREF_SUM8}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="AMT_PCT_9" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL9">
-		<variableExpression><![CDATA[($V{AMOUNTREF_SUM9}.signum()==0)?null:$V{AMOUNT_SUM9}.subtract( $V{AMOUNTREF_SUM9} ).divide( $V{AMOUNTREF_SUM9}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="AMT_PCT_9" resetType="Group" resetGroup="LEVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{AMOUNTREF_SUM9}.signum()==0)?null:$V{AMOUNT_SUM9}.subtract( $V{AMOUNTREF_SUM9} ).divide( $V{AMOUNTREF_SUM9}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
 	<variable name="AMT_PCT_T" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[($V{AMOUNTREF_TOTAL}.signum()==0)?null:$V{AMOUNT_TOTAL}.subtract( $V{AMOUNTREF_TOTAL} ).divide( $V{AMOUNTREF_TOTAL}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+		<expression><![CDATA[($V{AMOUNTREF_TOTAL}.signum()==0)?null:$V{AMOUNT_TOTAL}.subtract( $V{AMOUNTREF_TOTAL} ).divide( $V{AMOUNTREF_TOTAL}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="CONVAMT_PCT_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{CONVAMOUNTREF_SUM1}.signum()==0)?null:$V{CONVAMOUNT_SUM1}.subtract( $V{CONVAMOUNTREF_SUM1} ).divide( $V{CONVAMOUNTREF_SUM1}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="CONVAMT_PCT_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{CONVAMOUNTREF_SUM1}.signum()==0)?null:$V{CONVAMOUNT_SUM1}.subtract( $V{CONVAMOUNTREF_SUM1} ).divide( $V{CONVAMOUNTREF_SUM1}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="CONVAMT_PCT_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{CONVAMOUNTREF_SUM2}.signum()==0)?null:$V{CONVAMOUNT_SUM2}.subtract( $V{CONVAMOUNTREF_SUM2} ).divide( $V{CONVAMOUNTREF_SUM2}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="CONVAMT_PCT_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{CONVAMOUNTREF_SUM2}.signum()==0)?null:$V{CONVAMOUNT_SUM2}.subtract( $V{CONVAMOUNTREF_SUM2} ).divide( $V{CONVAMOUNTREF_SUM2}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="CONVAMT_PCT_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{CONVAMOUNTREF_SUM3}.signum()==0)?null:$V{CONVAMOUNT_SUM3}.subtract( $V{CONVAMOUNTREF_SUM3} ).divide( $V{CONVAMOUNTREF_SUM3}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="CONVAMT_PCT_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{CONVAMOUNTREF_SUM3}.signum()==0)?null:$V{CONVAMOUNT_SUM3}.subtract( $V{CONVAMOUNTREF_SUM3} ).divide( $V{CONVAMOUNTREF_SUM3}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="CONVAMT_PCT_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{CONVAMOUNTREF_SUM4}.signum()==0)?null:$V{CONVAMOUNT_SUM4}.subtract( $V{CONVAMOUNTREF_SUM4} ).divide( $V{CONVAMOUNTREF_SUM4}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="CONVAMT_PCT_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{CONVAMOUNTREF_SUM4}.signum()==0)?null:$V{CONVAMOUNT_SUM4}.subtract( $V{CONVAMOUNTREF_SUM4} ).divide( $V{CONVAMOUNTREF_SUM4}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="CONVAMT_PCT_5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5">
-		<variableExpression><![CDATA[($V{CONVAMOUNTREF_SUM5}.signum()==0)?null:$V{CONVAMOUNT_SUM5}.subtract( $V{CONVAMOUNTREF_SUM5} ).divide( $V{CONVAMOUNTREF_SUM5}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="CONVAMT_PCT_5" resetType="Group" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{CONVAMOUNTREF_SUM5}.signum()==0)?null:$V{CONVAMOUNT_SUM5}.subtract( $V{CONVAMOUNTREF_SUM5} ).divide( $V{CONVAMOUNTREF_SUM5}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="CONVAMT_PCT_6" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL6">
-		<variableExpression><![CDATA[($V{CONVAMOUNTREF_SUM6}.signum()==0)?null:$V{CONVAMOUNT_SUM6}.subtract( $V{CONVAMOUNTREF_SUM6} ).divide( $V{CONVAMOUNTREF_SUM6}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="CONVAMT_PCT_6" resetType="Group" resetGroup="LEVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{CONVAMOUNTREF_SUM6}.signum()==0)?null:$V{CONVAMOUNT_SUM6}.subtract( $V{CONVAMOUNTREF_SUM6} ).divide( $V{CONVAMOUNTREF_SUM6}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="CONVAMT_PCT_7" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL7">
-		<variableExpression><![CDATA[($V{CONVAMOUNTREF_SUM7}.signum()==0)?null:$V{CONVAMOUNT_SUM7}.subtract( $V{CONVAMOUNTREF_SUM7} ).divide( $V{CONVAMOUNTREF_SUM7}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="CONVAMT_PCT_7" resetType="Group" resetGroup="LEVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{CONVAMOUNTREF_SUM7}.signum()==0)?null:$V{CONVAMOUNT_SUM7}.subtract( $V{CONVAMOUNTREF_SUM7} ).divide( $V{CONVAMOUNTREF_SUM7}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="CONVAMT_PCT_8" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL8">
-		<variableExpression><![CDATA[($V{CONVAMOUNTREF_SUM8}.signum()==0)?null:$V{CONVAMOUNT_SUM8}.subtract( $V{CONVAMOUNTREF_SUM8} ).divide( $V{CONVAMOUNTREF_SUM8}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="CONVAMT_PCT_8" resetType="Group" resetGroup="LEVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{CONVAMOUNTREF_SUM8}.signum()==0)?null:$V{CONVAMOUNT_SUM8}.subtract( $V{CONVAMOUNTREF_SUM8} ).divide( $V{CONVAMOUNTREF_SUM8}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="CONVAMT_PCT_9" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL9">
-		<variableExpression><![CDATA[($V{CONVAMOUNTREF_SUM9}.signum()==0)?null:$V{CONVAMOUNT_SUM9}.subtract( $V{CONVAMOUNTREF_SUM9} ).divide( $V{CONVAMOUNTREF_SUM9}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="CONVAMT_PCT_9" resetType="Group" resetGroup="LEVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{CONVAMOUNTREF_SUM9}.signum()==0)?null:$V{CONVAMOUNT_SUM9}.subtract( $V{CONVAMOUNTREF_SUM9} ).divide( $V{CONVAMOUNTREF_SUM9}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="CONVAMT_PCT_10" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL10">
-		<variableExpression><![CDATA[($V{CONVAMOUNTREF_SUM10}.signum()==0)?null:$V{CONVAMOUNT_SUM10}.subtract( $V{CONVAMOUNTREF_SUM10} ).divide( $V{CONVAMOUNTREF_SUM10}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="CONVAMT_PCT_10" resetType="Group" resetGroup="LEVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{CONVAMOUNTREF_SUM10}.signum()==0)?null:$V{CONVAMOUNT_SUM10}.subtract( $V{CONVAMOUNTREF_SUM10} ).divide( $V{CONVAMOUNTREF_SUM10}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="CONVAMT_PCT_11" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL11">
-		<variableExpression><![CDATA[($V{CONVAMOUNTREF_SUM11}.signum()==0)?null:$V{CONVAMOUNT_SUM11}.subtract( $V{CONVAMOUNTREF_SUM11} ).divide( $V{CONVAMOUNTREF_SUM11}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="CONVAMT_PCT_11" resetType="Group" resetGroup="LEVEL11" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{CONVAMOUNTREF_SUM11}.signum()==0)?null:$V{CONVAMOUNT_SUM11}.subtract( $V{CONVAMOUNTREF_SUM11} ).divide( $V{CONVAMOUNTREF_SUM11}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
 	<variable name="CONVAMT_PCT_T" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[($V{CONVAMOUNTREF_TOTAL}.signum()==0)?null:$V{CONVAMOUNT_TOTAL}.subtract( $V{CONVAMOUNTREF_TOTAL} ).divide( $V{CONVAMOUNTREF_TOTAL}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+		<expression><![CDATA[($V{CONVAMOUNTREF_TOTAL}.signum()==0)?null:$V{CONVAMOUNT_TOTAL}.subtract( $V{CONVAMOUNTREF_TOTAL} ).divide( $V{CONVAMOUNTREF_TOTAL}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="QTY_PCT_1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1">
-		<variableExpression><![CDATA[($V{QTYREF_SUM1}.signum()==0)?null:$V{QTY_SUM1}.subtract( $V{QTYREF_SUM1} ).divide( $V{QTYREF_SUM1}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="QTY_PCT_1" resetType="Group" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM1}.signum()==0)?null:$V{QTY_SUM1}.subtract( $V{QTYREF_SUM1} ).divide( $V{QTYREF_SUM1}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="QTY_PCT_2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2">
-		<variableExpression><![CDATA[($V{QTYREF_SUM2}.signum()==0)?null:$V{QTY_SUM2}.subtract( $V{QTYREF_SUM2} ).divide( $V{QTYREF_SUM2}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="QTY_PCT_2" resetType="Group" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM2}.signum()==0)?null:$V{QTY_SUM2}.subtract( $V{QTYREF_SUM2} ).divide( $V{QTYREF_SUM2}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="QTY_PCT_3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3">
-		<variableExpression><![CDATA[($V{QTYREF_SUM3}.signum()==0)?null:$V{QTY_SUM3}.subtract( $V{QTYREF_SUM3} ).divide( $V{QTYREF_SUM3}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="QTY_PCT_3" resetType="Group" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM3}.signum()==0)?null:$V{QTY_SUM3}.subtract( $V{QTYREF_SUM3} ).divide( $V{QTYREF_SUM3}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="QTY_PCT_4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4">
-		<variableExpression><![CDATA[($V{QTYREF_SUM4}.signum()==0)?null:$V{QTY_SUM4}.subtract( $V{QTYREF_SUM4} ).divide( $V{QTYREF_SUM4}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="QTY_PCT_4" resetType="Group" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM4}.signum()==0)?null:$V{QTY_SUM4}.subtract( $V{QTYREF_SUM4} ).divide( $V{QTYREF_SUM4}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="QTY_PCT_5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5">
-		<variableExpression><![CDATA[($V{QTYREF_SUM5}.signum()==0)?null:$V{QTY_SUM5}.subtract( $V{QTYREF_SUM5} ).divide( $V{QTYREF_SUM5}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="QTY_PCT_5" resetType="Group" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM5}.signum()==0)?null:$V{QTY_SUM5}.subtract( $V{QTYREF_SUM5} ).divide( $V{QTYREF_SUM5}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="QTY_PCT_6" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL6">
-		<variableExpression><![CDATA[($V{QTYREF_SUM6}.signum()==0)?null:$V{QTY_SUM6}.subtract( $V{QTYREF_SUM6} ).divide( $V{QTYREF_SUM6}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="QTY_PCT_6" resetType="Group" resetGroup="LEVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM6}.signum()==0)?null:$V{QTY_SUM6}.subtract( $V{QTYREF_SUM6} ).divide( $V{QTYREF_SUM6}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="QTY_PCT_7" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL7">
-		<variableExpression><![CDATA[($V{QTYREF_SUM7}.signum()==0)?null:$V{QTY_SUM7}.subtract( $V{QTYREF_SUM7} ).divide( $V{QTYREF_SUM7}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="QTY_PCT_7" resetType="Group" resetGroup="LEVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM7}.signum()==0)?null:$V{QTY_SUM7}.subtract( $V{QTYREF_SUM7} ).divide( $V{QTYREF_SUM7}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="QTY_PCT_8" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL8">
-		<variableExpression><![CDATA[($V{QTYREF_SUM8}.signum()==0)?null:$V{QTY_SUM8}.subtract( $V{QTYREF_SUM8} ).divide( $V{QTYREF_SUM8}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="QTY_PCT_8" resetType="Group" resetGroup="LEVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM8}.signum()==0)?null:$V{QTY_SUM8}.subtract( $V{QTYREF_SUM8} ).divide( $V{QTYREF_SUM8}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="QTY_PCT_9" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL9">
-		<variableExpression><![CDATA[($V{QTYREF_SUM9}.signum()==0)?null:$V{QTY_SUM9}.subtract( $V{QTYREF_SUM9} ).divide( $V{QTYREF_SUM9}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="QTY_PCT_9" resetType="Group" resetGroup="LEVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM9}.signum()==0)?null:$V{QTY_SUM9}.subtract( $V{QTYREF_SUM9} ).divide( $V{QTYREF_SUM9}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="QTY_PCT_10" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL10">
-		<variableExpression><![CDATA[($V{QTYREF_SUM10}.signum()==0)?null:$V{QTY_SUM10}.subtract( $V{QTYREF_SUM10} ).divide( $V{QTYREF_SUM10}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="QTY_PCT_10" resetType="Group" resetGroup="LEVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM10}.signum()==0)?null:$V{QTY_SUM10}.subtract( $V{QTYREF_SUM10} ).divide( $V{QTYREF_SUM10}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
-	<variable name="QTY_PCT_11" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL11">
-		<variableExpression><![CDATA[($V{QTYREF_SUM11}.signum()==0)?null:$V{QTY_SUM11}.subtract( $V{QTYREF_SUM11} ).divide( $V{QTYREF_SUM11}, 6).multiply(new BigDecimal(100.0))]]></variableExpression>
+	<variable name="QTY_PCT_11" resetType="Group" resetGroup="LEVEL11" class="java.math.BigDecimal">
+		<expression><![CDATA[($V{QTYREF_SUM11}.signum()==0)?null:$V{QTY_SUM11}.subtract( $V{QTYREF_SUM11} ).divide( $V{QTYREF_SUM11}, 6).multiply(new BigDecimal(100.0))]]></expression>
 	</variable>
 	<group name="TOTALIZE">
-		<groupExpression><![CDATA[]]></groupExpression>
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band splitType="Stretch"/>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<textField evaluationTime="Report" isBlankWhenNull="false">
-					<reportElement key="textField-99" style="Total_Field" x="425" y="2" width="65" height="18" uuid="923416ad-3e1e-4c12-97a8-90966b5a95ec"/>
-					<box leftPadding="5">
+				<element kind="textField" uuid="923416ad-3e1e-4c12-97a8-90966b5a95ec" key="textField-99" x="425" y="2" width="65" height="18" fontSize="8.0" evaluationTime="Report" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{WEIGHT_TOTAL}!=null)?$V{WEIGHT_TOTAL}:BigDecimal.ZERO]]></expression>
+					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_TOTAL}!=null)?$V{WEIGHT_TOTAL}:BigDecimal.ZERO]]></textFieldExpression>
-					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-15" style="Report_Data_Label" x="206" y="2" width="34" height="18" uuid="afd632e9-9484-4a22-aba9-f66bc0c0820c"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="8"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="afd632e9-9484-4a22-aba9-f66bc0c0820c" key="staticText-15" x="206" y="2" width="34" height="18" fontSize="8.0" hTextAlign="Center" vTextAlign="Middle" style="Report_Data_Label">
 					<text><![CDATA[Totals]]></text>
-				</staticText>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-100" style="Total_Field" x="490" y="2" width="75" height="18" uuid="bf091e54-6dd6-4ed1-a1e1-4ffe05b76e71"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
+					<box style="Report_Data_Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_TOTAL}!=null)?$V{WEIGHTREF_TOTAL}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="bf091e54-6dd6-4ed1-a1e1-4ffe05b76e71" key="textField-100" x="490" y="2" width="75" height="18" fontSize="8.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{WEIGHTREF_TOTAL}!=null)?$V{WEIGHTREF_TOTAL}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Report" isBlankWhenNull="false">
-					<reportElement key="textField-101" style="Total_Field" x="240" y="2" width="65" height="18" uuid="68140b4e-44b3-454c-8c40-fe749fd68e37"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_TOTAL}!=null)?$V{CONVAMOUNT_TOTAL}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="68140b4e-44b3-454c-8c40-fe749fd68e37" key="textField-101" x="240" y="2" width="65" height="18" fontSize="8.0" evaluationTime="Report" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{CONVAMOUNT_TOTAL}!=null)?$V{CONVAMOUNT_TOTAL}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-102" style="Total_Field" x="320" y="2" width="65" height="18" uuid="4c63afb6-d130-45af-80d7-5a552e6f0909"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNTREF_TOTAL}!=null)?$V{CONVAMOUNTREF_TOTAL}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="4c63afb6-d130-45af-80d7-5a552e6f0909" key="textField-102" x="320" y="2" width="65" height="18" fontSize="8.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{CONVAMOUNTREF_TOTAL}!=null)?$V{CONVAMOUNTREF_TOTAL}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-103" style="Total_Field" x="400" y="2" width="25" height="18" uuid="2dd981de-73de-485c-bdd2-9bc10d5d3b95"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMT_PCT_T}!=null)?$V{CONVAMT_PCT_T}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="2dd981de-73de-485c-bdd2-9bc10d5d3b95" key="textField-103" x="400" y="2" width="25" height="18" fontSize="8.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{CONVAMT_PCT_T}!=null)?$V{CONVAMT_PCT_T}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-100" style="Total_Field" x="630" y="2" width="65" height="18" uuid="ce3b0947-5304-43aa-bb96-3d51faf27070"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_TOTAL}!=null)?$V{QTYREF_TOTAL}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="ce3b0947-5304-43aa-bb96-3d51faf27070" key="textField-100" x="630" y="2" width="65" height="18" fontSize="8.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{QTYREF_TOTAL}!=null)?$V{QTYREF_TOTAL}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-100" style="Total_Field" x="565" y="2" width="65" height="18" uuid="4351191d-1f34-4864-b99a-1c2a66f70614"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_TOTAL}!=null)?$V{QTY_TOTAL}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="4351191d-1f34-4864-b99a-1c2a66f70614" key="textField-100" x="565" y="2" width="65" height="18" fontSize="8.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{QTY_TOTAL}!=null)?$V{QTY_TOTAL}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-104" style="Detail_Header" mode="Opaque" x="0" y="2" width="15" height="18" uuid="eab948e5-487f-4d0a-a036-5f59c483f6b5"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-105" style="Detail_Header" mode="Opaque" x="15" y="2" width="15" height="18" uuid="1e590f9b-fd81-4466-af82-37d477dc04af"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-106" style="Detail_Header" mode="Opaque" x="30" y="2" width="15" height="18" uuid="decaf2ff-1063-46db-9c9d-224e1d2dabf8"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-107" style="Detail_Header" mode="Opaque" x="45" y="2" width="15" height="18" uuid="ba533bf7-e933-43f5-88fe-77ffdb662ffc"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-108" style="Detail_Header" mode="Opaque" x="60" y="2" width="15" height="18" uuid="6cf52364-033e-4af6-ba00-64943c9247ed"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-109" style="Detail_Header" mode="Opaque" x="75" y="2" width="15" height="18" uuid="8e9e314b-db7c-4c56-a9d3-34ab36325073"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(6))>=0)?"6":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-110" style="Detail_Header" mode="Opaque" x="90" y="2" width="15" height="18" uuid="8132d236-e542-4eac-b20a-9db5dca6c284"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(7))>=0)?"7":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-111" style="Detail_Header" mode="Opaque" x="105" y="2" width="15" height="18" uuid="18324dc5-0e9f-4f15-bc26-e7d298f844ee"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(8))>=0)?"8":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-112" style="Detail_Header" mode="Opaque" x="120" y="2" width="15" height="18" uuid="69550c32-e66c-42e6-8637-c9f10c2d1298"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(9))>=0)?"9":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-86" style="Detail_Header" positionType="FixRelativeToBottom" x="135" y="2" width="15" height="18" uuid="91d4dc4c-4f04-476a-a209-a8a2b5adfaf5"/>
-					<box leftPadding="2">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(10))>=0)?"10":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-86" style="Detail_Header" positionType="FixRelativeToBottom" x="150" y="2" width="15" height="18" uuid="13b16b45-eda1-44d5-809c-60f6415c06f2"/>
-					<box leftPadding="2">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(11))>=0)?"11":"")]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-5" x="0" y="1" width="730" height="1" uuid="ce088ca1-7b77-4909-a7f7-ed89f3cf6e54"/>
-				</line>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-133" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="305" y="2" width="15" height="18" uuid="14997ed4-0900-48bb-9fe1-84ff231eac5c"/>
-					<box rightPadding="3">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-134" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="385" y="2" width="15" height="18" uuid="9fa328d5-99a0-44bf-8978-40e2a2637618"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="eab948e5-487f-4d0a-a036-5f59c483f6b5" key="textField-104" mode="Opaque" x="0" y="2" width="15" height="18" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="1e590f9b-fd81-4466-af82-37d477dc04af" key="textField-105" mode="Opaque" x="15" y="2" width="15" height="18" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="decaf2ff-1063-46db-9c9d-224e1d2dabf8" key="textField-106" mode="Opaque" x="30" y="2" width="15" height="18" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="ba533bf7-e933-43f5-88fe-77ffdb662ffc" key="textField-107" mode="Opaque" x="45" y="2" width="15" height="18" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="6cf52364-033e-4af6-ba00-64943c9247ed" key="textField-108" mode="Opaque" x="60" y="2" width="15" height="18" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="8e9e314b-db7c-4c56-a9d3-34ab36325073" key="textField-109" mode="Opaque" x="75" y="2" width="15" height="18" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(6))>=0)?"6":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="8132d236-e542-4eac-b20a-9db5dca6c284" key="textField-110" mode="Opaque" x="90" y="2" width="15" height="18" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(7))>=0)?"7":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="18324dc5-0e9f-4f15-bc26-e7d298f844ee" key="textField-111" mode="Opaque" x="105" y="2" width="15" height="18" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(8))>=0)?"8":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="69550c32-e66c-42e6-8637-c9f10c2d1298" key="textField-112" mode="Opaque" x="120" y="2" width="15" height="18" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(9))>=0)?"9":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="91d4dc4c-4f04-476a-a209-a8a2b5adfaf5" key="textField-86" positionType="FixRelativeToBottom" x="135" y="2" width="15" height="18" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(10))>=0)?"10":"")]]></expression>
+					<box leftPadding="2" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="13b16b45-eda1-44d5-809c-60f6415c06f2" key="textField-86" positionType="FixRelativeToBottom" x="150" y="2" width="15" height="18" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(11))>=0)?"11":"")]]></expression>
+					<box leftPadding="2" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="line" uuid="ce088ca1-7b77-4909-a7f7-ed89f3cf6e54" key="line-5" x="0" y="1" width="730" height="1"/>
+				<element kind="textField" uuid="14997ed4-0900-48bb-9fe1-84ff231eac5c" key="textField-133" stretchType="ContainerHeight" mode="Opaque" x="305" y="2" width="15" height="18" fontSize="8.0" pdfFontName="Helvetica-Bold" evaluationTime="Group" pattern="" evaluationGroup="LEVEL8" blankWhenNull="false" bold="true" hTextAlign="Center" style="Level8_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="9fa328d5-99a0-44bf-8978-40e2a2637618" key="textField-134" stretchType="ContainerHeight" mode="Opaque" x="385" y="2" width="15" height="18" fontSize="8.0" pdfFontName="Helvetica-Bold" evaluationTime="Group" pattern="" evaluationGroup="LEVEL8" blankWhenNull="false" bold="true" hTextAlign="Center" style="Level8_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level8_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="NIVEL1">
-		<groupExpression><![CDATA[$F{NIVEL1}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL1}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="0" y="0" width="240" height="18" uuid="c4340ae4-f1ce-49b5-882a-da4a4aa0f8c5"/>
-					<box>
+				<element kind="textField" uuid="c4340ae4-f1ce-49b5-882a-da4a4aa0f8c5" key="textField" stretchType="ContainerHeight" mode="Opaque" x="0" y="0" width="240" height="18" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[$F{NIVEL1}]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL1}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="565" y="0" width="65" height="18" uuid="fe6e66de-618d-498b-8122-7f4571f47fc8">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM1}!=null)?$V{QTY_SUM1}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="fe6e66de-618d-498b-8122-7f4571f47fc8" key="textField" stretchType="ContainerHeight" mode="Opaque" x="565" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" evaluationGroup="NIVEL1" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM1}!=null)?$V{QTY_SUM1}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="425" y="0" width="65" height="18" uuid="62a514f7-ac24-4ba8-a6ae-a3a5b36dc9bc"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM1}!=null)?$V{WEIGHT_SUM1}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="62a514f7-ac24-4ba8-a6ae-a3a5b36dc9bc" key="textField" stretchType="ContainerHeight" mode="Opaque" x="425" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM1}!=null)?$V{WEIGHT_SUM1}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="490" y="0" width="75" height="18" uuid="bc47fc03-0472-4664-8284-de8f5453eb2b"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM1}!=null)?$V{WEIGHTREF_SUM1}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="bc47fc03-0472-4664-8284-de8f5453eb2b" key="textField" stretchType="ContainerHeight" mode="Opaque" x="490" y="0" width="75" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM1}!=null)?$V{WEIGHTREF_SUM1}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="630" y="0" width="65" height="18" uuid="1b3f2445-b09b-497d-b3ea-b4e65c05ae4e">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM1}!=null)?$V{QTYREF_SUM1}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="1b3f2445-b09b-497d-b3ea-b4e65c05ae4e" key="textField" stretchType="ContainerHeight" mode="Opaque" x="630" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM1}!=null)?$V{QTYREF_SUM1}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="695" y="0" width="35" height="18" uuid="3a696c3f-9cdd-4d56-88fa-a8e068b55feb">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PCT_1}!=null)?$V{QTY_PCT_1}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="3a696c3f-9cdd-4d56-88fa-a8e068b55feb" key="textField" stretchType="ContainerHeight" mode="Opaque" x="695" y="0" width="35" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PCT_1}!=null)?$V{QTY_PCT_1}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-12" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="240" y="0" width="65" height="18" uuid="3247444c-be0a-4db5-a27d-b0e5ddb18b47"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM1}!=null)?$V{CONVAMOUNT_SUM1}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="3247444c-be0a-4db5-a27d-b0e5ddb18b47" key="textField-12" stretchType="ContainerHeight" mode="Opaque" x="240" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM1}!=null)?$V{CONVAMOUNT_SUM1}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-13" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="320" y="0" width="65" height="18" uuid="b0bd86bd-819b-4043-8e72-ad85b11fe4db"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNTREF_SUM1}!=null)?$V{CONVAMOUNTREF_SUM1}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="b0bd86bd-819b-4043-8e72-ad85b11fe4db" key="textField-13" stretchType="ContainerHeight" mode="Opaque" x="320" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{CONVAMOUNTREF_SUM1}!=null)?$V{CONVAMOUNTREF_SUM1}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-14" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="400" y="0" width="25" height="18" uuid="e1ac5ff3-4f2c-4a1d-90f7-7e78b647e885"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMT_PCT_1}!=null)?$V{CONVAMT_PCT_1}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="e1ac5ff3-4f2c-4a1d-90f7-7e78b647e885" key="textField-14" stretchType="ContainerHeight" mode="Opaque" x="400" y="0" width="25" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{CONVAMT_PCT_1}!=null)?$V{CONVAMT_PCT_1}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-114" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="385" y="0" width="15" height="18" uuid="7a94b13a-ddf6-41fe-8eb4-dd476aecdf04"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-123" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="305" y="0" width="15" height="18" uuid="4a41e0cb-2225-4c1f-b45e-bab0a27d8cfb"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="7a94b13a-ddf6-41fe-8eb4-dd476aecdf04" key="textField-114" stretchType="ContainerHeight" mode="Opaque" x="385" y="0" width="15" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level1_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="4a41e0cb-2225-4c1f-b45e-bab0a27d8cfb" key="textField-123" stretchType="ContainerHeight" mode="Opaque" x="305" y="0" width="15" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level1_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level1_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -1081,180 +945,129 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL2">
-		<groupExpression><![CDATA[$F{NIVEL2}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL2}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="15" y="0" width="225" height="18" uuid="3e091c2c-c179-43af-b96d-dda215727d3e"/>
-					<box>
+				<element kind="textField" uuid="3e091c2c-c179-43af-b96d-dda215727d3e" key="textField" stretchType="ContainerHeight" mode="Opaque" x="15" y="0" width="225" height="18" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[$F{NIVEL2}]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL2}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="565" y="0" width="65" height="18" uuid="6e8f50ae-a130-47ae-9800-006d77dfa116">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM2}!=null)?$V{QTY_SUM2}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="6e8f50ae-a130-47ae-9800-006d77dfa116" key="textField" stretchType="ContainerHeight" mode="Opaque" x="565" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" evaluationGroup="NIVEL2" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM2}!=null)?$V{QTY_SUM2}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="425" y="0" width="65" height="18" uuid="97b3e338-44f2-4a10-8c26-a0cf803434d8"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM2}!=null)?$V{WEIGHT_SUM2}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="97b3e338-44f2-4a10-8c26-a0cf803434d8" key="textField" stretchType="ContainerHeight" mode="Opaque" x="425" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM2}!=null)?$V{WEIGHT_SUM2}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="490" y="0" width="75" height="18" uuid="e1a38f61-9fc1-49a0-bb2e-e01e0e79db33"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM2}!=null)?$V{WEIGHTREF_SUM2}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="e1a38f61-9fc1-49a0-bb2e-e01e0e79db33" key="textField" stretchType="ContainerHeight" mode="Opaque" x="490" y="0" width="75" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM2}!=null)?$V{WEIGHTREF_SUM2}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="630" y="0" width="65" height="18" uuid="1b0ab5a5-430e-44e8-bacb-ee0a61a10adc">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM2}!=null)?$V{QTYREF_SUM2}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="1b0ab5a5-430e-44e8-bacb-ee0a61a10adc" key="textField" stretchType="ContainerHeight" mode="Opaque" x="630" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM2}!=null)?$V{QTYREF_SUM2}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="695" y="0" width="35" height="18" uuid="d1c8bf20-bf05-48da-b268-85609070c134">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PCT_2}!=null)?$V{QTY_PCT_2}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="d1c8bf20-bf05-48da-b268-85609070c134" key="textField" stretchType="ContainerHeight" mode="Opaque" x="695" y="0" width="35" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PCT_2}!=null)?$V{QTY_PCT_2}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-15" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="240" y="0" width="65" height="18" uuid="ca8687b0-9bcd-4646-b93b-9be8b5dd3eeb"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM2}!=null)?$V{CONVAMOUNT_SUM2}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="ca8687b0-9bcd-4646-b93b-9be8b5dd3eeb" key="textField-15" stretchType="ContainerHeight" mode="Opaque" x="240" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM2}!=null)?$V{CONVAMOUNT_SUM2}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-16" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="320" y="0" width="65" height="18" uuid="80e70109-2cf1-4f66-9b4d-3370db0dc4c1"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNTREF_SUM2}!=null)?$V{CONVAMOUNTREF_SUM2}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="80e70109-2cf1-4f66-9b4d-3370db0dc4c1" key="textField-16" stretchType="ContainerHeight" mode="Opaque" x="320" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{CONVAMOUNTREF_SUM2}!=null)?$V{CONVAMOUNTREF_SUM2}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-17" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="400" y="0" width="25" height="18" uuid="a97cad08-3136-4865-adc6-e4988fd489f6"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMT_PCT_2}!=null)?$V{CONVAMT_PCT_2}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="a97cad08-3136-4865-adc6-e4988fd489f6" key="textField-17" stretchType="ContainerHeight" mode="Opaque" x="400" y="0" width="25" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{CONVAMT_PCT_2}!=null)?$V{CONVAMT_PCT_2}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-42" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="0" y="0" width="15" height="18" uuid="7f430e7b-4fb7-45f4-aee2-473891cbf138"/>
-					<box>
+					<box rightPadding="3" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-115" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="385" y="0" width="15" height="18" uuid="13074c7d-1da5-4453-bcf1-74b4544a0168"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="7f430e7b-4fb7-45f4-aee2-473891cbf138" key="textField-42" stretchType="ContainerHeight" mode="Opaque" x="0" y="0" width="15" height="18" rotation="Left" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-124" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="305" y="0" width="15" height="18" uuid="54e7f833-4961-48be-8fb2-a0654805d45e"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="13074c7d-1da5-4453-bcf1-74b4544a0168" key="textField-115" stretchType="ContainerHeight" mode="Opaque" x="385" y="0" width="15" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level2_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="54e7f833-4961-48be-8fb2-a0654805d45e" key="textField-124" stretchType="ContainerHeight" mode="Opaque" x="305" y="0" width="15" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level2_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level2_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -1262,193 +1075,138 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL3">
-		<groupExpression><![CDATA[$F{NIVEL3}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL3}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="30" y="0" width="210" height="18" uuid="a91dd01e-20cc-4c7f-ad44-3b71883f8bf9"/>
-					<box>
+				<element kind="textField" uuid="a91dd01e-20cc-4c7f-ad44-3b71883f8bf9" key="textField" stretchType="ContainerHeight" mode="Opaque" x="30" y="0" width="210" height="18" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[$F{NIVEL3}]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL3}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="565" y="0" width="65" height="18" uuid="9662dbf2-2ffb-4fb1-b51d-feb9e5162923">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM3}!=null)?$V{QTY_SUM3}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="9662dbf2-2ffb-4fb1-b51d-feb9e5162923" key="textField" stretchType="ContainerHeight" mode="Opaque" x="565" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" evaluationGroup="NIVEL3" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM3}!=null)?$V{QTY_SUM3}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="425" y="0" width="65" height="18" uuid="67c0e3b4-aec8-4941-9f66-e7e1ba6d0534"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM3}!=null)?$V{WEIGHT_SUM3}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="67c0e3b4-aec8-4941-9f66-e7e1ba6d0534" key="textField" stretchType="ContainerHeight" mode="Opaque" x="425" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM3}!=null)?$V{WEIGHT_SUM3}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="490" y="0" width="75" height="18" uuid="da8c01cb-c8d5-4dbb-96b1-0db30d11b7f6"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM3}!=null)?$V{WEIGHTREF_SUM3}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="da8c01cb-c8d5-4dbb-96b1-0db30d11b7f6" key="textField" stretchType="ContainerHeight" mode="Opaque" x="490" y="0" width="75" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM3}!=null)?$V{WEIGHTREF_SUM3}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="630" y="0" width="65" height="18" uuid="6fe42723-1579-4076-8a9f-e4a354df3fc3">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM3}!=null)?$V{QTYREF_SUM3}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="6fe42723-1579-4076-8a9f-e4a354df3fc3" key="textField" stretchType="ContainerHeight" mode="Opaque" x="630" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM3}!=null)?$V{QTYREF_SUM3}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="695" y="0" width="35" height="18" uuid="f0d3a9e8-0fcd-46c0-ba01-00b84551ac42">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PCT_3}!=null)?$V{QTY_PCT_3}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="f0d3a9e8-0fcd-46c0-ba01-00b84551ac42" key="textField" stretchType="ContainerHeight" mode="Opaque" x="695" y="0" width="35" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PCT_3}!=null)?$V{QTY_PCT_3}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-18" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="240" y="0" width="65" height="18" uuid="c0a744f8-516f-46d7-bba3-ebf2f6328f6a"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM3}!=null)?$V{CONVAMOUNT_SUM3}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="c0a744f8-516f-46d7-bba3-ebf2f6328f6a" key="textField-18" stretchType="ContainerHeight" mode="Opaque" x="240" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM3}!=null)?$V{CONVAMOUNT_SUM3}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-19" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="320" y="0" width="65" height="18" uuid="321f4fe7-001f-4da6-83e1-f46bc0cf950a"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNTREF_SUM3}!=null)?$V{CONVAMOUNTREF_SUM3}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="321f4fe7-001f-4da6-83e1-f46bc0cf950a" key="textField-19" stretchType="ContainerHeight" mode="Opaque" x="320" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{CONVAMOUNTREF_SUM3}!=null)?$V{CONVAMOUNTREF_SUM3}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-20" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="400" y="0" width="25" height="18" uuid="6c502530-52bd-4f78-b275-8c9ca4979969"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMT_PCT_3}!=null)?$V{CONVAMT_PCT_3}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="6c502530-52bd-4f78-b275-8c9ca4979969" key="textField-20" stretchType="ContainerHeight" mode="Opaque" x="400" y="0" width="25" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{CONVAMT_PCT_3}!=null)?$V{CONVAMT_PCT_3}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-43" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="0" y="0" width="15" height="18" uuid="159ebab5-da8f-41e8-9266-c709063ab5b4"/>
-					<box>
+					<box rightPadding="3" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-50" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="15" y="0" width="15" height="18" uuid="065745b9-5ada-449c-a52f-622be3c65c24"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="159ebab5-da8f-41e8-9266-c709063ab5b4" key="textField-43" stretchType="ContainerHeight" mode="Opaque" x="0" y="0" width="15" height="18" rotation="Left" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-116" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="385" y="0" width="15" height="18" uuid="f8687e26-a5d4-4318-8da1-57e6014a8b63"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="065745b9-5ada-449c-a52f-622be3c65c24" key="textField-50" stretchType="ContainerHeight" mode="Opaque" x="15" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-125" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="305" y="0" width="15" height="18" uuid="cd7aebd6-701a-4c23-8a4e-81519fcd16f9"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="f8687e26-a5d4-4318-8da1-57e6014a8b63" key="textField-116" stretchType="ContainerHeight" mode="Opaque" x="385" y="0" width="15" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level3_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="cd7aebd6-701a-4c23-8a4e-81519fcd16f9" key="textField-125" stretchType="ContainerHeight" mode="Opaque" x="305" y="0" width="15" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level3_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level3_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -1456,206 +1214,147 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL4">
-		<groupExpression><![CDATA[$F{NIVEL4}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL4}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="45" y="0" width="195" height="18" uuid="d8246dd0-d05c-4a85-868a-77aad4567d99"/>
-					<box>
+				<element kind="textField" uuid="d8246dd0-d05c-4a85-868a-77aad4567d99" key="textField" stretchType="ContainerHeight" mode="Opaque" x="45" y="0" width="195" height="18" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[$F{NIVEL4}]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL4}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="565" y="0" width="65" height="18" uuid="7e3589b2-ba5a-4e50-9f23-9a977fc28d0b">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM4}!=null)?$V{QTY_SUM4}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="7e3589b2-ba5a-4e50-9f23-9a977fc28d0b" key="textField" stretchType="ContainerHeight" mode="Opaque" x="565" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" evaluationGroup="NIVEL4" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM4}!=null)?$V{QTY_SUM4}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="425" y="0" width="65" height="18" uuid="0f60c6a2-6cfd-461e-9e82-a041141253de"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM4}!=null)?$V{WEIGHT_SUM4}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="0f60c6a2-6cfd-461e-9e82-a041141253de" key="textField" stretchType="ContainerHeight" mode="Opaque" x="425" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM4}!=null)?$V{WEIGHT_SUM4}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="490" y="0" width="75" height="18" uuid="699bf908-3b75-4452-a3b9-11ff11edaf70"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM4}!=null)?$V{WEIGHTREF_SUM4}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="699bf908-3b75-4452-a3b9-11ff11edaf70" key="textField" stretchType="ContainerHeight" mode="Opaque" x="490" y="0" width="75" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM4}!=null)?$V{WEIGHTREF_SUM4}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="630" y="0" width="65" height="18" uuid="eaf0d4db-0e6e-40d3-9543-83979298c39f">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM4}!=null)?$V{QTYREF_SUM4}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="eaf0d4db-0e6e-40d3-9543-83979298c39f" key="textField" stretchType="ContainerHeight" mode="Opaque" x="630" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM4}!=null)?$V{QTYREF_SUM4}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="695" y="0" width="35" height="18" uuid="acc09c0c-c739-49c9-8ca5-3ec2a7de52a5">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PCT_4}!=null)?$V{QTY_PCT_4}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="acc09c0c-c739-49c9-8ca5-3ec2a7de52a5" key="textField" stretchType="ContainerHeight" mode="Opaque" x="695" y="0" width="35" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PCT_4}!=null)?$V{QTY_PCT_4}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-21" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="240" y="0" width="65" height="18" uuid="16bc351e-01cb-4b49-8661-4c703b9c6a38"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM4}!=null)?$V{CONVAMOUNT_SUM4}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="16bc351e-01cb-4b49-8661-4c703b9c6a38" key="textField-21" stretchType="ContainerHeight" mode="Opaque" x="240" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM4}!=null)?$V{CONVAMOUNT_SUM4}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-22" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="320" y="0" width="65" height="18" uuid="180c84ed-2a42-4bf3-af6e-5c1d825bcd04"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNTREF_SUM4}!=null)?$V{CONVAMOUNTREF_SUM4}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="180c84ed-2a42-4bf3-af6e-5c1d825bcd04" key="textField-22" stretchType="ContainerHeight" mode="Opaque" x="320" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{CONVAMOUNTREF_SUM4}!=null)?$V{CONVAMOUNTREF_SUM4}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-23" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="400" y="0" width="25" height="18" uuid="99874d96-ccb6-4637-b986-bf1c465b91e8"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMT_PCT_4}!=null)?$V{CONVAMT_PCT_4}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="99874d96-ccb6-4637-b986-bf1c465b91e8" key="textField-23" stretchType="ContainerHeight" mode="Opaque" x="400" y="0" width="25" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{CONVAMT_PCT_4}!=null)?$V{CONVAMT_PCT_4}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-44" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="0" y="0" width="15" height="18" uuid="e1520ad1-5fb5-43e4-b569-4c9ee98f8972"/>
-					<box>
+					<box rightPadding="3" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-51" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="15" y="0" width="15" height="18" uuid="a09bd8dd-7023-4c01-8697-70d0ac5f09f6"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="e1520ad1-5fb5-43e4-b569-4c9ee98f8972" key="textField-44" stretchType="ContainerHeight" mode="Opaque" x="0" y="0" width="15" height="18" rotation="Left" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-57" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="30" y="0" width="15" height="18" uuid="b16d3a8e-1ccf-4f8d-a4ef-7a942c918568"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="a09bd8dd-7023-4c01-8697-70d0ac5f09f6" key="textField-51" stretchType="ContainerHeight" mode="Opaque" x="15" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-117" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="385" y="0" width="15" height="18" uuid="8a76dd76-f3f2-4c92-b552-0bb8b777b4f5"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="b16d3a8e-1ccf-4f8d-a4ef-7a942c918568" key="textField-57" stretchType="ContainerHeight" mode="Opaque" x="30" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-126" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="305" y="0" width="15" height="18" uuid="36dbcea8-9eef-4142-b234-41cbfca9413b"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="8a76dd76-f3f2-4c92-b552-0bb8b777b4f5" key="textField-117" stretchType="ContainerHeight" mode="Opaque" x="385" y="0" width="15" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level4_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="36dbcea8-9eef-4142-b234-41cbfca9413b" key="textField-126" stretchType="ContainerHeight" mode="Opaque" x="305" y="0" width="15" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level4_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level4_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -1663,219 +1362,156 @@
 		</groupFooter>
 	</group>
 	<group name="LEVEL5">
-		<groupExpression><![CDATA[$F{NIVEL5}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL5}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="60" y="0" width="180" height="18" uuid="ca8189fd-a2f8-4099-978c-a34a0affdac9"/>
-					<box>
+				<element kind="textField" uuid="ca8189fd-a2f8-4099-978c-a34a0affdac9" key="textField" stretchType="ContainerHeight" mode="Opaque" x="60" y="0" width="180" height="18" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[$F{NIVEL5}]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL5}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="565" y="0" width="65" height="18" uuid="6e4a0cb2-416a-447b-9afc-cbb1f6bff300">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM5}!=null)?$V{QTY_SUM5}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="6e4a0cb2-416a-447b-9afc-cbb1f6bff300" key="textField" stretchType="ContainerHeight" mode="Opaque" x="565" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" evaluationGroup="LEVEL5" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM5}!=null)?$V{QTY_SUM5}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="425" y="0" width="65" height="18" uuid="9e403463-bdb0-4fec-93a5-209d4329beb3"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM5}!=null)?$V{WEIGHT_SUM5}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="9e403463-bdb0-4fec-93a5-209d4329beb3" key="textField" stretchType="ContainerHeight" mode="Opaque" x="425" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM5}!=null)?$V{WEIGHT_SUM5}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="490" y="0" width="75" height="18" uuid="9a40649d-8118-403c-9882-9ea9ba6ee728"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM5}!=null)?$V{WEIGHTREF_SUM5}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="9a40649d-8118-403c-9882-9ea9ba6ee728" key="textField" stretchType="ContainerHeight" mode="Opaque" x="490" y="0" width="75" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM5}!=null)?$V{WEIGHTREF_SUM5}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="630" y="0" width="65" height="18" uuid="ac4c4ec6-1d4b-4a00-b607-ccc40c345adb">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM5}!=null)?$V{QTYREF_SUM5}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="ac4c4ec6-1d4b-4a00-b607-ccc40c345adb" key="textField" stretchType="ContainerHeight" mode="Opaque" x="630" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM5}!=null)?$V{QTYREF_SUM5}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="695" y="0" width="35" height="18" uuid="52f7369d-68a3-4063-8991-eb30ef79f512">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PCT_5}!=null)?$V{QTY_PCT_5}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="52f7369d-68a3-4063-8991-eb30ef79f512" key="textField" stretchType="ContainerHeight" mode="Opaque" x="695" y="0" width="35" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PCT_5}!=null)?$V{QTY_PCT_5}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-24" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="240" y="0" width="65" height="18" uuid="01b5500b-d067-4761-a1b8-448838e4360e"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM5}!=null)?$V{CONVAMOUNT_SUM5}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="01b5500b-d067-4761-a1b8-448838e4360e" key="textField-24" stretchType="ContainerHeight" mode="Opaque" x="240" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM5}!=null)?$V{CONVAMOUNT_SUM5}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-25" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="320" y="0" width="65" height="18" uuid="77674dac-c9ed-4fbc-b2d5-a5b62217696a"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNTREF_SUM5}!=null)?$V{CONVAMOUNTREF_SUM5}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="77674dac-c9ed-4fbc-b2d5-a5b62217696a" key="textField-25" stretchType="ContainerHeight" mode="Opaque" x="320" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{CONVAMOUNTREF_SUM5}!=null)?$V{CONVAMOUNTREF_SUM5}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-26" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="400" y="0" width="25" height="18" uuid="5438ed71-54d7-4dd6-9795-f599f113a223"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMT_PCT_5}!=null)?$V{CONVAMT_PCT_5}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="5438ed71-54d7-4dd6-9795-f599f113a223" key="textField-26" stretchType="ContainerHeight" mode="Opaque" x="400" y="0" width="25" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{CONVAMT_PCT_5}!=null)?$V{CONVAMT_PCT_5}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-45" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="0" y="0" width="15" height="18" uuid="8290c6e0-cfad-4fec-81f5-84b4867d7beb"/>
-					<box>
+					<box rightPadding="3" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-52" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="15" y="0" width="15" height="18" uuid="6e8b5972-07ce-4ca4-b96e-c84f52292395"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="8290c6e0-cfad-4fec-81f5-84b4867d7beb" key="textField-45" stretchType="ContainerHeight" mode="Opaque" x="0" y="0" width="15" height="18" rotation="Left" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-58" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="30" y="0" width="15" height="18" uuid="10444ae2-167b-4e11-a37b-422d0bf991fd"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="6e8b5972-07ce-4ca4-b96e-c84f52292395" key="textField-52" stretchType="ContainerHeight" mode="Opaque" x="15" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-63" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="45" y="0" width="15" height="18" uuid="fb1ce4d1-33c5-4d41-8c4c-b71ff60075ec"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="10444ae2-167b-4e11-a37b-422d0bf991fd" key="textField-58" stretchType="ContainerHeight" mode="Opaque" x="30" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-118" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="385" y="0" width="15" height="18" uuid="0d200137-ca1c-4d8b-b970-209d795c3011"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="fb1ce4d1-33c5-4d41-8c4c-b71ff60075ec" key="textField-63" stretchType="ContainerHeight" mode="Opaque" x="45" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-127" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="305" y="0" width="15" height="18" uuid="0b100c20-cd8b-4164-bfa9-702f242413e9"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="0d200137-ca1c-4d8b-b970-209d795c3011" key="textField-118" stretchType="ContainerHeight" mode="Opaque" x="385" y="0" width="15" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level5_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="0b100c20-cd8b-4164-bfa9-702f242413e9" key="textField-127" stretchType="ContainerHeight" mode="Opaque" x="305" y="0" width="15" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level5_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level5_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -1883,232 +1519,165 @@
 		</groupFooter>
 	</group>
 	<group name="LEVEL6">
-		<groupExpression><![CDATA[$F{NIVEL6}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL6}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=6)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="75" y="0" width="165" height="18" uuid="283caf49-533b-4822-9461-475c48cb337a"/>
-					<box>
+				<element kind="textField" uuid="283caf49-533b-4822-9461-475c48cb337a" key="textField" stretchType="ContainerHeight" mode="Opaque" x="75" y="0" width="165" height="18" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[$F{NIVEL6}]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL6}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL6" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="565" y="0" width="65" height="18" uuid="c6f8bef2-b8f8-4c9f-9e21-acc704fb2e44">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM6}!=null)?$V{QTY_SUM6}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="c6f8bef2-b8f8-4c9f-9e21-acc704fb2e44" key="textField" stretchType="ContainerHeight" mode="Opaque" x="565" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" evaluationGroup="LEVEL6" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level6_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM6}!=null)?$V{QTY_SUM6}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="425" y="0" width="65" height="18" uuid="9a1ab029-9cb8-43bc-aea1-b48e7a31cc6f"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM6}!=null)?$V{WEIGHT_SUM6}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="9a1ab029-9cb8-43bc-aea1-b48e7a31cc6f" key="textField" stretchType="ContainerHeight" mode="Opaque" x="425" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL6" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM6}!=null)?$V{WEIGHT_SUM6}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="490" y="0" width="75" height="18" uuid="d3db1934-2534-4621-80aa-a6c758b51fb3"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM6}!=null)?$V{WEIGHTREF_SUM6}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="d3db1934-2534-4621-80aa-a6c758b51fb3" key="textField" stretchType="ContainerHeight" mode="Opaque" x="490" y="0" width="75" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL6" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM6}!=null)?$V{WEIGHTREF_SUM6}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="630" y="0" width="65" height="18" uuid="ffab6a79-623a-42e2-b1b0-a8117e5fc9ec">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM6}!=null)?$V{QTYREF_SUM6}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="ffab6a79-623a-42e2-b1b0-a8117e5fc9ec" key="textField" stretchType="ContainerHeight" mode="Opaque" x="630" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL6" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level6_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM6}!=null)?$V{QTYREF_SUM6}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="695" y="0" width="35" height="18" uuid="74cc6d9a-1f5d-4151-b8cf-cc87c7acddcb">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PCT_6}!=null)?$V{QTY_PCT_6}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="74cc6d9a-1f5d-4151-b8cf-cc87c7acddcb" key="textField" stretchType="ContainerHeight" mode="Opaque" x="695" y="0" width="35" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL6" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level6_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PCT_6}!=null)?$V{QTY_PCT_6}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-27" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="240" y="0" width="65" height="18" uuid="a761cc9c-8e7c-437e-86b6-e92b8886750e"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM6}!=null)?$V{CONVAMOUNT_SUM6}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="a761cc9c-8e7c-437e-86b6-e92b8886750e" key="textField-27" stretchType="ContainerHeight" mode="Opaque" x="240" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL6" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM6}!=null)?$V{CONVAMOUNT_SUM6}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-28" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="320" y="0" width="65" height="18" uuid="2f810e71-3fe6-48eb-8bf7-e9442426247e"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNTREF_SUM6}!=null)?$V{CONVAMOUNTREF_SUM6}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="2f810e71-3fe6-48eb-8bf7-e9442426247e" key="textField-28" stretchType="ContainerHeight" mode="Opaque" x="320" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL6" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{CONVAMOUNTREF_SUM6}!=null)?$V{CONVAMOUNTREF_SUM6}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-29" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="400" y="0" width="25" height="18" uuid="884fc74b-d0f8-4b39-99b9-b17e4ba91a90"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMT_PCT_6}!=null)?$V{CONVAMT_PCT_6}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="884fc74b-d0f8-4b39-99b9-b17e4ba91a90" key="textField-29" stretchType="ContainerHeight" mode="Opaque" x="400" y="0" width="25" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL6" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{CONVAMT_PCT_6}!=null)?$V{CONVAMT_PCT_6}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-46" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="0" y="0" width="15" height="18" uuid="0047984f-95d9-4a05-9183-c4eaad8604f8"/>
-					<box>
+					<box rightPadding="3" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-53" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="15" y="0" width="15" height="18" uuid="e1df1f7e-7ed0-4b86-989e-321570ff3532"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="0047984f-95d9-4a05-9183-c4eaad8604f8" key="textField-46" stretchType="ContainerHeight" mode="Opaque" x="0" y="0" width="15" height="18" rotation="Left" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-59" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="30" y="0" width="15" height="18" uuid="5b30194d-3122-46f2-af65-9500f01b10b5"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="e1df1f7e-7ed0-4b86-989e-321570ff3532" key="textField-53" stretchType="ContainerHeight" mode="Opaque" x="15" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-64" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="45" y="0" width="15" height="18" uuid="e41607ad-b81e-47a4-ac32-728a0007c8c0"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="5b30194d-3122-46f2-af65-9500f01b10b5" key="textField-59" stretchType="ContainerHeight" mode="Opaque" x="30" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-68" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="60" y="0" width="15" height="18" uuid="c0ed6f5d-0b61-41e7-8429-f9d066292522"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="e41607ad-b81e-47a4-ac32-728a0007c8c0" key="textField-64" stretchType="ContainerHeight" mode="Opaque" x="45" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-119" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="385" y="0" width="15" height="18" uuid="1fe72fbc-2f40-4abe-a34c-47e9c33f58b9"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="c0ed6f5d-0b61-41e7-8429-f9d066292522" key="textField-68" stretchType="ContainerHeight" mode="Opaque" x="60" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-128" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="305" y="0" width="15" height="18" uuid="f71587a7-d718-46ab-b867-4cf118a8dcf4"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="1fe72fbc-2f40-4abe-a34c-47e9c33f58b9" key="textField-119" stretchType="ContainerHeight" mode="Opaque" x="385" y="0" width="15" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL6" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level6_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="f71587a7-d718-46ab-b867-4cf118a8dcf4" key="textField-128" stretchType="ContainerHeight" mode="Opaque" x="305" y="0" width="15" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL6" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level6_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level6_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -2116,245 +1685,174 @@
 		</groupFooter>
 	</group>
 	<group name="LEVEL7">
-		<groupExpression><![CDATA[$F{NIVEL7}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL7}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=7)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="90" y="0" width="150" height="18" uuid="86e10d57-f974-4eff-81ea-a9d86a8b9f98"/>
-					<box>
+				<element kind="textField" uuid="86e10d57-f974-4eff-81ea-a9d86a8b9f98" key="textField" stretchType="ContainerHeight" mode="Opaque" x="90" y="0" width="150" height="18" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[$F{NIVEL7}]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL7}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL7" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="565" y="0" width="65" height="18" uuid="617bc2ea-7162-4590-bcd7-fd33d92f68dd">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM7}!=null)?$V{QTY_SUM7}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="617bc2ea-7162-4590-bcd7-fd33d92f68dd" key="textField" stretchType="ContainerHeight" mode="Opaque" x="565" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" evaluationGroup="LEVEL7" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level7_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM7}!=null)?$V{QTY_SUM7}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="425" y="0" width="65" height="18" uuid="db46a7fe-ad38-44b6-8414-8c3f46b58405"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM7}!=null)?$V{WEIGHT_SUM7}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="db46a7fe-ad38-44b6-8414-8c3f46b58405" key="textField" stretchType="ContainerHeight" mode="Opaque" x="425" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL7" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM7}!=null)?$V{WEIGHT_SUM7}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="490" y="0" width="75" height="18" uuid="4c028599-0a84-4731-9cb4-6d3a137638e0"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM7}!=null)?$V{WEIGHTREF_SUM7}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="4c028599-0a84-4731-9cb4-6d3a137638e0" key="textField" stretchType="ContainerHeight" mode="Opaque" x="490" y="0" width="75" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL7" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM7}!=null)?$V{WEIGHTREF_SUM7}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="630" y="0" width="65" height="18" uuid="98ed6409-e487-4ce6-90a1-cf59f40f6303">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM7}!=null)?$V{QTYREF_SUM7}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="98ed6409-e487-4ce6-90a1-cf59f40f6303" key="textField" stretchType="ContainerHeight" mode="Opaque" x="630" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL7" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level7_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM7}!=null)?$V{QTYREF_SUM7}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="695" y="0" width="35" height="18" uuid="1ccb3156-d2a4-425d-8283-5d64856fa653">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PCT_7}!=null)?$V{QTY_PCT_7}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="1ccb3156-d2a4-425d-8283-5d64856fa653" key="textField" stretchType="ContainerHeight" mode="Opaque" x="695" y="0" width="35" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL7" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level7_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PCT_7}!=null)?$V{QTY_PCT_7}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-30" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="240" y="0" width="65" height="18" uuid="736436d8-f882-4e9b-8863-34796de93624"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM7}!=null)?$V{CONVAMOUNT_SUM7}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="736436d8-f882-4e9b-8863-34796de93624" key="textField-30" stretchType="ContainerHeight" mode="Opaque" x="240" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL7" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM7}!=null)?$V{CONVAMOUNT_SUM7}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-31" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="320" y="0" width="65" height="18" uuid="f1a3c9d7-bf0d-4e9a-8e43-5b925470322b"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNTREF_SUM7}!=null)?$V{CONVAMOUNTREF_SUM7}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="f1a3c9d7-bf0d-4e9a-8e43-5b925470322b" key="textField-31" stretchType="ContainerHeight" mode="Opaque" x="320" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL7" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{CONVAMOUNTREF_SUM7}!=null)?$V{CONVAMOUNTREF_SUM7}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-32" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="400" y="0" width="25" height="18" uuid="26081681-4bbb-49ea-a7c5-21c9033fb493"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMT_PCT_7}!=null)?$V{CONVAMT_PCT_7}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="26081681-4bbb-49ea-a7c5-21c9033fb493" key="textField-32" stretchType="ContainerHeight" mode="Opaque" x="400" y="0" width="25" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL7" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{CONVAMT_PCT_7}!=null)?$V{CONVAMT_PCT_7}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-47" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="0" y="0" width="15" height="18" uuid="cc3998ba-c42a-4ee3-9777-fcd9f72a6802"/>
-					<box>
+					<box rightPadding="3" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-54" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="15" y="0" width="15" height="18" uuid="2bd56205-d029-46c0-b3c5-7d6500411a1c"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="cc3998ba-c42a-4ee3-9777-fcd9f72a6802" key="textField-47" stretchType="ContainerHeight" mode="Opaque" x="0" y="0" width="15" height="18" rotation="Left" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-60" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="30" y="0" width="15" height="18" uuid="1982285b-12db-4461-b2e0-34dfa7d62fe2"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="2bd56205-d029-46c0-b3c5-7d6500411a1c" key="textField-54" stretchType="ContainerHeight" mode="Opaque" x="15" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-65" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="45" y="0" width="15" height="18" uuid="e676f0c4-9daa-4d84-a8e5-e1a5a8e3d08e"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="1982285b-12db-4461-b2e0-34dfa7d62fe2" key="textField-60" stretchType="ContainerHeight" mode="Opaque" x="30" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-69" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="60" y="0" width="15" height="18" uuid="d05e34f5-34d4-4966-bc2a-b0a8c1906223"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="e676f0c4-9daa-4d84-a8e5-e1a5a8e3d08e" key="textField-65" stretchType="ContainerHeight" mode="Opaque" x="45" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-72" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="75" y="0" width="15" height="18" uuid="5ef0aba8-3ea5-4d50-93ac-28c31d77fe5e"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="d05e34f5-34d4-4966-bc2a-b0a8c1906223" key="textField-69" stretchType="ContainerHeight" mode="Opaque" x="60" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-120" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="385" y="0" width="15" height="18" uuid="1045f7b1-e8f1-45b1-a5da-0e9ca2c87412"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="5ef0aba8-3ea5-4d50-93ac-28c31d77fe5e" key="textField-72" stretchType="ContainerHeight" mode="Opaque" x="75" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-129" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="305" y="0" width="15" height="18" uuid="1917739f-570c-4a60-85fb-2e72233e3057"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="1045f7b1-e8f1-45b1-a5da-0e9ca2c87412" key="textField-120" stretchType="ContainerHeight" mode="Opaque" x="385" y="0" width="15" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL7" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level7_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="1917739f-570c-4a60-85fb-2e72233e3057" key="textField-129" stretchType="ContainerHeight" mode="Opaque" x="305" y="0" width="15" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL7" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level7_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level7_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -2362,258 +1860,183 @@
 		</groupFooter>
 	</group>
 	<group name="LEVEL8">
-		<groupExpression><![CDATA[$F{NIVEL8}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL8}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=8)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="105" y="0" width="135" height="18" uuid="0f00e366-22a7-481e-bf95-8ac3a54f2f84"/>
-					<box>
+				<element kind="textField" uuid="0f00e366-22a7-481e-bf95-8ac3a54f2f84" key="textField" stretchType="ContainerHeight" mode="Opaque" x="105" y="0" width="135" height="18" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level8_Line">
+					<expression><![CDATA[$F{NIVEL8}]]></expression>
+					<box style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL8}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL8" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="565" y="0" width="65" height="18" uuid="f0b9c9cb-0725-4831-9825-87f590b1b267">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM8}!=null)?$V{QTY_SUM8}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="f0b9c9cb-0725-4831-9825-87f590b1b267" key="textField" stretchType="ContainerHeight" mode="Opaque" x="565" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" evaluationGroup="LEVEL8" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level8_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM8}!=null)?$V{QTY_SUM8}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="425" y="0" width="65" height="18" uuid="77c192a6-8d63-426b-8c6e-57e15a73938d"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM8}!=null)?$V{WEIGHT_SUM8}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="77c192a6-8d63-426b-8c6e-57e15a73938d" key="textField" stretchType="ContainerHeight" mode="Opaque" x="425" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL8" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM8}!=null)?$V{WEIGHT_SUM8}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="490" y="0" width="75" height="18" uuid="044e5dee-edf7-47a2-a1ac-f63b39e1f8e1"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM8}!=null)?$V{WEIGHTREF_SUM8}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="044e5dee-edf7-47a2-a1ac-f63b39e1f8e1" key="textField" stretchType="ContainerHeight" mode="Opaque" x="490" y="0" width="75" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL8" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM8}!=null)?$V{WEIGHTREF_SUM8}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="630" y="0" width="65" height="18" uuid="52dc832d-8943-409d-adf6-6ed9ffd4186d">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM8}!=null)?$V{QTYREF_SUM8}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="52dc832d-8943-409d-adf6-6ed9ffd4186d" key="textField" stretchType="ContainerHeight" mode="Opaque" x="630" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL8" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level8_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM8}!=null)?$V{QTYREF_SUM8}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="695" y="0" width="35" height="18" uuid="74fc1b9c-408c-4604-b36f-2f5780d83d88">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PCT_8}!=null)?$V{QTY_PCT_8}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="74fc1b9c-408c-4604-b36f-2f5780d83d88" key="textField" stretchType="ContainerHeight" mode="Opaque" x="695" y="0" width="35" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL8" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level8_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PCT_8}!=null)?$V{QTY_PCT_8}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-33" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="240" y="0" width="65" height="18" uuid="eb3b032d-7f2c-4cbc-96de-9cb67ad968c1"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM8}!=null)?$V{CONVAMOUNT_SUM8}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="eb3b032d-7f2c-4cbc-96de-9cb67ad968c1" key="textField-33" stretchType="ContainerHeight" mode="Opaque" x="240" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL8" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM8}!=null)?$V{CONVAMOUNT_SUM8}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-34" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="320" y="0" width="65" height="18" uuid="c944e2c4-28a1-4b89-9bd7-a7ca0cffc431"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNTREF_SUM8}!=null)?$V{CONVAMOUNTREF_SUM8}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="c944e2c4-28a1-4b89-9bd7-a7ca0cffc431" key="textField-34" stretchType="ContainerHeight" mode="Opaque" x="320" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL8" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{CONVAMOUNTREF_SUM8}!=null)?$V{CONVAMOUNTREF_SUM8}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-35" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="400" y="0" width="25" height="18" uuid="164aae45-edac-446a-a46f-c2e2e0ebbf74"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMT_PCT_8}!=null)?$V{CONVAMT_PCT_8}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="164aae45-edac-446a-a46f-c2e2e0ebbf74" key="textField-35" stretchType="ContainerHeight" mode="Opaque" x="400" y="0" width="25" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL8" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{CONVAMT_PCT_8}!=null)?$V{CONVAMT_PCT_8}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-48" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="0" y="0" width="15" height="18" uuid="10e81893-c577-4c4b-969d-333650496d9f"/>
-					<box>
+					<box rightPadding="3" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-55" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="15" y="0" width="15" height="18" uuid="c36c488a-32da-4de5-848f-82841f53efe5"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="10e81893-c577-4c4b-969d-333650496d9f" key="textField-48" stretchType="ContainerHeight" mode="Opaque" x="0" y="0" width="15" height="18" rotation="Left" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-61" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="30" y="0" width="15" height="18" uuid="2bf21148-0e64-4cdd-a450-0bb45fe7108e"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="c36c488a-32da-4de5-848f-82841f53efe5" key="textField-55" stretchType="ContainerHeight" mode="Opaque" x="15" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-66" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="45" y="0" width="15" height="18" uuid="13987580-0fba-4cd1-b6db-ead5932deb94"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="2bf21148-0e64-4cdd-a450-0bb45fe7108e" key="textField-61" stretchType="ContainerHeight" mode="Opaque" x="30" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-70" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="60" y="0" width="15" height="18" uuid="90d4e96c-6231-48a2-9af0-b265f00f8010"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="13987580-0fba-4cd1-b6db-ead5932deb94" key="textField-66" stretchType="ContainerHeight" mode="Opaque" x="45" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-73" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="75" y="0" width="15" height="18" uuid="96086921-ab80-4b47-9568-7f4b115ef7a0"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="90d4e96c-6231-48a2-9af0-b265f00f8010" key="textField-70" stretchType="ContainerHeight" mode="Opaque" x="60" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-75" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="90" y="0" width="15" height="18" uuid="f26b2f73-b850-4f12-b009-8a1c494235bf"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="96086921-ab80-4b47-9568-7f4b115ef7a0" key="textField-73" stretchType="ContainerHeight" mode="Opaque" x="75" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-121" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="385" y="0" width="15" height="18" uuid="5b3070ef-99d9-4bde-9877-4e366b039d82"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="f26b2f73-b850-4f12-b009-8a1c494235bf" key="textField-75" stretchType="ContainerHeight" mode="Opaque" x="90" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-130" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="305" y="0" width="15" height="18" uuid="cafc84e3-dec6-469d-ac13-68a4f3a4d7a0"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="5b3070ef-99d9-4bde-9877-4e366b039d82" key="textField-121" stretchType="ContainerHeight" mode="Opaque" x="385" y="0" width="15" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL8" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level8_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="cafc84e3-dec6-469d-ac13-68a4f3a4d7a0" key="textField-130" stretchType="ContainerHeight" mode="Opaque" x="305" y="0" width="15" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL8" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level8_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level8_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -2621,271 +2044,192 @@
 		</groupFooter>
 	</group>
 	<group name="LEVEL9">
-		<groupExpression><![CDATA[$F{NIVEL9}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL9}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=9)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level9_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="120" y="0" width="120" height="18" uuid="811db0cb-fdad-4791-8958-77814d83f297"/>
-					<box>
+				<element kind="textField" uuid="811db0cb-fdad-4791-8958-77814d83f297" key="textField" stretchType="ContainerHeight" mode="Opaque" x="120" y="0" width="120" height="18" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level9_Line">
+					<expression><![CDATA[$F{NIVEL9}]]></expression>
+					<box style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL9}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL9" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level9_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="565" y="0" width="65" height="18" uuid="8735dd30-6135-436f-8b66-ae1cd311870a">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM9}!=null)?$V{QTY_SUM9}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="8735dd30-6135-436f-8b66-ae1cd311870a" key="textField" stretchType="ContainerHeight" mode="Opaque" x="565" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" evaluationGroup="LEVEL9" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level9_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM9}!=null)?$V{QTY_SUM9}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level9_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="425" y="0" width="65" height="18" uuid="1a6554fe-484a-4469-9154-352bc12b9ef9"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM9}!=null)?$V{WEIGHT_SUM9}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="1a6554fe-484a-4469-9154-352bc12b9ef9" key="textField" stretchType="ContainerHeight" mode="Opaque" x="425" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL9" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM9}!=null)?$V{WEIGHT_SUM9}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level9_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="490" y="0" width="75" height="18" uuid="b1ad7390-70c1-4a24-af6e-4c75699dbaef"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM9}!=null)?$V{WEIGHTREF_SUM9}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="b1ad7390-70c1-4a24-af6e-4c75699dbaef" key="textField" stretchType="ContainerHeight" mode="Opaque" x="490" y="0" width="75" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL9" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM9}!=null)?$V{WEIGHTREF_SUM9}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level9_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="630" y="0" width="65" height="18" uuid="9f41553b-a524-4875-abe4-a7d81f08bd98">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM9}!=null)?$V{QTYREF_SUM9}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="9f41553b-a524-4875-abe4-a7d81f08bd98" key="textField" stretchType="ContainerHeight" mode="Opaque" x="630" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL9" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level9_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM9}!=null)?$V{QTYREF_SUM9}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level9_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="695" y="0" width="35" height="18" uuid="4d7da0fb-976f-45b6-98e2-3d67331ed2a2">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PCT_9}!=null)?$V{QTY_PCT_9}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="4d7da0fb-976f-45b6-98e2-3d67331ed2a2" key="textField" stretchType="ContainerHeight" mode="Opaque" x="695" y="0" width="35" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL9" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level9_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PCT_9}!=null)?$V{QTY_PCT_9}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-36" style="Level9_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="240" y="0" width="65" height="18" uuid="52862d9a-4742-42ab-9322-cf4301e374fa"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM9}!=null)?$V{CONVAMOUNT_SUM9}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="52862d9a-4742-42ab-9322-cf4301e374fa" key="textField-36" stretchType="ContainerHeight" mode="Opaque" x="240" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL9" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM9}!=null)?$V{CONVAMOUNT_SUM9}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-37" style="Level9_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="320" y="0" width="65" height="18" uuid="62eab7f8-3e10-47c4-a89e-1071ccd26a51"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNTREF_SUM9}!=null)?$V{CONVAMOUNTREF_SUM9}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="62eab7f8-3e10-47c4-a89e-1071ccd26a51" key="textField-37" stretchType="ContainerHeight" mode="Opaque" x="320" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL9" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{CONVAMOUNTREF_SUM9}!=null)?$V{CONVAMOUNTREF_SUM9}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-38" style="Level9_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="400" y="0" width="25" height="18" uuid="479e73dc-9e28-4a93-a79d-81b31fbc2a00"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMT_PCT_9}!=null)?$V{CONVAMT_PCT_9}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="479e73dc-9e28-4a93-a79d-81b31fbc2a00" key="textField-38" stretchType="ContainerHeight" mode="Opaque" x="400" y="0" width="25" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL9" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{CONVAMT_PCT_9}!=null)?$V{CONVAMT_PCT_9}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-49" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="0" y="0" width="15" height="18" uuid="ead2e8cc-cb0e-4b86-bcd3-6a4b35d9215c"/>
-					<box>
+					<box rightPadding="3" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-56" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="15" y="0" width="15" height="18" uuid="2c52cbc6-d658-4f36-a934-ae7946832fcb"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="ead2e8cc-cb0e-4b86-bcd3-6a4b35d9215c" key="textField-49" stretchType="ContainerHeight" mode="Opaque" x="0" y="0" width="15" height="18" rotation="Left" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-62" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="30" y="0" width="15" height="18" uuid="b7417b33-4f8d-4e82-94cd-7ec0977bcd07"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="2c52cbc6-d658-4f36-a934-ae7946832fcb" key="textField-56" stretchType="ContainerHeight" mode="Opaque" x="15" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-67" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="45" y="0" width="15" height="18" uuid="0b7d9138-bf7f-40bc-90c6-889de60f8264"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="b7417b33-4f8d-4e82-94cd-7ec0977bcd07" key="textField-62" stretchType="ContainerHeight" mode="Opaque" x="30" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-71" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="60" y="0" width="15" height="18" uuid="605c883b-b46c-4eae-9fcc-04313c4d0a62"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="0b7d9138-bf7f-40bc-90c6-889de60f8264" key="textField-67" stretchType="ContainerHeight" mode="Opaque" x="45" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-74" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="75" y="0" width="15" height="18" uuid="4c06380b-c14c-4160-aa90-d0cf5c1e1a17"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="605c883b-b46c-4eae-9fcc-04313c4d0a62" key="textField-71" stretchType="ContainerHeight" mode="Opaque" x="60" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-76" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="90" y="0" width="15" height="18" uuid="25ac9f23-8f1a-4db1-addd-793a58907991"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="4c06380b-c14c-4160-aa90-d0cf5c1e1a17" key="textField-74" stretchType="ContainerHeight" mode="Opaque" x="75" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-77" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="105" y="0" width="15" height="18" uuid="37d8cb5c-e9c9-429b-93ec-d6d2d9e1d015"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="25ac9f23-8f1a-4db1-addd-793a58907991" key="textField-76" stretchType="ContainerHeight" mode="Opaque" x="90" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-122" style="Level9_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="385" y="0" width="15" height="18" uuid="84639489-abb7-44c9-9098-364feea117e8"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="37d8cb5c-e9c9-429b-93ec-d6d2d9e1d015" key="textField-77" stretchType="ContainerHeight" mode="Opaque" x="105" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level8_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-131" style="Level9_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="305" y="0" width="15" height="18" uuid="c841e1bd-de71-4df0-b876-56ee946eb983"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="84639489-abb7-44c9-9098-364feea117e8" key="textField-122" stretchType="ContainerHeight" mode="Opaque" x="385" y="0" width="15" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL9" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level9_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="c841e1bd-de71-4df0-b876-56ee946eb983" key="textField-131" stretchType="ContainerHeight" mode="Opaque" x="305" y="0" width="15" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL9" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level9_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level9_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -2893,284 +2237,201 @@
 		</groupFooter>
 	</group>
 	<group name="LEVEL10">
-		<groupExpression><![CDATA[$F{NIVEL10}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL10}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=10)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level10_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="135" y="0" width="105" height="18" uuid="959e6c61-4d05-4b29-87f6-e0ec12f180fb"/>
-					<box>
+				<element kind="textField" uuid="959e6c61-4d05-4b29-87f6-e0ec12f180fb" key="textField" stretchType="ContainerHeight" mode="Opaque" x="135" y="0" width="105" height="18" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level10_Line">
+					<expression><![CDATA[$F{NIVEL10}]]></expression>
+					<box style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL10}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL10" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level10_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="565" y="0" width="65" height="18" uuid="6b3464ee-2e20-4ef2-8c70-50ebb60bb680">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM10}!=null)?$V{QTY_SUM10}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="6b3464ee-2e20-4ef2-8c70-50ebb60bb680" key="textField" stretchType="ContainerHeight" mode="Opaque" x="565" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" evaluationGroup="LEVEL10" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level10_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM10}!=null)?$V{QTY_SUM10}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level10_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="425" y="0" width="65" height="18" uuid="6e154a06-403d-416d-96d0-9d5736d7c5b5"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM10}!=null)?$V{WEIGHT_SUM10}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="6e154a06-403d-416d-96d0-9d5736d7c5b5" key="textField" stretchType="ContainerHeight" mode="Opaque" x="425" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL10" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM10}!=null)?$V{WEIGHT_SUM10}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level10_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="490" y="0" width="75" height="18" uuid="eff6db0a-0a92-4160-bbbf-7ff6ac99b7fe"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM10}!=null)?$V{WEIGHTREF_SUM10}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="eff6db0a-0a92-4160-bbbf-7ff6ac99b7fe" key="textField" stretchType="ContainerHeight" mode="Opaque" x="490" y="0" width="75" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL10" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM10}!=null)?$V{WEIGHTREF_SUM10}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level10_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="630" y="0" width="65" height="18" uuid="e9651ac5-2a17-4bcf-bf27-52440e5c31f2">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM10}!=null)?$V{QTYREF_SUM10}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="e9651ac5-2a17-4bcf-bf27-52440e5c31f2" key="textField" stretchType="ContainerHeight" mode="Opaque" x="630" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL10" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level10_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM10}!=null)?$V{QTYREF_SUM10}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level10_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="695" y="0" width="35" height="18" uuid="a84cee38-58c9-4c24-82ea-86d24ce1a25f">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PCT_10}!=null)?$V{QTY_PCT_10}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="a84cee38-58c9-4c24-82ea-86d24ce1a25f" key="textField" stretchType="ContainerHeight" mode="Opaque" x="695" y="0" width="35" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL10" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level10_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PCT_10}!=null)?$V{QTY_PCT_10}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-36" style="Level10_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="240" y="0" width="65" height="18" uuid="cd19e9d3-aa92-4a05-83d9-411ad002baed"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM10}!=null)?$V{CONVAMOUNT_SUM10}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="cd19e9d3-aa92-4a05-83d9-411ad002baed" key="textField-36" stretchType="ContainerHeight" mode="Opaque" x="240" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL10" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM10}!=null)?$V{CONVAMOUNT_SUM10}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-37" style="Level10_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="320" y="0" width="65" height="18" uuid="857a7113-0928-4d2f-9040-e5e96f1cca35"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNTREF_SUM10}!=null)?$V{CONVAMOUNTREF_SUM10}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="857a7113-0928-4d2f-9040-e5e96f1cca35" key="textField-37" stretchType="ContainerHeight" mode="Opaque" x="320" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL10" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{CONVAMOUNTREF_SUM10}!=null)?$V{CONVAMOUNTREF_SUM10}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-38" style="Level10_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="400" y="0" width="25" height="18" uuid="d59916dd-ec3a-47e8-a3a5-6130eb787a57"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMT_PCT_10}!=null)?$V{CONVAMT_PCT_10}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="d59916dd-ec3a-47e8-a3a5-6130eb787a57" key="textField-38" stretchType="ContainerHeight" mode="Opaque" x="400" y="0" width="25" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL10" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{CONVAMT_PCT_10}!=null)?$V{CONVAMT_PCT_10}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-49" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="0" y="0" width="15" height="18" uuid="c3dcec92-2ba3-43b9-8d6a-a1e5f5364402"/>
-					<box>
+					<box rightPadding="3" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-56" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="15" y="0" width="15" height="18" uuid="70b833ee-647c-421a-b25e-d4630d5177fb"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="c3dcec92-2ba3-43b9-8d6a-a1e5f5364402" key="textField-49" stretchType="ContainerHeight" mode="Opaque" x="0" y="0" width="15" height="18" rotation="Left" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-62" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="30" y="0" width="15" height="18" uuid="1e242a8c-528b-4684-b12c-c6e5c5c811ba"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="70b833ee-647c-421a-b25e-d4630d5177fb" key="textField-56" stretchType="ContainerHeight" mode="Opaque" x="15" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-67" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="45" y="0" width="15" height="18" uuid="e26d7f89-8d30-41f5-91a3-4e5a6207326b"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="1e242a8c-528b-4684-b12c-c6e5c5c811ba" key="textField-62" stretchType="ContainerHeight" mode="Opaque" x="30" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-71" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="60" y="0" width="15" height="18" uuid="8c1754a9-00d7-4d4e-9fc2-f00bcba84b65"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="e26d7f89-8d30-41f5-91a3-4e5a6207326b" key="textField-67" stretchType="ContainerHeight" mode="Opaque" x="45" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-74" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="75" y="0" width="15" height="18" uuid="a5f1301f-20f7-4eb8-ba11-ed7b7da7f74c"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="8c1754a9-00d7-4d4e-9fc2-f00bcba84b65" key="textField-71" stretchType="ContainerHeight" mode="Opaque" x="60" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-76" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="90" y="0" width="15" height="18" uuid="0d263f27-c2b3-4b5f-9614-3398aef4b5c5"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="a5f1301f-20f7-4eb8-ba11-ed7b7da7f74c" key="textField-74" stretchType="ContainerHeight" mode="Opaque" x="75" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-77" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="105" y="0" width="15" height="18" uuid="033cc159-b82f-4020-8d32-42b34480a936"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="0d263f27-c2b3-4b5f-9614-3398aef4b5c5" key="textField-76" stretchType="ContainerHeight" mode="Opaque" x="90" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-76" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="120" y="0" width="15" height="18" uuid="40296a89-b54f-48a4-b7ff-60b839620795"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="033cc159-b82f-4020-8d32-42b34480a936" key="textField-77" stretchType="ContainerHeight" mode="Opaque" x="105" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level8_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-122" style="Level10_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="385" y="0" width="15" height="18" uuid="d6f8c44b-d2ee-4d2c-a880-7fb608f3356a"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="40296a89-b54f-48a4-b7ff-60b839620795" key="textField-76" stretchType="ContainerHeight" mode="Opaque" x="120" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-131" style="Level10_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="305" y="0" width="15" height="18" uuid="673048ae-f86a-425e-89e6-f79ee888a295"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="d6f8c44b-d2ee-4d2c-a880-7fb608f3356a" key="textField-122" stretchType="ContainerHeight" mode="Opaque" x="385" y="0" width="15" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL10" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level10_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="673048ae-f86a-425e-89e6-f79ee888a295" key="textField-131" stretchType="ContainerHeight" mode="Opaque" x="305" y="0" width="15" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL10" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level10_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level10_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -3178,741 +2439,521 @@
 		</groupFooter>
 	</group>
 	<group name="LEVEL11">
-		<groupExpression><![CDATA[$F{NIVEL11}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL11}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=11)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level11_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="150" y="0" width="90" height="18" uuid="e71631d2-9012-48e5-866d-806bab88ac7a"/>
-					<box>
+				<element kind="textField" uuid="e71631d2-9012-48e5-866d-806bab88ac7a" key="textField" stretchType="ContainerHeight" mode="Opaque" x="150" y="0" width="90" height="18" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level11_Line">
+					<expression><![CDATA[$F{NIVEL11}]]></expression>
+					<box style="Level11_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NIVEL11}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL11" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level11_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="565" y="0" width="65" height="18" uuid="7897e2c4-86ac-474a-ab16-c9a6615ebc82">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=11)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_SUM11}!=null)?$V{QTY_SUM11}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="7897e2c4-86ac-474a-ab16-c9a6615ebc82" key="textField" stretchType="ContainerHeight" mode="Opaque" x="565" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" evaluationGroup="LEVEL11" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level11_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=11)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM11}!=null)?$V{QTY_SUM11}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL11" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level11_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="425" y="0" width="65" height="18" uuid="4da93268-487d-45ea-951d-84df29b65709"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level11_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM11}!=null)?$V{WEIGHT_SUM11}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="4da93268-487d-45ea-951d-84df29b65709" key="textField" stretchType="ContainerHeight" mode="Opaque" x="425" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL11" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level11_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM11}!=null)?$V{WEIGHT_SUM11}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL11" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level11_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="490" y="0" width="75" height="18" uuid="806e3436-f447-4b00-8c04-6490812ad2b0"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level11_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{WEIGHTREF_SUM11}!=null)?$V{WEIGHTREF_SUM11}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="806e3436-f447-4b00-8c04-6490812ad2b0" key="textField" stretchType="ContainerHeight" mode="Opaque" x="490" y="0" width="75" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL11" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level11_Line">
+					<expression><![CDATA[($V{WEIGHTREF_SUM11}!=null)?$V{WEIGHTREF_SUM11}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL11" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level11_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="630" y="0" width="65" height="18" uuid="1b07fc76-5250-4620-baf4-4e643ffab56f">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=11)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level11_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTYREF_SUM11}!=null)?$V{QTYREF_SUM11}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="1b07fc76-5250-4620-baf4-4e643ffab56f" key="textField" stretchType="ContainerHeight" mode="Opaque" x="630" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL11" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level11_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=11)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTYREF_SUM11}!=null)?$V{QTYREF_SUM11}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL11" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level11_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="695" y="0" width="35" height="18" uuid="904431fa-12c5-4ae5-9a7c-bf1934a56266">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=11)]]></printWhenExpression>
-					</reportElement>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level11_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{QTY_PCT_11}!=null)?$V{QTY_PCT_11}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="904431fa-12c5-4ae5-9a7c-bf1934a56266" key="textField" stretchType="ContainerHeight" mode="Opaque" x="695" y="0" width="35" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL11" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level11_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=11)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_PCT_11}!=null)?$V{QTY_PCT_11}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL11" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-36" style="Level11_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="240" y="0" width="65" height="18" uuid="5200c9df-a32b-4866-b113-62bfdb015544"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level11_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM11}!=null)?$V{CONVAMOUNT_SUM11}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="5200c9df-a32b-4866-b113-62bfdb015544" key="textField-36" stretchType="ContainerHeight" mode="Opaque" x="240" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL11" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level11_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM11}!=null)?$V{CONVAMOUNT_SUM11}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL11" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-37" style="Level11_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="320" y="0" width="65" height="18" uuid="6c74c84b-808c-4243-b158-203cd40df59e"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level11_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNTREF_SUM11}!=null)?$V{CONVAMOUNTREF_SUM11}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="6c74c84b-808c-4243-b158-203cd40df59e" key="textField-37" stretchType="ContainerHeight" mode="Opaque" x="320" y="0" width="65" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL11" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level11_Line">
+					<expression><![CDATA[($V{CONVAMOUNTREF_SUM11}!=null)?$V{CONVAMOUNTREF_SUM11}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL11" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-38" style="Level11_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="400" y="0" width="25" height="18" uuid="65f4f5a2-3728-45c0-9572-a9fb1c6c9863"/>
-					<box rightPadding="3">
+					<box rightPadding="3" style="Level11_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{CONVAMT_PCT_11}!=null)?$V{CONVAMT_PCT_11}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="65f4f5a2-3728-45c0-9572-a9fb1c6c9863" key="textField-38" stretchType="ContainerHeight" mode="Opaque" x="400" y="0" width="25" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL11" blankWhenNull="false" bold="false" hTextAlign="Right" style="Level11_Line">
+					<expression><![CDATA[($V{CONVAMT_PCT_11}!=null)?$V{CONVAMT_PCT_11}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-49" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="0" y="0" width="15" height="18" uuid="9803b151-2243-4895-a4e3-7c59daad922e"/>
-					<box>
+					<box rightPadding="3" style="Level11_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-56" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="15" y="0" width="15" height="18" uuid="be742f22-95b3-480b-893b-f2946518f0bf"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="9803b151-2243-4895-a4e3-7c59daad922e" key="textField-49" stretchType="ContainerHeight" mode="Opaque" x="0" y="0" width="15" height="18" rotation="Left" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-62" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="30" y="0" width="15" height="18" uuid="d136baf9-c69c-4465-811e-6676d94fcc53"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="be742f22-95b3-480b-893b-f2946518f0bf" key="textField-56" stretchType="ContainerHeight" mode="Opaque" x="15" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-67" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="45" y="0" width="15" height="18" uuid="388d76f8-ed10-47c6-82b7-7bd001e30a74"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="d136baf9-c69c-4465-811e-6676d94fcc53" key="textField-62" stretchType="ContainerHeight" mode="Opaque" x="30" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-71" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="60" y="0" width="15" height="18" uuid="c19db7e9-fdd1-4b7c-b807-6045bfbe5406"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="388d76f8-ed10-47c6-82b7-7bd001e30a74" key="textField-67" stretchType="ContainerHeight" mode="Opaque" x="45" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-74" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="75" y="0" width="15" height="18" uuid="cef11c7a-f443-4c09-ac54-1315bbd1fe92"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="c19db7e9-fdd1-4b7c-b807-6045bfbe5406" key="textField-71" stretchType="ContainerHeight" mode="Opaque" x="60" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-76" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="90" y="0" width="15" height="18" uuid="2b231ce6-4e35-4299-a62e-ec248b88eede"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="cef11c7a-f443-4c09-ac54-1315bbd1fe92" key="textField-74" stretchType="ContainerHeight" mode="Opaque" x="75" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-77" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="105" y="0" width="15" height="18" uuid="fe9deade-00bc-4d80-a540-bce7c007afad"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="2b231ce6-4e35-4299-a62e-ec248b88eede" key="textField-76" stretchType="ContainerHeight" mode="Opaque" x="90" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-76" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="120" y="0" width="15" height="18" uuid="46c17012-2b10-4b54-9c62-75d81a7994cc"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="fe9deade-00bc-4d80-a540-bce7c007afad" key="textField-77" stretchType="ContainerHeight" mode="Opaque" x="105" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level8_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-77" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="135" y="0" width="15" height="18" uuid="ec453810-31f4-4e67-bfe8-eac1e38f6a24"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="46c17012-2b10-4b54-9c62-75d81a7994cc" key="textField-76" stretchType="ContainerHeight" mode="Opaque" x="120" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL11" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-122" style="Level11_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="385" y="0" width="15" height="18" uuid="be20198a-b5cb-492d-8739-0720fa0a0c37"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="ec453810-31f4-4e67-bfe8-eac1e38f6a24" key="textField-77" stretchType="ContainerHeight" mode="Opaque" x="135" y="0" width="15" height="18" rotation="None" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" style="Level8_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL11" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-131" style="Level11_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="305" y="0" width="15" height="18" uuid="42c3a8e6-b08d-492f-90b6-1d47d5b77aac"/>
-					<box rightPadding="3">
+				</element>
+				<element kind="textField" uuid="be20198a-b5cb-492d-8739-0720fa0a0c37" key="textField-122" stretchType="ContainerHeight" mode="Opaque" x="385" y="0" width="15" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL11" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level11_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level11_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font size="8" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="42c3a8e6-b08d-492f-90b6-1d47d5b77aac" key="textField-131" stretchType="ContainerHeight" mode="Opaque" x="305" y="0" width="15" height="18" fontSize="8.0" evaluationTime="Group" pattern="" evaluationGroup="LEVEL11" blankWhenNull="false" bold="false" hTextAlign="Center" style="Level11_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box rightPadding="3" style="Level11_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band height="11" splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="101" splitType="Stretch">
-			<textField isBlankWhenNull="true">
-				<reportElement style="Detail_Header" x="470" y="82" width="20" height="18" uuid="22192c33-b242-4b19-9cde-925359f0c70b"/>
-				<textElement textAlignment="Center">
-					<font size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{WSYMBOL}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Report_Title" x="0" y="0" width="730" height="26" uuid="b0219860-1721-4a7f-9ce5-6dbf34e9d017"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Subtitle" x="0" y="31" width="730" height="18" uuid="71351d3d-2b7e-4bbc-96ac-582b16fdadea"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_SUBTITLE}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" style="Detail_Header" positionType="FixRelativeToBottom" mode="Opaque" x="695" y="82" width="35" height="18" uuid="7909f743-bffc-4bd5-a833-aec3745336c5"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Q %]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-3" style="Detail_Header" positionType="FixRelativeToBottom" mode="Opaque" x="425" y="82" width="45" height="18" uuid="fec64397-8bb7-4386-9b63-139ef89d99a0"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Weight]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-5" style="Detail_Header" positionType="FixRelativeToBottom" mode="Opaque" x="490" y="82" width="55" height="18" uuid="5f936807-fc68-4a94-828e-82c195016a50"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Wgt. Ref.]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-7" style="Detail_Header" positionType="FixRelativeToBottom" mode="Opaque" x="565" y="82" width="65" height="18" uuid="000b229a-a391-4176-a593-7350985ebff6"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Quantity]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-8" style="Detail_Header" positionType="FixRelativeToBottom" mode="Opaque" x="630" y="82" width="65" height="18" uuid="e0ccabd7-39db-4e76-b334-324ceaddc148"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Qty. Ref.]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-9" style="Detail_Header" positionType="FixRelativeToBottom" mode="Opaque" x="240" y="82" width="80" height="18" uuid="966e0253-01ed-495b-98d2-0bddc6ad287a"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Amount]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-10" style="Detail_Header" positionType="FixRelativeToBottom" mode="Opaque" x="320" y="82" width="80" height="18" uuid="932c0753-ee6c-4470-8d12-b5ed91d8ca08"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Amt. Ref.]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-11" style="Detail_Header" positionType="FixRelativeToBottom" mode="Opaque" x="400" y="82" width="25" height="18" uuid="dd768c17-cb35-4056-84ba-5c14c24e7174"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="8" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[A %]]></text>
-			</staticText>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Data_Field" x="115" y="57" width="615" height="18" uuid="2b2cd047-5e83-4668-9d1c-ae3606b0dd82"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{LEVEL_LABEL}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-12" style="Report_Data_Label" x="0" y="57" width="115" height="18" uuid="8d2644ef-81aa-411d-a6a0-e61a23a06010"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<text><![CDATA[Grouping Levels:]]></text>
-			</staticText>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-78" style="Detail_Header" positionType="FixRelativeToBottom" x="0" y="82" width="15" height="18" uuid="5bed946e-bce2-4210-b688-ab1814cac1f1"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement rotation="None">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-79" style="Detail_Header" positionType="FixRelativeToBottom" x="15" y="82" width="15" height="18" uuid="7f7ec855-f0d5-4a54-ab75-f0c7af59d1ff"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement rotation="None">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-80" style="Detail_Header" positionType="FixRelativeToBottom" x="30" y="82" width="15" height="18" uuid="5a3fe875-e736-4cba-9287-515ec4993127"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement rotation="None">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-81" style="Detail_Header" positionType="FixRelativeToBottom" x="45" y="82" width="15" height="18" uuid="12156480-328e-4156-94b8-fd2d3e4d64a1"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement rotation="None">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-82" style="Detail_Header" positionType="FixRelativeToBottom" x="60" y="82" width="15" height="18" uuid="e9efc4ec-0f29-4f28-a696-46b7ef2fc4d2"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement rotation="None">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":"")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-83" style="Detail_Header" positionType="FixRelativeToBottom" x="75" y="82" width="15" height="18" uuid="848ddce7-51cc-4054-84ee-ebd8201d2a44"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement rotation="None">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(6))>=0)?"6":"")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-84" style="Detail_Header" positionType="FixRelativeToBottom" x="90" y="82" width="15" height="18" uuid="f6c98dc9-05fd-4cc3-aea8-72c972ff2363"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement rotation="None">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(7))>=0)?"7":"")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-85" style="Detail_Header" positionType="FixRelativeToBottom" x="105" y="82" width="15" height="18" uuid="27bf09a2-f400-4ce0-8ed4-bacb701a641c"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement rotation="None">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(8))>=0)?"8":"")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-86" style="Detail_Header" positionType="FixRelativeToBottom" x="120" y="82" width="15" height="18" uuid="e8bbf825-a969-48f3-aeae-04ebffd330a2"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement rotation="None">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(9))>=0)?"9":"")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-86" style="Detail_Header" positionType="FixRelativeToBottom" x="135" y="82" width="15" height="18" uuid="943f7e84-e226-4f30-b7c8-e5f4b36e76c0"/>
-				<box leftPadding="2">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement rotation="None">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(10))>=0)?"10":"")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-86" style="Detail_Header" positionType="FixRelativeToBottom" x="150" y="82" width="15" height="18" uuid="cdad7118-fcf6-4301-8f04-9fbf7cdaf0b5"/>
-				<box leftPadding="2">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement rotation="None">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(11))>=0)?"11":"")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-3" x="0" y="26" width="730" height="1" uuid="23e902a8-f75e-4835-af83-04bef3391a73"/>
-			</line>
-			<line>
-				<reportElement key="line-4" x="0" y="49" width="730" height="1" uuid="98ce2e56-c53d-4c1a-88c6-6de7210c2fe8"/>
-			</line>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-135" style="Detail_Header" positionType="FixRelativeToBottom" x="171" y="82" width="69" height="18" uuid="70e7303e-9419-4bd8-b2f9-f8d25a10c888"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center" rotation="None">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement style="Detail_Header" x="545" y="82" width="20" height="18" uuid="3ead0cf5-6c79-4207-a65a-cb4c83f54963"/>
-				<textElement textAlignment="Center">
-					<font size="8" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{WSYMBOL}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background height="11" splitType="Stretch"/>
+	<title height="101" splitType="Stretch">
+		<element kind="textField" uuid="22192c33-b242-4b19-9cde-925359f0c70b" x="470" y="82" width="20" height="18" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="true" bold="true" hTextAlign="Center" style="Detail_Header">
+			<expression><![CDATA[$F{WSYMBOL}]]></expression>
+		</element>
+		<element kind="textField" uuid="b0219860-1721-4a7f-9ce5-6dbf34e9d017" key="textField" x="0" y="0" width="730" height="26" textAdjust="StretchHeight" blankWhenNull="true" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="71351d3d-2b7e-4bbc-96ac-582b16fdadea" key="textField" x="0" y="31" width="730" height="18" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="7909f743-bffc-4bd5-a833-aec3745336c5" key="staticText-1" positionType="FixRelativeToBottom" mode="Opaque" x="695" y="82" width="35" height="18" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Q %]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="fec64397-8bb7-4386-9b63-139ef89d99a0" key="staticText-3" positionType="FixRelativeToBottom" mode="Opaque" x="425" y="82" width="45" height="18" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Weight]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="5f936807-fc68-4a94-828e-82c195016a50" key="staticText-5" positionType="FixRelativeToBottom" mode="Opaque" x="490" y="82" width="55" height="18" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Wgt. Ref.]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="000b229a-a391-4176-a593-7350985ebff6" key="staticText-7" positionType="FixRelativeToBottom" mode="Opaque" x="565" y="82" width="65" height="18" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Quantity]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="e0ccabd7-39db-4e76-b334-324ceaddc148" key="staticText-8" positionType="FixRelativeToBottom" mode="Opaque" x="630" y="82" width="65" height="18" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Qty. Ref.]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="966e0253-01ed-495b-98d2-0bddc6ad287a" key="staticText-9" positionType="FixRelativeToBottom" mode="Opaque" x="240" y="82" width="80" height="18" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Amount]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="932c0753-ee6c-4470-8d12-b5ed91d8ca08" key="staticText-10" positionType="FixRelativeToBottom" mode="Opaque" x="320" y="82" width="80" height="18" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Amt. Ref.]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="dd768c17-cb35-4056-84ba-5c14c24e7174" key="staticText-11" positionType="FixRelativeToBottom" mode="Opaque" x="400" y="82" width="25" height="18" fontSize="8.0" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[A %]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="2b2cd047-5e83-4668-9d1c-ae3606b0dd82" key="textField" x="115" y="57" width="615" height="18" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Data_Field">
+			<expression><![CDATA[$P{LEVEL_LABEL}]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="8d2644ef-81aa-411d-a6a0-e61a23a06010" key="staticText-12" x="0" y="57" width="115" height="18" style="Report_Data_Label">
+			<text><![CDATA[Grouping Levels:]]></text>
+			<box style="Report_Data_Label">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="5bed946e-bce2-4210-b688-ab1814cac1f1" key="textField-78" positionType="FixRelativeToBottom" x="0" y="82" width="15" height="18" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+			<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></expression>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="7f7ec855-f0d5-4a54-ab75-f0c7af59d1ff" key="textField-79" positionType="FixRelativeToBottom" x="15" y="82" width="15" height="18" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+			<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></expression>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="5a3fe875-e736-4cba-9287-515ec4993127" key="textField-80" positionType="FixRelativeToBottom" x="30" y="82" width="15" height="18" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+			<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></expression>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="12156480-328e-4156-94b8-fd2d3e4d64a1" key="textField-81" positionType="FixRelativeToBottom" x="45" y="82" width="15" height="18" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+			<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></expression>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="e9efc4ec-0f29-4f28-a696-46b7ef2fc4d2" key="textField-82" positionType="FixRelativeToBottom" x="60" y="82" width="15" height="18" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+			<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":"")]]></expression>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="848ddce7-51cc-4054-84ee-ebd8201d2a44" key="textField-83" positionType="FixRelativeToBottom" x="75" y="82" width="15" height="18" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+			<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(6))>=0)?"6":"")]]></expression>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="f6c98dc9-05fd-4cc3-aea8-72c972ff2363" key="textField-84" positionType="FixRelativeToBottom" x="90" y="82" width="15" height="18" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+			<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(7))>=0)?"7":"")]]></expression>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="27bf09a2-f400-4ce0-8ed4-bacb701a641c" key="textField-85" positionType="FixRelativeToBottom" x="105" y="82" width="15" height="18" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+			<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(8))>=0)?"8":"")]]></expression>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="e8bbf825-a969-48f3-aeae-04ebffd330a2" key="textField-86" positionType="FixRelativeToBottom" x="120" y="82" width="15" height="18" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+			<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(9))>=0)?"9":"")]]></expression>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="943f7e84-e226-4f30-b7c8-e5f4b36e76c0" key="textField-86" positionType="FixRelativeToBottom" x="135" y="82" width="15" height="18" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+			<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(10))>=0)?"10":"")]]></expression>
+			<box leftPadding="2" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="cdad7118-fcf6-4301-8f04-9fbf7cdaf0b5" key="textField-86" positionType="FixRelativeToBottom" x="150" y="82" width="15" height="18" rotation="None" fontSize="8.0" blankWhenNull="true" style="Detail_Header">
+			<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(11))>=0)?"11":"")]]></expression>
+			<box leftPadding="2" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="line" uuid="23e902a8-f75e-4835-af83-04bef3391a73" key="line-3" x="0" y="26" width="730" height="1"/>
+		<element kind="line" uuid="98ce2e56-c53d-4c1a-88c6-6de7210c2fe8" key="line-4" x="0" y="49" width="730" height="1"/>
+		<element kind="textField" uuid="70e7303e-9419-4bd8-b2f9-f8d25a10c888" key="textField-135" positionType="FixRelativeToBottom" x="171" y="82" width="69" height="18" rotation="None" fontSize="8.0" blankWhenNull="true" hTextAlign="Center" style="Detail_Header">
+			<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="3ead0cf5-6c79-4207-a65a-cb4c83f54963" x="545" y="82" width="20" height="18" fontSize="8.0" pdfFontName="Helvetica-Bold" blankWhenNull="true" bold="true" hTextAlign="Center" style="Detail_Header">
+			<expression><![CDATA[$F{WSYMBOL}]]></expression>
+		</element>
 	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band splitType="Stretch"/>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="22" splitType="Stretch">
-			<line>
-				<reportElement key="line-2" x="0" y="1" width="730" height="1" uuid="92831bc4-366f-4a75-8b06-9cc7acc6ef13"/>
-			</line>
-			<staticText>
-				<reportElement key="staticText-13" style="Report_Footer" x="6" y="4" width="140" height="16" uuid="d569c49c-1743-4de8-a195-7a19cc3bbc0f">
-					<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
-				</reportElement>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[other footer data]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-14" style="Report_Footer" x="274" y="4" width="78" height="16" uuid="189a1929-91b0-4b75-b318-7b90af0c857a"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<text><![CDATA[Generated on ]]></text>
-			</staticText>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-96" style="Report_Footer" x="355" y="4" width="90" height="16" uuid="3885527e-cfe5-4cca-9f5b-5e326a5be56c"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-97" style="Report_Footer" x="597" y="4" width="95" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="a954e17a-a796-4ae3-aaee-c7c8cf531e48"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-98" style="Report_Footer" x="693" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="f1261c35-3af2-449c-9e4f-1f23c623c1b4"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="22" splitType="Stretch">
+		<element kind="line" uuid="92831bc4-366f-4a75-8b06-9cc7acc6ef13" key="line-2" x="0" y="1" width="730" height="1"/>
+		<element kind="staticText" uuid="d569c49c-1743-4de8-a195-7a19cc3bbc0f" key="staticText-13" x="6" y="4" width="140" height="16" fontSize="8.0" style="Report_Footer">
+			<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
+			<text><![CDATA[other footer data]]></text>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="189a1929-91b0-4b75-b318-7b90af0c857a" key="staticText-14" x="274" y="4" width="78" height="16" fontName="Times-Roman" fontSize="8.0" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
+			<text><![CDATA[Generated on ]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="3885527e-cfe5-4cca-9f5b-5e326a5be56c" key="textField-96" x="355" y="4" width="90" height="16" fontName="Times-Roman" fontSize="8.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="a954e17a-a796-4ae3-aaee-c7c8cf531e48" key="textField-97" x="597" y="4" width="95" height="16" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="8.0" pdfFontName="Helvetica" pdfEncoding="CP1252" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
+			<paragraph lineSpacing="Single" style="Report_Footer"/>
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="f1261c35-3af2-449c-9e4f-1f23c623c1b4" key="textField-98" x="693" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="8.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle" style="Report_Footer">
+			<paragraph lineSpacing="Single" style="Report_Footer"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/WeightDimensionalNoComparative.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/WeightDimensionalNoComparative.jrxml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="WeightDimensionalNoComparative" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="730" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="ace3ae64-07eb-4915-a6f0-85c6e9228f21">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="WeightDimensionalNoComparative" language="java" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="730" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="ace3ae64-07eb-4915-a6f0-85c6e9228f21">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
@@ -7,126 +7,124 @@
 	<property name="ireport.x" value="7995"/>
 	<property name="ireport.y" value="1617"/>
 	<property name="net.sf.jasperreports.export.xls.detect.cell.type" value="true"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" isDefault="true" vAlign="Middle" fontName="SansSerif" fontSize="11"/>
-	<style name="Report_Title" fontName="SansSerif" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="11.0"/>
+	<style name="Report_Title" fontName="SansSerif" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="SansSerif" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="SansSerif" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Data_Label" fontName="SansSerif" fontSize="11" isBold="false"/>
-	<style name="Report_Data_Field" fontName="SansSerif" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false">
+	<style name="Report_Data_Label" fontName="SansSerif" fontSize="11.0" bold="false"/>
+	<style name="Report_Data_Field" fontName="SansSerif" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="11.0" bold="false">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="SansSerif" fontSize="10" isBold="true">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="10.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="Detail_Line" fontName="SansSerif" fontSize="8" isBold="true">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="SansSerif" fontSize="8.0" bold="true">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
-	<style name="Level1_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
-	<style name="Level2_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
-	<style name="Level3_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
-	<style name="Level4_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
-	<style name="Level5_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
-	<style name="Level6_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
-	<style name="Level7_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
-	<style name="Level8_Line" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
-	<style name="Level9_Line" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
-	<style name="Level10_Line" mode="Opaque" backcolor="#CCCCCC" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
-	<style name="Level11_Line" mode="Opaque" backcolor="#E5E5E5" vAlign="Middle" fontName="SansSerif" fontSize="11" isBold="false"/>
-	<style name="Report_Footer" vAlign="Middle" fontName="SansSerif" fontSize="11"/>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<style name="Level1_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="11.0" bold="false"/>
+	<style name="Level2_Line" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="11.0" bold="false"/>
+	<style name="Level3_Line" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="11.0" bold="false"/>
+	<style name="Level4_Line" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="11.0" bold="false"/>
+	<style name="Level5_Line" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="11.0" bold="false"/>
+	<style name="Level6_Line" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="11.0" bold="false"/>
+	<style name="Level7_Line" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="11.0" bold="false"/>
+	<style name="Level8_Line" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="11.0" bold="false"/>
+	<style name="Level9_Line" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="11.0" bold="false"/>
+	<style name="Level10_Line" mode="Opaque" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="11.0" bold="false"/>
+	<style name="Level11_Line" mode="Opaque" backcolor="#E5E5E5" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="11.0" bold="false"/>
+	<style name="Report_Footer" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="11.0"/>
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["0,1000000"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["0,1000000"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATEFROM" class="java.util.Date" isForPrompting="false">
+	<parameter name="DATEFROM" forPrompting="false" class="java.util.Date">
 		<defaultValueExpression><![CDATA[(new SimpleDateFormat("dd-MM-yyyy")).parse("01-01-1900")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATETO" class="java.util.Date" isForPrompting="false">
+	<parameter name="DATETO" forPrompting="false" class="java.util.Date">
 		<defaultValueExpression><![CDATA[(new SimpleDateFormat("dd-MM-yyyy")).parse("31-12-3000")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="cBpGroupId" class="java.lang.String" isForPrompting="false">
+	<parameter name="cBpGroupId" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="cBpGroupId_Aux" class="java.lang.String" isForPrompting="false">
+	<parameter name="cBpGroupId_Aux" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{cBpGroupId}.equals("") ? " " : (" AND C_BP_Group.C_BP_Group_ID = " + $P{cBpGroupId})]]></defaultValueExpression>
 	</parameter>
-	<parameter name="cBpartnerId" class="java.lang.String" isForPrompting="false">
+	<parameter name="cBpartnerId" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="cBpartnerId_Aux" class="java.lang.String" isForPrompting="false">
+	<parameter name="cBpartnerId_Aux" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{cBpartnerId}.equals(""))?"  ":" AND C_BPartner.C_BPartner_ID IN " + $P{cBpartnerId}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="mProductCategoryId" class="java.lang.String" isForPrompting="false">
+	<parameter name="mProductCategoryId" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="mProductCategoryId_Aux" class="java.lang.String" isForPrompting="false">
+	<parameter name="mProductCategoryId_Aux" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{mProductCategoryId}.equals(""))?"  ":" AND M_Product_Category.M_Product_Category_Id = " + $P{mProductCategoryId}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="mProductId" class="java.lang.String" isForPrompting="false">
+	<parameter name="mProductId" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="mProductId_Aux" class="java.lang.String" isForPrompting="false">
+	<parameter name="mProductId_Aux" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[($P{mProductId}.equals(""))?" ":" AND M_Product.M_Product_ID IN " + $P{mProductId}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="orderBy" class="java.lang.String" isForPrompting="false">
+	<parameter name="orderBy" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[" ORDER BY 1 "]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Purchase Orders Report"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="PRODUCT_LEVEL" class="java.lang.Integer" isForPrompting="false">
+	<parameter name="PRODUCT_LEVEL" forPrompting="false" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[new Integer(3)]]></defaultValueExpression>
 	</parameter>
-	<parameter name="THEME" class="java.lang.String" isForPrompting="false">
+	<parameter name="THEME" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Default"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false">
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/var/lib/tomcat-5.5/webapps/alerts/web"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL1_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL1_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Partner Group"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL2_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL2_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Product Category"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL3_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL3_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Product"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL4_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL4_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["Partner"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL5_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL6_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL7_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL8_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL9_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL10_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LEVEL11_LABEL" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="DIMENSIONS" class="java.lang.Integer" isForPrompting="false">
+	<parameter name="LEVEL5_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL6_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL7_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL8_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL9_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL10_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LEVEL11_LABEL" forPrompting="false" class="java.lang.String"/>
+	<parameter name="DIMENSIONS" forPrompting="false" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[new Integer(4)]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LEVEL_LABEL" class="java.lang.String" isForPrompting="false">
+	<parameter name="LEVEL_LABEL" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["1.- "+$P{LEVEL1_LABEL}+($P{LEVEL2_LABEL}==""?"":", 2.- "+$P{LEVEL2_LABEL})+($P{LEVEL3_LABEL}==""?"":", 3.- "+$P{LEVEL3_LABEL})+($P{LEVEL4_LABEL}==""?"":", 4.- "+$P{LEVEL4_LABEL})+($P{LEVEL5_LABEL}==""?"":", 5.- "+$P{LEVEL5_LABEL})+($P{LEVEL5_LABEL}==""?"":", 6.- "+$P{LEVEL6_LABEL})+($P{LEVEL7_LABEL}==""?"":", 7.- "+$P{LEVEL7_LABEL})+($P{LEVEL8_LABEL}==""?"":", 8.- "+$P{LEVEL8_LABEL})+($P{LEVEL9_LABEL}==""?"":", 9.- "+$P{LEVEL9_LABEL})+($P{LEVEL10_LABEL}==""?"":", 10.- "+$P{LEVEL10_LABEL})+($P{LEVEL11_LABEL}==""?"":", 11.- "+$P{LEVEL11_LABEL})]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10, NIVEL11, 
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10, NIVEL11, 
 	  SUM(AMOUNT) AS AMOUNT, SUM(QTY) AS QTY, SUM(WEIGHT) AS WEIGHT,
 	  SUM(AMOUNTREF) AS AMOUNTREF, SUM(QTYREF) AS QTYREF, SUM(WEIGHTREF) AS WEIGHTREF, UOMSYMBOL,
 	  SUM(CONVAMOUNT) AS CONVAMOUNT,
@@ -163,8 +161,7 @@
       AND C_ORDER.AD_CLIENT_ID IN ('8')
       AND 1=1) AA
       GROUP BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10, NIVEL11, UOMSYMBOL, TRCURRENCYID, TRDATE, TRCLIENTID, TRORGID) ZZ
-      GROUP BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10, NIVEL11, UOMSYMBOL, CONVSYM, CONVISOSYM, 1]]>
-	</queryString>
+      GROUP BY NIVEL1, NIVEL2, NIVEL3, NIVEL4, NIVEL5, NIVEL6, NIVEL7, NIVEL8, NIVEL9, NIVEL10, NIVEL11, UOMSYMBOL, CONVSYM, CONVISOSYM, 1]]></query>
 	<field name="NIVEL1" class="java.lang.String"/>
 	<field name="NIVEL2" class="java.lang.String"/>
 	<field name="NIVEL3" class="java.lang.String"/>
@@ -187,418 +184,374 @@
 	<field name="CONVSYM" class="java.lang.String"/>
 	<field name="CONVISOSYM" class="java.lang.String"/>
 	<field name="WSYMBOL" class="java.lang.String"/>
-	<variable name="QUANTITY_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QUANTITY_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM11" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL11" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM11" resetType="Group" calculation="Sum" resetGroup="LEVEL11" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="QTY_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM10" resetType="Group" calculation="Sum" resetGroup="LEVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="QTY_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM9" resetType="Group" calculation="Sum" resetGroup="LEVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="QTY_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM8" resetType="Group" calculation="Sum" resetGroup="LEVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="QTY_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM7" resetType="Group" calculation="Sum" resetGroup="LEVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="QTY_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM6" resetType="Group" calculation="Sum" resetGroup="LEVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="QTY_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
-	<variable name="QTY_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="QTY_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{QTY}]]></variableExpression>
+	<variable name="QTY_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QTY}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM6" resetType="Group" calculation="Sum" resetGroup="LEVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM7" resetType="Group" calculation="Sum" resetGroup="LEVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM8" resetType="Group" calculation="Sum" resetGroup="LEVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="AMOUNT_SUM9" resetType="Group" calculation="Sum" resetGroup="LEVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM6" resetType="Group" calculation="Sum" resetGroup="LEVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM7" resetType="Group" calculation="Sum" resetGroup="LEVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM8" resetType="Group" calculation="Sum" resetGroup="LEVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM9" resetType="Group" calculation="Sum" resetGroup="LEVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM10" resetType="Group" calculation="Sum" resetGroup="LEVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="CONVAMOUNT_SUM11" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL11" calculation="Sum">
-		<variableExpression><![CDATA[$F{CONVAMOUNT}]]></variableExpression>
+	<variable name="CONVAMOUNT_SUM11" resetType="Group" calculation="Sum" resetGroup="LEVEL11" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{CONVAMOUNT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_TOTAL" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_TOTAL" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM1" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL1" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM1" resetType="Group" calculation="Sum" resetGroup="NIVEL1" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM2" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL2" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM2" resetType="Group" calculation="Sum" resetGroup="NIVEL2" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM3" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL3" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM3" resetType="Group" calculation="Sum" resetGroup="NIVEL3" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM4" class="java.math.BigDecimal" resetType="Group" resetGroup="NIVEL4" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM4" resetType="Group" calculation="Sum" resetGroup="NIVEL4" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM5" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL5" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM5" resetType="Group" calculation="Sum" resetGroup="LEVEL5" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM6" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL6" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM6" resetType="Group" calculation="Sum" resetGroup="LEVEL6" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM7" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL7" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM7" resetType="Group" calculation="Sum" resetGroup="LEVEL7" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM8" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL8" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM8" resetType="Group" calculation="Sum" resetGroup="LEVEL8" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM9" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL9" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM9" resetType="Group" calculation="Sum" resetGroup="LEVEL9" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM10" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL10" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM10" resetType="Group" calculation="Sum" resetGroup="LEVEL10" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
-	<variable name="WEIGHT_SUM11" class="java.math.BigDecimal" resetType="Group" resetGroup="LEVEL11" calculation="Sum">
-		<variableExpression><![CDATA[$F{WEIGHT}]]></variableExpression>
+	<variable name="WEIGHT_SUM11" resetType="Group" calculation="Sum" resetGroup="LEVEL11" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{WEIGHT}]]></expression>
 	</variable>
 	<group name="TOTALIZE">
-		<groupExpression><![CDATA[]]></groupExpression>
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band splitType="Stretch"/>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-57" style="Total_Field" x="560" y="2" width="94" height="18" uuid="21345657-f685-4544-85be-bcadc1e4a2a3"/>
-					<box leftPadding="5">
+				<element kind="textField" uuid="21345657-f685-4544-85be-bcadc1e4a2a3" key="textField-57" x="560" y="2" width="94" height="18" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{WEIGHT_TOTAL}!=null)? $V{WEIGHT_TOTAL} : BigDecimal.ZERO]]></expression>
+					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_TOTAL}!=null)? $V{WEIGHT_TOTAL} : BigDecimal.ZERO]]></textFieldExpression>
-					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-9" style="Report_Data_Label" x="395" y="2" width="50" height="18" uuid="7bd179a8-e59c-44bc-8274-975a56fc9575"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle"/>
+				</element>
+				<element kind="staticText" uuid="7bd179a8-e59c-44bc-8274-975a56fc9575" key="staticText-9" x="395" y="2" width="50" height="18" hTextAlign="Center" vTextAlign="Middle" style="Report_Data_Label">
 					<text><![CDATA[Totals]]></text>
-				</staticText>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-58" style="Total_Field" x="445" y="2" width="91" height="18" uuid="c2dd3203-dbf2-496f-86ef-8998730162b4"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
+					<box leftPadding="5" style="Report_Data_Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_TOTAL}!=null)?$V{CONVAMOUNT_TOTAL}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="c2dd3203-dbf2-496f-86ef-8998730162b4" key="textField-58" x="445" y="2" width="91" height="18" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{CONVAMOUNT_TOTAL}!=null)?$V{CONVAMOUNT_TOTAL}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<line>
-					<reportElement key="line-5" x="0" y="1" width="729" height="1" uuid="fed11dc1-1ca8-4a42-920b-03df2aa93a5c"/>
-				</line>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-96" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="536" y="2" width="24" height="18" uuid="a751edd6-dcc6-4e28-a723-492df66bdfc7"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Center"/>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-57" style="Total_Field" x="654" y="2" width="75" height="18" uuid="b3423916-1dcc-4465-9606-5547f7c6f16d"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QUANTITY_TOTAL}!=null)?$V{QUANTITY_TOTAL}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="line" uuid="fed11dc1-1ca8-4a42-920b-03df2aa93a5c" key="line-5" x="0" y="1" width="729" height="1"/>
+				<element kind="textField" uuid="a751edd6-dcc6-4e28-a723-492df66bdfc7" key="textField-96" stretchType="ContainerHeight" mode="Opaque" x="536" y="2" width="24" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Center" style="Level2_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level2_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="b3423916-1dcc-4465-9606-5547f7c6f16d" key="textField-57" x="654" y="2" width="75" height="18" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{QUANTITY_TOTAL}!=null)?$V{QUANTITY_TOTAL}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-97" style="Detail_Header" positionType="FixRelativeToBottom" x="0" y="2" width="15" height="18" uuid="4573afd8-2426-48da-b29c-0e225b939b68"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Total_Field">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="4573afd8-2426-48da-b29c-0e225b939b68" key="textField-97" positionType="FixRelativeToBottom" x="0" y="2" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-98" style="Detail_Header" positionType="FixRelativeToBottom" x="15" y="2" width="15" height="18" uuid="70afe265-ff24-4386-bef8-2fe88cb8ea66"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="70afe265-ff24-4386-bef8-2fe88cb8ea66" key="textField-98" positionType="FixRelativeToBottom" x="15" y="2" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-99" style="Detail_Header" positionType="FixRelativeToBottom" x="30" y="2" width="15" height="18" uuid="b199b3c6-b378-4b7a-9235-8e62f19c6abf"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="b199b3c6-b378-4b7a-9235-8e62f19c6abf" key="textField-99" positionType="FixRelativeToBottom" x="30" y="2" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-100" style="Detail_Header" positionType="FixRelativeToBottom" x="45" y="2" width="15" height="18" uuid="97dc1ec0-a600-461b-9fe9-35235ebef123"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="97dc1ec0-a600-461b-9fe9-35235ebef123" key="textField-100" positionType="FixRelativeToBottom" x="45" y="2" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-101" style="Detail_Header" positionType="FixRelativeToBottom" x="60" y="2" width="15" height="18" uuid="40e262d3-2172-4f36-80a8-695a5a95a1e8"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="40e262d3-2172-4f36-80a8-695a5a95a1e8" key="textField-101" positionType="FixRelativeToBottom" x="60" y="2" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-102" style="Detail_Header" positionType="FixRelativeToBottom" x="75" y="2" width="15" height="18" uuid="7a283b2d-837a-420d-a1fd-77f374cf7020"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="7a283b2d-837a-420d-a1fd-77f374cf7020" key="textField-102" positionType="FixRelativeToBottom" x="75" y="2" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(6))>=0)?"6":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(6))>=0)?"6":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-103" style="Detail_Header" positionType="FixRelativeToBottom" x="90" y="2" width="15" height="18" uuid="21bdfcaa-2582-49f5-b2e1-4402a5e6531d"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="21bdfcaa-2582-49f5-b2e1-4402a5e6531d" key="textField-103" positionType="FixRelativeToBottom" x="90" y="2" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(7))>=0)?"7":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(7))>=0)?"7":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-104" style="Detail_Header" positionType="FixRelativeToBottom" x="105" y="2" width="15" height="18" uuid="4be5bc8e-1cb5-48d8-b349-bb16555cbc68"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="4be5bc8e-1cb5-48d8-b349-bb16555cbc68" key="textField-104" positionType="FixRelativeToBottom" x="105" y="2" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(8))>=0)?"8":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(8))>=0)?"8":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-105" style="Detail_Header" positionType="FixRelativeToBottom" x="120" y="2" width="15" height="18" isPrintInFirstWholeBand="true" uuid="15a840ed-cdb8-46da-a5e0-0d510556cbf9"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="15a840ed-cdb8-46da-a5e0-0d510556cbf9" key="textField-105" positionType="FixRelativeToBottom" x="120" y="2" width="15" height="18" rotation="None" blankWhenNull="true" printInFirstWholeBand="true" style="Detail_Header">
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(9))>=0)?"9":"")]]></expression>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(9))>=0)?"9":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-106" style="Detail_Header" positionType="FixRelativeToBottom" x="135" y="2" width="15" height="18" isPrintInFirstWholeBand="true" uuid="63d554d3-3425-445c-a3b4-0452a9c8b8e7"/>
-					<box leftPadding="2">
+				</element>
+				<element kind="textField" uuid="63d554d3-3425-445c-a3b4-0452a9c8b8e7" key="textField-106" positionType="FixRelativeToBottom" x="135" y="2" width="15" height="18" rotation="None" blankWhenNull="true" printInFirstWholeBand="true" style="Detail_Header">
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(10))>=0)?"10":"")]]></expression>
+					<box leftPadding="2" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(10))>=0)?"10":"")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-107" style="Detail_Header" positionType="FixRelativeToBottom" x="150" y="2" width="15" height="18" isPrintInFirstWholeBand="true" uuid="6a9a90b8-c202-42b4-9ab7-12e3587aeebe"/>
-					<box leftPadding="2">
+				</element>
+				<element kind="textField" uuid="6a9a90b8-c202-42b4-9ab7-12e3587aeebe" key="textField-107" positionType="FixRelativeToBottom" x="150" y="2" width="15" height="18" rotation="None" blankWhenNull="true" printInFirstWholeBand="true" style="Detail_Header">
+					<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(11))>=0)?"11":"")]]></expression>
+					<box leftPadding="2" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(11))>=0)?"11":"")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="NIVEL1">
-		<groupExpression><![CDATA[$F{NIVEL1}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL1}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=1)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="0" y="0" width="445" height="18" uuid="19319a4e-fd75-4bc4-af09-5bdaaf08d3c3"/>
-					<box>
+				<element kind="textField" uuid="19319a4e-fd75-4bc4-af09-5bdaaf08d3c3" key="textField" stretchType="ContainerHeight" mode="Opaque" x="0" y="0" width="445" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[$F{NIVEL1}]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL1}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" x="654" y="0" width="75" height="18" uuid="6db26946-d5e8-45c8-800a-be943664a8d8">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
-					</reportElement>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM1}!=null)?$V{QTY_SUM1}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="6db26946-d5e8-45c8-800a-be943664a8d8" key="textField" stretchType="ContainerHeight" x="654" y="0" width="75" height="18" evaluationTime="Group" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=1)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM1}!=null)?$V{QTY_SUM1}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level1_Line" stretchType="RelativeToBandHeight" x="560" y="0" width="94" height="18" uuid="40dc9a97-8306-46ef-ab43-e8f84b8093e9"/>
-					<box>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM1}!=null)?$V{WEIGHT_SUM1}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="40dc9a97-8306-46ef-ab43-e8f84b8093e9" key="textField" stretchType="ContainerHeight" x="560" y="0" width="94" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM1}!=null)?$V{WEIGHT_SUM1}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-63" style="Level1_Line" stretchType="RelativeToBandHeight" x="445" y="0" width="91" height="18" uuid="e12dfc48-dc23-4f3e-ac15-64a2a106e2bd"/>
-					<box>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM1}!=null)?$V{CONVAMOUNT_SUM1}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="e12dfc48-dc23-4f3e-ac15-64a2a106e2bd" key="textField-63" stretchType="ContainerHeight" x="445" y="0" width="91" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Right" style="Level1_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM1}!=null)?$V{CONVAMOUNT_SUM1}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-79" style="Level1_Line" stretchType="RelativeToBandHeight" x="536" y="0" width="24" height="18" uuid="797a17a0-2925-41b5-8835-535755098e3a"/>
-					<box>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center"/>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="797a17a0-2925-41b5-8835-535755098e3a" key="textField-79" stretchType="ContainerHeight" x="536" y="0" width="24" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Center" style="Level1_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level1_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -606,80 +559,68 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL2">
-		<groupExpression><![CDATA[$F{NIVEL2}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL2}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=2)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="15" y="0" width="430" height="18" uuid="7851f53a-2e7a-489c-a969-c4346c5a6e8b"/>
-					<box>
+				<element kind="textField" uuid="7851f53a-2e7a-489c-a969-c4346c5a6e8b" key="textField" stretchType="ContainerHeight" mode="Opaque" x="15" y="0" width="430" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[$F{NIVEL2}]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL2}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="654" y="0" width="75" height="18" uuid="4d2f06b8-cbfe-4c9a-9b6a-8e819b615bc9">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
-					</reportElement>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM2}!=null)?$V{QTY_SUM2}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="4d2f06b8-cbfe-4c9a-9b6a-8e819b615bc9" key="textField" stretchType="ContainerHeight" mode="Opaque" x="654" y="0" width="75" height="18" evaluationTime="Group" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=2)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM2}!=null)?$V{QTY_SUM2}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="560" y="0" width="94" height="18" uuid="053e7b5d-727b-4c2d-b00a-954dd2089ff8"/>
-					<box>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM2}!=null)?$V{WEIGHT_SUM2}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="053e7b5d-727b-4c2d-b00a-954dd2089ff8" key="textField" stretchType="ContainerHeight" mode="Opaque" x="560" y="0" width="94" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM2}!=null)?$V{WEIGHT_SUM2}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-18" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="0" y="0" width="15" height="18" uuid="8f32ac62-32b2-44e5-8dd8-b2d4e859e4e7"/>
-					<box>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-64" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="445" y="0" width="91" height="18" uuid="de773b69-8c81-451e-9505-bc4619f55a7c"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="8f32ac62-32b2-44e5-8dd8-b2d4e859e4e7" key="textField-18" stretchType="ContainerHeight" mode="Opaque" x="0" y="0" width="15" height="18" rotation="Left" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM2}!=null)?$V{CONVAMOUNT_SUM2}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="de773b69-8c81-451e-9505-bc4619f55a7c" key="textField-64" stretchType="ContainerHeight" mode="Opaque" x="445" y="0" width="91" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Right" style="Level2_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM2}!=null)?$V{CONVAMOUNT_SUM2}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-81" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="536" y="0" width="24" height="18" uuid="374852c2-5354-4f23-9acc-870389656abe"/>
-					<box>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center"/>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="374852c2-5354-4f23-9acc-870389656abe" key="textField-81" stretchType="ContainerHeight" mode="Opaque" x="536" y="0" width="24" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Center" style="Level2_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level2_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -687,91 +628,77 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL3">
-		<groupExpression><![CDATA[$F{NIVEL3}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL3}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=3)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="30" y="0" width="415" height="18" uuid="a07c0712-616c-4264-a427-28fd16277589"/>
-					<box>
+				<element kind="textField" uuid="a07c0712-616c-4264-a427-28fd16277589" key="textField" stretchType="ContainerHeight" mode="Opaque" x="30" y="0" width="415" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[$F{NIVEL3}]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL3}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="654" y="0" width="75" height="18" uuid="ed59f89d-560b-4540-b5bc-6b583647c22c">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
-					</reportElement>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM3}!=null)?$V{QTY_SUM3}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="ed59f89d-560b-4540-b5bc-6b583647c22c" key="textField" stretchType="ContainerHeight" mode="Opaque" x="654" y="0" width="75" height="18" evaluationTime="Group" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=3)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM3}!=null)?$V{QTY_SUM3}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="560" y="0" width="94" height="18" uuid="f882bc36-09a0-4f7f-b52b-7202367e5e68"/>
-					<box>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM3}!=null)?$V{WEIGHT_SUM3}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="f882bc36-09a0-4f7f-b52b-7202367e5e68" key="textField" stretchType="ContainerHeight" mode="Opaque" x="560" y="0" width="94" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM3}!=null)?$V{WEIGHT_SUM3}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-21" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="0" y="0" width="15" height="18" uuid="a0cd3a61-523d-40b1-9abb-5d4748cc6e82"/>
-					<box>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-26" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="15" y="0" width="15" height="18" uuid="ee898ecb-210b-4fcd-9555-5c4bf09c71b0"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="a0cd3a61-523d-40b1-9abb-5d4748cc6e82" key="textField-21" stretchType="ContainerHeight" mode="Opaque" x="0" y="0" width="15" height="18" rotation="Left" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL3" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-65" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="445" y="0" width="91" height="18" uuid="56f208c3-575c-4303-8b63-7d207db98d36"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="ee898ecb-210b-4fcd-9555-5c4bf09c71b0" key="textField-26" stretchType="ContainerHeight" mode="Opaque" x="15" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM3}!=null)?$V{CONVAMOUNT_SUM3}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="56f208c3-575c-4303-8b63-7d207db98d36" key="textField-65" stretchType="ContainerHeight" mode="Opaque" x="445" y="0" width="91" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL3" blankWhenNull="false" hTextAlign="Right" style="Level3_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM3}!=null)?$V{CONVAMOUNT_SUM3}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-83" style="Level1_Line" stretchType="RelativeToBandHeight" x="536" y="0" width="24" height="18" uuid="374ac65a-737c-4d69-b9d6-0288c5565319"/>
-					<box>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center"/>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="374ac65a-737c-4d69-b9d6-0288c5565319" key="textField-83" stretchType="ContainerHeight" x="536" y="0" width="24" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Center" style="Level1_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level1_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -779,102 +706,86 @@
 		</groupFooter>
 	</group>
 	<group name="NIVEL4">
-		<groupExpression><![CDATA[$F{NIVEL4}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL4}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=4)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="45" y="0" width="400" height="18" uuid="bd0626f6-7980-4301-b7ed-06c5ba93a13a"/>
-					<box>
+				<element kind="textField" uuid="bd0626f6-7980-4301-b7ed-06c5ba93a13a" key="textField" stretchType="ContainerHeight" mode="Opaque" x="45" y="0" width="400" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[$F{NIVEL4}]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL4}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="654" y="0" width="75" height="18" uuid="eb6db262-bec0-41d6-b95e-a0e54cf79d1a">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
-					</reportElement>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM4}!=null)?$V{QTY_SUM4}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="eb6db262-bec0-41d6-b95e-a0e54cf79d1a" key="textField" stretchType="ContainerHeight" mode="Opaque" x="654" y="0" width="75" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=4)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM4}!=null)?$V{QTY_SUM4}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="560" y="0" width="94" height="18" uuid="b9fde1ce-b791-46bf-b157-0ea34eee56ae"/>
-					<box>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM4}!=null)?$V{WEIGHT_SUM4}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="b9fde1ce-b791-46bf-b157-0ea34eee56ae" key="textField" stretchType="ContainerHeight" mode="Opaque" x="560" y="0" width="94" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM4}!=null)?$V{WEIGHT_SUM4}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-20" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="0" y="0" width="15" height="18" uuid="917de0f6-1f77-49a4-9a88-075d0060a11d"/>
-					<box>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-27" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="15" y="0" width="15" height="18" uuid="a29389cf-c2c4-4209-b08d-ea3dbc71c471"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="917de0f6-1f77-49a4-9a88-075d0060a11d" key="textField-20" stretchType="ContainerHeight" mode="Opaque" x="0" y="0" width="15" height="18" rotation="Left" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-33" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="30" y="0" width="15" height="18" uuid="45c1273d-d438-4550-b15a-3db1f6354f5b"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="a29389cf-c2c4-4209-b08d-ea3dbc71c471" key="textField-27" stretchType="ContainerHeight" mode="Opaque" x="15" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL4" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-66" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="445" y="0" width="91" height="18" uuid="6c1b6602-3029-4dc7-82c4-6e76931fc142"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="45c1273d-d438-4550-b15a-3db1f6354f5b" key="textField-33" stretchType="ContainerHeight" mode="Opaque" x="30" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM4}!=null)?$V{CONVAMOUNT_SUM4}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="6c1b6602-3029-4dc7-82c4-6e76931fc142" key="textField-66" stretchType="ContainerHeight" mode="Opaque" x="445" y="0" width="91" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL4" blankWhenNull="false" hTextAlign="Right" style="Level4_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM4}!=null)?$V{CONVAMOUNT_SUM4}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-85" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="536" y="0" width="24" height="18" uuid="05828413-7620-48c6-b95a-32b02ca0f06c"/>
-					<box>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center"/>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="05828413-7620-48c6-b95a-32b02ca0f06c" key="textField-85" stretchType="ContainerHeight" mode="Opaque" x="536" y="0" width="24" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Center" style="Level2_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level2_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -882,113 +793,95 @@
 		</groupFooter>
 	</group>
 	<group name="LEVEL5">
-		<groupExpression><![CDATA[$F{NIVEL5}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL5}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=5)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="60" y="0" width="385" height="18" uuid="dae054ee-4d2a-4ce8-9660-ea18c7f03e48"/>
-					<box>
+				<element kind="textField" uuid="dae054ee-4d2a-4ce8-9660-ea18c7f03e48" key="textField" stretchType="ContainerHeight" mode="Opaque" x="60" y="0" width="385" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[$F{NIVEL5}]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL5}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="654" y="0" width="75" height="18" uuid="c915dfe0-7eae-48c8-864d-af421d622c5b">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
-					</reportElement>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM5}!=null)?$V{QTY_SUM5}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="c915dfe0-7eae-48c8-864d-af421d622c5b" key="textField" stretchType="ContainerHeight" mode="Opaque" x="654" y="0" width="75" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=5)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM5}!=null)?$V{QTY_SUM5}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="560" y="0" width="94" height="18" uuid="fc638ea7-8b2c-44c0-a1d3-ee5b32439031"/>
-					<box>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM5}!=null)?$V{WEIGHT_SUM5}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="fc638ea7-8b2c-44c0-a1d3-ee5b32439031" key="textField" stretchType="ContainerHeight" mode="Opaque" x="560" y="0" width="94" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM5}!=null)?$V{WEIGHT_SUM5}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-19" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="0" y="0" width="15" height="18" uuid="5f19e3f7-52e2-4061-8641-88eed205e1e4"/>
-					<box>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-28" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="15" y="0" width="15" height="18" uuid="3f35badd-84a3-46ba-bbe4-8085035c8fd7"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="5f19e3f7-52e2-4061-8641-88eed205e1e4" key="textField-19" stretchType="ContainerHeight" mode="Opaque" x="0" y="0" width="15" height="18" rotation="Left" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-34" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="30" y="0" width="15" height="18" uuid="95aa398b-9b79-4a39-a34a-bdc0742ea155"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="3f35badd-84a3-46ba-bbe4-8085035c8fd7" key="textField-28" stretchType="ContainerHeight" mode="Opaque" x="15" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-39" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="45" y="0" width="15" height="18" uuid="81df97de-92e4-48f8-a6bd-29599c3bee7b"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="95aa398b-9b79-4a39-a34a-bdc0742ea155" key="textField-34" stretchType="ContainerHeight" mode="Opaque" x="30" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL5" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-67" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="445" y="0" width="91" height="18" uuid="83dce14f-810c-4f6f-a0cc-e83eeffae455"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="81df97de-92e4-48f8-a6bd-29599c3bee7b" key="textField-39" stretchType="ContainerHeight" mode="Opaque" x="45" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM5}!=null)?$V{CONVAMOUNT_SUM5}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="83dce14f-810c-4f6f-a0cc-e83eeffae455" key="textField-67" stretchType="ContainerHeight" mode="Opaque" x="445" y="0" width="91" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL5" blankWhenNull="false" hTextAlign="Right" style="Level5_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM5}!=null)?$V{CONVAMOUNT_SUM5}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-87" style="Level1_Line" stretchType="RelativeToBandHeight" x="536" y="0" width="24" height="18" uuid="3040921f-78e0-45de-ac76-077b4bc5c01f"/>
-					<box>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center"/>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="3040921f-78e0-45de-ac76-077b4bc5c01f" key="textField-87" stretchType="ContainerHeight" x="536" y="0" width="24" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Center" style="Level1_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level1_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -996,124 +889,104 @@
 		</groupFooter>
 	</group>
 	<group name="LEVEL6">
-		<groupExpression><![CDATA[$F{NIVEL6}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL6}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=6)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="75" y="0" width="370" height="18" uuid="5c697616-7fdb-4e84-b52f-66de76e01f92"/>
-					<box>
+				<element kind="textField" uuid="5c697616-7fdb-4e84-b52f-66de76e01f92" key="textField" stretchType="ContainerHeight" mode="Opaque" x="75" y="0" width="370" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[$F{NIVEL6}]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL6}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL6" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="654" y="0" width="75" height="18" uuid="f3710c6a-975e-4902-b773-d0d90b329160">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
-					</reportElement>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM6}!=null)?$V{QTY_SUM6}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="f3710c6a-975e-4902-b773-d0d90b329160" key="textField" stretchType="ContainerHeight" mode="Opaque" x="654" y="0" width="75" height="18" evaluationTime="Group" evaluationGroup="LEVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=6)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM6}!=null)?$V{QTY_SUM6}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="560" y="0" width="94" height="18" uuid="9f7261fc-9835-4678-90f5-5fc0c73b3757"/>
-					<box>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM6}!=null)?$V{WEIGHT_SUM6}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="9f7261fc-9835-4678-90f5-5fc0c73b3757" key="textField" stretchType="ContainerHeight" mode="Opaque" x="560" y="0" width="94" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM6}!=null)?$V{WEIGHT_SUM6}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-22" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="0" y="0" width="15" height="18" uuid="03503b4d-e444-4c5e-b349-d1c756729cf5"/>
-					<box>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-29" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="15" y="0" width="15" height="18" uuid="dcc02aca-f14c-446e-bbd8-6ab280d505d8"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="03503b4d-e444-4c5e-b349-d1c756729cf5" key="textField-22" stretchType="ContainerHeight" mode="Opaque" x="0" y="0" width="15" height="18" rotation="Left" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-35" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="30" y="0" width="15" height="18" uuid="84a77481-d6be-45d4-a17c-6d35fdcb3343"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="dcc02aca-f14c-446e-bbd8-6ab280d505d8" key="textField-29" stretchType="ContainerHeight" mode="Opaque" x="15" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-40" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="45" y="0" width="15" height="18" uuid="39c7f560-91d8-4499-9ffc-d00f443603e2"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="84a77481-d6be-45d4-a17c-6d35fdcb3343" key="textField-35" stretchType="ContainerHeight" mode="Opaque" x="30" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-44" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="60" y="0" width="15" height="18" uuid="b11a796b-d43e-418b-ad16-837a927306f4"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="39c7f560-91d8-4499-9ffc-d00f443603e2" key="textField-40" stretchType="ContainerHeight" mode="Opaque" x="45" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL6" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-68" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="445" y="0" width="91" height="18" uuid="578cc75c-3403-4d2a-ae85-6186d2cb411d"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="b11a796b-d43e-418b-ad16-837a927306f4" key="textField-44" stretchType="ContainerHeight" mode="Opaque" x="60" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM6}!=null)?$V{CONVAMOUNT_SUM6}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="578cc75c-3403-4d2a-ae85-6186d2cb411d" key="textField-68" stretchType="ContainerHeight" mode="Opaque" x="445" y="0" width="91" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL6" blankWhenNull="false" hTextAlign="Right" style="Level6_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM6}!=null)?$V{CONVAMOUNT_SUM6}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-89" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="536" y="0" width="24" height="18" uuid="cb3b1ca4-a5dc-480a-aa1e-f70f75e3c676"/>
-					<box>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center"/>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="cb3b1ca4-a5dc-480a-aa1e-f70f75e3c676" key="textField-89" stretchType="ContainerHeight" mode="Opaque" x="536" y="0" width="24" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Center" style="Level2_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level2_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -1121,135 +994,113 @@
 		</groupFooter>
 	</group>
 	<group name="LEVEL7">
-		<groupExpression><![CDATA[$F{NIVEL7}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL7}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=7)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="90" y="0" width="355" height="18" uuid="48932f4a-2c07-47a3-a5bb-0e36b2fd8cd4"/>
-					<box>
+				<element kind="textField" uuid="48932f4a-2c07-47a3-a5bb-0e36b2fd8cd4" key="textField" stretchType="ContainerHeight" mode="Opaque" x="90" y="0" width="355" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[$F{NIVEL7}]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL7}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL7" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="654" y="0" width="75" height="18" uuid="f6758721-53ef-484f-b062-d40c3f70f532">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
-					</reportElement>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM7}!=null)?$V{QTY_SUM7}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="f6758721-53ef-484f-b062-d40c3f70f532" key="textField" stretchType="ContainerHeight" mode="Opaque" x="654" y="0" width="75" height="18" evaluationTime="Group" evaluationGroup="LEVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=7)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM7}!=null)?$V{QTY_SUM7}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="560" y="0" width="94" height="18" uuid="798f4456-912b-44ea-aeda-31c2dcdbac0d"/>
-					<box>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM7}!=null)?$V{WEIGHT_SUM7}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="798f4456-912b-44ea-aeda-31c2dcdbac0d" key="textField" stretchType="ContainerHeight" mode="Opaque" x="560" y="0" width="94" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM7}!=null)?$V{WEIGHT_SUM7}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-23" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="0" y="0" width="15" height="18" uuid="789f48df-8ca5-45c8-9b04-e297c27378ba"/>
-					<box>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-30" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="15" y="0" width="15" height="18" uuid="3cb1ecd4-ab35-4bf6-be57-6a53d6b48b3c"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="789f48df-8ca5-45c8-9b04-e297c27378ba" key="textField-23" stretchType="ContainerHeight" mode="Opaque" x="0" y="0" width="15" height="18" rotation="Left" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-36" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="30" y="0" width="15" height="18" uuid="176b2f26-9716-4086-a22d-281b33cf506a"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="3cb1ecd4-ab35-4bf6-be57-6a53d6b48b3c" key="textField-30" stretchType="ContainerHeight" mode="Opaque" x="15" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-41" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="45" y="0" width="15" height="18" uuid="114cf07d-c0e2-4fac-a4cf-edd45de163f5"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="176b2f26-9716-4086-a22d-281b33cf506a" key="textField-36" stretchType="ContainerHeight" mode="Opaque" x="30" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-45" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="60" y="0" width="15" height="18" uuid="41cec756-79c0-4a3b-93c0-d295271a20e7"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="114cf07d-c0e2-4fac-a4cf-edd45de163f5" key="textField-41" stretchType="ContainerHeight" mode="Opaque" x="45" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-48" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="75" y="0" width="15" height="18" uuid="ce39b40d-64d0-40d7-a5f7-a44979c4baad"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="41cec756-79c0-4a3b-93c0-d295271a20e7" key="textField-45" stretchType="ContainerHeight" mode="Opaque" x="60" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL7" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-69" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="445" y="0" width="91" height="18" uuid="e9776645-51c6-4c48-ab76-7c31eea28ba3"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="ce39b40d-64d0-40d7-a5f7-a44979c4baad" key="textField-48" stretchType="ContainerHeight" mode="Opaque" x="75" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM7}!=null)?$V{CONVAMOUNT_SUM7}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="e9776645-51c6-4c48-ab76-7c31eea28ba3" key="textField-69" stretchType="ContainerHeight" mode="Opaque" x="445" y="0" width="91" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL7" blankWhenNull="false" hTextAlign="Right" style="Level7_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM7}!=null)?$V{CONVAMOUNT_SUM7}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-91" style="Level1_Line" stretchType="RelativeToBandHeight" x="536" y="0" width="24" height="18" uuid="a4b41c5a-f12b-4b8e-a97d-7eea6afd0751"/>
-					<box>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center"/>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="a4b41c5a-f12b-4b8e-a97d-7eea6afd0751" key="textField-91" stretchType="ContainerHeight" x="536" y="0" width="24" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Center" style="Level1_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level1_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -1257,146 +1108,122 @@
 		</groupFooter>
 	</group>
 	<group name="LEVEL8">
-		<groupExpression><![CDATA[$F{NIVEL8}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL8}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=8)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="105" y="0" width="340" height="18" uuid="50c4f2b1-4ea8-4712-9077-d8a575e50ba9"/>
-					<box>
+				<element kind="textField" uuid="50c4f2b1-4ea8-4712-9077-d8a575e50ba9" key="textField" stretchType="ContainerHeight" mode="Opaque" x="105" y="0" width="340" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level8_Line">
+					<expression><![CDATA[$F{NIVEL8}]]></expression>
+					<box style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL8}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL8" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="654" y="0" width="75" height="18" uuid="792a0750-b11d-464d-a927-7ce0ac25fea8">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
-					</reportElement>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM8}!=null)?$V{QTY_SUM8}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="792a0750-b11d-464d-a927-7ce0ac25fea8" key="textField" stretchType="ContainerHeight" mode="Opaque" x="654" y="0" width="75" height="18" evaluationTime="Group" evaluationGroup="LEVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=8)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM8}!=null)?$V{QTY_SUM8}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="560" y="0" width="94" height="18" uuid="49f9dcda-a8cc-4e1e-b079-b33849d07a31"/>
-					<box>
+					<box style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM8}!=null)?$V{WEIGHT_SUM8}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="49f9dcda-a8cc-4e1e-b079-b33849d07a31" key="textField" stretchType="ContainerHeight" mode="Opaque" x="560" y="0" width="94" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM8}!=null)?$V{WEIGHT_SUM8}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-24" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="0" y="0" width="15" height="18" uuid="c4c4d5dc-8687-48ad-8c7b-d7a620baee16"/>
-					<box>
+					<box style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-31" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="15" y="0" width="15" height="18" uuid="203688ee-ee90-48b2-a427-ce55d4f7fc5e"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="c4c4d5dc-8687-48ad-8c7b-d7a620baee16" key="textField-24" stretchType="ContainerHeight" mode="Opaque" x="0" y="0" width="15" height="18" rotation="Left" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-37" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="30" y="0" width="15" height="18" uuid="e6e4fa3a-fd85-4c23-83e5-e319edcc841b"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="203688ee-ee90-48b2-a427-ce55d4f7fc5e" key="textField-31" stretchType="ContainerHeight" mode="Opaque" x="15" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-42" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="45" y="0" width="15" height="18" uuid="68e43434-50de-48a2-9397-356952592177"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="e6e4fa3a-fd85-4c23-83e5-e319edcc841b" key="textField-37" stretchType="ContainerHeight" mode="Opaque" x="30" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-46" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="60" y="0" width="15" height="18" uuid="8490438f-296f-4278-8745-7558a725d345"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="68e43434-50de-48a2-9397-356952592177" key="textField-42" stretchType="ContainerHeight" mode="Opaque" x="45" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-49" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="75" y="0" width="15" height="18" uuid="65025659-9fd1-4f49-8b06-2f376fd32f27"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="8490438f-296f-4278-8745-7558a725d345" key="textField-46" stretchType="ContainerHeight" mode="Opaque" x="60" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-51" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="90" y="0" width="15" height="18" uuid="3b833b6b-3cf2-4640-bb9a-c4e115158e22"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="65025659-9fd1-4f49-8b06-2f376fd32f27" key="textField-49" stretchType="ContainerHeight" mode="Opaque" x="75" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL8" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-70" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="445" y="0" width="91" height="18" uuid="e0c69141-edad-4773-82f1-c55b88097814"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="3b833b6b-3cf2-4640-bb9a-c4e115158e22" key="textField-51" stretchType="ContainerHeight" mode="Opaque" x="90" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM8}!=null)?$V{CONVAMOUNT_SUM8}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="e0c69141-edad-4773-82f1-c55b88097814" key="textField-70" stretchType="ContainerHeight" mode="Opaque" x="445" y="0" width="91" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL8" blankWhenNull="false" hTextAlign="Right" style="Level8_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM8}!=null)?$V{CONVAMOUNT_SUM8}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL2" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-93" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="536" y="0" width="24" height="18" uuid="8f7d7541-264f-4a20-865d-bf2003af8a92"/>
-					<box>
+					<box style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center"/>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="8f7d7541-264f-4a20-865d-bf2003af8a92" key="textField-93" stretchType="ContainerHeight" mode="Opaque" x="536" y="0" width="24" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL2" blankWhenNull="false" hTextAlign="Center" style="Level2_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level2_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -1404,157 +1231,131 @@
 		</groupFooter>
 	</group>
 	<group name="LEVEL9">
-		<groupExpression><![CDATA[$F{NIVEL9}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL9}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=9)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level9_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="120" y="0" width="325" height="18" uuid="75341daa-99aa-4243-a39b-98a478334f14"/>
-					<box>
+				<element kind="textField" uuid="75341daa-99aa-4243-a39b-98a478334f14" key="textField" stretchType="ContainerHeight" mode="Opaque" x="120" y="0" width="325" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level9_Line">
+					<expression><![CDATA[$F{NIVEL9}]]></expression>
+					<box style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL9}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL9" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level9_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="654" y="0" width="75" height="18" uuid="1269e920-14e2-49d7-9672-557157f34e35">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
-					</reportElement>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM9}!=null)?$V{QTY_SUM9}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="1269e920-14e2-49d7-9672-557157f34e35" key="textField" stretchType="ContainerHeight" mode="Opaque" x="654" y="0" width="75" height="18" evaluationTime="Group" evaluationGroup="LEVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=9)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM9}!=null)?$V{QTY_SUM9}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level9_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="560" y="0" width="94" height="18" uuid="a7ab64f8-75e2-4911-a26f-0cc2bd2efc6b"/>
-					<box>
+					<box style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM9}!=null)?$V{WEIGHT_SUM9}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="a7ab64f8-75e2-4911-a26f-0cc2bd2efc6b" key="textField" stretchType="ContainerHeight" mode="Opaque" x="560" y="0" width="94" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM9}!=null)?$V{WEIGHT_SUM9}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-25" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="0" y="0" width="15" height="18" uuid="2cc4429f-8646-4a3b-8c5a-43bcd666b480"/>
-					<box>
+					<box style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-32" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="15" y="0" width="15" height="18" uuid="a2b88a77-a6a6-4c66-8237-28bb5569fdd8"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="2cc4429f-8646-4a3b-8c5a-43bcd666b480" key="textField-25" stretchType="ContainerHeight" mode="Opaque" x="0" y="0" width="15" height="18" rotation="Left" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-38" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="30" y="0" width="15" height="18" uuid="0bfa07cd-b16b-4101-9f04-3fdffdfd0c64"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="a2b88a77-a6a6-4c66-8237-28bb5569fdd8" key="textField-32" stretchType="ContainerHeight" mode="Opaque" x="15" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-43" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="45" y="0" width="15" height="18" uuid="a3d35f17-b68b-4f6b-bc17-e95f5ddef59a"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="0bfa07cd-b16b-4101-9f04-3fdffdfd0c64" key="textField-38" stretchType="ContainerHeight" mode="Opaque" x="30" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-47" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="60" y="0" width="15" height="18" uuid="cd2c416b-5716-4786-8593-1b6fa8471ef4"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="a3d35f17-b68b-4f6b-bc17-e95f5ddef59a" key="textField-43" stretchType="ContainerHeight" mode="Opaque" x="45" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-50" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="75" y="0" width="15" height="18" uuid="e9945a99-3060-48b1-8f58-33851d38fce3"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="cd2c416b-5716-4786-8593-1b6fa8471ef4" key="textField-47" stretchType="ContainerHeight" mode="Opaque" x="60" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-52" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="90" y="0" width="15" height="18" uuid="3cb464e6-baa2-49fe-9746-179b51c1e231"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="e9945a99-3060-48b1-8f58-33851d38fce3" key="textField-50" stretchType="ContainerHeight" mode="Opaque" x="75" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-53" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="105" y="0" width="15" height="18" uuid="c77a9373-a784-4e8f-95fe-0da9dc2c3605"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="3cb464e6-baa2-49fe-9746-179b51c1e231" key="textField-52" stretchType="ContainerHeight" mode="Opaque" x="90" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL9" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-71" style="Level9_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="445" y="0" width="91" height="18" uuid="fdcd0aef-ffb2-4737-9652-03c8d0454c9c"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="c77a9373-a784-4e8f-95fe-0da9dc2c3605" key="textField-53" stretchType="ContainerHeight" mode="Opaque" x="105" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level8_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM9}!=null)?$V{CONVAMOUNT_SUM9}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="fdcd0aef-ffb2-4737-9652-03c8d0454c9c" key="textField-71" stretchType="ContainerHeight" mode="Opaque" x="445" y="0" width="91" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL9" blankWhenNull="false" hTextAlign="Right" style="Level9_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM9}!=null)?$V{CONVAMOUNT_SUM9}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-95" style="Level1_Line" stretchType="RelativeToBandHeight" x="536" y="0" width="24" height="18" uuid="3824fbec-fea8-4611-a42a-3ab4bb55e99d"/>
-					<box>
+					<box style="Level9_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center"/>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="3824fbec-fea8-4611-a42a-3ab4bb55e99d" key="textField-95" stretchType="ContainerHeight" x="536" y="0" width="24" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Center" style="Level1_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level1_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -1562,168 +1363,140 @@
 		</groupFooter>
 	</group>
 	<group name="LEVEL10">
-		<groupExpression><![CDATA[$F{NIVEL10}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL10}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=10)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level10_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="135" y="0" width="310" height="18" uuid="7c23126a-4600-439f-b7bd-fe405da232e2"/>
-					<box>
+				<element kind="textField" uuid="7c23126a-4600-439f-b7bd-fe405da232e2" key="textField" stretchType="ContainerHeight" mode="Opaque" x="135" y="0" width="310" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level10_Line">
+					<expression><![CDATA[$F{NIVEL10}]]></expression>
+					<box style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL10}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL10" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level10_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="654" y="0" width="75" height="18" uuid="1aafe991-8785-4c60-a5bb-967f4a9bd823">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
-					</reportElement>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM10}!=null)?$V{QTY_SUM10}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="1aafe991-8785-4c60-a5bb-967f4a9bd823" key="textField" stretchType="ContainerHeight" mode="Opaque" x="654" y="0" width="75" height="18" evaluationTime="Group" evaluationGroup="LEVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=10)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM10}!=null)?$V{QTY_SUM10}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level10_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="560" y="0" width="94" height="18" uuid="251a0b6e-4927-4171-aacb-752a84ae2659"/>
-					<box>
+					<box style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM10}!=null)?$V{WEIGHT_SUM10}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="251a0b6e-4927-4171-aacb-752a84ae2659" key="textField" stretchType="ContainerHeight" mode="Opaque" x="560" y="0" width="94" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM10}!=null)?$V{WEIGHT_SUM10}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-98" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="0" y="0" width="15" height="18" uuid="6236b170-0a11-4e30-8905-8473a1f8425d"/>
-					<box>
+					<box style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-99" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="15" y="0" width="15" height="18" uuid="cf10a1e4-543a-400f-bbca-d3c74d1e9413"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="6236b170-0a11-4e30-8905-8473a1f8425d" key="textField-98" stretchType="ContainerHeight" mode="Opaque" x="0" y="0" width="15" height="18" rotation="Left" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-100" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="30" y="0" width="15" height="18" uuid="487674d5-61a9-4944-80ca-09938e72decc"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="cf10a1e4-543a-400f-bbca-d3c74d1e9413" key="textField-99" stretchType="ContainerHeight" mode="Opaque" x="15" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-101" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="45" y="0" width="15" height="18" uuid="18b92aae-edfa-48b9-8df8-7dec883d1bff"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="487674d5-61a9-4944-80ca-09938e72decc" key="textField-100" stretchType="ContainerHeight" mode="Opaque" x="30" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-102" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="60" y="0" width="15" height="18" uuid="1f46075d-2854-443e-9cce-71d9bfcc996f"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="18b92aae-edfa-48b9-8df8-7dec883d1bff" key="textField-101" stretchType="ContainerHeight" mode="Opaque" x="45" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-103" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="75" y="0" width="15" height="18" uuid="935005d8-7eea-4c1d-9bc1-184b453101e9"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="1f46075d-2854-443e-9cce-71d9bfcc996f" key="textField-102" stretchType="ContainerHeight" mode="Opaque" x="60" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-104" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="90" y="0" width="15" height="18" uuid="839d7e59-2e71-48ac-9ee7-082591451340"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="935005d8-7eea-4c1d-9bc1-184b453101e9" key="textField-103" stretchType="ContainerHeight" mode="Opaque" x="75" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-105" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="105" y="0" width="15" height="18" uuid="aa0412d4-c065-4e36-83b9-8da407814217"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="839d7e59-2e71-48ac-9ee7-082591451340" key="textField-104" stretchType="ContainerHeight" mode="Opaque" x="90" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-104" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="120" y="0" width="15" height="18" uuid="c36662e0-7989-4596-b27d-1beb881aa8db"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="aa0412d4-c065-4e36-83b9-8da407814217" key="textField-105" stretchType="ContainerHeight" mode="Opaque" x="105" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level8_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL10" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-106" style="Level10_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="445" y="0" width="91" height="18" uuid="c45d96fa-93d5-42ed-a3ac-4be2d809bc0c"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="c36662e0-7989-4596-b27d-1beb881aa8db" key="textField-104" stretchType="ContainerHeight" mode="Opaque" x="120" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM10}!=null)?$V{CONVAMOUNT_SUM10}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="c45d96fa-93d5-42ed-a3ac-4be2d809bc0c" key="textField-106" stretchType="ContainerHeight" mode="Opaque" x="445" y="0" width="91" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL10" blankWhenNull="false" hTextAlign="Right" style="Level10_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM10}!=null)?$V{CONVAMOUNT_SUM10}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-107" style="Level10_Line" stretchType="RelativeToBandHeight" x="536" y="0" width="24" height="18" uuid="59da69c6-bdb8-48a4-be77-4a2762acd1b4"/>
-					<box>
+					<box style="Level10_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center"/>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="59da69c6-bdb8-48a4-be77-4a2762acd1b4" key="textField-107" stretchType="ContainerHeight" x="536" y="0" width="24" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Center" style="Level10_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level10_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -1731,536 +1504,421 @@
 		</groupFooter>
 	</group>
 	<group name="LEVEL11">
-		<groupExpression><![CDATA[$F{NIVEL11}]]></groupExpression>
+		<expression><![CDATA[$F{NIVEL11}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{DIMENSIONS}.intValue()>=11)]]></printWhenExpression>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="Level11_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="150" y="0" width="295" height="18" uuid="9dbe8270-cd9b-442a-be7b-2136909c3802"/>
-					<box>
+				<element kind="textField" uuid="9dbe8270-cd9b-442a-be7b-2136909c3802" key="textField" stretchType="ContainerHeight" mode="Opaque" x="150" y="0" width="295" height="18" textAdjust="StretchHeight" blankWhenNull="true" style="Level11_Line">
+					<expression><![CDATA[$F{NIVEL11}]]></expression>
+					<box style="Level11_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{NIVEL11}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL11" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level11_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="654" y="0" width="75" height="18" uuid="f2be1ce0-fc9e-4321-9284-55da60b2513e">
-						<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=11)]]></printWhenExpression>
-					</reportElement>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{QTY_SUM11}!=null)?$V{QTY_SUM11}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="f2be1ce0-fc9e-4321-9284-55da60b2513e" key="textField" stretchType="ContainerHeight" mode="Opaque" x="654" y="0" width="75" height="18" evaluationTime="Group" evaluationGroup="LEVEL11" blankWhenNull="false" hTextAlign="Right" style="Level11_Line">
+					<printWhenExpression><![CDATA[new Boolean($P{PRODUCT_LEVEL}.intValue()<=11)]]></printWhenExpression>
+					<expression><![CDATA[($V{QTY_SUM11}!=null)?$V{QTY_SUM11}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL11" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Level11_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="560" y="0" width="94" height="18" uuid="495b192f-23b2-494e-8f61-f8e3fbcc6c9d"/>
-					<box>
+					<box style="Level11_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{WEIGHT_SUM11}!=null)?$V{WEIGHT_SUM11}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="495b192f-23b2-494e-8f61-f8e3fbcc6c9d" key="textField" stretchType="ContainerHeight" mode="Opaque" x="560" y="0" width="94" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL11" blankWhenNull="false" hTextAlign="Right" style="Level11_Line">
+					<expression><![CDATA[($V{WEIGHT_SUM11}!=null)?$V{WEIGHT_SUM11}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-98" style="Level1_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="0" y="0" width="15" height="18" uuid="f7c9a139-a25f-443f-872d-e346716a9cb5"/>
-					<box>
+					<box style="Level11_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="Left"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-99" style="Level2_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="15" y="0" width="15" height="18" uuid="d16c5197-c70f-448e-b673-aa6e3ff87186"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="f7c9a139-a25f-443f-872d-e346716a9cb5" key="textField-98" stretchType="ContainerHeight" mode="Opaque" x="0" y="0" width="15" height="18" rotation="Left" textAdjust="StretchHeight" blankWhenNull="true" style="Level1_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level1_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-100" style="Level3_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="30" y="0" width="15" height="18" uuid="c86ecf62-1849-4eb2-912d-a83d3cfd63c8"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="d16c5197-c70f-448e-b673-aa6e3ff87186" key="textField-99" stretchType="ContainerHeight" mode="Opaque" x="15" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level2_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level2_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-101" style="Level4_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="45" y="0" width="15" height="18" uuid="c991e8fa-ddc0-46b8-b47f-3ace781a96fa"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="c86ecf62-1849-4eb2-912d-a83d3cfd63c8" key="textField-100" stretchType="ContainerHeight" mode="Opaque" x="30" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level3_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level3_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-102" style="Level5_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="60" y="0" width="15" height="18" uuid="d2d13d9a-65d7-4363-b060-fc58cb9dcc34"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="c991e8fa-ddc0-46b8-b47f-3ace781a96fa" key="textField-101" stretchType="ContainerHeight" mode="Opaque" x="45" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level4_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level4_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-103" style="Level6_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="75" y="0" width="15" height="18" uuid="4f0092dc-7587-4425-9831-bd6452d7b269"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="d2d13d9a-65d7-4363-b060-fc58cb9dcc34" key="textField-102" stretchType="ContainerHeight" mode="Opaque" x="60" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level5_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level5_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-104" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="90" y="0" width="15" height="18" uuid="3592b52c-2e63-493e-9272-3a5156e9506d"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="4f0092dc-7587-4425-9831-bd6452d7b269" key="textField-103" stretchType="ContainerHeight" mode="Opaque" x="75" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level6_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level6_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-105" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="105" y="0" width="15" height="18" uuid="8158d664-b897-40e6-9f3c-be3006a25907"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="3592b52c-2e63-493e-9272-3a5156e9506d" key="textField-104" stretchType="ContainerHeight" mode="Opaque" x="90" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-104" style="Level7_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="120" y="0" width="15" height="18" uuid="5a5df1d4-f0c4-42e3-bf31-9afbc0dd6338"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="8158d664-b897-40e6-9f3c-be3006a25907" key="textField-105" stretchType="ContainerHeight" mode="Opaque" x="105" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level8_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-105" style="Level8_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="135" y="0" width="15" height="18" uuid="e007d1b2-1459-4b1d-96a3-341e3120df38"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="5a5df1d4-f0c4-42e3-bf31-9afbc0dd6338" key="textField-104" stretchType="ContainerHeight" mode="Opaque" x="120" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level7_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level7_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement rotation="None"/>
-					<textFieldExpression><![CDATA[]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="LEVEL11" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-106" style="Level11_Line" stretchType="RelativeToBandHeight" mode="Opaque" x="445" y="0" width="91" height="18" uuid="cc3b3dcf-e1b1-4be3-b79a-cc4778b99874"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="e007d1b2-1459-4b1d-96a3-341e3120df38" key="textField-105" stretchType="ContainerHeight" mode="Opaque" x="135" y="0" width="15" height="18" rotation="None" textAdjust="StretchHeight" blankWhenNull="true" style="Level8_Line">
+					<expression><![CDATA[]]></expression>
+					<box style="Level8_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{CONVAMOUNT_SUM11}!=null)?$V{CONVAMOUNT_SUM11}:BigDecimal.ZERO]]></textFieldExpression>
+				</element>
+				<element kind="textField" uuid="cc3b3dcf-e1b1-4be3-b79a-cc4778b99874" key="textField-106" stretchType="ContainerHeight" mode="Opaque" x="445" y="0" width="91" height="18" evaluationTime="Group" pattern="" evaluationGroup="LEVEL11" blankWhenNull="false" hTextAlign="Right" style="Level11_Line">
+					<expression><![CDATA[($V{CONVAMOUNT_SUM11}!=null)?$V{CONVAMOUNT_SUM11}:BigDecimal.ZERO]]></expression>
 					<patternExpression><![CDATA[$P{NUMBERFORMAT}.toPattern()]]></patternExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="NIVEL1" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-107" style="Level11_Line" stretchType="RelativeToBandHeight" x="536" y="0" width="24" height="18" uuid="059f8867-1188-45d4-a25e-0cba7248f1bf"/>
-					<box>
+					<box style="Level11_Line">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center"/>
-					<textFieldExpression><![CDATA[$F{CONVSYM}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="059f8867-1188-45d4-a25e-0cba7248f1bf" key="textField-107" stretchType="ContainerHeight" x="536" y="0" width="24" height="18" evaluationTime="Group" pattern="" evaluationGroup="NIVEL1" blankWhenNull="false" hTextAlign="Center" style="Level11_Line">
+					<expression><![CDATA[$F{CONVSYM}]]></expression>
+					<box style="Level11_Line">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band height="11" splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="105" splitType="Stretch">
-			<frame>
-				<reportElement key="frame-1" positionType="FixRelativeToBottom" mode="Opaque" x="0" y="85" width="729" height="20" backcolor="#5D5D5D" uuid="2c8c3784-346a-4dcf-8ca8-781a6e8e34a4"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-			</frame>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField" style="Report_Title" x="0" y="0" width="730" height="26" uuid="89bbee40-c938-42dd-8fcd-93d60bac8fea"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Subtitle" x="0" y="31" width="729" height="18" uuid="7afa710a-0465-43a7-b293-d11d580284fc"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_SUBTITLE}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" style="Detail_Header" positionType="FixRelativeToBottom" mode="Opaque" x="654" y="87" width="75" height="17" uuid="74c76bf3-0ee2-4844-b9a5-d9ee0f992808"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Quantity]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-3" style="Detail_Header" positionType="FixRelativeToBottom" mode="Opaque" x="560" y="87" width="60" height="17" uuid="c1175488-aad3-4926-a4ed-0066e375d160"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Weight]]></text>
-			</staticText>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-12" style="Report_Data_Field" x="115" y="62" width="615" height="18" uuid="69e9c8f9-1ca9-4daf-a6b8-3a5cf23de36a"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{LEVEL_LABEL}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-6" style="Report_Data_Label" x="0" y="62" width="115" height="18" uuid="414ec174-adf8-4f4e-85e3-4f32c7135b90"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<text><![CDATA[Grouping Levels:]]></text>
-			</staticText>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-13" style="Detail_Header" positionType="FixRelativeToBottom" x="0" y="86" width="15" height="18" uuid="04318b66-7626-4f17-bb0c-f181f188fd57"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement rotation="None"/>
-				<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-14" style="Detail_Header" positionType="FixRelativeToBottom" x="15" y="86" width="15" height="18" uuid="d3b735f6-8d05-43f9-877a-a6da378c4a34"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement rotation="None"/>
-				<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-15" style="Detail_Header" positionType="FixRelativeToBottom" x="30" y="86" width="15" height="18" uuid="c7ef7634-8650-41f0-8f4e-68f867ce7313"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement rotation="None"/>
-				<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-16" style="Detail_Header" positionType="FixRelativeToBottom" x="45" y="86" width="15" height="18" uuid="f35fda37-fafa-4b72-b2d6-c33b5d72f52d"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement rotation="None"/>
-				<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-17" style="Detail_Header" positionType="FixRelativeToBottom" x="60" y="86" width="15" height="18" uuid="721303ae-918b-4f8c-bb0c-7fe7b5bc15fa"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement rotation="None"/>
-				<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":"")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="49" width="730" height="1" uuid="36030414-2ec2-4d51-a518-d97dd9858743"/>
-			</line>
-			<line>
-				<reportElement key="line-2" x="0" y="26" width="730" height="1" uuid="137a1bdc-d6bd-40d1-b921-2846cf683cd8"/>
-			</line>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-59" style="Detail_Header" positionType="FixRelativeToBottom" x="75" y="86" width="15" height="18" uuid="bc7a7021-e9a6-4fd8-b4ee-6e10cad2798f"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement rotation="None"/>
-				<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(6))>=0)?"6":"")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-60" style="Detail_Header" positionType="FixRelativeToBottom" x="90" y="86" width="15" height="18" uuid="4c34da90-a0da-4a59-a3de-7a009a64f746"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement rotation="None"/>
-				<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(7))>=0)?"7":"")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-61" style="Detail_Header" positionType="FixRelativeToBottom" x="105" y="86" width="15" height="18" uuid="d54af924-cc28-488a-b605-ffd4256fd466"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement rotation="None"/>
-				<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(8))>=0)?"8":"")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-62" style="Detail_Header" positionType="FixRelativeToBottom" x="120" y="86" width="15" height="18" isPrintInFirstWholeBand="true" uuid="f3bd9dbb-b66e-4284-b351-4b335e09c7d6"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement rotation="None"/>
-				<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(9))>=0)?"9":"")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-63" style="Detail_Header" positionType="FixRelativeToBottom" x="135" y="86" width="15" height="18" isPrintInFirstWholeBand="true" uuid="54218280-1caf-471c-9085-ff39880ef41f"/>
-				<box leftPadding="2">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement rotation="None"/>
-				<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(10))>=0)?"10":"")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-64" style="Detail_Header" positionType="FixRelativeToBottom" x="150" y="86" width="15" height="18" isPrintInFirstWholeBand="true" uuid="ce46693d-78cc-4512-b520-c9db2f15a5c0"/>
-				<box leftPadding="2">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement rotation="None"/>
-				<textFieldExpression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(11))>=0)?"11":"")]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-10" style="Detail_Header" positionType="FixRelativeToBottom" mode="Opaque" x="446" y="87" width="63" height="17" uuid="ce01aca1-a731-4338-822d-83751f76e2bd"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Amount]]></text>
-			</staticText>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-72" style="Detail_Header" positionType="FixRelativeToBottom" x="509" y="87" width="51" height="17" uuid="330da4a2-2f14-4e25-9560-52db1916c71a"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left">
-					<font pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{CONVISOSYM}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-72" style="Detail_Header" positionType="FixRelativeToBottom" x="620" y="87" width="34" height="17" uuid="c8dfed20-3887-4bba-abbb-2e7165392cf2"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{WSYMBOL}!=null)? "("+$F{WSYMBOL}+")":" "]]></textFieldExpression>
-			</textField>
-		</band>
+	<background height="11" splitType="Stretch"/>
+	<title height="105" splitType="Stretch">
+		<element kind="frame" uuid="2c8c3784-346a-4dcf-8ca8-781a6e8e34a4" key="frame-1" positionType="FixRelativeToBottom" mode="Opaque" x="0" y="85" width="729" height="20" backcolor="#5D5D5D">
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="89bbee40-c938-42dd-8fcd-93d60bac8fea" key="textField" x="0" y="0" width="730" height="26" textAdjust="StretchHeight" blankWhenNull="true" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="7afa710a-0465-43a7-b293-d11d580284fc" key="textField" x="0" y="31" width="729" height="18" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="74c76bf3-0ee2-4844-b9a5-d9ee0f992808" key="staticText-1" positionType="FixRelativeToBottom" mode="Opaque" x="654" y="87" width="75" height="17" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Quantity]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="c1175488-aad3-4926-a4ed-0066e375d160" key="staticText-3" positionType="FixRelativeToBottom" mode="Opaque" x="560" y="87" width="60" height="17" pdfFontName="Helvetica-Bold" hTextAlign="Center" style="Detail_Header">
+			<text><![CDATA[Weight]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="69e9c8f9-1ca9-4daf-a6b8-3a5cf23de36a" key="textField-12" x="115" y="62" width="615" height="18" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Data_Field">
+			<expression><![CDATA[$P{LEVEL_LABEL}]]></expression>
+			<box style="Report_Data_Field">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="414ec174-adf8-4f4e-85e3-4f32c7135b90" key="staticText-6" x="0" y="62" width="115" height="18" style="Report_Data_Label">
+			<text><![CDATA[Grouping Levels:]]></text>
+			<box style="Report_Data_Label">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="04318b66-7626-4f17-bb0c-f181f188fd57" key="textField-13" positionType="FixRelativeToBottom" x="0" y="86" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+			<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(1))>=0)?"1":"")]]></expression>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="d3b735f6-8d05-43f9-877a-a6da378c4a34" key="textField-14" positionType="FixRelativeToBottom" x="15" y="86" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+			<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(2))>=0)?"2":"")]]></expression>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="c7ef7634-8650-41f0-8f4e-68f867ce7313" key="textField-15" positionType="FixRelativeToBottom" x="30" y="86" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+			<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(3))>=0)?"3":"")]]></expression>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="f35fda37-fafa-4b72-b2d6-c33b5d72f52d" key="textField-16" positionType="FixRelativeToBottom" x="45" y="86" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+			<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(4))>=0)?"4":"")]]></expression>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="721303ae-918b-4f8c-bb0c-7fe7b5bc15fa" key="textField-17" positionType="FixRelativeToBottom" x="60" y="86" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+			<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(5))>=0)?"5":"")]]></expression>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="line" uuid="36030414-2ec2-4d51-a518-d97dd9858743" key="line-1" x="0" y="49" width="730" height="1"/>
+		<element kind="line" uuid="137a1bdc-d6bd-40d1-b921-2846cf683cd8" key="line-2" x="0" y="26" width="730" height="1"/>
+		<element kind="textField" uuid="bc7a7021-e9a6-4fd8-b4ee-6e10cad2798f" key="textField-59" positionType="FixRelativeToBottom" x="75" y="86" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+			<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(6))>=0)?"6":"")]]></expression>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="4c34da90-a0da-4a59-a3de-7a009a64f746" key="textField-60" positionType="FixRelativeToBottom" x="90" y="86" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+			<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(7))>=0)?"7":"")]]></expression>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="d54af924-cc28-488a-b605-ffd4256fd466" key="textField-61" positionType="FixRelativeToBottom" x="105" y="86" width="15" height="18" rotation="None" blankWhenNull="true" style="Detail_Header">
+			<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(8))>=0)?"8":"")]]></expression>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="f3bd9dbb-b66e-4284-b351-4b335e09c7d6" key="textField-62" positionType="FixRelativeToBottom" x="120" y="86" width="15" height="18" rotation="None" blankWhenNull="true" printInFirstWholeBand="true" style="Detail_Header">
+			<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(9))>=0)?"9":"")]]></expression>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="54218280-1caf-471c-9085-ff39880ef41f" key="textField-63" positionType="FixRelativeToBottom" x="135" y="86" width="15" height="18" rotation="None" blankWhenNull="true" printInFirstWholeBand="true" style="Detail_Header">
+			<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(10))>=0)?"10":"")]]></expression>
+			<box leftPadding="2" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="ce46693d-78cc-4512-b520-c9db2f15a5c0" key="textField-64" positionType="FixRelativeToBottom" x="150" y="86" width="15" height="18" rotation="None" blankWhenNull="true" printInFirstWholeBand="true" style="Detail_Header">
+			<expression><![CDATA[(($P{DIMENSIONS}.compareTo(new Integer(11))>=0)?"11":"")]]></expression>
+			<box leftPadding="2" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="ce01aca1-a731-4338-822d-83751f76e2bd" key="staticText-10" positionType="FixRelativeToBottom" mode="Opaque" x="446" y="87" width="63" height="17" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Amount]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="330da4a2-2f14-4e25-9560-52db1916c71a" key="textField-72" positionType="FixRelativeToBottom" x="509" y="87" width="51" height="17" pdfFontName="Helvetica-Bold" blankWhenNull="true" hTextAlign="Left" style="Detail_Header">
+			<expression><![CDATA[$F{CONVISOSYM}]]></expression>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="c8dfed20-3887-4bba-abbb-2e7165392cf2" key="textField-72" positionType="FixRelativeToBottom" x="620" y="87" width="34" height="17" pdfFontName="Helvetica-Bold" blankWhenNull="true" hTextAlign="Center" style="Detail_Header">
+			<expression><![CDATA[($F{WSYMBOL}!=null)? "("+$F{WSYMBOL}+")":" "]]></expression>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
 	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band splitType="Stretch"/>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="20" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-7" style="Report_Footer" x="1" y="4" width="140" height="16" uuid="c56764dc-3e51-487e-91fa-5a6a25cbefa5">
-					<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
-				</reportElement>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<text><![CDATA[other footer data]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-8" style="Report_Footer" x="269" y="4" width="78" height="16" uuid="9c552976-12f2-4303-996d-c272dca03a91"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<text><![CDATA[Generated on ]]></text>
-			</staticText>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-54" style="Report_Footer" x="353" y="4" width="90" height="16" uuid="160c4e72-052b-4846-b9c0-18d02df4b9b4"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-55" style="Report_Footer" x="593" y="4" width="95" height="16" uuid="b70d0ee2-05e0-4d7b-acf1-a70c16613020"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-56" style="Report_Footer" x="690" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="572e1046-2914-4f31-9712-84cee01f9185"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="10"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-4" x="0" y="2" width="729" height="1" uuid="8201f62b-f2da-4796-b17d-9d70c28cb208"/>
-			</line>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="20" splitType="Stretch">
+		<element kind="staticText" uuid="c56764dc-3e51-487e-91fa-5a6a25cbefa5" key="staticText-7" x="1" y="4" width="140" height="16" style="Report_Footer">
+			<printWhenExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()==1)]]></printWhenExpression>
+			<text><![CDATA[other footer data]]></text>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="9c552976-12f2-4303-996d-c272dca03a91" key="staticText-8" x="269" y="4" width="78" height="16" fontName="Times-Roman" fontSize="10.0" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
+			<text><![CDATA[Generated on ]]></text>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="160c4e72-052b-4846-b9c0-18d02df4b9b4" key="textField-54" x="353" y="4" width="90" height="16" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA[new Date()]]></expression>
+			<box topPadding="2" leftPadding="5" style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="b70d0ee2-05e0-4d7b-acf1-a70c16613020" key="textField-55" x="593" y="4" width="95" height="16" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="572e1046-2914-4f31-9712-84cee01f9185" key="textField-56" x="690" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" evaluationTime="Report" pattern="" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="Report_Footer">
+			<paragraph lineSpacing="Single" style="Report_Footer"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="8201f62b-f2da-4796-b17d-9d70c28cb208" key="line-4" x="0" y="2" width="729" height="1"/>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/productionReport.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/productionReport.jrxml
@@ -1,76 +1,74 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="productionReport" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="8c121782-d590-487f-b029-6edf1317475c">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="productionReport" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="8c121782-d590-487f-b029-6edf1317475c">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{PRODUCTION_NAME_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/opt/AppsOpenbravo/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT_SUBTITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="ReportData" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
+	<parameter name="ReportData" forPrompting="false" class="java.lang.String"/>
+	<parameter name="SUBREPORT_DIR" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{BASE_DESIGN}]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATE_FROM" class="java.util.Date" isForPrompting="false">
+	<parameter name="DATE_FROM" forPrompting="false" class="java.util.Date">
 		<defaultValueExpression><![CDATA[new SimpleDateFormat("dd-MM-yyyy").parse("01-01-2000")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DATE_TO" class="java.util.Date" isForPrompting="false">
+	<parameter name="DATE_TO" forPrompting="false" class="java.util.Date">
 		<defaultValueExpression><![CDATA[new SimpleDateFormat("dd-MM-yyyy").parse("01-01-3000")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="SR_LINES" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT PRODUCTION_NAME, MOVEMENTDATE, PRODUCT_NAME, MOVEMENTQTY, DESCRIPTION, UOM_NAME
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="SR_LINES" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<query language="sql"><![CDATA[SELECT PRODUCTION_NAME, MOVEMENTDATE, PRODUCT_NAME, MOVEMENTQTY, DESCRIPTION, UOM_NAME
   FROM (SELECT M_PRODUCTION.NAME AS PRODUCTION_NAME, M_PRODUCTION.MOVEMENTDATE, M_PRODUCT.NAME AS PRODUCT_NAME,
                SUM((CASE 'Y' WHEN 'Y' THEN ROUND(M_PRODUCTIONLINE.MOVEMENTQTY, 2) ELSE (CASE SIGN(M_PRODUCTIONLINE.MOVEMENTQTY) WHEN -1 THEN 0 ELSE ROUND(M_PRODUCTIONLINE.MOVEMENTQTY, 2) END) END)) AS MOVEMENTQTY, M_ATTRIBUTESETINSTANCE.DESCRIPTION, C_UOM.NAME AS UOM_NAME
           FROM M_PRODUCTIONLINE left join M_ATTRIBUTESETINSTANCE on M_PRODUCTIONLINE.M_ATTRIBUTESETINSTANCE_ID = M_ATTRIBUTESETINSTANCE.M_ATTRIBUTESETINSTANCE_ID,
@@ -83,8 +81,7 @@
            AND M_PRODUCTION.ISSOTRX = 'Y'
          GROUP BY M_PRODUCTION.NAME, M_PRODUCTION.MOVEMENTDATE, M_PRODUCT.NAME, M_ATTRIBUTESETINSTANCE.DESCRIPTION, C_UOM.NAME
          ORDER BY PRODUCTION_NAME, MOVEMENTDATE, MOVEMENTQTY DESC) AA
- WHERE MOVEMENTQTY <> 0]]>
-	</queryString>
+ WHERE MOVEMENTQTY <> 0]]></query>
 	<field name="PRODUCTION_NAME" class="java.lang.String"/>
 	<field name="MOVEMENTDATE" class="java.util.Date"/>
 	<field name="PRODUCT_NAME" class="java.lang.String"/>
@@ -93,363 +90,261 @@
 	<field name="UOM_NAME" class="java.lang.String"/>
 	<variable name="DetailFieldTotal" class="java.math.BigDecimal"/>
 	<group name="PRODUCTION_NAME">
-		<groupExpression><![CDATA[$F{PRODUCTION_NAME}]]></groupExpression>
+		<expression><![CDATA[$F{PRODUCTION_NAME}]]></expression>
 		<groupHeader>
 			<band height="50" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="1" y="0" width="116" height="20" uuid="1f41a95d-b0c9-4071-86db-5cd61ab3e46b"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
+				<element kind="staticText" uuid="1f41a95d-b0c9-4071-86db-5cd61ab3e46b" key="staticText" x="1" y="0" width="116" height="20" fontName="Bitstream Vera Sans" style="GroupHeader_DarkGray">
 					<text><![CDATA[Production]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="117" y="0" width="282" height="20" uuid="650bac29-c870-450d-ae70-f11a803d54de"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{PRODUCTION_NAME}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="535" y="1" width="1" height="49" forecolor="#555555" uuid="d1860717-8bfa-4d0d-ae91-fc976b854a46"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="1" y="34" width="219" height="16" uuid="48b338f2-a1f4-4117-8bb6-196906e161f3"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="650bac29-c870-450d-ae70-f11a803d54de" key="textField" x="117" y="0" width="282" height="20" fontName="Bitstream Vera Sans" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{PRODUCTION_NAME}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="d1860717-8bfa-4d0d-ae91-fc976b854a46" key="line-3" stretchType="ContainerHeight" x="535" y="1" width="1" height="49" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="48b338f2-a1f4-4117-8bb6-196906e161f3" key="element-90" x="1" y="34" width="219" height="16" fontName="Bitstream Vera Sans" style="Detail_Header">
 					<text><![CDATA[Product]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="220" y="34" width="179" height="16" uuid="e9ac5c37-fa6f-49de-8843-61e5c47cd83b"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="e9ac5c37-fa6f-49de-8843-61e5c47cd83b" key="element-90" x="220" y="34" width="179" height="16" fontName="Bitstream Vera Sans" style="Detail_Header">
 					<text><![CDATA[Attribute]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="399" y="34" width="136" height="16" uuid="5c83a417-c977-47aa-8853-5e69a865036d"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="5c83a417-c977-47aa-8853-5e69a865036d" key="element-90" x="399" y="34" width="136" height="16" fontName="Bitstream Vera Sans" hTextAlign="Center" style="Detail_Header">
+					<text><![CDATA[Quantity]]></text>
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#666666"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
-					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField-4" style="GroupHeader_DarkGray" x="399" y="0" width="136" height="20" uuid="6aca1e05-045e-4c13-8a90-68db3b953ed5"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="6aca1e05-045e-4c13-8a90-68db3b953ed5" key="textField-4" x="399" y="0" width="136" height="20" fontName="Bitstream Vera Sans" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Right" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{MOVEMENTDATE}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{MOVEMENTDATE}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-35" stretchType="RelativeToBandHeight" x="0" y="1" width="1" height="49" forecolor="#555555" uuid="57068c4b-129c-4c0b-b5f6-c7f9bc8c6a51"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				</element>
+				<element kind="line" uuid="57068c4b-129c-4c0b-b5f6-c7f9bc8c6a51" key="line-35" stretchType="ContainerHeight" x="0" y="1" width="1" height="49" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<line>
-					<reportElement key="line-32" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="10" forecolor="#555555" uuid="775b7c89-d727-4107-8e14-45ac88593113"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="10" forecolor="#555555" uuid="a5fae1bc-ffe2-40c4-84e3-4bdd22f4e411"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-34" x="1" y="9" width="534" height="1" forecolor="#555555" uuid="1037250d-bbd0-4506-8c63-4f2334207adf"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="775b7c89-d727-4107-8e14-45ac88593113" key="line-32" stretchType="ContainerHeight" x="0" y="0" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="a5fae1bc-ffe2-40c4-84e3-4bdd22f4e411" key="line-33" stretchType="ContainerHeight" x="535" y="0" width="1" height="10" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="1037250d-bbd0-4506-8c63-4f2334207adf" key="line-34" x="1" y="9" width="534" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="20" splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="71" splitType="Stretch">
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Title" x="0" y="0" width="535" height="20" uuid="ad5a02bb-5f43-4587-8b5d-25b22fa9b50b"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="20" width="535" height="1" uuid="975c628f-5f9e-4c22-85a0-b9220e2d2244"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Subtitle" x="0" y="25" width="535" height="20" uuid="16f08cca-f63d-4bf2-9ffc-a6604b422cd5"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($P{REPORT_SUBTITLE}==null?"":$P{REPORT_SUBTITLE})]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="20" splitType="Stretch"/>
+	<pageHeader height="71" splitType="Stretch">
+		<element kind="textField" uuid="ad5a02bb-5f43-4587-8b5d-25b22fa9b50b" key="textField" x="0" y="0" width="535" height="20" fontName="Bitstream Vera Sans" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="975c628f-5f9e-4c22-85a0-b9220e2d2244" key="line-1" x="0" y="20" width="535" height="1">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="16f08cca-f63d-4bf2-9ffc-a6604b422cd5" key="textField" x="0" y="25" width="535" height="20" fontName="Bitstream Vera Sans" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[($P{REPORT_SUBTITLE}==null?"":$P{REPORT_SUBTITLE})]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<frame>
-				<reportElement key="frame-1" style="Detail_Line" x="1" y="0" width="533" height="16" uuid="c649b2f6-0f49-409f-8784-3f82e68925e9"/>
-				<box>
+			<element kind="frame" uuid="c649b2f6-0f49-409f-8784-3f82e68925e9" key="frame-1" x="1" y="0" width="533" height="16" style="Detail_Line">
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-			</frame>
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="16" forecolor="#555555" uuid="41bf1dd6-2e91-4569-948a-baee23155959"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-17" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="16" forecolor="#555555" uuid="f5624919-6a29-406e-88a2-a95896d8bbc6"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" stretchType="RelativeToBandHeight" x="2" y="0" width="217" height="16" uuid="65861e7e-8c1d-44a5-a7f9-413205bcdb95"/>
+			</element>
+			<element kind="line" uuid="41bf1dd6-2e91-4569-948a-baee23155959" key="line-16" stretchType="ContainerHeight" x="535" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="f5624919-6a29-406e-88a2-a95896d8bbc6" key="line-17" stretchType="ContainerHeight" x="0" y="0" width="1" height="16" forecolor="#555555">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="textField" uuid="65861e7e-8c1d-44a5-a7f9-413205bcdb95" key="textField" stretchType="ContainerHeight" x="2" y="0" width="217" height="16" fontName="Bitstream Vera Sans" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle">
+				<expression><![CDATA[$F{PRODUCT_NAME}]]></expression>
 				<box leftPadding="5">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRODUCT_NAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" stretchType="RelativeToBandHeight" x="400" y="0" width="75" height="16" uuid="25ae4e97-bb5b-403e-bb6f-b963f21cb661"/>
+			</element>
+			<element kind="textField" uuid="25ae4e97-bb5b-403e-bb6f-b963f21cb661" key="textField" stretchType="ContainerHeight" x="400" y="0" width="75" height="16" fontName="Bitstream Vera Sans" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{MOVEMENTQTY}!=null)?$P{NUMBERFORMAT}.format($F{MOVEMENTQTY}):new String(" ")]]></expression>
 				<box leftPadding="5">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{MOVEMENTQTY}!=null)?$P{NUMBERFORMAT}.format($F{MOVEMENTQTY}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" stretchType="RelativeToBandHeight" x="220" y="0" width="179" height="16" uuid="a8c85852-3b5a-4d3e-8db6-5336a3779d7a"/>
+			</element>
+			<element kind="textField" uuid="a8c85852-3b5a-4d3e-8db6-5336a3779d7a" key="textField" stretchType="ContainerHeight" x="220" y="0" width="179" height="16" fontName="Bitstream Vera Sans" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle">
+				<expression><![CDATA[$F{DESCRIPTION}]]></expression>
 				<box leftPadding="5">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DESCRIPTION}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" stretchType="RelativeToBandHeight" x="475" y="0" width="59" height="16" uuid="0d499e0b-1925-499c-a91b-fe99fde20c6c"/>
+			</element>
+			<element kind="textField" uuid="0d499e0b-1925-499c-a91b-fe99fde20c6c" key="textField" stretchType="ContainerHeight" x="475" y="0" width="59" height="16" fontName="Bitstream Vera Sans" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle">
+				<expression><![CDATA[$F{UOM_NAME}]]></expression>
 				<box leftPadding="5" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{UOM_NAME}]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Prevent"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="30" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="400" y="4" width="95" height="16" uuid="e4518f46-9513-47f3-94aa-0ea3c2e5f17c"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="499" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="d7abc64f-4ae3-475a-bdf7-5858d08bbb51"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="1" width="535" height="1" forecolor="#000000" uuid="50dc71f7-ef47-430c-b648-6a6eca464662"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="277" y="4" width="113" height="16" uuid="e82d0314-1064-42d0-8c44-7e3a9da73ae0"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" x="195" y="4" width="78" height="16" uuid="4f2a5e7c-7cba-4831-bb15-5180458310f1"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Bitstream Vera Sans"/>
-				</textElement>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-		</band>
+	<columnFooter splitType="Prevent"/>
+	<pageFooter height="30" splitType="Stretch">
+		<element kind="textField" uuid="e4518f46-9513-47f3-94aa-0ea3c2e5f17c" key="textField" x="400" y="4" width="95" height="16" pattern="" blankWhenNull="false" hTextAlign="Right">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="d7abc64f-4ae3-475a-bdf7-5858d08bbb51" key="textField" x="499" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" evaluationTime="Report" pattern="" blankWhenNull="false">
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="50dc71f7-ef47-430c-b648-6a6eca464662" key="line" x="0" y="1" width="535" height="1" forecolor="#000000">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="e82d0314-1064-42d0-8c44-7e3a9da73ae0" key="textField" x="277" y="4" width="113" height="16" fontName="Times-Roman" pattern="" blankWhenNull="false" vTextAlign="Middle">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="4f2a5e7c-7cba-4831-bb15-5180458310f1" key="staticText-1" x="195" y="4" width="78" height="16" fontName="Bitstream Vera Sans" hTextAlign="Right" vTextAlign="Middle">
+			<text><![CDATA[Generated on]]></text>
+			<box leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band height="68" splitType="Stretch">
-			<subreport isUsingCache="false">
-				<reportElement key="subreport-1" x="77" y="11" width="365" height="48" uuid="6cc436c3-aa60-4de9-93d0-575f0d3cba3c"/>
-				<subreportParameter name="DATE_FROM">
-					<subreportParameterExpression><![CDATA[$P{DATE_FROM}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="DATE_TO">
-					<subreportParameterExpression><![CDATA[$P{DATE_TO}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="USER_CLIENT">
-					<subreportParameterExpression><![CDATA[$P{USER_CLIENT}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="USER_ORG">
-					<subreportParameterExpression><![CDATA[$P{USER_ORG}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LANGUAGE">
-					<subreportParameterExpression><![CDATA[$P{LANGUAGE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="ATTACH">
-					<subreportParameterExpression><![CDATA[$P{ATTACH}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="BASE_WEB">
-					<subreportParameterExpression><![CDATA[$P{BASE_WEB}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="BASE_DESIGN">
-					<subreportParameterExpression><![CDATA[$P{BASE_DESIGN}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="REPORT_TITLE">
-					<subreportParameterExpression><![CDATA[$P{REPORT_TITLE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="REPORT_SUBTITLE">
-					<subreportParameterExpression><![CDATA[$P{REPORT_SUBTITLE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="ReportData">
-					<subreportParameterExpression><![CDATA[$P{ReportData}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="SUBREPORT_DIR">
-					<subreportParameterExpression><![CDATA[$P{SUBREPORT_DIR}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[$P{NUMBERFORMAT}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LOCALE">
-					<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{SR_LINES}]]></subreportExpression>
-			</subreport>
-		</band>
+	<summary height="68" splitType="Stretch">
+		<element kind="subreport" uuid="6cc436c3-aa60-4de9-93d0-575f0d3cba3c" key="subreport-1" x="77" y="11" width="365" height="48" usingCache="false">
+			<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
+			<expression><![CDATA[$P{SR_LINES}]]></expression>
+			<parameter name="DATE_FROM">
+				<expression><![CDATA[$P{DATE_FROM}]]></expression>
+			</parameter>
+			<parameter name="DATE_TO">
+				<expression><![CDATA[$P{DATE_TO}]]></expression>
+			</parameter>
+			<parameter name="USER_CLIENT">
+				<expression><![CDATA[$P{USER_CLIENT}]]></expression>
+			</parameter>
+			<parameter name="USER_ORG">
+				<expression><![CDATA[$P{USER_ORG}]]></expression>
+			</parameter>
+			<parameter name="LANGUAGE">
+				<expression><![CDATA[$P{LANGUAGE}]]></expression>
+			</parameter>
+			<parameter name="ATTACH">
+				<expression><![CDATA[$P{ATTACH}]]></expression>
+			</parameter>
+			<parameter name="BASE_WEB">
+				<expression><![CDATA[$P{BASE_WEB}]]></expression>
+			</parameter>
+			<parameter name="BASE_DESIGN">
+				<expression><![CDATA[$P{BASE_DESIGN}]]></expression>
+			</parameter>
+			<parameter name="REPORT_TITLE">
+				<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			</parameter>
+			<parameter name="REPORT_SUBTITLE">
+				<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+			</parameter>
+			<parameter name="ReportData">
+				<expression><![CDATA[$P{ReportData}]]></expression>
+			</parameter>
+			<parameter name="SUBREPORT_DIR">
+				<expression><![CDATA[$P{SUBREPORT_DIR}]]></expression>
+			</parameter>
+			<parameter name="NUMBERFORMAT">
+				<expression><![CDATA[$P{NUMBERFORMAT}]]></expression>
+			</parameter>
+			<parameter name="LOCALE">
+				<expression><![CDATA[$P{LOCALE}]]></expression>
+			</parameter>
+		</element>
 	</summary>
 </jasperReport>

--- a/src/org/openbravo/erpCommon/ad_reports/productionSubReport.jrxml
+++ b/src/org/openbravo/erpCommon/ad_reports/productionSubReport.jrxml
@@ -1,33 +1,32 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="productionSubReport" pageWidth="421" pageHeight="595" columnWidth="421" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="ed90010f-a284-4d7a-b41c-9a785c9beff3">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="productionSubReport" language="java" pageWidth="421" pageHeight="595" columnWidth="421" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="ed90010f-a284-4d7a-b41c-9a785c9beff3">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="2.5937424601000023"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
 	<parameter name="DATE_FROM" class="java.util.Date">
 		<defaultValueExpression><![CDATA[new SimpleDateFormat("dd-MM-yyyy").parse("01-01-2000")]]></defaultValueExpression>
 	</parameter>
 	<parameter name="DATE_TO" class="java.util.Date">
 		<defaultValueExpression><![CDATA[new SimpleDateFormat("dd-MM-yyyy").parse("01-01-3000")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT M_PRODUCT.NAME AS PRODUCT_NAME, SUM(ROUND(M_PRODUCTIONLINE.MOVEMENTQTY,2)) AS MOVEMENTQTY, C_UOM.NAME AS UOM_NAME
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT M_PRODUCT.NAME AS PRODUCT_NAME, SUM(ROUND(M_PRODUCTIONLINE.MOVEMENTQTY,2)) AS MOVEMENTQTY, C_UOM.NAME AS UOM_NAME
       FROM M_PRODUCTION, M_PRODUCTIONPLAN, M_PRODUCTIONLINE, M_PRODUCT, C_UOM
       WHERE M_PRODUCTION.M_PRODUCTION_ID = M_PRODUCTIONPLAN.M_PRODUCTION_ID
       AND M_PRODUCTIONPLAN.M_PRODUCTIONPLAN_ID = M_PRODUCTIONLINE.M_PRODUCTIONPLAN_ID
@@ -41,87 +40,56 @@
       AND TRUNC(M_PRODUCTION.MOVEMENTDATE) <= $P{DATE_TO}
       AND M_PRODUCTION.ISSOTRX = 'Y'
       GROUP BY M_PRODUCT.NAME, C_UOM.NAME
-      HAVING SUM(ROUND(M_PRODUCTIONLINE.MOVEMENTQTY,2)) > 0]]>
-	</queryString>
+      HAVING SUM(ROUND(M_PRODUCTIONLINE.MOVEMENTQTY,2)) > 0]]></query>
 	<field name="PRODUCT_NAME" class="java.lang.String"/>
 	<field name="MOVEMENTQTY" class="java.math.BigDecimal"/>
 	<field name="UOM_NAME" class="java.lang.String"/>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band height="20" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText" x="0" y="3" width="170" height="17" forecolor="#000000" uuid="2c851a97-85a4-46ea-b1bc-58e92596053a"/>
-				<box leftPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left">
-					<font fontName="Bitstream Vera Sans" size="10" isBold="true" isUnderline="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[BOM PRODUCTION REPORT]]></text>
-			</staticText>
-		</band>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader height="20" splitType="Stretch">
+		<element kind="staticText" uuid="2c851a97-85a4-46ea-b1bc-58e92596053a" key="staticText" x="0" y="3" width="170" height="17" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pdfFontName="Helvetica-Bold" underline="true" bold="true" hTextAlign="Left">
+			<text><![CDATA[BOM PRODUCTION REPORT]]></text>
+			<box leftPadding="2">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</columnHeader>
 	<detail>
 		<band height="18" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="0" y="1" width="230" height="16" forecolor="#000000" uuid="25c81123-9918-4568-9d5c-7ef8005bf09e"/>
+			<element kind="textField" uuid="25c81123-9918-4568-9d5c-7ef8005bf09e" key="textField" x="0" y="1" width="230" height="16" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" bold="false" hTextAlign="Left">
+				<expression><![CDATA[$F{PRODUCT_NAME}]]></expression>
 				<box leftPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left">
-					<font fontName="Bitstream Vera Sans" size="10" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRODUCT_NAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="232" y="1" width="72" height="16" forecolor="#000000" uuid="1e53acad-1ad6-490f-b197-5a811bf6dfcd"/>
+			</element>
+			<element kind="textField" uuid="1e53acad-1ad6-490f-b197-5a811bf6dfcd" key="textField" x="232" y="1" width="72" height="16" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" bold="false" hTextAlign="Right">
+				<expression><![CDATA[($F{MOVEMENTQTY}!=null)?$P{NUMBERFORMAT}.format($F{MOVEMENTQTY}):new String(" ")]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="Bitstream Vera Sans" size="10" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{MOVEMENTQTY}!=null)?$P{NUMBERFORMAT}.format($F{MOVEMENTQTY}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="304" y="1" width="69" height="16" forecolor="#000000" uuid="6fc943e4-8ec7-4ba0-8c70-f5162d4630bd"/>
+			</element>
+			<element kind="textField" uuid="6fc943e4-8ec7-4ba0-8c70-f5162d4630bd" key="textField" x="304" y="1" width="69" height="16" forecolor="#000000" fontName="Bitstream Vera Sans" fontSize="10.0" pattern="" blankWhenNull="false" bold="false" hTextAlign="Left">
+				<expression><![CDATA[$F{UOM_NAME}]]></expression>
 				<box leftPadding="4">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left">
-					<font fontName="Bitstream Vera Sans" size="10" isBold="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{UOM_NAME}]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/C_OrderJR.jrxml
+++ b/src/org/openbravo/erpReports/C_OrderJR.jrxml
@@ -1,73 +1,71 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="C_OrderJR" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="b8c38fdf-cd0f-434d-9f80-06408d31ee33">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="C_OrderJR" language="java" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="b8c38fdf-cd0f-434d-9f80-06408d31ee33">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="193"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/opt/AppsOpenbravo/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["('1000000')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["('0')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="SUBREPORT_DIR" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{BASE_DESIGN} + "/org/openbravo/erpReports"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DOCUMENT_ID" class="java.lang.String" isForPrompting="false">
+	<parameter name="DOCUMENT_ID" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'1000069'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="SUBREP_C_OrderLinesJR" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="SUBREP_C_OrderLinesTaxIncludedJR" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="SUBREP_RptC_Order_TaxLines" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT C_ORDER.C_ORDER_ID, C_BPARTNER.NAME, L.ADDRESS1 ||
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="SUBREP_C_OrderLinesJR" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="SUBREP_C_OrderLinesTaxIncludedJR" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="SUBREP_RptC_Order_TaxLines" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<query language="sql"><![CDATA[SELECT C_ORDER.C_ORDER_ID, C_BPARTNER.NAME, L.ADDRESS1 ||
 (CASE WHEN (L.POSTAL||L.CITY||R.NAME) IS NOT NULL THEN (CHR(10)||L.POSTAL || (CASE WHEN L.POSTAL IS NOT NULL THEN (' - '||TO_CHAR(L.CITY)) END) ||
 (CASE WHEN R.NAME IS NOT NULL THEN (' ('||TO_CHAR(R.NAME)|| ')') END)) END) AS ADDRESS1,
 C_BPARTNER_LOCATION.PHONE,C_BPARTNER_LOCATION.FAX,C_BPARTNER.URL,
@@ -104,8 +102,7 @@ AND C_ORDER.AD_CLIENT_ID = AD_CLIENT.AD_CLIENT_ID
 AND C_ORDER.C_ORDER_ID IN ($P{DOCUMENT_ID})
 AND C_ORDER.DELIVERYRULE = DELIVERYRULE.VALUE
 AND C_ORDER.C_PAYMENTTERM_ID = PAYMENTTERM.C_PAYMENTTERM_ID
-AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]>
-	</queryString>
+AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]></query>
 	<field name="C_ORDER_ID" class="java.lang.String"/>
 	<field name="NAME" class="java.lang.String"/>
 	<field name="ADDRESS1" class="java.lang.String"/>
@@ -133,8 +130,8 @@ AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]>
 	<field name="ISTAXINCLUDED" class="java.lang.String"/>
 	<variable name="SHOWLOGO" class="java.lang.String"/>
 	<variable name="SHOWCOMPANYDATA" class="java.lang.String"/>
-	<group name="PrintLarge" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintLarge" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="120" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{HEADERMARGIN}.equalsIgnoreCase("large"))]]></printWhenExpression>
@@ -144,8 +141,8 @@ AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="PrintMedium" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintMedium" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="80" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{HEADERMARGIN}.equalsIgnoreCase("medium"))]]></printWhenExpression>
@@ -155,8 +152,8 @@ AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="PrintSmall" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintSmall" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="50" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{HEADERMARGIN}.equalsIgnoreCase("small"))]]></printWhenExpression>
@@ -166,288 +163,200 @@ AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="C_ORDER_ID" isStartNewPage="true" isResetPageNumber="true">
-		<groupExpression><![CDATA[$F{C_ORDER_ID}]]></groupExpression>
+	<group name="C_ORDER_ID" startNewPage="true" resetPageNumber="true">
+		<expression><![CDATA[$F{C_ORDER_ID}]]></expression>
 		<groupHeader>
 			<band height="255" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText-6" style="Group_Data_Label" x="0" y="214" width="150" height="18" forecolor="#999999" backcolor="#FFFFFF" uuid="46d86c42-be5e-47db-b779-e86e49112bb7"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Left">
-						<font size="11"/>
-					</textElement>
+				<element kind="staticText" uuid="46d86c42-be5e-47db-b779-e86e49112bb7" key="staticText-6" x="0" y="214" width="150" height="18" forecolor="#999999" backcolor="#FFFFFF" fontSize="11.0" hTextAlign="Left" style="Group_Data_Label">
 					<text><![CDATA[Order Number]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-8" x="0" y="234" width="150" height="20" uuid="0bbb0e98-9ee6-4cb3-adf4-2a4292b26ea6"/>
+					<box style="Group_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="0bbb0e98-9ee6-4cb3-adf4-2a4292b26ea6" key="textField-8" x="0" y="234" width="150" height="20" blankWhenNull="false">
+					<expression><![CDATA[$F{ALBARAN}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{ALBARAN}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-1" x="1" y="233" width="475" height="1" uuid="9fb891e5-64ad-44eb-b7b5-d89b0054b5be"/>
-				</line>
-				<staticText>
-					<reportElement key="staticText-8" style="Group_Data_Label" x="397" y="214" width="80" height="18" forecolor="#999999" backcolor="#FFFFFF" uuid="13afe13b-e2cc-44bf-8962-cad5b6d56c1b"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="11" isBold="true" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="9fb891e5-64ad-44eb-b7b5-d89b0054b5be" key="line-1" x="1" y="233" width="475" height="1"/>
+				<element kind="staticText" uuid="13afe13b-e2cc-44bf-8962-cad5b6d56c1b" key="staticText-8" x="397" y="214" width="80" height="18" forecolor="#999999" backcolor="#FFFFFF" fontSize="11.0" pdfFontName="Helvetica" bold="true" hTextAlign="Right" style="Group_Data_Label">
 					<text><![CDATA[Date]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField" x="397" y="234" width="80" height="20" uuid="3f681506-1ae7-4bfd-a7d8-f26a758edcec"/>
+					<box style="Group_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="3f681506-1ae7-4bfd-a7d8-f26a758edcec" key="textField" x="397" y="234" width="80" height="20" blankWhenNull="false" hTextAlign="Right">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.applyCountryDateFormat($F{DATEORDERED},$F{ORGANIZATIONID})]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.applyCountryDateFormat($F{DATEORDERED},$F{ORGANIZATIONID})]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-16" x="121" y="168" width="275" height="55" forecolor="#FF0000" uuid="0c9ee35b-0efa-4554-896d-42cc2b93216f"/>
-					<textElement textAlignment="Justified" verticalAlignment="Middle">
-						<font size="36"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($F{STATUS}.compareTo("VO")==0) ? "VOIDED" : " ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-17" x="0" y="93" width="206" height="110" isPrintWhenDetailOverflows="true" uuid="73e1ebcb-23d2-4733-bc28-b796dba549e1"/>
-					<textElement verticalAlignment="Top"/>
-					<textFieldExpression><![CDATA[$F{NAME} + "\n" + $F{BP_DATA}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-20" x="251" y="93" width="232" height="42" isPrintWhenDetailOverflows="true" uuid="6cd0fdfc-8ecb-4841-abfd-070fb6829980">
-						<printWhenExpression><![CDATA[new Boolean($F{SHOWCOMPANYDATA}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($F{LOCATION}==null ? $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" : $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" + $F{LOCATION})]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-11" style="Group_Data_Label" x="210" y="214" width="150" height="18" forecolor="#999999" backcolor="#FFFFFF" uuid="5b449950-7d73-4f70-943d-c0726b9e1f8d"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Top">
-						<font size="11" isBold="true" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="textField" uuid="0c9ee35b-0efa-4554-896d-42cc2b93216f" key="textField-16" x="121" y="168" width="275" height="55" forecolor="#FF0000" fontSize="36.0" blankWhenNull="false" hTextAlign="Justified" vTextAlign="Middle">
+					<expression><![CDATA[(($F{STATUS}.compareTo("VO")==0) ? "VOIDED" : " ")]]></expression>
+				</element>
+				<element kind="textField" uuid="73e1ebcb-23d2-4733-bc28-b796dba549e1" key="textField-17" x="0" y="93" width="206" height="110" blankWhenNull="false" printWhenDetailOverflows="true" vTextAlign="Top">
+					<expression><![CDATA[$F{NAME} + "\n" + $F{BP_DATA}]]></expression>
+				</element>
+				<element kind="textField" uuid="6cd0fdfc-8ecb-4841-abfd-070fb6829980" key="textField-20" x="251" y="93" width="232" height="42" blankWhenNull="false" printWhenDetailOverflows="true" hTextAlign="Right">
+					<printWhenExpression><![CDATA[new Boolean($F{SHOWCOMPANYDATA}.equalsIgnoreCase("Y"))]]></printWhenExpression>
+					<expression><![CDATA[($F{LOCATION}==null ? $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" : $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" + $F{LOCATION})]]></expression>
+				</element>
+				<element kind="staticText" uuid="5b449950-7d73-4f70-943d-c0726b9e1f8d" key="staticText-11" x="210" y="214" width="150" height="18" forecolor="#999999" backcolor="#FFFFFF" fontSize="11.0" pdfFontName="Helvetica" bold="true" hTextAlign="Left" vTextAlign="Top" style="Group_Data_Label">
 					<text><![CDATA[Currency]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-24" x="210" y="234" width="150" height="20" uuid="2d752356-0af8-4e23-9733-daca92c59ffc"/>
+					<box style="Group_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="2d752356-0af8-4e23-9733-daca92c59ffc" key="textField-24" x="210" y="234" width="150" height="20" blankWhenNull="false">
+					<expression><![CDATA[$F{CURRENCY_ISO}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{CURRENCY_ISO}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-12" x="0" y="6" width="310" height="37" uuid="6d166c37-f215-49f8-851b-8abe450efd8d">
-						<printWhenExpression><![CDATA[new Boolean($F{DOC_TYPE}.equalsIgnoreCase("Purchase Order Report template"))]]></printWhenExpression>
-					</reportElement>
-					<textElement>
-						<font size="26"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="6d166c37-f215-49f8-851b-8abe450efd8d" key="staticText-12" x="0" y="6" width="310" height="37" fontSize="26.0">
+					<printWhenExpression><![CDATA[new Boolean($F{DOC_TYPE}.equalsIgnoreCase("Purchase Order Report template"))]]></printWhenExpression>
 					<text><![CDATA[PURCHASE ORDER]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-13" x="0" y="6" width="310" height="37" uuid="09a73713-1c4b-4ca8-a37d-bd11adb75be5">
-						<printWhenExpression><![CDATA[new Boolean($F{DOC_TYPE}.equalsIgnoreCase("Purchase Order Report template") == false)]]></printWhenExpression>
-					</reportElement>
-					<textElement>
-						<font size="26"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="09a73713-1c4b-4ca8-a37d-bd11adb75be5" key="staticText-13" x="0" y="6" width="310" height="37" fontSize="26.0">
+					<printWhenExpression><![CDATA[new Boolean($F{DOC_TYPE}.equalsIgnoreCase("Purchase Order Report template") == false)]]></printWhenExpression>
 					<text><![CDATA[SALES ORDER]]></text>
-				</staticText>
-				<image scaleImage="RetainShape" hAlign="Right" vAlign="Top" isUsingCache="true">
-					<reportElement key="image-1" x="313" y="0" width="170" height="91" uuid="dd4237a0-c42a-466a-8e17-1c79c62f63ad">
-						<printWhenExpression><![CDATA[new Boolean($F{SHOWLOGO}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<imageExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylegal", $F{ORGANIZATIONID})]]></imageExpression>
-				</image>
+				</element>
+				<element kind="image" uuid="dd4237a0-c42a-466a-8e17-1c79c62f63ad" key="image-1" x="313" y="0" width="170" height="91" scaleImage="RetainShape" usingCache="true" hImageAlign="Right" vImageAlign="Top">
+					<printWhenExpression><![CDATA[new Boolean($F{SHOWLOGO}.equalsIgnoreCase("Y"))]]></printWhenExpression>
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylegal", $F{ORGANIZATIONID})]]></expression>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="45" splitType="Stretch">
-			<subreport isUsingCache="false">
-				<reportElement key="subreport-1" x="0" y="5" width="482" height="36" uuid="f0d4d2cf-9c07-4f08-a418-e6421dc3b821">
-					<printWhenExpression><![CDATA[$F{ISTAXINCLUDED}.equals("N")]]></printWhenExpression>
-				</reportElement>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LOCALE">
-					<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="C_ORDER_ID">
-					<subreportParameterExpression><![CDATA[$F{C_ORDER_ID}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="ISTAXINCLUDED">
-					<subreportParameterExpression><![CDATA[$F{ISTAXINCLUDED}]]></subreportParameterExpression>
-				</subreportParameter>
+			<element kind="subreport" uuid="f0d4d2cf-9c07-4f08-a418-e6421dc3b821" key="subreport-1" x="0" y="5" width="482" height="36" usingCache="false">
+				<printWhenExpression><![CDATA[$F{ISTAXINCLUDED}.equals("N")]]></printWhenExpression>
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{SUBREP_C_OrderLinesJR}]]></subreportExpression>
-			</subreport>
-			<subreport isUsingCache="false">
-				<reportElement key="subreport-1" x="0" y="5" width="482" height="36" uuid="46be049b-9bed-40fd-b338-9c4d8b205685">
-					<printWhenExpression><![CDATA[$F{ISTAXINCLUDED}.equals("Y")]]></printWhenExpression>
-				</reportElement>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LOCALE">
-					<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="C_ORDER_ID">
-					<subreportParameterExpression><![CDATA[$F{C_ORDER_ID}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="ISTAXINCLUDED">
-					<subreportParameterExpression><![CDATA[$F{ISTAXINCLUDED}]]></subreportParameterExpression>
-				</subreportParameter>
+				<expression><![CDATA[$P{SUBREP_C_OrderLinesJR}]]></expression>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></expression>
+				</parameter>
+				<parameter name="LOCALE">
+					<expression><![CDATA[$P{LOCALE}]]></expression>
+				</parameter>
+				<parameter name="C_ORDER_ID">
+					<expression><![CDATA[$F{C_ORDER_ID}]]></expression>
+				</parameter>
+				<parameter name="ISTAXINCLUDED">
+					<expression><![CDATA[$F{ISTAXINCLUDED}]]></expression>
+				</parameter>
+			</element>
+			<element kind="subreport" uuid="46be049b-9bed-40fd-b338-9c4d8b205685" key="subreport-1" x="0" y="5" width="482" height="36" usingCache="false">
+				<printWhenExpression><![CDATA[$F{ISTAXINCLUDED}.equals("Y")]]></printWhenExpression>
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{SUBREP_C_OrderLinesTaxIncludedJR}]]></subreportExpression>
-			</subreport>
+				<expression><![CDATA[$P{SUBREP_C_OrderLinesTaxIncludedJR}]]></expression>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></expression>
+				</parameter>
+				<parameter name="LOCALE">
+					<expression><![CDATA[$P{LOCALE}]]></expression>
+				</parameter>
+				<parameter name="C_ORDER_ID">
+					<expression><![CDATA[$F{C_ORDER_ID}]]></expression>
+				</parameter>
+				<parameter name="ISTAXINCLUDED">
+					<expression><![CDATA[$F{ISTAXINCLUDED}]]></expression>
+				</parameter>
+			</element>
 		</band>
 		<band height="27">
-			<subreport isUsingCache="false">
-				<reportElement key="subreport-1" x="0" y="4" width="482" height="18" uuid="53cd2dae-12f7-4c22-9ae4-5dacaa9ea1e6">
-					<printWhenExpression><![CDATA[$F{ISTAXINCLUDED}.equals("Y")]]></printWhenExpression>
-				</reportElement>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LOCALE">
-					<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="C_ORDER_ID">
-					<subreportParameterExpression><![CDATA[$F{C_ORDER_ID}]]></subreportParameterExpression>
-				</subreportParameter>
+			<element kind="subreport" uuid="53cd2dae-12f7-4c22-9ae4-5dacaa9ea1e6" key="subreport-1" x="0" y="4" width="482" height="18" usingCache="false">
+				<printWhenExpression><![CDATA[$F{ISTAXINCLUDED}.equals("Y")]]></printWhenExpression>
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{SUBREP_RptC_Order_TaxLines}]]></subreportExpression>
-			</subreport>
+				<expression><![CDATA[$P{SUBREP_RptC_Order_TaxLines}]]></expression>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></expression>
+				</parameter>
+				<parameter name="LOCALE">
+					<expression><![CDATA[$P{LOCALE}]]></expression>
+				</parameter>
+				<parameter name="C_ORDER_ID">
+					<expression><![CDATA[$F{C_ORDER_ID}]]></expression>
+				</parameter>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="90" splitType="Stretch">
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-9" x="439" y="64" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="bfe7b166-6340-4b3c-89da-280d1bb8bb89"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-10" x="340" y="64" width="95" height="19" uuid="6e0072e8-87d5-4d73-afcf-105638957ec9"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-2" x="0" y="61" width="483" height="1" uuid="507f5736-d70f-4dd6-b75a-9d19527587e6"/>
-				<graphicElement>
-					<pen lineWidth="0.25" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<staticText>
-				<reportElement key="staticText-9" style="default" x="295" y="7" width="89" height="18" forecolor="#999999" uuid="b4263ed9-eee8-4078-a0b6-f6401da7af01"/>
-				<box leftPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left">
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Payment Terms]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-10" style="default" x="-3" y="7" width="79" height="18" forecolor="#999999" uuid="91db1403-7190-4bec-8eb1-70a46d739e1e"/>
-				<box leftPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Delivery Term]]></text>
-			</staticText>
-			<line>
-				<reportElement key="line-3" style="default" x="0" y="25" width="483" height="1" uuid="e0f1efc0-cbd2-4ee0-b53f-75014c14219c"/>
-			</line>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-21" x="0" y="28" width="79" height="18" uuid="b367a8ab-40b5-4176-9e87-dda8ad838351"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DELIVERYTERM}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-22" x="298" y="28" width="89" height="18" isPrintWhenDetailOverflows="true" uuid="bdc5f1cd-8d70-425e-8a62-19a79484e0ca"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PAYMENTTERM}]]></textFieldExpression>
-			</textField>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="90" splitType="Stretch">
+		<element kind="textField" uuid="bfe7b166-6340-4b3c-89da-280d1bb8bb89" key="textField-9" x="439" y="64" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="8.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="6e0072e8-87d5-4d73-afcf-105638957ec9" key="textField-10" x="340" y="64" width="95" height="19" fontName="Helvetica" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="507f5736-d70f-4dd6-b75a-9d19527587e6" key="line-2" x="0" y="61" width="483" height="1">
+			<pen lineWidth="0.25" lineStyle="Solid"/>
+		</element>
+		<element kind="staticText" uuid="b4263ed9-eee8-4078-a0b6-f6401da7af01" key="staticText-9" x="295" y="7" width="89" height="18" forecolor="#999999" fontSize="8.0" hTextAlign="Left" style="default">
+			<text><![CDATA[Payment Terms]]></text>
+			<box leftPadding="2" style="default">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="91db1403-7190-4bec-8eb1-70a46d739e1e" key="staticText-10" x="-3" y="7" width="79" height="18" forecolor="#999999" fontSize="8.0" style="default">
+			<text><![CDATA[Delivery Term]]></text>
+			<box leftPadding="2" style="default">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="e0f1efc0-cbd2-4ee0-b53f-75014c14219c" key="line-3" x="0" y="25" width="483" height="1" style="default"/>
+		<element kind="textField" uuid="b367a8ab-40b5-4176-9e87-dda8ad838351" key="textField-21" x="0" y="28" width="79" height="18" fontSize="8.0" blankWhenNull="false">
+			<expression><![CDATA[$F{DELIVERYTERM}]]></expression>
+		</element>
+		<element kind="textField" uuid="bdc5f1cd-8d70-425e-8a62-19a79484e0ca" key="textField-22" x="298" y="28" width="89" height="18" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="false" printWhenDetailOverflows="true">
+			<expression><![CDATA[$F{PAYMENTTERM}]]></expression>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/C_OrderJR_new.jrxml
+++ b/src/org/openbravo/erpReports/C_OrderJR_new.jrxml
@@ -1,76 +1,74 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="C_OrderJR_new" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="b3f285ed-96c8-4c04-9e91-d9172b1f71ef">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="C_OrderJR_new" language="java" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="b3f285ed-96c8-4c04-9e91-d9172b1f71ef">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="318"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/opt/AppsOpenbravo/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["('1000000')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["('0')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="SUBREPORT_DIR" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{BASE_DESIGN} + "/org/openbravo/erpReports"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DOCUMENT_ID" class="java.lang.String" isForPrompting="false">
+	<parameter name="DOCUMENT_ID" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'1000069'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="SUBREP_C_OrderLinesJR_new" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="SUBREP_C_OrderLinesTaxIncludedJR_new" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="SUBREP_RptC_Order_TaxLines_new" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="SUBREP_C_OrderLinesJR_new" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="SUBREP_C_OrderLinesTaxIncludedJR_new" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="SUBREP_RptC_Order_TaxLines_new" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
 	<parameter name="SHOW_LOGO" class="java.lang.String"/>
-	<parameter name="SHOW_COMPANYDATA" class="java.lang.String" isForPrompting="false"/>
+	<parameter name="SHOW_COMPANYDATA" forPrompting="false" class="java.lang.String"/>
 	<parameter name="HEADER_MARGIN" class="java.lang.String"/>
-	<queryString>
-		<![CDATA[SELECT C_ORDER.C_ORDER_ID, C_ORDER.ISSOTRX,C_BPARTNER.NAME, L.ADDRESS1 ||
+	<query language="sql"><![CDATA[SELECT C_ORDER.C_ORDER_ID, C_ORDER.ISSOTRX,C_BPARTNER.NAME, L.ADDRESS1 ||
 (CASE WHEN (L.POSTAL||L.CITY||R.NAME) IS NOT NULL THEN (CHR(10)||L.POSTAL || (CASE WHEN L.POSTAL IS NOT NULL THEN (' - '||TO_CHAR(L.CITY)) END) ||
 (CASE WHEN R.NAME IS NOT NULL THEN (' ('||TO_CHAR(R.NAME)|| ')') END)) END) AS ADDRESS1,
 C_BPARTNER_LOCATION.PHONE,C_BPARTNER_LOCATION.FAX,C_BPARTNER.URL,
@@ -106,8 +104,7 @@ AND C_ORDER.AD_CLIENT_ID = AD_CLIENT.AD_CLIENT_ID
 AND C_ORDER.C_ORDER_ID IN ($P{DOCUMENT_ID})
 AND C_ORDER.DELIVERYRULE = DELIVERYRULE.VALUE
 AND C_ORDER.C_PAYMENTTERM_ID = PAYMENTTERM.C_PAYMENTTERM_ID
-AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]>
-	</queryString>
+AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]></query>
 	<field name="c_order_id" class="java.lang.String"/>
 	<field name="issotrx" class="java.lang.String"/>
 	<field name="name" class="java.lang.String"/>
@@ -135,8 +132,8 @@ AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]>
 	<field name="istaxincluded" class="java.lang.String"/>
 	<variable name="SHOWLOGO" class="java.lang.String"/>
 	<variable name="SHOWCOMPANYDATA" class="java.lang.String"/>
-	<group name="PrintLarge" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintLarge" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="120" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{headermargin}.equalsIgnoreCase("large"))]]></printWhenExpression>
@@ -146,8 +143,8 @@ AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="PrintMedium" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintMedium" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="80" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{headermargin}.equalsIgnoreCase("medium"))]]></printWhenExpression>
@@ -157,8 +154,8 @@ AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="PrintSmall" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintSmall" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="50" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{headermargin}.equalsIgnoreCase("small"))]]></printWhenExpression>
@@ -168,336 +165,219 @@ AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="C_ORDER_ID" isStartNewPage="true" isResetPageNumber="true">
-		<groupExpression><![CDATA[$F{c_order_id}]]></groupExpression>
+	<group name="C_ORDER_ID" startNewPage="true" resetPageNumber="true">
+		<expression><![CDATA[$F{c_order_id}]]></expression>
 		<groupHeader>
 			<band height="255" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText-6" style="Group_Data_Label" x="305" y="140" width="57" height="18" forecolor="#7E7979" backcolor="#FFFFFF" uuid="2930dc9a-a228-4860-a40c-4911584a412b"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="9"/>
-					</textElement>
+				<element kind="staticText" uuid="2930dc9a-a228-4860-a40c-4911584a412b" key="staticText-6" x="305" y="140" width="57" height="18" forecolor="#7E7979" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="9.0" hTextAlign="Center" vTextAlign="Middle" style="Group_Data_Label">
 					<text><![CDATA[Order Nº]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-8" x="305" y="160" width="57" height="20" uuid="9bec79b5-a277-4443-b7b9-8bd17482133a"/>
+					<box style="Group_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="9bec79b5-a277-4443-b7b9-8bd17482133a" key="textField-8" x="305" y="160" width="57" height="20" fontName="DejaVu Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Center">
+					<expression><![CDATA[$F{albaran}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{albaran}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-1" x="1" y="136" width="482" height="1" forecolor="#CCCCCC" uuid="adeb2d94-3b52-4481-85ee-3e980389a8eb"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-8" style="Group_Data_Label" x="425" y="140" width="57" height="18" forecolor="#7E7979" backcolor="#FFFFFF" uuid="8148c244-242e-47af-927b-05bdf1fdd2d8"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="9" isBold="true" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="adeb2d94-3b52-4481-85ee-3e980389a8eb" key="line-1" x="1" y="136" width="482" height="1" forecolor="#CCCCCC">
+					<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
+				</element>
+				<element kind="staticText" uuid="8148c244-242e-47af-927b-05bdf1fdd2d8" key="staticText-8" x="425" y="140" width="57" height="18" forecolor="#7E7979" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="9.0" pdfFontName="Helvetica" bold="true" hTextAlign="Center" vTextAlign="Middle" style="Group_Data_Label">
 					<text><![CDATA[Date]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField" x="425" y="160" width="57" height="20" uuid="c8fa10a7-7678-4d64-8d5c-60c02b283f1c"/>
+					<box style="Group_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="c8fa10a7-7678-4d64-8d5c-60c02b283f1c" key="textField" x="425" y="160" width="57" height="20" fontName="DejaVu Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Center">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.applyCountryDateFormat($F{dateordered},$F{organizationid})]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.applyCountryDateFormat($F{dateordered},$F{organizationid})]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-17" x="1" y="143" width="188" height="57" isPrintWhenDetailOverflows="true" uuid="6c1b1683-d560-4faf-95b3-37015ccedd9d"/>
-					<textElement verticalAlignment="Top">
-						<font fontName="DejaVu Sans" size="9" isBold="true"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{name} + "\n" + $F{bp_data}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-20" x="165" y="2" width="155" height="91" isPrintWhenDetailOverflows="true" uuid="974be258-0088-4f4f-89af-c53fd173b5d1">
-						<printWhenExpression><![CDATA[new Boolean($F{showcompanydata}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<textElement>
-						<font fontName="DejaVu Sans" size="9"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{location}==null ? $F{org_name} + "\n" + $F{org_taxid} + "\n" : $F{org_name} + "\n" + $F{org_taxid} + "\n" + $F{location})]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-11" style="Group_Data_Label" x="365" y="140" width="57" height="18" forecolor="#7E7979" backcolor="#FFFFFF" uuid="ab08adf8-ea24-4b53-b60e-1eb0b5497cef"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="9" isBold="true" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="textField" uuid="6c1b1683-d560-4faf-95b3-37015ccedd9d" key="textField-17" x="1" y="143" width="188" height="57" fontName="DejaVu Sans" fontSize="9.0" blankWhenNull="false" printWhenDetailOverflows="true" bold="true" vTextAlign="Top">
+					<expression><![CDATA[$F{name} + "\n" + $F{bp_data}]]></expression>
+				</element>
+				<element kind="textField" uuid="974be258-0088-4f4f-89af-c53fd173b5d1" key="textField-20" x="165" y="2" width="155" height="91" fontName="DejaVu Sans" fontSize="9.0" blankWhenNull="false" printWhenDetailOverflows="true">
+					<printWhenExpression><![CDATA[new Boolean($F{showcompanydata}.equalsIgnoreCase("Y"))]]></printWhenExpression>
+					<expression><![CDATA[($F{location}==null ? $F{org_name} + "\n" + $F{org_taxid} + "\n" : $F{org_name} + "\n" + $F{org_taxid} + "\n" + $F{location})]]></expression>
+				</element>
+				<element kind="staticText" uuid="ab08adf8-ea24-4b53-b60e-1eb0b5497cef" key="staticText-11" x="365" y="140" width="57" height="18" forecolor="#7E7979" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="9.0" pdfFontName="Helvetica" bold="true" hTextAlign="Center" vTextAlign="Middle" style="Group_Data_Label">
 					<text><![CDATA[Currency]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-24" x="365" y="160" width="57" height="20" uuid="f4faef7a-a7cb-409e-a709-b169cf3038a4"/>
+					<box style="Group_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="f4faef7a-a7cb-409e-a709-b169cf3038a4" key="textField-24" x="365" y="160" width="57" height="20" fontName="DejaVu Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Center">
+					<expression><![CDATA[$F{currency_iso}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{currency_iso}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-12" x="284" y="103" width="198" height="25" uuid="fc9acb39-f49b-4777-9ac4-0e7ff463ffff">
-						<printWhenExpression><![CDATA[new Boolean($F{issotrx}.equalsIgnoreCase("N"))]]></printWhenExpression>
-					</reportElement>
-					<textElement textAlignment="Right">
-						<font fontName="DejaVu Sans" size="16"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="fc9acb39-f49b-4777-9ac4-0e7ff463ffff" key="staticText-12" x="284" y="103" width="198" height="25" fontName="DejaVu Sans" fontSize="16.0" hTextAlign="Right">
+					<printWhenExpression><![CDATA[new Boolean($F{issotrx}.equalsIgnoreCase("N"))]]></printWhenExpression>
 					<text><![CDATA[This is a Purchase order]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-13" x="284" y="102" width="198" height="25" uuid="daab30c5-8dfe-4455-9981-c6cdcdd68bf6">
-						<printWhenExpression><![CDATA[new Boolean($F{issotrx}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<textElement textAlignment="Right">
-						<font fontName="DejaVu Sans" size="16"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="daab30c5-8dfe-4455-9981-c6cdcdd68bf6" key="staticText-13" x="284" y="102" width="198" height="25" fontName="DejaVu Sans" fontSize="16.0" hTextAlign="Right">
+					<printWhenExpression><![CDATA[new Boolean($F{issotrx}.equalsIgnoreCase("Y"))]]></printWhenExpression>
 					<text><![CDATA[This is a Sales order]]></text>
-				</staticText>
-				<image scaleImage="RetainShape" hAlign="Right" vAlign="Top" isUsingCache="true">
-					<reportElement key="image-1" x="0" y="13" width="153" height="78" uuid="65b7d12e-8cae-45cc-be04-988103e14401">
-						<printWhenExpression><![CDATA[new Boolean($F{showlogo}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<imageExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylegal", $F{organizationid})]]></imageExpression>
-				</image>
-				<line>
-					<reportElement key="line-1" x="304" y="183" width="179" height="1" forecolor="#CCCCCC" uuid="82ba0ddf-4321-4100-a15e-2a24301dbc7a"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
-					</graphicElement>
-				</line>
-				<line direction="BottomUp">
-					<reportElement key="line-1" x="303" y="137" width="1" height="46" forecolor="#CCCCCC" uuid="2a69afd3-97d5-4692-ba7b-b956caf30303"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
-					</graphicElement>
-				</line>
-				<line direction="BottomUp">
-					<reportElement key="line-1" x="423" y="137" width="1" height="46" forecolor="#CCCCCC" uuid="1c026366-ecb6-4224-ab70-b8e3ef8cb301"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
-					</graphicElement>
-				</line>
-				<line direction="BottomUp">
-					<reportElement key="line-1" x="363" y="137" width="1" height="46" forecolor="#CCCCCC" uuid="561b052f-0618-4f47-9552-1c7aa46cf40d"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
-					</graphicElement>
-				</line>
-				<line direction="BottomUp">
-					<reportElement key="line-1" x="483" y="137" width="1" height="46" forecolor="#CCCCCC" uuid="485998c7-5ca3-4bfb-926b-63b7570531c2"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
-					</graphicElement>
-				</line>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-16" x="314" y="18" width="168" height="27" forecolor="#FF0000" uuid="1dbda0db-b66e-474e-9194-dc09d332f222"/>
-					<textElement textAlignment="Justified" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="22"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($F{status}.compareTo("VO")==0) ? "VOIDED" : " ")]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="image" uuid="65b7d12e-8cae-45cc-be04-988103e14401" key="image-1" x="0" y="13" width="153" height="78" scaleImage="RetainShape" usingCache="true" hImageAlign="Right" vImageAlign="Top">
+					<printWhenExpression><![CDATA[new Boolean($F{showlogo}.equalsIgnoreCase("Y"))]]></printWhenExpression>
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylegal", $F{organizationid})]]></expression>
+				</element>
+				<element kind="line" uuid="82ba0ddf-4321-4100-a15e-2a24301dbc7a" key="line-1" x="304" y="183" width="179" height="1" forecolor="#CCCCCC">
+					<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
+				</element>
+				<element kind="line" uuid="2a69afd3-97d5-4692-ba7b-b956caf30303" key="line-1" x="303" y="137" width="1" height="46" forecolor="#CCCCCC" direction="BottomUp">
+					<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
+				</element>
+				<element kind="line" uuid="1c026366-ecb6-4224-ab70-b8e3ef8cb301" key="line-1" x="423" y="137" width="1" height="46" forecolor="#CCCCCC" direction="BottomUp">
+					<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
+				</element>
+				<element kind="line" uuid="561b052f-0618-4f47-9552-1c7aa46cf40d" key="line-1" x="363" y="137" width="1" height="46" forecolor="#CCCCCC" direction="BottomUp">
+					<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
+				</element>
+				<element kind="line" uuid="485998c7-5ca3-4bfb-926b-63b7570531c2" key="line-1" x="483" y="137" width="1" height="46" forecolor="#CCCCCC" direction="BottomUp">
+					<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
+				</element>
+				<element kind="textField" uuid="1dbda0db-b66e-474e-9194-dc09d332f222" key="textField-16" x="314" y="18" width="168" height="27" forecolor="#FF0000" fontName="DejaVu Sans" fontSize="22.0" blankWhenNull="false" hTextAlign="Justified" vTextAlign="Middle">
+					<expression><![CDATA[(($F{status}.compareTo("VO")==0) ? "VOIDED" : " ")]]></expression>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="45" splitType="Stretch">
-			<subreport isUsingCache="false">
-				<reportElement key="subreport-1" x="0" y="5" width="482" height="36" uuid="acca5f7e-1035-4cb9-9b91-d7686d2b9d51">
-					<printWhenExpression><![CDATA[$F{istaxincluded}.equals("N")]]></printWhenExpression>
-				</reportElement>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{organizationid},$P{NUMBERFORMAT})]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LOCALE">
-					<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="C_ORDER_ID">
-					<subreportParameterExpression><![CDATA[$F{c_order_id}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="ISTAXINCLUDED">
-					<subreportParameterExpression><![CDATA[$F{istaxincluded}]]></subreportParameterExpression>
-				</subreportParameter>
+			<element kind="subreport" uuid="acca5f7e-1035-4cb9-9b91-d7686d2b9d51" key="subreport-1" x="0" y="5" width="482" height="36" usingCache="false">
+				<printWhenExpression><![CDATA[$F{istaxincluded}.equals("N")]]></printWhenExpression>
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{SUBREP_C_OrderLinesJR_new}]]></subreportExpression>
-			</subreport>
-			<subreport isUsingCache="false">
-				<reportElement key="subreport-1" x="0" y="5" width="482" height="36" uuid="829a0ef4-8bc9-4385-8661-440d9778d13b">
-					<printWhenExpression><![CDATA[$F{istaxincluded}.equals("Y")]]></printWhenExpression>
-				</reportElement>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{organizationid},$P{NUMBERFORMAT})]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LOCALE">
-					<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="C_ORDER_ID">
-					<subreportParameterExpression><![CDATA[$F{c_order_id}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="ISTAXINCLUDED">
-					<subreportParameterExpression><![CDATA[$F{istaxincluded}]]></subreportParameterExpression>
-				</subreportParameter>
+				<expression><![CDATA[$P{SUBREP_C_OrderLinesJR_new}]]></expression>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{organizationid},$P{NUMBERFORMAT})]]></expression>
+				</parameter>
+				<parameter name="LOCALE">
+					<expression><![CDATA[$P{LOCALE}]]></expression>
+				</parameter>
+				<parameter name="C_ORDER_ID">
+					<expression><![CDATA[$F{c_order_id}]]></expression>
+				</parameter>
+				<parameter name="ISTAXINCLUDED">
+					<expression><![CDATA[$F{istaxincluded}]]></expression>
+				</parameter>
+			</element>
+			<element kind="subreport" uuid="829a0ef4-8bc9-4385-8661-440d9778d13b" key="subreport-1" x="0" y="5" width="482" height="36" usingCache="false">
+				<printWhenExpression><![CDATA[$F{istaxincluded}.equals("Y")]]></printWhenExpression>
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{SUBREP_C_OrderLinesTaxIncludedJR_new}]]></subreportExpression>
-			</subreport>
+				<expression><![CDATA[$P{SUBREP_C_OrderLinesTaxIncludedJR_new}]]></expression>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{organizationid},$P{NUMBERFORMAT})]]></expression>
+				</parameter>
+				<parameter name="LOCALE">
+					<expression><![CDATA[$P{LOCALE}]]></expression>
+				</parameter>
+				<parameter name="C_ORDER_ID">
+					<expression><![CDATA[$F{c_order_id}]]></expression>
+				</parameter>
+				<parameter name="ISTAXINCLUDED">
+					<expression><![CDATA[$F{istaxincluded}]]></expression>
+				</parameter>
+			</element>
 		</band>
 		<band height="27">
-			<subreport isUsingCache="false">
-				<reportElement key="subreport-1" x="0" y="7" width="482" height="18" uuid="c8a22070-416c-421e-b0e3-9fdec9d3984e">
-					<printWhenExpression><![CDATA[$F{istaxincluded}.equals("Y")]]></printWhenExpression>
-				</reportElement>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{organizationid},$P{NUMBERFORMAT})]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LOCALE">
-					<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="C_ORDER_ID">
-					<subreportParameterExpression><![CDATA[$F{c_order_id}]]></subreportParameterExpression>
-				</subreportParameter>
+			<element kind="subreport" uuid="c8a22070-416c-421e-b0e3-9fdec9d3984e" key="subreport-1" x="0" y="7" width="482" height="18" usingCache="false">
+				<printWhenExpression><![CDATA[$F{istaxincluded}.equals("Y")]]></printWhenExpression>
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{SUBREP_RptC_Order_TaxLines_new}]]></subreportExpression>
-			</subreport>
+				<expression><![CDATA[$P{SUBREP_RptC_Order_TaxLines_new}]]></expression>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{organizationid},$P{NUMBERFORMAT})]]></expression>
+				</parameter>
+				<parameter name="LOCALE">
+					<expression><![CDATA[$P{LOCALE}]]></expression>
+				</parameter>
+				<parameter name="C_ORDER_ID">
+					<expression><![CDATA[$F{c_order_id}]]></expression>
+				</parameter>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="90" splitType="Stretch">
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-9" x="439" y="64" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="7a3b19bc-5b0a-476c-b94b-83533d1830de"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-10" x="340" y="64" width="95" height="19" uuid="6493ee4e-82d4-4d8d-a860-21bc8301821e"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-2" x="0" y="61" width="483" height="1" forecolor="#CCCCCC" uuid="1b1b987c-04a5-492b-afbe-5564b644bed6"/>
-				<graphicElement>
-					<pen lineWidth="0.25" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<staticText>
-				<reportElement key="staticText-9" style="default" x="295" y="7" width="89" height="18" forecolor="#7E7979" uuid="512becc3-23fc-4997-bea1-e40cc57ba474"/>
-				<box leftPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left">
-					<font fontName="DejaVu Sans" size="9" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Payment Terms]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-10" style="default" x="-3" y="7" width="79" height="18" forecolor="#7E7979" uuid="b7ddff7c-3214-40ef-a2c5-0174b5fd8474"/>
-				<box leftPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font fontName="DejaVu Sans" size="9" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Delivery Term]]></text>
-			</staticText>
-			<line>
-				<reportElement key="line-3" style="default" x="0" y="25" width="483" height="1" forecolor="#CCCCCC" uuid="e485d40f-016a-4382-ba6d-3e518584b3f2"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-21" x="0" y="28" width="79" height="18" uuid="3fe89b3b-edf5-49fd-b1d8-38b0402232a7"/>
-				<textElement>
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{deliveryterm}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-22" x="298" y="28" width="89" height="18" isPrintWhenDetailOverflows="true" uuid="1a86a25e-c30a-4c87-83a9-307eb6fa5ce0"/>
-				<textElement>
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{paymentterm}]]></textFieldExpression>
-			</textField>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="90" splitType="Stretch">
+		<element kind="textField" uuid="7a3b19bc-5b0a-476c-b94b-83533d1830de" key="textField-9" x="439" y="64" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="DejaVu Sans" fontSize="8.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="6493ee4e-82d4-4d8d-a860-21bc8301821e" key="textField-10" x="340" y="64" width="95" height="19" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="1b1b987c-04a5-492b-afbe-5564b644bed6" key="line-2" x="0" y="61" width="483" height="1" forecolor="#CCCCCC">
+			<pen lineWidth="0.25" lineStyle="Solid"/>
+		</element>
+		<element kind="staticText" uuid="512becc3-23fc-4997-bea1-e40cc57ba474" key="staticText-9" x="295" y="7" width="89" height="18" forecolor="#7E7979" fontName="DejaVu Sans" fontSize="9.0" bold="true" hTextAlign="Left" style="default">
+			<text><![CDATA[Payment Terms]]></text>
+			<box leftPadding="2" style="default">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="b7ddff7c-3214-40ef-a2c5-0174b5fd8474" key="staticText-10" x="-3" y="7" width="79" height="18" forecolor="#7E7979" fontName="DejaVu Sans" fontSize="9.0" bold="true" style="default">
+			<text><![CDATA[Delivery Term]]></text>
+			<box leftPadding="2" style="default">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="e485d40f-016a-4382-ba6d-3e518584b3f2" key="line-3" x="0" y="25" width="483" height="1" forecolor="#CCCCCC" style="default">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="3fe89b3b-edf5-49fd-b1d8-38b0402232a7" key="textField-21" x="0" y="28" width="79" height="18" fontName="DejaVu Sans" fontSize="8.0" blankWhenNull="false">
+			<expression><![CDATA[$F{deliveryterm}]]></expression>
+		</element>
+		<element kind="textField" uuid="1a86a25e-c30a-4c87-83a9-307eb6fa5ce0" key="textField-22" x="298" y="28" width="89" height="18" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="false" printWhenDetailOverflows="true">
+			<expression><![CDATA[$F{paymentterm}]]></expression>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/C_OrderLinesJR.jrxml
+++ b/src/org/openbravo/erpReports/C_OrderLinesJR.jrxml
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="C_OrderLinesJR" pageWidth="477" pageHeight="802" columnWidth="477" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="5e43318e-b337-416e-8b13-60f71161338c">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="C_OrderLinesJR" language="java" pageWidth="477" pageHeight="802" columnWidth="477" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="5e43318e-b337-416e-8b13-60f71161338c">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
@@ -22,11 +21,10 @@
 	<parameter name="C_ORDER_ID" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'1000069'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
 	<parameter name="ISTAXINCLUDED" class="java.lang.String"/>
-	<queryString>
-		<![CDATA[SELECT 1 AS ISBOM, C_ORDERLINE.LINE, COALESCE(M_PRODUCT.NAME, C_ORDERLINE.DESCRIPTION) AS PRODUCT_NAME, C_ORDERLINE.QTYORDERED AS QUANTITY,
+	<query language="sql"><![CDATA[SELECT 1 AS ISBOM, C_ORDERLINE.LINE, COALESCE(M_PRODUCT.NAME, C_ORDERLINE.DESCRIPTION) AS PRODUCT_NAME, C_ORDERLINE.QTYORDERED AS QUANTITY,
         TO_CHAR(C_UOM.NAME) AS UOM,  CASE WHEN $P{ISTAXINCLUDED} = 'N' THEN C_ORDERLINE.PRICEACTUAL ELSE C_ORDERLINE.GROSS_UNIT_PRICE END as PRICEACTUAL ,
         TO_NUMBER(NULL) AS BASE, CASE WHEN $P{ISTAXINCLUDED} = 'N' THEN C_ORDERLINE.LINENETAMT ELSE C_ORDERLINE.LINE_GROSS_AMOUNT END as LINENETAMT,
         TO_NUMBER(NULL) AS TAXLINE,
@@ -56,8 +54,7 @@
             AND C_ORDERTAX.TAXAMT <> 0
             AND C_ORDER.C_ORDER_ID = $P{C_ORDER_ID}
             AND $P{ISTAXINCLUDED} = 'N'
-        ORDER BY LINE,ISBOM, TAXLINE]]>
-	</queryString>
+        ORDER BY LINE,ISBOM, TAXLINE]]></query>
 	<field name="ISBOM" class="java.lang.Integer"/>
 	<field name="LINE" class="java.math.BigDecimal"/>
 	<field name="PRODUCT_NAME" class="java.lang.String"/>
@@ -69,288 +66,168 @@
 	<field name="TAXLINE" class="java.math.BigDecimal"/>
 	<field name="STATUS" class="java.lang.String"/>
 	<field name="VALUE" class="java.lang.String"/>
-	<variable name="SUM_LINENETAMT" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{LINENETAMT}]]></variableExpression>
+	<variable name="SUM_LINENETAMT" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{LINENETAMT}]]></expression>
 	</variable>
-	<group name="C_Order_Id" isResetPageNumber="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="C_Order_Id" resetPageNumber="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="20" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="Detail_Header" mode="Opaque" x="235" y="3" width="60" height="17" forecolor="#FFFFFF" backcolor="#666666" uuid="77ccd252-88a3-460c-96a2-678e6f909963"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Top">
-						<font size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" isPdfEmbedded="false"/>
-					</textElement>
+				<element kind="staticText" uuid="77ccd252-88a3-460c-96a2-678e6f909963" key="staticText" mode="Opaque" x="235" y="3" width="60" height="17" forecolor="#FFFFFF" backcolor="#666666" fontSize="10.0" pdfFontName="Helvetica" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Top" style="Detail_Header">
 					<text><![CDATA[QUANTITY]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText" style="Detail_Header" x="200" y="3" width="35" height="17" forecolor="#FFFFFF" uuid="6194a160-8372-461d-aef8-9daba282c268"/>
-					<box leftPadding="2" rightPadding="2">
+					<box leftPadding="2" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Top">
-						<font size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="6194a160-8372-461d-aef8-9daba282c268" key="staticText" x="200" y="3" width="35" height="17" forecolor="#FFFFFF" fontSize="10.0" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" vTextAlign="Top" style="Detail_Header">
 					<text><![CDATA[UOM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText" style="Detail_Header" x="65" y="3" width="135" height="17" forecolor="#FFFFFF" uuid="d692cb9a-debe-4bd0-b719-2ddd1bd56006"/>
-					<box leftPadding="2" rightPadding="2">
+					<box leftPadding="2" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Top">
-						<font size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="d692cb9a-debe-4bd0-b719-2ddd1bd56006" key="staticText" x="65" y="3" width="135" height="17" forecolor="#FFFFFF" fontSize="10.0" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" vTextAlign="Top" style="Detail_Header">
 					<text><![CDATA[PRODUCT NAME]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-1" style="Detail_Header" x="1" y="3" width="65" height="17" uuid="a6fe269b-bd03-4628-aa48-3dca4843cb9d"/>
-					<textElement verticalAlignment="Top">
-						<font isBold="false"/>
-					</textElement>
+					<box leftPadding="2" rightPadding="2" style="Detail_Header">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="a6fe269b-bd03-4628-aa48-3dca4843cb9d" key="staticText-1" x="1" y="3" width="65" height="17" bold="false" vTextAlign="Top" style="Detail_Header">
 					<text><![CDATA[REFERENCE]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-2" style="Detail_Header" x="295" y="3" width="60" height="17" forecolor="#FFFFFF" backcolor="#666666" uuid="69c188aa-dbfa-4480-ba3b-23e492fc1b98"/>
-					<textElement textAlignment="Right" verticalAlignment="Top">
-						<font isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="69c188aa-dbfa-4480-ba3b-23e492fc1b98" key="staticText-2" x="295" y="3" width="60" height="17" forecolor="#FFFFFF" backcolor="#666666" pdfFontName="Helvetica" bold="false" hTextAlign="Right" vTextAlign="Top" style="Detail_Header">
 					<text><![CDATA[PRICE]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-3" style="Detail_Header" x="355" y="3" width="60" height="17" forecolor="#FFFFFF" backcolor="#666666" uuid="c4d90928-80e4-48b1-8177-efbdabd59e2b"/>
-					<textElement textAlignment="Right" verticalAlignment="Top">
-						<font isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="c4d90928-80e4-48b1-8177-efbdabd59e2b" key="staticText-3" x="355" y="3" width="60" height="17" forecolor="#FFFFFF" backcolor="#666666" pdfFontName="Helvetica" bold="false" hTextAlign="Right" vTextAlign="Top" style="Detail_Header">
 					<text><![CDATA[BASE]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-4" style="Detail_Header" x="415" y="3" width="60" height="17" forecolor="#FFFFFF" backcolor="#666666" uuid="2ebf9ade-bfa2-4252-901d-bc179da985ae">
-						<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("N")]]></printWhenExpression>
-					</reportElement>
-					<textElement textAlignment="Right" verticalAlignment="Top">
-						<font isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="2ebf9ade-bfa2-4252-901d-bc179da985ae" key="staticText-4" x="415" y="3" width="60" height="17" forecolor="#FFFFFF" backcolor="#666666" pdfFontName="Helvetica" bold="false" hTextAlign="Right" vTextAlign="Top" style="Detail_Header">
+					<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("N")]]></printWhenExpression>
 					<text><![CDATA[TOTAL]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-14" x="295" y="3" width="1" height="17" forecolor="#FFFFFF" uuid="3f1b3f6a-12cd-40aa-8130-89374949c8a6"/>
-				</line>
-				<line>
-					<reportElement key="line-15" x="0" y="3" width="1" height="17" forecolor="#FFFFFF" uuid="9a180523-c4d5-45b1-8176-e83e66aa53a8"/>
-				</line>
-				<line>
-					<reportElement key="line-16" x="235" y="3" width="1" height="17" forecolor="#FFFFFF" uuid="5099f1c7-be80-4a7f-8246-22c46afd1a38"/>
-				</line>
-				<line>
-					<reportElement key="line-17" x="415" y="3" width="1" height="17" forecolor="#FFFFFF" uuid="49c3e5ea-f805-4fe7-a34d-77d95bbaed20"/>
-				</line>
-				<line>
-					<reportElement key="line-18" x="355" y="3" width="1" height="17" forecolor="#FFFFFF" uuid="075ea5c4-3b7c-4890-84fd-8cf98263bcff"/>
-				</line>
-				<line>
-					<reportElement key="line-19" x="200" y="3" width="1" height="17" forecolor="#FFFFFF" uuid="2b5751bf-a5dc-48fb-81dd-90f211082d4a"/>
-				</line>
-				<line>
-					<reportElement key="line-20" x="475" y="3" width="1" height="17" forecolor="#FFFFFF" uuid="bd768e01-7857-49e4-bcb7-a8ec3dfa9be0"/>
-				</line>
-				<line>
-					<reportElement key="line-21" x="65" y="3" width="1" height="17" forecolor="#FFFFFF" uuid="caec7b6c-b3bb-4ef3-baaa-059de8bef9ff"/>
-				</line>
+				</element>
+				<element kind="line" uuid="3f1b3f6a-12cd-40aa-8130-89374949c8a6" key="line-14" x="295" y="3" width="1" height="17" forecolor="#FFFFFF"/>
+				<element kind="line" uuid="9a180523-c4d5-45b1-8176-e83e66aa53a8" key="line-15" x="0" y="3" width="1" height="17" forecolor="#FFFFFF"/>
+				<element kind="line" uuid="5099f1c7-be80-4a7f-8246-22c46afd1a38" key="line-16" x="235" y="3" width="1" height="17" forecolor="#FFFFFF"/>
+				<element kind="line" uuid="49c3e5ea-f805-4fe7-a34d-77d95bbaed20" key="line-17" x="415" y="3" width="1" height="17" forecolor="#FFFFFF"/>
+				<element kind="line" uuid="075ea5c4-3b7c-4890-84fd-8cf98263bcff" key="line-18" x="355" y="3" width="1" height="17" forecolor="#FFFFFF"/>
+				<element kind="line" uuid="2b5751bf-a5dc-48fb-81dd-90f211082d4a" key="line-19" x="200" y="3" width="1" height="17" forecolor="#FFFFFF"/>
+				<element kind="line" uuid="bd768e01-7857-49e4-bcb7-a8ec3dfa9be0" key="line-20" x="475" y="3" width="1" height="17" forecolor="#FFFFFF"/>
+				<element kind="line" uuid="caec7b6c-b3bb-4ef3-baaa-059de8bef9ff" key="line-21" x="65" y="3" width="1" height="17" forecolor="#FFFFFF"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<frame>
-				<reportElement key="frame-1" style="Detail_Line" x="0" y="0" width="475" height="16" uuid="bc15ed0b-795c-476a-b1f8-5bb8d28b44b4"/>
-				<box>
+			<element kind="frame" uuid="bc15ed0b-795c-476a-b1f8-5bb8d28b44b4" key="frame-1" x="0" y="0" width="475" height="16" style="Detail_Line">
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-			</frame>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="235" y="0" width="60" height="16" forecolor="#000000" uuid="0cdf2749-a216-41af-98d0-53d1bf31fda6"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="0cdf2749-a216-41af-98d0-53d1bf31fda6" key="textField" x="235" y="0" width="60" height="16" forecolor="#000000" fontSize="8.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{QUANTITY}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITY}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QUANTITY}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITY}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="default" x="200" y="0" width="35" height="16" forecolor="#000000" uuid="08896136-e045-44b4-859d-f6829a900dbd"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="08896136-e045-44b4-859d-f6829a900dbd" key="textField" x="200" y="0" width="35" height="16" forecolor="#000000" fontSize="8.0" pattern="" blankWhenNull="true" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" vTextAlign="Middle" style="default">
+				<expression><![CDATA[$F{UOM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{UOM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="default" x="65" y="0" width="135" height="16" forecolor="#000000" uuid="3d792726-64fa-413f-b678-283b4a64f7e1"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="3d792726-64fa-413f-b678-283b4a64f7e1" key="textField" x="65" y="0" width="135" height="16" forecolor="#000000" fontSize="8.0" pattern="" blankWhenNull="true" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" vTextAlign="Middle" style="default">
+				<expression><![CDATA[$F{PRODUCT_NAME}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRODUCT_NAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="295" y="0" width="60" height="16" forecolor="#000000" uuid="6a3d95e2-b9ad-4261-adfc-031278bc8fb0"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="6a3d95e2-b9ad-4261-adfc-031278bc8fb0" key="textField" x="295" y="0" width="60" height="16" forecolor="#000000" fontSize="8.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}).toString():new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}).toString():new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="355" y="0" width="60" height="16" forecolor="#000000" uuid="39e5681d-7938-4744-a976-8b4da8024d35"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="39e5681d-7938-4744-a976-8b4da8024d35" key="textField" x="355" y="0" width="60" height="16" forecolor="#000000" fontSize="8.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{BASE}!=null)?$P{NUMBERFORMAT}.format($F{BASE}).toString() :new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{BASE}!=null)?$P{NUMBERFORMAT}.format($F{BASE}).toString() :new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="415" y="0" width="60" height="16" forecolor="#000000" uuid="2e3788fe-25cc-4a58-ac84-fa2f18e4c2ed"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="2e3788fe-25cc-4a58-ac84-fa2f18e4c2ed" key="textField" x="415" y="0" width="60" height="16" forecolor="#000000" fontSize="8.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}) : new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}) : new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="16" uuid="b39c4145-ac96-45b9-b4aa-37967d7dde37"/>
-			</line>
-			<line>
-				<reportElement key="line-3" stretchType="RelativeToBandHeight" x="200" y="0" width="1" height="16" uuid="60789d9f-d105-4233-875a-192b29500687"/>
-			</line>
-			<line>
-				<reportElement key="line-4" stretchType="RelativeToBandHeight" x="235" y="0" width="1" height="16" uuid="b8ed19cd-2aba-4096-a33d-c176f56727a6"/>
-			</line>
-			<line>
-				<reportElement key="line-5" stretchType="RelativeToBandHeight" x="295" y="0" width="1" height="16" uuid="305d7e31-74b3-47d5-8cb0-92fba96824cf"/>
-			</line>
-			<line>
-				<reportElement key="line-6" stretchType="RelativeToBandHeight" x="355" y="0" width="1" height="16" uuid="0bc71c94-c29d-4281-b6c3-b7dfa5d0bfad"/>
-			</line>
-			<line>
-				<reportElement key="line-7" stretchType="RelativeToBandHeight" x="415" y="0" width="1" height="16" uuid="2612d47a-8651-40d9-a6fd-26051f8cc0a3"/>
-			</line>
-			<line>
-				<reportElement key="line-8" stretchType="RelativeToBandHeight" x="475" y="0" width="1" height="16" uuid="1627f0c0-9f5a-4615-9417-493fe2bb987d"/>
-			</line>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-6" style="default" x="1" y="0" width="65" height="16" uuid="4f77fc8e-ea93-416e-a700-d833e06b724a"/>
-				<textElement verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{VALUE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-22" stretchType="RelativeToBandHeight" x="65" y="0" width="1" height="16" uuid="b5e0d020-aedd-4b55-a1ee-32c8acdb8469"/>
-			</line>
+			</element>
+			<element kind="line" uuid="b39c4145-ac96-45b9-b4aa-37967d7dde37" key="line-2" stretchType="ContainerHeight" x="0" y="0" width="1" height="16"/>
+			<element kind="line" uuid="60789d9f-d105-4233-875a-192b29500687" key="line-3" stretchType="ContainerHeight" x="200" y="0" width="1" height="16"/>
+			<element kind="line" uuid="b8ed19cd-2aba-4096-a33d-c176f56727a6" key="line-4" stretchType="ContainerHeight" x="235" y="0" width="1" height="16"/>
+			<element kind="line" uuid="305d7e31-74b3-47d5-8cb0-92fba96824cf" key="line-5" stretchType="ContainerHeight" x="295" y="0" width="1" height="16"/>
+			<element kind="line" uuid="0bc71c94-c29d-4281-b6c3-b7dfa5d0bfad" key="line-6" stretchType="ContainerHeight" x="355" y="0" width="1" height="16"/>
+			<element kind="line" uuid="2612d47a-8651-40d9-a6fd-26051f8cc0a3" key="line-7" stretchType="ContainerHeight" x="415" y="0" width="1" height="16"/>
+			<element kind="line" uuid="1627f0c0-9f5a-4615-9417-493fe2bb987d" key="line-8" stretchType="ContainerHeight" x="475" y="0" width="1" height="16"/>
+			<element kind="textField" uuid="4f77fc8e-ea93-416e-a700-d833e06b724a" key="textField-6" x="1" y="0" width="65" height="16" fontSize="8.0" blankWhenNull="false" vTextAlign="Middle" style="default">
+				<expression><![CDATA[$F{VALUE}]]></expression>
+			</element>
+			<element kind="line" uuid="b5e0d020-aedd-4b55-a1ee-32c8acdb8469" key="line-22" stretchType="ContainerHeight" x="65" y="0" width="1" height="16"/>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band height="18" splitType="Stretch">
-			<line>
-				<reportElement key="line-1" x="0" y="0" width="476" height="1" uuid="f6bd6849-2b58-4a1a-9f3b-176fade70aa6"/>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-1" style="Total_Gray" x="397" y="2" width="78" height="16" uuid="cca5da08-b201-498f-a948-89e638ea1adf"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($V{SUM_LINENETAMT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-10" x="318" y="3" width="1" height="15" uuid="7f519f64-628a-46a9-af9c-24b02d500a23"/>
-			</line>
-			<line>
-				<reportElement key="line-11" x="318" y="17" width="158" height="1" uuid="e79e584a-75ba-46d9-a7bd-53be40e4a024"/>
-			</line>
-			<line>
-				<reportElement key="line-12" x="318" y="2" width="158" height="1" uuid="ed54ca84-e051-444e-9181-dbeef81fed1e"/>
-			</line>
-			<line>
-				<reportElement key="line-13" x="475" y="3" width="1" height="15" uuid="94c00d8e-9ba5-47a8-ae21-82a4409641da"/>
-			</line>
-			<staticText>
-				<reportElement key="staticText-5" x="319" y="2" width="78" height="16" uuid="271b1e27-2539-4aa1-803e-1d71f5c4595a"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Left" verticalAlignment="Middle"/>
-				<text><![CDATA[TOTAL]]></text>
-			</staticText>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary height="18" splitType="Stretch">
+		<element kind="line" uuid="f6bd6849-2b58-4a1a-9f3b-176fade70aa6" key="line-1" x="0" y="0" width="476" height="1"/>
+		<element kind="textField" uuid="cca5da08-b201-498f-a948-89e638ea1adf" key="textField-1" x="397" y="2" width="78" height="16" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Gray">
+			<expression><![CDATA[($V{SUM_LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($V{SUM_LINENETAMT}):new String(" ")]]></expression>
+			<box style="Total_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="7f519f64-628a-46a9-af9c-24b02d500a23" key="line-10" x="318" y="3" width="1" height="15"/>
+		<element kind="line" uuid="e79e584a-75ba-46d9-a7bd-53be40e4a024" key="line-11" x="318" y="17" width="158" height="1"/>
+		<element kind="line" uuid="ed54ca84-e051-444e-9181-dbeef81fed1e" key="line-12" x="318" y="2" width="158" height="1"/>
+		<element kind="line" uuid="94c00d8e-9ba5-47a8-ae21-82a4409641da" key="line-13" x="475" y="3" width="1" height="15"/>
+		<element kind="staticText" uuid="271b1e27-2539-4aa1-803e-1d71f5c4595a" key="staticText-5" x="319" y="2" width="78" height="16" hTextAlign="Left" vTextAlign="Middle">
+			<text><![CDATA[TOTAL]]></text>
+			<box leftPadding="2"/>
+		</element>
 	</summary>
 </jasperReport>

--- a/src/org/openbravo/erpReports/C_OrderLinesJR_new.jrxml
+++ b/src/org/openbravo/erpReports/C_OrderLinesJR_new.jrxml
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="C_OrderLinesJR_new" pageWidth="477" pageHeight="802" columnWidth="477" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="6adf6da8-eb81-443d-8699-e1e24140b799">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="C_OrderLinesJR_new" language="java" pageWidth="477" pageHeight="802" columnWidth="477" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="6adf6da8-eb81-443d-8699-e1e24140b799">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.5"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
@@ -22,11 +21,10 @@
 	<parameter name="C_ORDER_ID" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'1000069'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
 	<parameter name="ISTAXINCLUDED" class="java.lang.String"/>
-	<queryString>
-		<![CDATA[SELECT 1 AS ISBOM, C_ORDERLINE.LINE, COALESCE(M_PRODUCT.NAME, C_ORDERLINE.DESCRIPTION) AS PRODUCT_NAME, C_ORDERLINE.QTYORDERED AS QUANTITY,
+	<query language="sql"><![CDATA[SELECT 1 AS ISBOM, C_ORDERLINE.LINE, COALESCE(M_PRODUCT.NAME, C_ORDERLINE.DESCRIPTION) AS PRODUCT_NAME, C_ORDERLINE.QTYORDERED AS QUANTITY,
         TO_CHAR(C_UOM.NAME) AS UOM,  CASE WHEN $P{ISTAXINCLUDED} = 'N' THEN C_ORDERLINE.PRICEACTUAL ELSE C_ORDERLINE.GROSS_UNIT_PRICE END as PRICEACTUAL ,
         TO_NUMBER(NULL) AS BASE, CASE WHEN $P{ISTAXINCLUDED} = 'N' THEN C_ORDERLINE.LINENETAMT ELSE C_ORDERLINE.LINE_GROSS_AMOUNT END as LINENETAMT,
         TO_NUMBER(NULL) AS TAXLINE,
@@ -58,8 +56,7 @@
             AND C_ORDERTAX.TAXAMT <> 0
             AND C_ORDER.C_ORDER_ID = $P{C_ORDER_ID}
             AND $P{ISTAXINCLUDED} = 'N'
-        ORDER BY LINE,ISBOM, TAXLINE]]>
-	</queryString>
+        ORDER BY LINE,ISBOM, TAXLINE]]></query>
 	<field name="ISBOM" class="java.lang.Integer"/>
 	<field name="LINE" class="java.math.BigDecimal"/>
 	<field name="PRODUCT_NAME" class="java.lang.String"/>
@@ -71,251 +68,159 @@
 	<field name="TAXLINE" class="java.math.BigDecimal"/>
 	<field name="STATUS" class="java.lang.String"/>
 	<field name="VALUE" class="java.lang.String"/>
-	<variable name="SUM_LINENETAMT" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{LINENETAMT}]]></variableExpression>
+	<variable name="SUM_LINENETAMT" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{LINENETAMT}]]></expression>
 	</variable>
-	<group name="C_Order_Id" isResetPageNumber="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="C_Order_Id" resetPageNumber="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="25" splitType="Stretch">
-				<line>
-					<reportElement key="line-1" x="0" y="23" width="477" height="1" forecolor="#CCCCCC" uuid="ac724a84-3f58-44f1-b573-1268ad3dc4c7"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Double" lineColor="#A3A1A1"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="" style="default" mode="Transparent" x="235" y="2" width="60" height="22" forecolor="#7E7979" uuid="6d7d3f9b-8def-4cb3-8046-dc758729888d"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="9" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" isPdfEmbedded="false"/>
-					</textElement>
+				<element kind="line" uuid="ac724a84-3f58-44f1-b573-1268ad3dc4c7" key="line-1" x="0" y="23" width="477" height="1" forecolor="#CCCCCC">
+					<pen lineWidth="2.0" lineStyle="Double" lineColor="#A3A1A1"/>
+				</element>
+				<element kind="staticText" uuid="6d7d3f9b-8def-4cb3-8046-dc758729888d" key="" mode="Transparent" x="235" y="2" width="60" height="22" forecolor="#7E7979" fontName="DejaVu Sans" fontSize="9.0" pdfFontName="Helvetica" pdfEmbedded="false" underline="false" strikeThrough="false" bold="true" italic="false" hTextAlign="Right" vTextAlign="Middle" style="default">
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="" style="default" x="200" y="2" width="35" height="22" forecolor="#7E7979" uuid="bee75408-c527-4616-a496-9cb14a63eeea"/>
-					<box leftPadding="2" rightPadding="2">
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="9" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="bee75408-c527-4616-a496-9cb14a63eeea" key="" x="200" y="2" width="35" height="22" forecolor="#7E7979" fontName="DejaVu Sans" fontSize="9.0" pdfEmbedded="false" underline="false" strikeThrough="false" bold="true" italic="false" vTextAlign="Middle" style="default">
 					<text><![CDATA[Uom]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="" style="default" x="65" y="2" width="135" height="22" forecolor="#7E7979" uuid="b14f7823-b93f-4052-8118-29a044d408e9"/>
-					<box leftPadding="2" rightPadding="2">
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="9" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="b14f7823-b93f-4052-8118-29a044d408e9" key="" x="65" y="2" width="135" height="22" forecolor="#7E7979" fontName="DejaVu Sans" fontSize="9.0" pdfEmbedded="false" underline="false" strikeThrough="false" bold="true" italic="false" hTextAlign="Left" vTextAlign="Middle" style="default">
 					<text><![CDATA[Product name]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="" style="default" x="1" y="2" width="65" height="22" forecolor="#7E7979" uuid="3a167058-cc05-496a-98d2-6e471b87e189"/>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="9" isBold="true"/>
-					</textElement>
+					<box leftPadding="2" rightPadding="2" style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="3a167058-cc05-496a-98d2-6e471b87e189" key="" x="1" y="2" width="65" height="22" forecolor="#7E7979" fontName="DejaVu Sans" fontSize="9.0" bold="true" hTextAlign="Left" vTextAlign="Middle" style="default">
 					<text><![CDATA[Reference]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="" style="default" x="295" y="2" width="60" height="22" forecolor="#7E7979" uuid="f073af3e-5624-4b47-85fd-3d4664722bfe"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="9" isBold="true" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="f073af3e-5624-4b47-85fd-3d4664722bfe" key="" x="295" y="2" width="60" height="22" forecolor="#7E7979" fontName="DejaVu Sans" fontSize="9.0" pdfFontName="Helvetica" bold="true" hTextAlign="Right" vTextAlign="Middle" style="default">
 					<text><![CDATA[Price]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="" style="default" mode="Transparent" x="355" y="2" width="60" height="22" forecolor="#7E7979" uuid="5421034d-2091-405c-863f-fabf5c25a4d0"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="9" isBold="true" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="5421034d-2091-405c-863f-fabf5c25a4d0" key="" mode="Transparent" x="355" y="2" width="60" height="22" forecolor="#7E7979" fontName="DejaVu Sans" fontSize="9.0" pdfFontName="Helvetica" bold="true" hTextAlign="Right" vTextAlign="Middle" style="default">
 					<text><![CDATA[Base]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="" style="default" mode="Transparent" x="415" y="2" width="60" height="22" forecolor="#7E7979" uuid="70e8c073-229d-414a-97a0-4163967fc627">
-						<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("N")]]></printWhenExpression>
-					</reportElement>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="9" isBold="true" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="70e8c073-229d-414a-97a0-4163967fc627" key="" mode="Transparent" x="415" y="2" width="60" height="22" forecolor="#7E7979" fontName="DejaVu Sans" fontSize="9.0" pdfFontName="Helvetica" bold="true" hTextAlign="Right" vTextAlign="Middle" style="default">
+					<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("N")]]></printWhenExpression>
 					<text><![CDATA[Total]]></text>
-				</staticText>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="25" splitType="Stretch">
-			<frame>
-				<reportElement key="frame-1" style="default" x="0" y="0" width="475" height="21" forecolor="#000000" uuid="c78bf9f6-10eb-4598-b04d-03197b66d0ef"/>
-				<box>
+			<element kind="frame" uuid="c78bf9f6-10eb-4598-b04d-03197b66d0ef" key="frame-1" x="0" y="0" width="475" height="21" forecolor="#000000" style="default">
+				<box style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-			</frame>
-			<line>
-				<reportElement key="line-1" x="0" y="22" width="477" height="1" forecolor="#CCCCCC" uuid="d9b889d5-1fd2-4685-8c8e-fbcbfe6f1e1a"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="235" y="0" width="60" height="21" forecolor="#000000" uuid="ea4c6e60-6897-4efe-9fca-14e2a08168b6"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="line" uuid="d9b889d5-1fd2-4685-8c8e-fbcbfe6f1e1a" key="line-1" x="0" y="22" width="477" height="1" forecolor="#CCCCCC">
+				<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
+			</element>
+			<element kind="textField" uuid="ea4c6e60-6897-4efe-9fca-14e2a08168b6" key="textField" x="235" y="0" width="60" height="21" forecolor="#000000" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{QUANTITY}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITY}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QUANTITY}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITY}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="default" x="200" y="0" width="35" height="21" forecolor="#000000" uuid="8f37cc83-e687-4e78-8eac-cc3509b969cf"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="8f37cc83-e687-4e78-8eac-cc3509b969cf" key="textField" x="200" y="0" width="35" height="21" forecolor="#000000" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="true" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" vTextAlign="Middle" style="default">
+				<expression><![CDATA[$F{UOM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{UOM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="default" x="65" y="0" width="135" height="21" forecolor="#000000" uuid="224406b1-3f40-4a25-887d-eedf1864f33f"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="224406b1-3f40-4a25-887d-eedf1864f33f" key="textField" x="65" y="0" width="135" height="21" forecolor="#000000" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="true" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" vTextAlign="Middle" style="default">
+				<expression><![CDATA[$F{PRODUCT_NAME}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRODUCT_NAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="295" y="0" width="60" height="21" forecolor="#000000" uuid="2449ae5f-2d46-4588-b7e5-854f23de6a4e"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="2449ae5f-2d46-4588-b7e5-854f23de6a4e" key="textField" x="295" y="0" width="60" height="21" forecolor="#000000" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}).toString():new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}).toString():new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="355" y="0" width="60" height="21" forecolor="#000000" uuid="27deab15-aba8-442c-9219-5824a5fcf2a3"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="27deab15-aba8-442c-9219-5824a5fcf2a3" key="textField" x="355" y="0" width="60" height="21" forecolor="#000000" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{BASE}!=null)?$P{NUMBERFORMAT}.format($F{BASE}).toString() :new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{BASE}!=null)?$P{NUMBERFORMAT}.format($F{BASE}).toString() :new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="415" y="0" width="60" height="21" forecolor="#000000" uuid="9b8f2f13-1630-4dbd-9633-c7a4fda17323"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="9b8f2f13-1630-4dbd-9633-c7a4fda17323" key="textField" x="415" y="0" width="60" height="21" forecolor="#000000" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}) : new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}) : new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="1" y="0" width="65" height="21" forecolor="#000000" uuid="7779d78e-f1f0-4874-bb19-0ffbd89bac91"/>
-				<textElement verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{VALUE}]]></textFieldExpression>
-			</textField>
+			</element>
+			<element kind="textField" uuid="7779d78e-f1f0-4874-bb19-0ffbd89bac91" key="textField" x="1" y="0" width="65" height="21" forecolor="#000000" fontName="DejaVu Sans" fontSize="8.0" blankWhenNull="false" vTextAlign="Middle" style="default">
+				<expression><![CDATA[$F{VALUE}]]></expression>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band height="39" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-1" style="Total_Gray" x="397" y="16" width="78" height="21" backcolor="#FFFFFF" uuid="0616a050-8350-4a5a-a020-1b4440f38f4b"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="10" isBold="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($V{SUM_LINENETAMT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-11" x="343" y="37" width="133" height="1" forecolor="#CCCCCC" uuid="b6c99d84-9e55-4ac5-8297-60db3534145b"/>
-				<graphicElement>
-					<pen lineWidth="2.0"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-12" x="343" y="16" width="133" height="1" forecolor="#CCCCCC" uuid="dffee318-ca02-47ef-94f3-83417d0a038d"/>
-				<graphicElement>
-					<pen lineWidth="2.0"/>
-				</graphicElement>
-			</line>
-			<staticText>
-				<reportElement key="staticText-5" x="343" y="16" width="54" height="21" forecolor="#7E7979" uuid="0ac2e26e-2e9b-46e6-9e0e-91c7925bc906"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="12" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Total]]></text>
-			</staticText>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary height="39" splitType="Stretch">
+		<element kind="textField" uuid="0616a050-8350-4a5a-a020-1b4440f38f4b" key="textField-1" x="397" y="16" width="78" height="21" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="10.0" pattern="" blankWhenNull="false" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Total_Gray">
+			<expression><![CDATA[($V{SUM_LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($V{SUM_LINENETAMT}):new String(" ")]]></expression>
+			<box style="Total_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="b6c99d84-9e55-4ac5-8297-60db3534145b" key="line-11" x="343" y="37" width="133" height="1" forecolor="#CCCCCC">
+			<pen lineWidth="2.0"/>
+		</element>
+		<element kind="line" uuid="dffee318-ca02-47ef-94f3-83417d0a038d" key="line-12" x="343" y="16" width="133" height="1" forecolor="#CCCCCC">
+			<pen lineWidth="2.0"/>
+		</element>
+		<element kind="staticText" uuid="0ac2e26e-2e9b-46e6-9e0e-91c7925bc906" key="staticText-5" x="343" y="16" width="54" height="21" forecolor="#7E7979" fontName="DejaVu Sans" fontSize="12.0" bold="true" hTextAlign="Left" vTextAlign="Middle">
+			<text><![CDATA[Total]]></text>
+			<box leftPadding="2"/>
+		</element>
 	</summary>
 </jasperReport>

--- a/src/org/openbravo/erpReports/C_OrderLinesTaxIncludedJR.jrxml
+++ b/src/org/openbravo/erpReports/C_OrderLinesTaxIncludedJR.jrxml
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="C_OrderLinesTaxIncludedJR" pageWidth="477" pageHeight="802" columnWidth="477" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="34705d46-7514-4753-935c-78f1d9dfbbd4">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="C_OrderLinesTaxIncludedJR" language="java" pageWidth="477" pageHeight="802" columnWidth="477" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="34705d46-7514-4753-935c-78f1d9dfbbd4">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
@@ -22,11 +21,10 @@
 	<parameter name="C_ORDER_ID" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'1000069'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
 	<parameter name="ISTAXINCLUDED" class="java.lang.String"/>
-	<queryString>
-		<![CDATA[SELECT 1 AS ISBOM, C_ORDERLINE.LINE, COALESCE(M_PRODUCT.NAME, C_ORDERLINE.DESCRIPTION) AS PRODUCT_NAME, C_ORDERLINE.QTYORDERED AS QUANTITY,
+	<query language="sql"><![CDATA[SELECT 1 AS ISBOM, C_ORDERLINE.LINE, COALESCE(M_PRODUCT.NAME, C_ORDERLINE.DESCRIPTION) AS PRODUCT_NAME, C_ORDERLINE.QTYORDERED AS QUANTITY,
         TO_CHAR(C_UOM.NAME) AS UOM,  CASE WHEN $P{ISTAXINCLUDED} = 'N' THEN C_ORDERLINE.PRICEACTUAL ELSE C_ORDERLINE.GROSS_UNIT_PRICE END as PRICEACTUAL ,
         TO_NUMBER(NULL) AS BASE, CASE WHEN $P{ISTAXINCLUDED} = 'N' THEN C_ORDERLINE.LINENETAMT ELSE C_ORDERLINE.LINE_GROSS_AMOUNT END as LINENETAMT,
         TO_NUMBER(NULL) AS TAXLINE,
@@ -56,8 +54,7 @@
             AND C_ORDERTAX.TAXAMT <> 0
             AND C_ORDER.C_ORDER_ID = $P{C_ORDER_ID}
             AND $P{ISTAXINCLUDED} = 'N'
-        ORDER BY LINE,ISBOM, TAXLINE]]>
-	</queryString>
+        ORDER BY LINE,ISBOM, TAXLINE]]></query>
 	<field name="ISBOM" class="java.lang.Integer"/>
 	<field name="LINE" class="java.math.BigDecimal"/>
 	<field name="PRODUCT_NAME" class="java.lang.String"/>
@@ -69,260 +66,153 @@
 	<field name="TAXLINE" class="java.math.BigDecimal"/>
 	<field name="STATUS" class="java.lang.String"/>
 	<field name="VALUE" class="java.lang.String"/>
-	<variable name="SUM_LINENETAMT" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{LINENETAMT}]]></variableExpression>
+	<variable name="SUM_LINENETAMT" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{LINENETAMT}]]></expression>
 	</variable>
-	<group name="C_Order_Id" isResetPageNumber="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="C_Order_Id" resetPageNumber="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="20" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="Detail_Header" mode="Opaque" x="235" y="3" width="60" height="17" forecolor="#FFFFFF" backcolor="#666666" uuid="4e12aed1-d71a-4ff5-b42b-91893da9decf"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Top">
-						<font size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" isPdfEmbedded="false"/>
-					</textElement>
+				<element kind="staticText" uuid="4e12aed1-d71a-4ff5-b42b-91893da9decf" key="staticText" mode="Opaque" x="235" y="3" width="60" height="17" forecolor="#FFFFFF" backcolor="#666666" fontSize="10.0" pdfFontName="Helvetica" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Top" style="Detail_Header">
 					<text><![CDATA[QUANTITY]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText" style="Detail_Header" x="200" y="3" width="35" height="17" forecolor="#FFFFFF" uuid="cdb86781-da61-40c1-b244-21fe3188a224"/>
-					<box leftPadding="2" rightPadding="2">
+					<box leftPadding="2" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Top">
-						<font size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="cdb86781-da61-40c1-b244-21fe3188a224" key="staticText" x="200" y="3" width="35" height="17" forecolor="#FFFFFF" fontSize="10.0" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" vTextAlign="Top" style="Detail_Header">
 					<text><![CDATA[UOM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText" style="Detail_Header" x="65" y="3" width="135" height="17" forecolor="#FFFFFF" uuid="be3679ea-60d4-4e51-b0ba-71a5be80bb96"/>
-					<box leftPadding="2" rightPadding="2">
+					<box leftPadding="2" rightPadding="2" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Top">
-						<font size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="be3679ea-60d4-4e51-b0ba-71a5be80bb96" key="staticText" x="65" y="3" width="135" height="17" forecolor="#FFFFFF" fontSize="10.0" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" vTextAlign="Top" style="Detail_Header">
 					<text><![CDATA[PRODUCT NAME]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-1" style="Detail_Header" x="1" y="3" width="65" height="17" uuid="abc59543-1ee4-456d-b1cc-4f6295e7a8f9"/>
-					<textElement verticalAlignment="Top">
-						<font isBold="false"/>
-					</textElement>
+					<box leftPadding="2" rightPadding="2" style="Detail_Header">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="abc59543-1ee4-456d-b1cc-4f6295e7a8f9" key="staticText-1" x="1" y="3" width="65" height="17" bold="false" vTextAlign="Top" style="Detail_Header">
 					<text><![CDATA[REFERENCE]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-2" style="Detail_Header" x="295" y="3" width="80" height="17" forecolor="#FFFFFF" backcolor="#666666" uuid="d166e197-da6b-4418-be4d-52889120d0fa"/>
-					<textElement textAlignment="Right" verticalAlignment="Top">
-						<font isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="d166e197-da6b-4418-be4d-52889120d0fa" key="staticText-2" x="295" y="3" width="80" height="17" forecolor="#FFFFFF" backcolor="#666666" pdfFontName="Helvetica" bold="false" hTextAlign="Right" vTextAlign="Top" style="Detail_Header">
 					<text><![CDATA[PRICE]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-4" style="Detail_Header" x="375" y="3" width="100" height="17" forecolor="#FFFFFF" backcolor="#666666" uuid="a03ad811-6053-4b72-a2c9-60c1c10972df"/>
-					<textElement textAlignment="Right" verticalAlignment="Top">
-						<font isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="a03ad811-6053-4b72-a2c9-60c1c10972df" key="staticText-4" x="375" y="3" width="100" height="17" forecolor="#FFFFFF" backcolor="#666666" pdfFontName="Helvetica" bold="false" hTextAlign="Right" vTextAlign="Top" style="Detail_Header">
 					<text><![CDATA[TOTAL]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-14" x="295" y="3" width="1" height="17" forecolor="#FFFFFF" uuid="aa44e8f3-1484-4df5-a9b3-e9369c1c9763"/>
-				</line>
-				<line>
-					<reportElement key="line-15" x="0" y="3" width="1" height="17" forecolor="#FFFFFF" uuid="9796c714-76d9-4d67-a63c-3edf494d80fa"/>
-				</line>
-				<line>
-					<reportElement key="line-16" x="235" y="3" width="1" height="17" forecolor="#FFFFFF" uuid="6bbc3afc-1ac2-40c0-843b-745549c8e01f"/>
-				</line>
-				<line>
-					<reportElement key="line-17" x="375" y="3" width="1" height="17" forecolor="#FFFFFF" uuid="b0767026-d2aa-4421-bdd7-d62f579efae0"/>
-				</line>
-				<line>
-					<reportElement key="line-19" x="200" y="3" width="1" height="17" forecolor="#FFFFFF" uuid="1a769af8-e01f-4e1e-85a6-9a2857dea9aa"/>
-				</line>
-				<line>
-					<reportElement key="line-20" x="475" y="3" width="1" height="17" forecolor="#FFFFFF" uuid="032e31fa-3f73-4457-80b5-f5f8b9d62fcb"/>
-				</line>
-				<line>
-					<reportElement key="line-21" x="65" y="3" width="1" height="17" forecolor="#FFFFFF" uuid="752e3981-d30d-4bd9-b026-ccbd0851ede4"/>
-				</line>
+				</element>
+				<element kind="line" uuid="aa44e8f3-1484-4df5-a9b3-e9369c1c9763" key="line-14" x="295" y="3" width="1" height="17" forecolor="#FFFFFF"/>
+				<element kind="line" uuid="9796c714-76d9-4d67-a63c-3edf494d80fa" key="line-15" x="0" y="3" width="1" height="17" forecolor="#FFFFFF"/>
+				<element kind="line" uuid="6bbc3afc-1ac2-40c0-843b-745549c8e01f" key="line-16" x="235" y="3" width="1" height="17" forecolor="#FFFFFF"/>
+				<element kind="line" uuid="b0767026-d2aa-4421-bdd7-d62f579efae0" key="line-17" x="375" y="3" width="1" height="17" forecolor="#FFFFFF"/>
+				<element kind="line" uuid="1a769af8-e01f-4e1e-85a6-9a2857dea9aa" key="line-19" x="200" y="3" width="1" height="17" forecolor="#FFFFFF"/>
+				<element kind="line" uuid="032e31fa-3f73-4457-80b5-f5f8b9d62fcb" key="line-20" x="475" y="3" width="1" height="17" forecolor="#FFFFFF"/>
+				<element kind="line" uuid="752e3981-d30d-4bd9-b026-ccbd0851ede4" key="line-21" x="65" y="3" width="1" height="17" forecolor="#FFFFFF"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<frame>
-				<reportElement key="frame-1" style="Detail_Line" x="0" y="0" width="475" height="16" uuid="611c983e-2242-453c-892c-25a866e8a440"/>
-				<box>
+			<element kind="frame" uuid="611c983e-2242-453c-892c-25a866e8a440" key="frame-1" x="0" y="0" width="475" height="16" style="Detail_Line">
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-			</frame>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="235" y="0" width="60" height="16" forecolor="#000000" uuid="977b77d2-f530-4632-9900-422477fa14fb"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="977b77d2-f530-4632-9900-422477fa14fb" key="textField" x="235" y="0" width="60" height="16" forecolor="#000000" fontSize="8.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{QUANTITY}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITY}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QUANTITY}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITY}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="default" x="200" y="0" width="35" height="16" forecolor="#000000" uuid="699b8779-9d55-4006-bf5a-71ffc579bcac"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="699b8779-9d55-4006-bf5a-71ffc579bcac" key="textField" x="200" y="0" width="35" height="16" forecolor="#000000" fontSize="8.0" pattern="" blankWhenNull="true" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" vTextAlign="Middle" style="default">
+				<expression><![CDATA[$F{UOM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{UOM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="default" x="65" y="0" width="135" height="16" forecolor="#000000" uuid="75d3bd6a-4d21-429c-81b0-13227b1527b8"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="75d3bd6a-4d21-429c-81b0-13227b1527b8" key="textField" x="65" y="0" width="135" height="16" forecolor="#000000" fontSize="8.0" pattern="" blankWhenNull="true" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" vTextAlign="Middle" style="default">
+				<expression><![CDATA[$F{PRODUCT_NAME}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRODUCT_NAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="295" y="0" width="80" height="16" forecolor="#000000" uuid="cc0ec2d7-3466-4522-b498-e9ba9150fe78"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="cc0ec2d7-3466-4522-b498-e9ba9150fe78" key="textField" x="295" y="0" width="80" height="16" forecolor="#000000" fontSize="8.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}).toString():new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}).toString():new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="375" y="0" width="100" height="16" forecolor="#000000" uuid="101a709d-69d6-488c-9aa6-a2f743ded6d1"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="101a709d-69d6-488c-9aa6-a2f743ded6d1" key="textField" x="375" y="0" width="100" height="16" forecolor="#000000" fontSize="8.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}) : new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}) : new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="16" uuid="8b05061b-1dce-4cf3-9cf8-3658821be67a"/>
-			</line>
-			<line>
-				<reportElement key="line-3" stretchType="RelativeToBandHeight" x="200" y="0" width="1" height="16" uuid="7880a3ec-7dc5-42bd-a72a-8ec75e5d3a58"/>
-			</line>
-			<line>
-				<reportElement key="line-4" stretchType="RelativeToBandHeight" x="235" y="0" width="1" height="16" uuid="442ea37d-34f2-4d8b-bcbd-3d6a46b4234f"/>
-			</line>
-			<line>
-				<reportElement key="line-5" stretchType="RelativeToBandHeight" x="295" y="0" width="1" height="16" uuid="f9599f42-8281-4b75-9fff-0c9b04882ec9"/>
-			</line>
-			<line>
-				<reportElement key="line-7" stretchType="RelativeToBandHeight" x="375" y="0" width="1" height="16" uuid="3571c6d2-bd3e-451e-a513-3ee3d28d451c"/>
-			</line>
-			<line>
-				<reportElement key="line-8" stretchType="RelativeToBandHeight" x="475" y="0" width="1" height="16" uuid="5a41f08e-8086-4163-85f3-86603a6ed679"/>
-			</line>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-6" style="default" x="1" y="0" width="65" height="16" uuid="ac6ae038-2b41-4490-ade3-e478aff7f0f6"/>
-				<textElement verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{VALUE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-22" stretchType="RelativeToBandHeight" x="65" y="0" width="1" height="16" uuid="02d42347-8edf-4533-8fea-e1c7ccf4e55d"/>
-			</line>
+			</element>
+			<element kind="line" uuid="8b05061b-1dce-4cf3-9cf8-3658821be67a" key="line-2" stretchType="ContainerHeight" x="0" y="0" width="1" height="16"/>
+			<element kind="line" uuid="7880a3ec-7dc5-42bd-a72a-8ec75e5d3a58" key="line-3" stretchType="ContainerHeight" x="200" y="0" width="1" height="16"/>
+			<element kind="line" uuid="442ea37d-34f2-4d8b-bcbd-3d6a46b4234f" key="line-4" stretchType="ContainerHeight" x="235" y="0" width="1" height="16"/>
+			<element kind="line" uuid="f9599f42-8281-4b75-9fff-0c9b04882ec9" key="line-5" stretchType="ContainerHeight" x="295" y="0" width="1" height="16"/>
+			<element kind="line" uuid="3571c6d2-bd3e-451e-a513-3ee3d28d451c" key="line-7" stretchType="ContainerHeight" x="375" y="0" width="1" height="16"/>
+			<element kind="line" uuid="5a41f08e-8086-4163-85f3-86603a6ed679" key="line-8" stretchType="ContainerHeight" x="475" y="0" width="1" height="16"/>
+			<element kind="textField" uuid="ac6ae038-2b41-4490-ade3-e478aff7f0f6" key="textField-6" x="1" y="0" width="65" height="16" fontSize="8.0" blankWhenNull="false" vTextAlign="Middle" style="default">
+				<expression><![CDATA[$F{VALUE}]]></expression>
+			</element>
+			<element kind="line" uuid="02d42347-8edf-4533-8fea-e1c7ccf4e55d" key="line-22" stretchType="ContainerHeight" x="65" y="0" width="1" height="16"/>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band height="18" splitType="Stretch">
-			<line>
-				<reportElement key="line-1" x="0" y="0" width="476" height="1" uuid="bea2622f-3625-43aa-b1aa-12a1d61879c6"/>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-1" style="Total_Gray" x="397" y="2" width="78" height="16" uuid="989cba52-0fda-46d4-876c-bd9d93728c6c"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($V{SUM_LINENETAMT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-10" x="318" y="3" width="1" height="15" uuid="6d0721b8-e10d-442f-86f9-6770ffdae6e5"/>
-			</line>
-			<line>
-				<reportElement key="line-11" x="318" y="17" width="158" height="1" uuid="7ebd2972-0ae3-42ca-8e68-808a0875b4a9"/>
-			</line>
-			<line>
-				<reportElement key="line-12" x="318" y="2" width="158" height="1" uuid="5d7cf833-bbab-4c72-aed1-80bc9779de15"/>
-			</line>
-			<line>
-				<reportElement key="line-13" x="475" y="3" width="1" height="15" uuid="6d92c7bf-013d-4119-8f7b-f643c70d3211"/>
-			</line>
-			<staticText>
-				<reportElement key="staticText-5" x="319" y="2" width="78" height="16" uuid="5bce7e40-a895-4948-ac8f-c72af70ece38"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Left" verticalAlignment="Middle"/>
-				<text><![CDATA[TOTAL]]></text>
-			</staticText>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary height="18" splitType="Stretch">
+		<element kind="line" uuid="bea2622f-3625-43aa-b1aa-12a1d61879c6" key="line-1" x="0" y="0" width="476" height="1"/>
+		<element kind="textField" uuid="989cba52-0fda-46d4-876c-bd9d93728c6c" key="textField-1" x="397" y="2" width="78" height="16" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Gray">
+			<expression><![CDATA[($V{SUM_LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($V{SUM_LINENETAMT}):new String(" ")]]></expression>
+			<box style="Total_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="6d0721b8-e10d-442f-86f9-6770ffdae6e5" key="line-10" x="318" y="3" width="1" height="15"/>
+		<element kind="line" uuid="7ebd2972-0ae3-42ca-8e68-808a0875b4a9" key="line-11" x="318" y="17" width="158" height="1"/>
+		<element kind="line" uuid="5d7cf833-bbab-4c72-aed1-80bc9779de15" key="line-12" x="318" y="2" width="158" height="1"/>
+		<element kind="line" uuid="6d92c7bf-013d-4119-8f7b-f643c70d3211" key="line-13" x="475" y="3" width="1" height="15"/>
+		<element kind="staticText" uuid="5bce7e40-a895-4948-ac8f-c72af70ece38" key="staticText-5" x="319" y="2" width="78" height="16" hTextAlign="Left" vTextAlign="Middle">
+			<text><![CDATA[TOTAL]]></text>
+			<box leftPadding="2"/>
+		</element>
 	</summary>
 </jasperReport>

--- a/src/org/openbravo/erpReports/C_OrderLinesTaxIncludedJR_new.jrxml
+++ b/src/org/openbravo/erpReports/C_OrderLinesTaxIncludedJR_new.jrxml
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="C_OrderLinesTaxIncludedJR_new" pageWidth="477" pageHeight="802" columnWidth="477" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="3a786c24-2240-4fab-ba17-60a530e8f3d1">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="C_OrderLinesTaxIncludedJR_new" language="java" pageWidth="477" pageHeight="802" columnWidth="477" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="3a786c24-2240-4fab-ba17-60a530e8f3d1">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.5"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
@@ -22,11 +21,10 @@
 	<parameter name="C_ORDER_ID" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'1000069'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
 	<parameter name="ISTAXINCLUDED" class="java.lang.String"/>
-	<queryString>
-		<![CDATA[SELECT 1 AS ISBOM, C_ORDERLINE.LINE, COALESCE(M_PRODUCT.NAME, C_ORDERLINE.DESCRIPTION) AS PRODUCT_NAME, C_ORDERLINE.QTYORDERED AS QUANTITY,
+	<query language="sql"><![CDATA[SELECT 1 AS ISBOM, C_ORDERLINE.LINE, COALESCE(M_PRODUCT.NAME, C_ORDERLINE.DESCRIPTION) AS PRODUCT_NAME, C_ORDERLINE.QTYORDERED AS QUANTITY,
         TO_CHAR(C_UOM.NAME) AS UOM,  CASE WHEN $P{ISTAXINCLUDED} = 'N' THEN C_ORDERLINE.PRICEACTUAL ELSE C_ORDERLINE.GROSS_UNIT_PRICE END as PRICEACTUAL ,
         TO_NUMBER(NULL) AS BASE, CASE WHEN $P{ISTAXINCLUDED} = 'N' THEN C_ORDERLINE.LINENETAMT ELSE C_ORDERLINE.LINE_GROSS_AMOUNT END as LINENETAMT,
         TO_NUMBER(NULL) AS TAXLINE,
@@ -58,8 +56,7 @@
             AND C_ORDERTAX.TAXAMT <> 0
             AND C_ORDER.C_ORDER_ID = $P{C_ORDER_ID}
             AND $P{ISTAXINCLUDED} = 'N'
-        ORDER BY LINE,ISBOM, TAXLINE]]>
-	</queryString>
+        ORDER BY LINE,ISBOM, TAXLINE]]></query>
 	<field name="ISBOM" class="java.lang.Integer"/>
 	<field name="LINE" class="java.math.BigDecimal"/>
 	<field name="PRODUCT_NAME" class="java.lang.String"/>
@@ -71,229 +68,146 @@
 	<field name="TAXLINE" class="java.math.BigDecimal"/>
 	<field name="STATUS" class="java.lang.String"/>
 	<field name="VALUE" class="java.lang.String"/>
-	<variable name="SUM_LINENETAMT" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{LINENETAMT}]]></variableExpression>
+	<variable name="SUM_LINENETAMT" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{LINENETAMT}]]></expression>
 	</variable>
-	<group name="C_Order_Id" isResetPageNumber="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="C_Order_Id" resetPageNumber="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="25" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="default" mode="Transparent" x="235" y="2" width="60" height="22" forecolor="#7E7979" uuid="f80fb70c-26aa-4db7-b30b-bd95e89d5a8b"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="9" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" isPdfEmbedded="false"/>
-					</textElement>
+				<element kind="staticText" uuid="f80fb70c-26aa-4db7-b30b-bd95e89d5a8b" key="staticText" mode="Transparent" x="235" y="2" width="60" height="22" forecolor="#7E7979" fontName="DejaVu Sans" fontSize="9.0" pdfFontName="Helvetica" pdfEmbedded="false" underline="false" strikeThrough="false" bold="true" italic="false" hTextAlign="Right" vTextAlign="Middle" style="default">
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText" style="default" mode="Transparent" x="200" y="2" width="35" height="22" forecolor="#7E7979" uuid="f4a85f53-58dd-46ac-90cb-62864dfa7cea"/>
-					<box leftPadding="2" rightPadding="2">
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="9" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="f4a85f53-58dd-46ac-90cb-62864dfa7cea" key="staticText" mode="Transparent" x="200" y="2" width="35" height="22" forecolor="#7E7979" fontName="DejaVu Sans" fontSize="9.0" pdfEmbedded="false" underline="false" strikeThrough="false" bold="true" italic="false" vTextAlign="Middle" style="default">
 					<text><![CDATA[Uom]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText" style="default" mode="Transparent" x="65" y="2" width="135" height="22" forecolor="#7E7979" uuid="73cd9602-a609-4462-9c08-8661ed2468a6"/>
-					<box leftPadding="2" rightPadding="2">
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="9" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="73cd9602-a609-4462-9c08-8661ed2468a6" key="staticText" mode="Transparent" x="65" y="2" width="135" height="22" forecolor="#7E7979" fontName="DejaVu Sans" fontSize="9.0" pdfEmbedded="false" underline="false" strikeThrough="false" bold="true" italic="false" vTextAlign="Middle" style="default">
 					<text><![CDATA[Product Name]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-1" style="default" mode="Transparent" x="1" y="2" width="65" height="22" forecolor="#7E7979" uuid="2352d745-7f41-4099-85dd-117d8ae44add"/>
-					<textElement verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="9" isBold="true"/>
-					</textElement>
+					<box leftPadding="2" rightPadding="2" style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="2352d745-7f41-4099-85dd-117d8ae44add" key="staticText-1" mode="Transparent" x="1" y="2" width="65" height="22" forecolor="#7E7979" fontName="DejaVu Sans" fontSize="9.0" bold="true" vTextAlign="Middle" style="default">
 					<text><![CDATA[Reference]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-2" style="default" mode="Transparent" x="295" y="2" width="80" height="22" forecolor="#7E7979" uuid="9b89a5f8-ff30-4096-8d8f-8d654ecf1e99"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="9" isBold="true" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="9b89a5f8-ff30-4096-8d8f-8d654ecf1e99" key="staticText-2" mode="Transparent" x="295" y="2" width="80" height="22" forecolor="#7E7979" fontName="DejaVu Sans" fontSize="9.0" pdfFontName="Helvetica" bold="true" hTextAlign="Right" vTextAlign="Middle" style="default">
 					<text><![CDATA[Price]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-4" style="default" mode="Transparent" x="375" y="2" width="100" height="22" forecolor="#7E7979" uuid="35f8d80d-3615-4957-bb27-a80a70ed9ac4"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="9" isBold="true" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="35f8d80d-3615-4957-bb27-a80a70ed9ac4" key="staticText-4" mode="Transparent" x="375" y="2" width="100" height="22" forecolor="#7E7979" fontName="DejaVu Sans" fontSize="9.0" pdfFontName="Helvetica" bold="true" hTextAlign="Right" vTextAlign="Middle" style="default">
 					<text><![CDATA[Total]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-1" x="0" y="23" width="477" height="1" forecolor="#CCCCCC" uuid="caef4620-adc1-47d7-82db-63381192a4e0"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Double" lineColor="#A3A1A1"/>
-					</graphicElement>
-				</line>
+				</element>
+				<element kind="line" uuid="caef4620-adc1-47d7-82db-63381192a4e0" key="line-1" x="0" y="23" width="477" height="1" forecolor="#CCCCCC">
+					<pen lineWidth="2.0" lineStyle="Double" lineColor="#A3A1A1"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="22" splitType="Stretch">
-			<frame>
-				<reportElement key="frame-1" style="default" x="0" y="0" width="475" height="21" uuid="3bfcde94-bb5d-4124-983d-63d442859b7e"/>
-				<box>
+			<element kind="frame" uuid="3bfcde94-bb5d-4124-983d-63d442859b7e" key="frame-1" x="0" y="0" width="475" height="21" style="default">
+				<box style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-			</frame>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="235" y="0" width="60" height="21" forecolor="#000000" uuid="4a9c203a-298c-4825-9648-50dee3f74b15"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="4a9c203a-298c-4825-9648-50dee3f74b15" key="textField" x="235" y="0" width="60" height="21" forecolor="#000000" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{QUANTITY}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITY}):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QUANTITY}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITY}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="default" x="200" y="0" width="35" height="21" forecolor="#000000" uuid="618bc2ae-9f71-453d-b641-f3d08c18d19b"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="618bc2ae-9f71-453d-b641-f3d08c18d19b" key="textField" x="200" y="0" width="35" height="21" forecolor="#000000" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="true" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" vTextAlign="Middle" style="default">
+				<expression><![CDATA[$F{UOM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{UOM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="default" x="65" y="0" width="135" height="21" forecolor="#000000" uuid="d89c1a08-ef39-4514-b3d9-343ae4fb9496"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="d89c1a08-ef39-4514-b3d9-343ae4fb9496" key="textField" x="65" y="0" width="135" height="21" forecolor="#000000" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="true" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" vTextAlign="Middle" style="default">
+				<expression><![CDATA[$F{PRODUCT_NAME}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRODUCT_NAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="295" y="0" width="80" height="21" forecolor="#000000" uuid="55e7ca80-0f3d-4acd-bc46-fbe8e9632de0"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="55e7ca80-0f3d-4acd-bc46-fbe8e9632de0" key="textField" x="295" y="0" width="80" height="21" forecolor="#000000" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}).toString():new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}).toString():new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="375" y="0" width="100" height="21" forecolor="#000000" uuid="c7ad061c-31d8-45a3-8dc3-30b23f4a9383"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="c7ad061c-31d8-45a3-8dc3-30b23f4a9383" key="textField" x="375" y="0" width="100" height="21" forecolor="#000000" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}) : new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}) : new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="1" y="0" width="65" height="21" uuid="6202e7f7-574e-45ae-a8d8-52e65970bb55"/>
-				<textElement verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{VALUE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="21" width="477" height="1" forecolor="#CCCCCC" uuid="9935d04e-6bea-41e9-8747-c79f089ad172"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
-				</graphicElement>
-			</line>
+			</element>
+			<element kind="textField" uuid="6202e7f7-574e-45ae-a8d8-52e65970bb55" key="textField" x="1" y="0" width="65" height="21" fontName="DejaVu Sans" fontSize="8.0" blankWhenNull="false" vTextAlign="Middle" style="default">
+				<expression><![CDATA[$F{VALUE}]]></expression>
+			</element>
+			<element kind="line" uuid="9935d04e-6bea-41e9-8747-c79f089ad172" key="line-1" x="0" y="21" width="477" height="1" forecolor="#CCCCCC">
+				<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band height="39" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-1" style="Total_Gray" x="397" y="16" width="78" height="21" backcolor="#FFFFFF" uuid="6440e327-a474-4b45-8d34-63baec5107a5"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="10" isBold="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($V{SUM_LINENETAMT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-11" x="343" y="38" width="133" height="1" forecolor="#CCCCCC" uuid="85028f43-c1e4-4381-beec-ede4b8c0cbee"/>
-				<graphicElement>
-					<pen lineWidth="2.0"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-12" x="343" y="16" width="133" height="1" forecolor="#CCCCCC" uuid="dded8ec0-de00-490c-a767-969c28e06fd8"/>
-				<graphicElement>
-					<pen lineWidth="2.0"/>
-				</graphicElement>
-			</line>
-			<staticText>
-				<reportElement key="staticText-5" x="343" y="16" width="54" height="21" forecolor="#7E7979" uuid="d284e0fa-91e5-438b-ae4f-3b40f79e30a4"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="12" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Total]]></text>
-			</staticText>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary height="39" splitType="Stretch">
+		<element kind="textField" uuid="6440e327-a474-4b45-8d34-63baec5107a5" key="textField-1" x="397" y="16" width="78" height="21" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="10.0" pattern="" blankWhenNull="false" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Total_Gray">
+			<expression><![CDATA[($V{SUM_LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($V{SUM_LINENETAMT}):new String(" ")]]></expression>
+			<box style="Total_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="85028f43-c1e4-4381-beec-ede4b8c0cbee" key="line-11" x="343" y="38" width="133" height="1" forecolor="#CCCCCC">
+			<pen lineWidth="2.0"/>
+		</element>
+		<element kind="line" uuid="dded8ec0-de00-490c-a767-969c28e06fd8" key="line-12" x="343" y="16" width="133" height="1" forecolor="#CCCCCC">
+			<pen lineWidth="2.0"/>
+		</element>
+		<element kind="staticText" uuid="d284e0fa-91e5-438b-ae4f-3b40f79e30a4" key="staticText-5" x="343" y="16" width="54" height="21" forecolor="#7E7979" fontName="DejaVu Sans" fontSize="12.0" bold="true" hTextAlign="Left" vTextAlign="Middle">
+			<text><![CDATA[Total]]></text>
+			<box leftPadding="2"/>
+		</element>
 	</summary>
 </jasperReport>

--- a/src/org/openbravo/erpReports/C_QuotationJR.jrxml
+++ b/src/org/openbravo/erpReports/C_QuotationJR.jrxml
@@ -1,73 +1,71 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="C_OrderJR" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="e75eaaf1-7e11-4001-877a-b481cec96428">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="C_OrderJR" language="java" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="e75eaaf1-7e11-4001-877a-b481cec96428">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="193"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/opt/AppsOpenbravo/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["('1000000')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["('0')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="SUBREPORT_DIR" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{BASE_DESIGN} + "/org/openbravo/erpReports"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DOCUMENT_ID" class="java.lang.String" isForPrompting="false">
+	<parameter name="DOCUMENT_ID" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'1000069'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="SUBREP_C_OrderLinesJR" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="SUBREP_C_OrderLinesTaxIncludedJR" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="SUBREP_RptC_Order_TaxLines" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT C_ORDER.C_ORDER_ID, C_BPARTNER.NAME, L.ADDRESS1 ||
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="SUBREP_C_OrderLinesJR" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="SUBREP_C_OrderLinesTaxIncludedJR" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="SUBREP_RptC_Order_TaxLines" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<query language="sql"><![CDATA[SELECT C_ORDER.C_ORDER_ID, C_BPARTNER.NAME, L.ADDRESS1 ||
 (CASE WHEN (L.POSTAL||L.CITY||R.NAME) IS NOT NULL THEN (CHR(10)||L.POSTAL || (CASE WHEN L.POSTAL IS NOT NULL THEN (' - '||TO_CHAR(L.CITY)) END) ||
 (CASE WHEN R.NAME IS NOT NULL THEN (' ('||TO_CHAR(R.NAME)|| ')') END)) END) AS ADDRESS1,
 C_BPARTNER_LOCATION.PHONE,C_BPARTNER_LOCATION.FAX,C_BPARTNER.URL,
@@ -104,8 +102,7 @@ AND C_ORDER.AD_CLIENT_ID = AD_CLIENT.AD_CLIENT_ID
 AND C_ORDER.C_ORDER_ID IN ($P{DOCUMENT_ID})
 AND C_ORDER.DELIVERYRULE = DELIVERYRULE.VALUE
 AND C_ORDER.C_PAYMENTTERM_ID = PAYMENTTERM.C_PAYMENTTERM_ID
-AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]>
-	</queryString>
+AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]></query>
 	<field name="C_ORDER_ID" class="java.lang.String"/>
 	<field name="NAME" class="java.lang.String"/>
 	<field name="ADDRESS1" class="java.lang.String"/>
@@ -133,8 +130,8 @@ AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]>
 	<field name="ISTAXINCLUDED" class="java.lang.String"/>
 	<variable name="SHOWLOGO" class="java.lang.String"/>
 	<variable name="SHOWCOMPANYDATA" class="java.lang.String"/>
-	<group name="PrintLarge" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintLarge" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="120" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{HEADERMARGIN}.equalsIgnoreCase("large"))]]></printWhenExpression>
@@ -144,8 +141,8 @@ AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="PrintMedium" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintMedium" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="80" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{HEADERMARGIN}.equalsIgnoreCase("medium"))]]></printWhenExpression>
@@ -155,8 +152,8 @@ AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="PrintSmall" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintSmall" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="50" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{HEADERMARGIN}.equalsIgnoreCase("small"))]]></printWhenExpression>
@@ -166,279 +163,196 @@ AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="C_ORDER_ID" isStartNewPage="true" isResetPageNumber="true">
-		<groupExpression><![CDATA[$F{C_ORDER_ID}]]></groupExpression>
+	<group name="C_ORDER_ID" startNewPage="true" resetPageNumber="true">
+		<expression><![CDATA[$F{C_ORDER_ID}]]></expression>
 		<groupHeader>
 			<band height="255" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText-6" style="Group_Data_Label" x="0" y="214" width="150" height="18" forecolor="#999999" backcolor="#FFFFFF" uuid="00b10152-1898-4b01-9d17-3eca394e3f9d"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Left">
-						<font size="11"/>
-					</textElement>
+				<element kind="staticText" uuid="00b10152-1898-4b01-9d17-3eca394e3f9d" key="staticText-6" x="0" y="214" width="150" height="18" forecolor="#999999" backcolor="#FFFFFF" fontSize="11.0" hTextAlign="Left" style="Group_Data_Label">
 					<text><![CDATA[Order Number]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-8" x="0" y="234" width="150" height="20" uuid="5c15aded-f732-4ee8-b22b-8b1e4c0bc573"/>
+					<box style="Group_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="5c15aded-f732-4ee8-b22b-8b1e4c0bc573" key="textField-8" x="0" y="234" width="150" height="20" blankWhenNull="false">
+					<expression><![CDATA[$F{ALBARAN}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{ALBARAN}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-1" x="1" y="233" width="475" height="1" uuid="f7093a94-4002-4a9d-a745-fd682de2c8fd"/>
-				</line>
-				<staticText>
-					<reportElement key="staticText-8" style="Group_Data_Label" x="397" y="214" width="80" height="18" forecolor="#999999" backcolor="#FFFFFF" uuid="6d8e73dc-1be5-41c8-a30b-e3cb0c1d3ca0"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="11" isBold="true" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="f7093a94-4002-4a9d-a745-fd682de2c8fd" key="line-1" x="1" y="233" width="475" height="1"/>
+				<element kind="staticText" uuid="6d8e73dc-1be5-41c8-a30b-e3cb0c1d3ca0" key="staticText-8" x="397" y="214" width="80" height="18" forecolor="#999999" backcolor="#FFFFFF" fontSize="11.0" pdfFontName="Helvetica" bold="true" hTextAlign="Right" style="Group_Data_Label">
 					<text><![CDATA[Date]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField" x="397" y="234" width="80" height="20" uuid="7600f792-f38a-4829-b56c-4787558ab8a9"/>
+					<box style="Group_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="7600f792-f38a-4829-b56c-4787558ab8a9" key="textField" x="397" y="234" width="80" height="20" blankWhenNull="false" hTextAlign="Right">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.applyCountryDateFormat($F{DATEORDERED},$F{ORGANIZATIONID})]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.applyCountryDateFormat($F{DATEORDERED},$F{ORGANIZATIONID})]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-16" x="121" y="168" width="275" height="55" forecolor="#FF0000" uuid="9b2d9db4-42bc-465f-823d-350cda133d45"/>
-					<textElement textAlignment="Justified" verticalAlignment="Middle">
-						<font size="36"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($F{STATUS}.compareTo("VO")==0) ? "VOIDED" : " ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-17" x="0" y="93" width="206" height="110" isPrintWhenDetailOverflows="true" uuid="976bd732-0719-4885-a8ee-310c6124bf4b"/>
-					<textElement verticalAlignment="Top"/>
-					<textFieldExpression><![CDATA[$F{NAME} + "\n" + $F{BP_DATA}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-20" x="251" y="93" width="232" height="42" isPrintWhenDetailOverflows="true" uuid="e3950c6a-6a33-4c72-9966-d16570607da6">
-						<printWhenExpression><![CDATA[new Boolean($F{SHOWCOMPANYDATA}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($F{LOCATION}==null ? $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" : $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" + $F{LOCATION})]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-11" style="Group_Data_Label" x="210" y="214" width="150" height="18" forecolor="#999999" backcolor="#FFFFFF" uuid="95dfd3f3-6b23-482c-8d07-c10ffc8d958c"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Top">
-						<font size="11" isBold="true" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="textField" uuid="9b2d9db4-42bc-465f-823d-350cda133d45" key="textField-16" x="121" y="168" width="275" height="55" forecolor="#FF0000" fontSize="36.0" blankWhenNull="false" hTextAlign="Justified" vTextAlign="Middle">
+					<expression><![CDATA[(($F{STATUS}.compareTo("VO")==0) ? "VOIDED" : " ")]]></expression>
+				</element>
+				<element kind="textField" uuid="976bd732-0719-4885-a8ee-310c6124bf4b" key="textField-17" x="0" y="93" width="206" height="110" blankWhenNull="false" printWhenDetailOverflows="true" vTextAlign="Top">
+					<expression><![CDATA[$F{NAME} + "\n" + $F{BP_DATA}]]></expression>
+				</element>
+				<element kind="textField" uuid="e3950c6a-6a33-4c72-9966-d16570607da6" key="textField-20" x="251" y="93" width="232" height="42" blankWhenNull="false" printWhenDetailOverflows="true" hTextAlign="Right">
+					<printWhenExpression><![CDATA[new Boolean($F{SHOWCOMPANYDATA}.equalsIgnoreCase("Y"))]]></printWhenExpression>
+					<expression><![CDATA[($F{LOCATION}==null ? $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" : $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" + $F{LOCATION})]]></expression>
+				</element>
+				<element kind="staticText" uuid="95dfd3f3-6b23-482c-8d07-c10ffc8d958c" key="staticText-11" x="210" y="214" width="150" height="18" forecolor="#999999" backcolor="#FFFFFF" fontSize="11.0" pdfFontName="Helvetica" bold="true" hTextAlign="Left" vTextAlign="Top" style="Group_Data_Label">
 					<text><![CDATA[Currency]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-24" x="210" y="234" width="150" height="20" uuid="7854e2a7-6499-4528-bac4-4425936ec0d6"/>
+					<box style="Group_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="7854e2a7-6499-4528-bac4-4425936ec0d6" key="textField-24" x="210" y="234" width="150" height="20" blankWhenNull="false">
+					<expression><![CDATA[$F{CURRENCY_ISO}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{CURRENCY_ISO}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-13" x="0" y="6" width="310" height="37" uuid="01b54847-991c-4085-bb20-35a990056abf">
-						<printWhenExpression><![CDATA[new Boolean($F{DOC_TYPE}.equalsIgnoreCase("Purchase Order Report template") == false)]]></printWhenExpression>
-					</reportElement>
-					<textElement>
-						<font size="26"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="01b54847-991c-4085-bb20-35a990056abf" key="staticText-13" x="0" y="6" width="310" height="37" fontSize="26.0">
+					<printWhenExpression><![CDATA[new Boolean($F{DOC_TYPE}.equalsIgnoreCase("Purchase Order Report template") == false)]]></printWhenExpression>
 					<text><![CDATA[SALES QUOTATION]]></text>
-				</staticText>
-				<image scaleImage="RetainShape" hAlign="Right" vAlign="Top" isUsingCache="true">
-					<reportElement key="image-1" x="313" y="0" width="170" height="91" uuid="9dd4845f-3519-434a-bac0-665eb1b5e0e4">
-						<printWhenExpression><![CDATA[new Boolean($F{SHOWLOGO}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<imageExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylegal", $F{ORGANIZATIONID})]]></imageExpression>
-				</image>
+				</element>
+				<element kind="image" uuid="9dd4845f-3519-434a-bac0-665eb1b5e0e4" key="image-1" x="313" y="0" width="170" height="91" scaleImage="RetainShape" usingCache="true" hImageAlign="Right" vImageAlign="Top">
+					<printWhenExpression><![CDATA[new Boolean($F{SHOWLOGO}.equalsIgnoreCase("Y"))]]></printWhenExpression>
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylegal", $F{ORGANIZATIONID})]]></expression>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="45" splitType="Stretch">
-			<subreport isUsingCache="false">
-				<reportElement key="subreport-1" x="0" y="5" width="482" height="36" uuid="51d6cb6a-a3ac-43e9-bd68-98b56a2281b8">
-					<printWhenExpression><![CDATA[$F{ISTAXINCLUDED}.equals("N")]]></printWhenExpression>
-				</reportElement>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LOCALE">
-					<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="C_ORDER_ID">
-					<subreportParameterExpression><![CDATA[$F{C_ORDER_ID}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="ISTAXINCLUDED">
-					<subreportParameterExpression><![CDATA[$F{ISTAXINCLUDED}]]></subreportParameterExpression>
-				</subreportParameter>
+			<element kind="subreport" uuid="51d6cb6a-a3ac-43e9-bd68-98b56a2281b8" key="subreport-1" x="0" y="5" width="482" height="36" usingCache="false">
+				<printWhenExpression><![CDATA[$F{ISTAXINCLUDED}.equals("N")]]></printWhenExpression>
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{SUBREP_C_OrderLinesJR}]]></subreportExpression>
-			</subreport>
-			<subreport isUsingCache="false">
-				<reportElement key="subreport-1" x="0" y="5" width="482" height="36" uuid="651e3bb0-902e-4030-b832-25091b43b101">
-					<printWhenExpression><![CDATA[$F{ISTAXINCLUDED}.equals("Y")]]></printWhenExpression>
-				</reportElement>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LOCALE">
-					<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="C_ORDER_ID">
-					<subreportParameterExpression><![CDATA[$F{C_ORDER_ID}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="ISTAXINCLUDED">
-					<subreportParameterExpression><![CDATA[$F{ISTAXINCLUDED}]]></subreportParameterExpression>
-				</subreportParameter>
+				<expression><![CDATA[$P{SUBREP_C_OrderLinesJR}]]></expression>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></expression>
+				</parameter>
+				<parameter name="LOCALE">
+					<expression><![CDATA[$P{LOCALE}]]></expression>
+				</parameter>
+				<parameter name="C_ORDER_ID">
+					<expression><![CDATA[$F{C_ORDER_ID}]]></expression>
+				</parameter>
+				<parameter name="ISTAXINCLUDED">
+					<expression><![CDATA[$F{ISTAXINCLUDED}]]></expression>
+				</parameter>
+			</element>
+			<element kind="subreport" uuid="651e3bb0-902e-4030-b832-25091b43b101" key="subreport-1" x="0" y="5" width="482" height="36" usingCache="false">
+				<printWhenExpression><![CDATA[$F{ISTAXINCLUDED}.equals("Y")]]></printWhenExpression>
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{SUBREP_C_OrderLinesTaxIncludedJR}]]></subreportExpression>
-			</subreport>
+				<expression><![CDATA[$P{SUBREP_C_OrderLinesTaxIncludedJR}]]></expression>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></expression>
+				</parameter>
+				<parameter name="LOCALE">
+					<expression><![CDATA[$P{LOCALE}]]></expression>
+				</parameter>
+				<parameter name="C_ORDER_ID">
+					<expression><![CDATA[$F{C_ORDER_ID}]]></expression>
+				</parameter>
+				<parameter name="ISTAXINCLUDED">
+					<expression><![CDATA[$F{ISTAXINCLUDED}]]></expression>
+				</parameter>
+			</element>
 		</band>
 		<band height="27">
-			<subreport isUsingCache="false">
-				<reportElement key="subreport-1" x="0" y="4" width="482" height="18" uuid="19e9a307-8305-4bd1-8ace-cc83bc5b3ff8">
-					<printWhenExpression><![CDATA[$F{ISTAXINCLUDED}.equals("Y")]]></printWhenExpression>
-				</reportElement>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LOCALE">
-					<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="C_ORDER_ID">
-					<subreportParameterExpression><![CDATA[$F{C_ORDER_ID}]]></subreportParameterExpression>
-				</subreportParameter>
+			<element kind="subreport" uuid="19e9a307-8305-4bd1-8ace-cc83bc5b3ff8" key="subreport-1" x="0" y="4" width="482" height="18" usingCache="false">
+				<printWhenExpression><![CDATA[$F{ISTAXINCLUDED}.equals("Y")]]></printWhenExpression>
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{SUBREP_RptC_Order_TaxLines}]]></subreportExpression>
-			</subreport>
+				<expression><![CDATA[$P{SUBREP_RptC_Order_TaxLines}]]></expression>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></expression>
+				</parameter>
+				<parameter name="LOCALE">
+					<expression><![CDATA[$P{LOCALE}]]></expression>
+				</parameter>
+				<parameter name="C_ORDER_ID">
+					<expression><![CDATA[$F{C_ORDER_ID}]]></expression>
+				</parameter>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="90" splitType="Stretch">
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-9" x="439" y="64" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="6744801a-e359-467f-951f-b06b3cf0f6af"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-10" x="340" y="64" width="95" height="19" uuid="aa0547da-3026-436e-a820-46698cedff39"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-2" x="0" y="61" width="483" height="1" uuid="01b38c80-f92e-4634-ad61-60492564f0fb"/>
-				<graphicElement>
-					<pen lineWidth="0.25" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<staticText>
-				<reportElement key="staticText-9" style="default" x="295" y="7" width="89" height="18" forecolor="#999999" uuid="a95b4526-0caf-4da7-ba5a-1c2171205fcd"/>
-				<box leftPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left">
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Payment Terms]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-10" style="default" x="-3" y="7" width="79" height="18" forecolor="#999999" uuid="fa9eeb72-2392-4ca9-a44f-03cea458c1d5"/>
-				<box leftPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Delivery Term]]></text>
-			</staticText>
-			<line>
-				<reportElement key="line-3" style="default" x="0" y="25" width="483" height="1" uuid="d98e53ca-7277-4789-a1f2-eccf3dd9509d"/>
-			</line>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-21" x="0" y="28" width="79" height="18" uuid="f020e1a1-56c0-477f-bd92-d24e3b382081"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DELIVERYTERM}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-22" x="298" y="28" width="89" height="18" uuid="1421bb6e-6a96-4dc7-929d-2a6c91e6877c"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PAYMENTTERM}]]></textFieldExpression>
-			</textField>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="90" splitType="Stretch">
+		<element kind="textField" uuid="6744801a-e359-467f-951f-b06b3cf0f6af" key="textField-9" x="439" y="64" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="8.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="aa0547da-3026-436e-a820-46698cedff39" key="textField-10" x="340" y="64" width="95" height="19" fontName="Helvetica" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="01b38c80-f92e-4634-ad61-60492564f0fb" key="line-2" x="0" y="61" width="483" height="1">
+			<pen lineWidth="0.25" lineStyle="Solid"/>
+		</element>
+		<element kind="staticText" uuid="a95b4526-0caf-4da7-ba5a-1c2171205fcd" key="staticText-9" x="295" y="7" width="89" height="18" forecolor="#999999" fontSize="8.0" hTextAlign="Left" style="default">
+			<text><![CDATA[Payment Terms]]></text>
+			<box leftPadding="2" style="default">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="fa9eeb72-2392-4ca9-a44f-03cea458c1d5" key="staticText-10" x="-3" y="7" width="79" height="18" forecolor="#999999" fontSize="8.0" style="default">
+			<text><![CDATA[Delivery Term]]></text>
+			<box leftPadding="2" style="default">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="d98e53ca-7277-4789-a1f2-eccf3dd9509d" key="line-3" x="0" y="25" width="483" height="1" style="default"/>
+		<element kind="textField" uuid="f020e1a1-56c0-477f-bd92-d24e3b382081" key="textField-21" x="0" y="28" width="79" height="18" fontSize="8.0" blankWhenNull="false">
+			<expression><![CDATA[$F{DELIVERYTERM}]]></expression>
+		</element>
+		<element kind="textField" uuid="1421bb6e-6a96-4dc7-929d-2a6c91e6877c" key="textField-22" x="298" y="28" width="89" height="18" fontSize="8.0" blankWhenNull="false">
+			<expression><![CDATA[$F{PAYMENTTERM}]]></expression>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/C_RMOrderJR.jrxml
+++ b/src/org/openbravo/erpReports/C_RMOrderJR.jrxml
@@ -1,68 +1,66 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="C_OrderJR" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="ac503a95-16da-4471-91ac-4e3c6e42c41b">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="C_OrderJR" language="java" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="ac503a95-16da-4471-91ac-4e3c6e42c41b">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/opt/AppsOpenbravo/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["('1000000')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["('0')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="SUBREPORT_DIR" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{BASE_DESIGN} + "/org/openbravo/erpReports"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DOCUMENT_ID" class="java.lang.String" isForPrompting="false">
+	<parameter name="DOCUMENT_ID" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'1000069'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="SUBREP_C_RMOrderLinesJR" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT C_ORDER.C_ORDER_ID, C_BPARTNER.NAME, L.ADDRESS1 ||
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="SUBREP_C_RMOrderLinesJR" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<query language="sql"><![CDATA[SELECT C_ORDER.C_ORDER_ID, C_BPARTNER.NAME, L.ADDRESS1 ||
 (CASE WHEN (L.POSTAL||L.CITY||R.NAME) IS NOT NULL THEN (CHR(10)||L.POSTAL || (CASE WHEN L.POSTAL IS NOT NULL THEN (' - '||TO_CHAR(L.CITY)) END) ||
 (CASE WHEN R.NAME IS NOT NULL THEN (' ('||TO_CHAR(R.NAME)|| ')') END)) END) AS ADDRESS1,
 C_BPARTNER_LOCATION.PHONE,C_BPARTNER_LOCATION.FAX,C_BPARTNER.URL,
@@ -98,8 +96,7 @@ AND C_ORDER.AD_CLIENT_ID = AD_CLIENT.AD_CLIENT_ID
 AND C_ORDER.C_ORDER_ID IN ($P{DOCUMENT_ID})
 AND C_ORDER.DELIVERYRULE = DELIVERYRULE.VALUE
 AND C_ORDER.C_PAYMENTTERM_ID = PAYMENTTERM.C_PAYMENTTERM_ID
-AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]>
-	</queryString>
+AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]></query>
 	<field name="C_ORDER_ID" class="java.lang.String"/>
 	<field name="NAME" class="java.lang.String"/>
 	<field name="ADDRESS1" class="java.lang.String"/>
@@ -126,8 +123,8 @@ AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]>
 	<field name="CURRENCY_ISO" class="java.lang.String"/>
 	<field name="ISSOTRX" class="java.lang.String"/>
 	<field name="POREFERENCE" class="java.lang.String"/>
-	<group name="PrintLarge" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintLarge" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="120" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{HEADERMARGIN}.equalsIgnoreCase("large"))]]></printWhenExpression>
@@ -137,8 +134,8 @@ AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="PrintMedium" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintMedium" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="80" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{HEADERMARGIN}.equalsIgnoreCase("medium"))]]></printWhenExpression>
@@ -148,8 +145,8 @@ AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="PrintSmall" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintSmall" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="50" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{HEADERMARGIN}.equalsIgnoreCase("small"))]]></printWhenExpression>
@@ -159,273 +156,183 @@ AND C_CURRENCY.C_CURRENCY_ID=C_ORDER.C_CURRENCY_ID]]>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="C_ORDER_ID" isStartNewPage="true" isResetPageNumber="true">
-		<groupExpression><![CDATA[$F{C_ORDER_ID}]]></groupExpression>
+	<group name="C_ORDER_ID" startNewPage="true" resetPageNumber="true">
+		<expression><![CDATA[$F{C_ORDER_ID}]]></expression>
 		<groupHeader>
 			<band height="205" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText-6" style="Group_Data_Label" positionType="FixRelativeToBottom" x="0" y="164" width="140" height="18" forecolor="#999999" backcolor="#FFFFFF" uuid="66a700d2-ec90-4181-846b-f424b7548147"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Left">
-						<font size="11"/>
-					</textElement>
+				<element kind="staticText" uuid="66a700d2-ec90-4181-846b-f424b7548147" key="staticText-6" positionType="FixRelativeToBottom" x="0" y="164" width="140" height="18" forecolor="#999999" backcolor="#FFFFFF" fontSize="11.0" hTextAlign="Left" style="Group_Data_Label">
 					<text><![CDATA[Order No]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-8" positionType="FixRelativeToBottom" x="0" y="184" width="140" height="20" uuid="edecc28b-07da-4dce-85d5-c9a65c026fcb"/>
+					<box style="Group_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="edecc28b-07da-4dce-85d5-c9a65c026fcb" key="textField-8" positionType="FixRelativeToBottom" x="0" y="184" width="140" height="20" blankWhenNull="false">
+					<expression><![CDATA[$F{ALBARAN}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{ALBARAN}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-1" positionType="FixRelativeToBottom" x="1" y="183" width="475" height="1" uuid="15971666-bdb3-46b9-b33e-b037e2feec35"/>
-				</line>
-				<staticText>
-					<reportElement key="staticText-8" style="Group_Data_Label" positionType="FixRelativeToBottom" x="397" y="164" width="80" height="18" forecolor="#999999" backcolor="#FFFFFF" uuid="c34ca714-3e62-4be6-abce-fa4cbba6f2c5"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font size="11" isBold="true" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="line" uuid="15971666-bdb3-46b9-b33e-b037e2feec35" key="line-1" positionType="FixRelativeToBottom" x="1" y="183" width="475" height="1"/>
+				<element kind="staticText" uuid="c34ca714-3e62-4be6-abce-fa4cbba6f2c5" key="staticText-8" positionType="FixRelativeToBottom" x="397" y="164" width="80" height="18" forecolor="#999999" backcolor="#FFFFFF" fontSize="11.0" pdfFontName="Helvetica" bold="true" hTextAlign="Right" style="Group_Data_Label">
 					<text><![CDATA[Date]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField" positionType="FixRelativeToBottom" x="397" y="184" width="80" height="20" uuid="e69f6b27-c1ee-4143-91b8-40a83c88d2b7"/>
+					<box style="Group_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="e69f6b27-c1ee-4143-91b8-40a83c88d2b7" key="textField" positionType="FixRelativeToBottom" x="397" y="184" width="80" height="20" blankWhenNull="false" hTextAlign="Right">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.applyCountryDateFormat($F{DATEORDERED},$F{ORGANIZATIONID})]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.applyCountryDateFormat($F{DATEORDERED},$F{ORGANIZATIONID})]]></textFieldExpression>
-				</textField>
-				<image scaleImage="RetainShape" hAlign="Right" vAlign="Top" isUsingCache="true">
-					<reportElement key="image-1" x="313" y="0" width="170" height="91" uuid="113a498a-deee-4cf6-b2da-9a500b90c8d2">
-						<printWhenExpression><![CDATA[new Boolean($F{SHOWLOGO}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<imageExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylegal", $F{ORGANIZATIONID})]]></imageExpression>
-				</image>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-16" positionType="FixRelativeToBottom" x="121" y="118" width="275" height="55" forecolor="#FF0000" uuid="df5bd25b-b15b-41b4-a93c-6f097194373d"/>
-					<textElement textAlignment="Justified" verticalAlignment="Middle">
-						<font size="36"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($F{STATUS}.compareTo("VO")==0) ? "VOIDED" : " ")]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-					<reportElement key="textField-17" x="0" y="93" width="206" height="55" isPrintWhenDetailOverflows="true" uuid="eb2c32ed-5d4f-40bf-b12a-17e87b799f7a"/>
-					<textElement verticalAlignment="Top"/>
-					<textFieldExpression><![CDATA[$F{NAME} + "\n" + $F{BP_DATA}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-20" x="251" y="93" width="232" height="42" isPrintWhenDetailOverflows="true" uuid="293789f2-4bb8-45d7-94a0-fa8452bff98c">
-						<printWhenExpression><![CDATA[new Boolean($F{SHOWCOMPANYDATA}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($F{LOCATION}==null ? $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" : $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" + $F{LOCATION})]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-11" style="Group_Data_Label" positionType="FixRelativeToBottom" x="293" y="164" width="103" height="18" forecolor="#999999" backcolor="#FFFFFF" uuid="ec5e08db-7b3d-4349-a9f8-57e47ac2e9c4"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Top">
-						<font size="11" isBold="true" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="image" uuid="113a498a-deee-4cf6-b2da-9a500b90c8d2" key="image-1" x="313" y="0" width="170" height="91" scaleImage="RetainShape" usingCache="true" hImageAlign="Right" vImageAlign="Top">
+					<printWhenExpression><![CDATA[new Boolean($F{SHOWLOGO}.equalsIgnoreCase("Y"))]]></printWhenExpression>
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylegal", $F{ORGANIZATIONID})]]></expression>
+				</element>
+				<element kind="textField" uuid="df5bd25b-b15b-41b4-a93c-6f097194373d" key="textField-16" positionType="FixRelativeToBottom" x="121" y="118" width="275" height="55" forecolor="#FF0000" fontSize="36.0" blankWhenNull="false" hTextAlign="Justified" vTextAlign="Middle">
+					<expression><![CDATA[(($F{STATUS}.compareTo("VO")==0) ? "VOIDED" : " ")]]></expression>
+				</element>
+				<element kind="textField" uuid="eb2c32ed-5d4f-40bf-b12a-17e87b799f7a" key="textField-17" x="0" y="93" width="206" height="55" textAdjust="StretchHeight" blankWhenNull="false" printWhenDetailOverflows="true" vTextAlign="Top">
+					<expression><![CDATA[$F{NAME} + "\n" + $F{BP_DATA}]]></expression>
+				</element>
+				<element kind="textField" uuid="293789f2-4bb8-45d7-94a0-fa8452bff98c" key="textField-20" x="251" y="93" width="232" height="42" blankWhenNull="false" printWhenDetailOverflows="true" hTextAlign="Right">
+					<printWhenExpression><![CDATA[new Boolean($F{SHOWCOMPANYDATA}.equalsIgnoreCase("Y"))]]></printWhenExpression>
+					<expression><![CDATA[($F{LOCATION}==null ? $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" : $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" + $F{LOCATION})]]></expression>
+				</element>
+				<element kind="staticText" uuid="ec5e08db-7b3d-4349-a9f8-57e47ac2e9c4" key="staticText-11" positionType="FixRelativeToBottom" x="293" y="164" width="103" height="18" forecolor="#999999" backcolor="#FFFFFF" fontSize="11.0" pdfFontName="Helvetica" bold="true" hTextAlign="Left" vTextAlign="Top" style="Group_Data_Label">
 					<text><![CDATA[Currency]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-24" positionType="FixRelativeToBottom" x="293" y="184" width="103" height="20" uuid="88b5a967-abf5-4bae-ae21-f36847048807"/>
+					<box style="Group_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="88b5a967-abf5-4bae-ae21-f36847048807" key="textField-24" positionType="FixRelativeToBottom" x="293" y="184" width="103" height="20" blankWhenNull="false">
+					<expression><![CDATA[$F{CURRENCY_ISO}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{CURRENCY_ISO}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-12" x="0" y="6" width="310" height="37" uuid="a1f904fc-2e51-4389-aecd-a0accf009ef6">
-						<printWhenExpression><![CDATA[new Boolean($F{ISSOTRX}.equals("N"))]]></printWhenExpression>
-					</reportElement>
-					<textElement>
-						<font size="26"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="a1f904fc-2e51-4389-aecd-a0accf009ef6" key="staticText-12" x="0" y="6" width="310" height="37" fontSize="26.0">
+					<printWhenExpression><![CDATA[new Boolean($F{ISSOTRX}.equals("N"))]]></printWhenExpression>
 					<text><![CDATA[Return to Vendor]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-13" x="0" y="6" width="310" height="37" uuid="ddf760ac-2263-4074-9c0b-4e50d7e29783">
-						<printWhenExpression><![CDATA[new Boolean($F{ISSOTRX}.equals("Y"))]]></printWhenExpression>
-					</reportElement>
-					<textElement>
-						<font size="26"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="ddf760ac-2263-4074-9c0b-4e50d7e29783" key="staticText-13" x="0" y="6" width="310" height="37" fontSize="26.0">
+					<printWhenExpression><![CDATA[new Boolean($F{ISSOTRX}.equals("Y"))]]></printWhenExpression>
 					<text><![CDATA[Return from Customer]]></text>
-				</staticText>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-8" positionType="FixRelativeToBottom" x="140" y="184" width="140" height="20" uuid="17928f39-e975-4fc0-b7b1-5c17041cc4d3">
-						<printWhenExpression><![CDATA[new Boolean($F{ISSOTRX}.equals("N"))]]></printWhenExpression>
-					</reportElement>
+				</element>
+				<element kind="textField" uuid="17928f39-e975-4fc0-b7b1-5c17041cc4d3" key="textField-8" positionType="FixRelativeToBottom" x="140" y="184" width="140" height="20" blankWhenNull="true">
+					<printWhenExpression><![CDATA[new Boolean($F{ISSOTRX}.equals("N"))]]></printWhenExpression>
+					<expression><![CDATA[$F{POREFERENCE}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{POREFERENCE}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-6" style="Group_Data_Label" positionType="FixRelativeToBottom" x="140" y="164" width="140" height="18" forecolor="#999999" backcolor="#FFFFFF" uuid="4c883dc9-8341-4382-95cc-d1e26592d46e">
-						<printWhenExpression><![CDATA[new Boolean($F{ISSOTRX}.equals("N"))]]></printWhenExpression>
-					</reportElement>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Left">
-						<font size="11"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="4c883dc9-8341-4382-95cc-d1e26592d46e" key="staticText-6" positionType="FixRelativeToBottom" x="140" y="164" width="140" height="18" forecolor="#999999" backcolor="#FFFFFF" fontSize="11.0" hTextAlign="Left" style="Group_Data_Label">
+					<printWhenExpression><![CDATA[new Boolean($F{ISSOTRX}.equals("N"))]]></printWhenExpression>
 					<text><![CDATA[RMA Vendor ref]]></text>
-				</staticText>
+					<box style="Group_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="45" splitType="Stretch">
-			<subreport isUsingCache="false">
-				<reportElement key="subreport-1" x="0" y="5" width="482" height="36" uuid="e4ee4fb4-151a-47ed-8ba2-ced818c01b4b"/>
-				<subreportParameter name="C_ORDER_ID">
-					<subreportParameterExpression><![CDATA[$F{C_ORDER_ID}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LOCALE">
-					<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-				</subreportParameter>
+			<element kind="subreport" uuid="e4ee4fb4-151a-47ed-8ba2-ced818c01b4b" key="subreport-1" x="0" y="5" width="482" height="36" usingCache="false">
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{SUBREP_C_RMOrderLinesJR}]]></subreportExpression>
-			</subreport>
+				<expression><![CDATA[$P{SUBREP_C_RMOrderLinesJR}]]></expression>
+				<parameter name="C_ORDER_ID">
+					<expression><![CDATA[$F{C_ORDER_ID}]]></expression>
+				</parameter>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></expression>
+				</parameter>
+				<parameter name="LOCALE">
+					<expression><![CDATA[$P{LOCALE}]]></expression>
+				</parameter>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="90" splitType="Stretch">
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-9" x="439" y="64" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="7a24511b-feb0-409f-8e07-1b0cb3da2d19"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-10" x="340" y="64" width="95" height="19" uuid="66bbaf94-300f-4de9-abc8-57db12986db7"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-2" x="0" y="61" width="483" height="1" uuid="249d3735-b61d-44d7-be94-1fb5b8284a65"/>
-				<graphicElement>
-					<pen lineWidth="0.25" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<staticText>
-				<reportElement key="staticText-9" style="default" x="295" y="11" width="89" height="18" forecolor="#999999" uuid="68b8f806-f0b2-4a8b-b2a9-c8ad277614fd"/>
-				<box leftPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left">
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Payment Terms]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-10" style="default" x="-3" y="11" width="79" height="18" forecolor="#999999" uuid="e6286f42-04c7-4851-96b7-2be7359e4747"/>
-				<box leftPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Delivery Term]]></text>
-			</staticText>
-			<line>
-				<reportElement key="line-3" style="default" x="0" y="29" width="483" height="1" uuid="24b44025-06cb-4145-bf25-1969b3701ff7"/>
-			</line>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-21" x="0" y="32" width="79" height="18" uuid="5e2e632e-b431-417e-aeda-b839ae694b15"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DELIVERYTERM}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-22" x="298" y="32" width="89" height="18" uuid="9c0ebdf6-7349-42d9-817b-1e59f8857af1"/>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PAYMENTTERM}]]></textFieldExpression>
-			</textField>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="90" splitType="Stretch">
+		<element kind="textField" uuid="7a24511b-feb0-409f-8e07-1b0cb3da2d19" key="textField-9" x="439" y="64" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="8.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="66bbaf94-300f-4de9-abc8-57db12986db7" key="textField-10" x="340" y="64" width="95" height="19" fontName="Helvetica" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="249d3735-b61d-44d7-be94-1fb5b8284a65" key="line-2" x="0" y="61" width="483" height="1">
+			<pen lineWidth="0.25" lineStyle="Solid"/>
+		</element>
+		<element kind="staticText" uuid="68b8f806-f0b2-4a8b-b2a9-c8ad277614fd" key="staticText-9" x="295" y="11" width="89" height="18" forecolor="#999999" fontSize="8.0" hTextAlign="Left" style="default">
+			<text><![CDATA[Payment Terms]]></text>
+			<box leftPadding="2" style="default">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="e6286f42-04c7-4851-96b7-2be7359e4747" key="staticText-10" x="-3" y="11" width="79" height="18" forecolor="#999999" fontSize="8.0" style="default">
+			<text><![CDATA[Delivery Term]]></text>
+			<box leftPadding="2" style="default">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="24b44025-06cb-4145-bf25-1969b3701ff7" key="line-3" x="0" y="29" width="483" height="1" style="default"/>
+		<element kind="textField" uuid="5e2e632e-b431-417e-aeda-b839ae694b15" key="textField-21" x="0" y="32" width="79" height="18" fontSize="8.0" blankWhenNull="false">
+			<expression><![CDATA[$F{DELIVERYTERM}]]></expression>
+		</element>
+		<element kind="textField" uuid="9c0ebdf6-7349-42d9-817b-1e59f8857af1" key="textField-22" x="298" y="32" width="89" height="18" fontSize="8.0" blankWhenNull="false">
+			<expression><![CDATA[$F{PAYMENTTERM}]]></expression>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/C_RMOrderLinesJR.jrxml
+++ b/src/org/openbravo/erpReports/C_RMOrderLinesJR.jrxml
@@ -1,17 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="C_OrderLinesJR" pageWidth="482" pageHeight="802" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="ed28d8ce-8cee-4a66-9809-b422098bf614">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="C_OrderLinesJR" language="java" pageWidth="482" pageHeight="802" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="ed28d8ce-8cee-4a66-9809-b422098bf614">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
@@ -19,10 +18,9 @@
 	<parameter name="C_ORDER_ID" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'1000069'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT 1 AS ISBOM, C_ORDERLINE.LINE, COALESCE(M_PRODUCT.NAME, C_ORDERLINE.DESCRIPTION) AS PRODUCT_NAME, C_ORDERLINE.QTYORDERED AS QUANTITY,
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT 1 AS ISBOM, C_ORDERLINE.LINE, COALESCE(M_PRODUCT.NAME, C_ORDERLINE.DESCRIPTION) AS PRODUCT_NAME, C_ORDERLINE.QTYORDERED AS QUANTITY,
        TO_CHAR(C_UOM.NAME) AS UOM,  C_ORDERLINE.PRICEACTUAL, TO_NUMBER(NULL) AS BASE, C_ORDERLINE.LINENETAMT, TO_NUMBER(NULL) AS TAXLINE,
        C_ORDER.docstatus AS STATUS, TO_CHAR(M_PRODUCT.VALUE) AS VALUE, TO_CHAR(M_ATTRIBUTESETINSTANCE.DESCRIPTION) AS ATTRIBUTE
 FROM C_ORDERLINE left join M_PRODUCT on C_ORDERLINE.M_PRODUCT_ID = M_PRODUCT.M_PRODUCT_ID
@@ -51,8 +49,7 @@ WHERE C_ORDER.C_ORDER_ID = C_ORDERTAX.C_ORDER_ID
   AND C_TAX.C_TAX_ID = C_ORDERTAX.C_TAX_ID
   AND C_ORDERTAX.TAXAMT <> 0
   AND C_ORDER.C_ORDER_ID = $P{C_ORDER_ID}
-ORDER BY LINE,ISBOM, TAXLINE]]>
-	</queryString>
+ORDER BY LINE,ISBOM, TAXLINE]]></query>
 	<field name="ISBOM" class="java.math.BigDecimal"/>
 	<field name="LINE" class="java.math.BigDecimal"/>
 	<field name="PRODUCT_NAME" class="java.lang.String"/>
@@ -65,293 +62,163 @@ ORDER BY LINE,ISBOM, TAXLINE]]>
 	<field name="STATUS" class="java.lang.String"/>
 	<field name="VALUE" class="java.lang.String"/>
 	<field name="ATTRIBUTE" class="java.lang.String"/>
-	<variable name="SUM_LINENETAMT" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{LINENETAMT}]]></variableExpression>
+	<variable name="SUM_LINENETAMT" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{LINENETAMT}]]></expression>
 	</variable>
-	<group name="C_Order_Id" isResetPageNumber="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="C_Order_Id" resetPageNumber="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="17" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="Detail_Header" mode="Opaque" x="272" y="0" width="45" height="17" forecolor="#FFFFFF" backcolor="#666666" uuid="cec3abaa-feeb-47d8-8a5d-659662a8f55d"/>
-					<box leftPadding="2" rightPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" isPdfEmbedded="false"/>
-					</textElement>
+				<element kind="staticText" uuid="cec3abaa-feeb-47d8-8a5d-659662a8f55d" key="staticText" mode="Opaque" x="272" y="0" width="45" height="17" forecolor="#FFFFFF" backcolor="#666666" fontSize="10.0" pdfFontName="Helvetica" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Qty]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText" style="Detail_Header" x="237" y="0" width="35" height="17" forecolor="#FFFFFF" uuid="917f39e0-fcf7-432c-83ee-650929a9d5d6"/>
-					<box leftPadding="2" rightPadding="2"/>
-					<textElement verticalAlignment="Middle">
-						<font size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-					</textElement>
+					<box leftPadding="2" rightPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="staticText" uuid="917f39e0-fcf7-432c-83ee-650929a9d5d6" key="staticText" x="237" y="0" width="35" height="17" forecolor="#FFFFFF" fontSize="10.0" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[UOM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText" style="Detail_Header" x="50" y="0" width="130" height="17" forecolor="#FFFFFF" uuid="c8c44497-0416-4c43-83f7-d0094064c88b"/>
-					<box leftPadding="2" rightPadding="2"/>
-					<textElement verticalAlignment="Middle">
-						<font size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-					</textElement>
+					<box leftPadding="2" rightPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="staticText" uuid="c8c44497-0416-4c43-83f7-d0094064c88b" key="staticText" x="50" y="0" width="130" height="17" forecolor="#FFFFFF" fontSize="10.0" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Product Name]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-1" style="Detail_Header" x="1" y="0" width="50" height="17" uuid="94f9e559-39d8-4cc0-a7b1-69ed7c5354ff"/>
-					<box leftPadding="2" rightPadding="2"/>
-					<textElement verticalAlignment="Middle">
-						<font isBold="false"/>
-					</textElement>
+					<box leftPadding="2" rightPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="staticText" uuid="94f9e559-39d8-4cc0-a7b1-69ed7c5354ff" key="staticText-1" x="1" y="0" width="50" height="17" bold="false" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Ref.]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-2" style="Detail_Header" x="317" y="0" width="55" height="17" forecolor="#FFFFFF" backcolor="#666666" uuid="f047f5f2-91c2-4ee4-b4af-8e81229d1b81"/>
-					<box leftPadding="2" rightPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
+					<box leftPadding="2" rightPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="staticText" uuid="f047f5f2-91c2-4ee4-b4af-8e81229d1b81" key="staticText-2" x="317" y="0" width="55" height="17" forecolor="#FFFFFF" backcolor="#666666" pdfFontName="Helvetica" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Price]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-3" style="Detail_Header" x="372" y="0" width="55" height="17" forecolor="#FFFFFF" backcolor="#666666" uuid="9b2d9127-1455-46e4-9966-a3d215d17d6b"/>
-					<box leftPadding="2" rightPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
+					<box leftPadding="2" rightPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="staticText" uuid="9b2d9127-1455-46e4-9966-a3d215d17d6b" key="staticText-3" x="372" y="0" width="55" height="17" forecolor="#FFFFFF" backcolor="#666666" pdfFontName="Helvetica" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Base]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-4" style="Detail_Header" x="427" y="0" width="55" height="17" forecolor="#FFFFFF" backcolor="#666666" uuid="13f79e3c-bacf-42bd-ac2d-b32cf55ebc73"/>
-					<box leftPadding="2" rightPadding="2"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
+					<box leftPadding="2" rightPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="staticText" uuid="13f79e3c-bacf-42bd-ac2d-b32cf55ebc73" key="staticText-4" x="427" y="0" width="55" height="17" forecolor="#FFFFFF" backcolor="#666666" pdfFontName="Helvetica" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Net]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText" style="Detail_Header" x="180" y="0" width="57" height="17" forecolor="#FFFFFF" uuid="034bf449-3e57-4516-846c-cbbca0a2ce76"/>
-					<box leftPadding="2" rightPadding="2"/>
-					<textElement verticalAlignment="Middle">
-						<font size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-					</textElement>
+					<box leftPadding="2" rightPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="staticText" uuid="034bf449-3e57-4516-846c-cbbca0a2ce76" key="staticText" x="180" y="0" width="57" height="17" forecolor="#FFFFFF" fontSize="10.0" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Attribute]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-14" x="317" y="0" width="1" height="17" forecolor="#FFFFFF" uuid="0e44dc4f-e4c7-4570-8945-8e7cda5ca2df"/>
-				</line>
-				<line>
-					<reportElement key="line-15" x="0" y="0" width="1" height="17" forecolor="#FFFFFF" uuid="dc339654-aeb4-4929-84ce-9477e04a6658"/>
-				</line>
-				<line>
-					<reportElement key="line-16" x="272" y="0" width="1" height="17" forecolor="#FFFFFF" uuid="4a76222d-1c64-438b-be04-795b434403da"/>
-				</line>
-				<line>
-					<reportElement key="line-17" x="427" y="0" width="1" height="17" forecolor="#FFFFFF" uuid="5ea82c16-4318-4fa6-8a00-34460298dc71"/>
-				</line>
-				<line>
-					<reportElement key="line-18" x="372" y="0" width="1" height="17" forecolor="#FFFFFF" uuid="60ca1b77-dd28-40cf-9edb-56ead810bea4"/>
-				</line>
-				<line>
-					<reportElement key="line-19" x="237" y="0" width="1" height="17" forecolor="#FFFFFF" uuid="dd565678-3620-4aaf-8038-b7dc7b7479d5"/>
-				</line>
-				<line>
-					<reportElement key="line-20" x="482" y="0" width="1" height="17" forecolor="#FFFFFF" uuid="056a8007-d5a4-4775-aeec-27bc2e7f80c8"/>
-				</line>
-				<line>
-					<reportElement key="line-21" x="50" y="0" width="1" height="17" forecolor="#FFFFFF" uuid="dafd2074-ee36-4101-b8c7-f30a9207a982"/>
-				</line>
-				<line>
-					<reportElement key="line-19" x="180" y="0" width="1" height="17" forecolor="#FFFFFF" uuid="51415793-adec-41fc-94ad-b19943640053"/>
-				</line>
+					<box leftPadding="2" rightPadding="2" style="Detail_Header"/>
+				</element>
+				<element kind="line" uuid="0e44dc4f-e4c7-4570-8945-8e7cda5ca2df" key="line-14" x="317" y="0" width="1" height="17" forecolor="#FFFFFF"/>
+				<element kind="line" uuid="dc339654-aeb4-4929-84ce-9477e04a6658" key="line-15" x="0" y="0" width="1" height="17" forecolor="#FFFFFF"/>
+				<element kind="line" uuid="4a76222d-1c64-438b-be04-795b434403da" key="line-16" x="272" y="0" width="1" height="17" forecolor="#FFFFFF"/>
+				<element kind="line" uuid="5ea82c16-4318-4fa6-8a00-34460298dc71" key="line-17" x="427" y="0" width="1" height="17" forecolor="#FFFFFF"/>
+				<element kind="line" uuid="60ca1b77-dd28-40cf-9edb-56ead810bea4" key="line-18" x="372" y="0" width="1" height="17" forecolor="#FFFFFF"/>
+				<element kind="line" uuid="dd565678-3620-4aaf-8038-b7dc7b7479d5" key="line-19" x="237" y="0" width="1" height="17" forecolor="#FFFFFF"/>
+				<element kind="line" uuid="056a8007-d5a4-4775-aeec-27bc2e7f80c8" key="line-20" x="482" y="0" width="1" height="17" forecolor="#FFFFFF"/>
+				<element kind="line" uuid="dafd2074-ee36-4101-b8c7-f30a9207a982" key="line-21" x="50" y="0" width="1" height="17" forecolor="#FFFFFF"/>
+				<element kind="line" uuid="51415793-adec-41fc-94ad-b19943640053" key="line-19" x="180" y="0" width="1" height="17" forecolor="#FFFFFF"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="272" y="0" width="45" height="16" forecolor="#000000" uuid="91993002-0a57-414d-85d5-a878dab92c71"/>
-				<box leftPadding="2" rightPadding="2">
+			<element kind="textField" uuid="91993002-0a57-414d-85d5-a878dab92c71" key="textField" x="272" y="0" width="45" height="16" forecolor="#000000" fontSize="8.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{QUANTITY}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITY}.negate()):new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QUANTITY}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITY}.negate()):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="default" x="237" y="0" width="35" height="16" forecolor="#000000" uuid="13fd97be-d6ea-4980-883a-bac3dd31553b"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="13fd97be-d6ea-4980-883a-bac3dd31553b" key="textField" x="237" y="0" width="35" height="16" forecolor="#000000" fontSize="8.0" pattern="" blankWhenNull="true" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" vTextAlign="Middle" style="default">
+				<expression><![CDATA[$F{UOM}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{UOM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="default" x="50" y="0" width="130" height="16" forecolor="#000000" uuid="20051ac8-75f0-4cfc-862b-19e17cfd2035"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="20051ac8-75f0-4cfc-862b-19e17cfd2035" key="textField" x="50" y="0" width="130" height="16" forecolor="#000000" fontSize="8.0" pattern="" blankWhenNull="true" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" vTextAlign="Middle" style="default">
+				<expression><![CDATA[$F{PRODUCT_NAME}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PRODUCT_NAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="317" y="0" width="55" height="16" forecolor="#000000" uuid="2dc11875-e67d-4d3b-bc45-5a6c4f8f252b"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="2dc11875-e67d-4d3b-bc45-5a6c4f8f252b" key="textField" x="317" y="0" width="55" height="16" forecolor="#000000" fontSize="8.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}).toString():new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}).toString():new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="372" y="0" width="55" height="16" forecolor="#000000" uuid="4b803388-e4f4-49cc-adf7-84ee0df35a85"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="4b803388-e4f4-49cc-adf7-84ee0df35a85" key="textField" x="372" y="0" width="55" height="16" forecolor="#000000" fontSize="8.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{BASE}!=null)?$P{NUMBERFORMAT}.format($F{BASE}.negate()).toString() :new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{BASE}!=null)?$P{NUMBERFORMAT}.format($F{BASE}.negate()).toString() :new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="427" y="0" width="55" height="16" forecolor="#000000" uuid="6f2e5881-686d-40ac-a031-1c878ed4badc"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="6f2e5881-686d-40ac-a031-1c878ed4badc" key="textField" x="427" y="0" width="55" height="16" forecolor="#000000" fontSize="8.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}.negate()) : new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}.negate()) : new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField-6" style="default" x="1" y="0" width="50" height="16" uuid="6d88a474-63e9-47d4-8eb3-8a9cc6282388"/>
-				<textElement verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{VALUE}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" style="default" x="180" y="0" width="57" height="16" forecolor="#000000" uuid="95234b4d-0cd6-4ca6-81cf-4d1b08d13906"/>
-				<box leftPadding="2" rightPadding="2">
+			</element>
+			<element kind="textField" uuid="6d88a474-63e9-47d4-8eb3-8a9cc6282388" key="textField-6" x="1" y="0" width="50" height="16" fontSize="8.0" blankWhenNull="true" vTextAlign="Middle" style="default">
+				<expression><![CDATA[$F{VALUE}]]></expression>
+			</element>
+			<element kind="textField" uuid="95234b4d-0cd6-4ca6-81cf-4d1b08d13906" key="textField" x="180" y="0" width="57" height="16" forecolor="#000000" fontSize="8.0" pattern="" blankWhenNull="true" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" vTextAlign="Middle" style="default">
+				<expression><![CDATA[$F{ATTRIBUTE}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{ATTRIBUTE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="16" uuid="a4a32d02-f0c1-4097-9dbe-f841fb452937"/>
-			</line>
-			<line>
-				<reportElement key="line-3" stretchType="RelativeToBandHeight" x="237" y="0" width="1" height="16" uuid="b6bea78e-4c3d-4a3d-ab64-5def06a1ba3c"/>
-			</line>
-			<line>
-				<reportElement key="line-4" stretchType="RelativeToBandHeight" x="272" y="0" width="1" height="16" uuid="d201bb06-b9f2-4368-a5c2-64c1b788dd9f"/>
-			</line>
-			<line>
-				<reportElement key="line-5" stretchType="RelativeToBandHeight" x="317" y="0" width="1" height="16" uuid="2c3235c7-5a7b-4e3f-9121-a70bf7c89eab"/>
-			</line>
-			<line>
-				<reportElement key="line-6" stretchType="RelativeToBandHeight" x="372" y="0" width="1" height="16" uuid="74599103-17a7-4b5a-9e4e-fec39811511f"/>
-			</line>
-			<line>
-				<reportElement key="line-7" stretchType="RelativeToBandHeight" x="427" y="0" width="1" height="16" uuid="42ca90e2-a5fe-402e-8f9f-9fea0aff9ed9"/>
-			</line>
-			<line>
-				<reportElement key="line-8" stretchType="RelativeToBandHeight" x="482" y="0" width="1" height="16" uuid="20322f06-191d-40c1-9102-f7dc7f2995ad"/>
-			</line>
-			<line>
-				<reportElement key="line-22" stretchType="RelativeToBandHeight" x="50" y="0" width="1" height="16" uuid="e1c36bbe-a62b-4cdc-b10f-525f216abe32"/>
-			</line>
-			<line>
-				<reportElement key="line-3" stretchType="RelativeToBandHeight" x="180" y="0" width="1" height="16" uuid="fe8e46d7-3256-4042-ac25-a5be53e367d6"/>
-			</line>
-			<line>
-				<reportElement key="line-1" x="0" y="15" width="482" height="1" uuid="8ddd4ef0-0101-4150-8ac3-8332b4ee1605"/>
-			</line>
+			</element>
+			<element kind="line" uuid="a4a32d02-f0c1-4097-9dbe-f841fb452937" key="line-2" stretchType="ContainerHeight" x="0" y="0" width="1" height="16"/>
+			<element kind="line" uuid="b6bea78e-4c3d-4a3d-ab64-5def06a1ba3c" key="line-3" stretchType="ContainerHeight" x="237" y="0" width="1" height="16"/>
+			<element kind="line" uuid="d201bb06-b9f2-4368-a5c2-64c1b788dd9f" key="line-4" stretchType="ContainerHeight" x="272" y="0" width="1" height="16"/>
+			<element kind="line" uuid="2c3235c7-5a7b-4e3f-9121-a70bf7c89eab" key="line-5" stretchType="ContainerHeight" x="317" y="0" width="1" height="16"/>
+			<element kind="line" uuid="74599103-17a7-4b5a-9e4e-fec39811511f" key="line-6" stretchType="ContainerHeight" x="372" y="0" width="1" height="16"/>
+			<element kind="line" uuid="42ca90e2-a5fe-402e-8f9f-9fea0aff9ed9" key="line-7" stretchType="ContainerHeight" x="427" y="0" width="1" height="16"/>
+			<element kind="line" uuid="20322f06-191d-40c1-9102-f7dc7f2995ad" key="line-8" stretchType="ContainerHeight" x="482" y="0" width="1" height="16"/>
+			<element kind="line" uuid="e1c36bbe-a62b-4cdc-b10f-525f216abe32" key="line-22" stretchType="ContainerHeight" x="50" y="0" width="1" height="16"/>
+			<element kind="line" uuid="fe8e46d7-3256-4042-ac25-a5be53e367d6" key="line-3" stretchType="ContainerHeight" x="180" y="0" width="1" height="16"/>
+			<element kind="line" uuid="8ddd4ef0-0101-4150-8ac3-8332b4ee1605" key="line-1" x="0" y="15" width="482" height="1"/>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band height="18" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-1" style="Total_Gray" x="397" y="2" width="78" height="16" uuid="5274812a-95d0-438a-b26f-fcf6589cffc0"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($V{SUM_LINENETAMT}.negate()):new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-10" x="318" y="3" width="1" height="15" uuid="6fc0e692-3d25-4b87-9ff2-962a2f052f25"/>
-			</line>
-			<line>
-				<reportElement key="line-11" x="318" y="17" width="158" height="1" uuid="70391db5-0773-4e51-ad97-0d163d6c9848"/>
-			</line>
-			<line>
-				<reportElement key="line-12" x="318" y="2" width="158" height="1" uuid="af9b3a24-32ff-4e65-933a-def068112f68"/>
-			</line>
-			<line>
-				<reportElement key="line-13" x="475" y="3" width="1" height="15" uuid="2e6e2715-27bf-47ee-a387-cc36597f84da"/>
-			</line>
-			<staticText>
-				<reportElement key="staticText-5" x="319" y="2" width="78" height="16" uuid="948a38bc-4637-4fe4-8c01-9bad4c96daa1"/>
-				<box leftPadding="2"/>
-				<textElement textAlignment="Left" verticalAlignment="Middle"/>
-				<text><![CDATA[TOTAL]]></text>
-			</staticText>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary height="18" splitType="Stretch">
+		<element kind="textField" uuid="5274812a-95d0-438a-b26f-fcf6589cffc0" key="textField-1" x="397" y="2" width="78" height="16" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Gray">
+			<expression><![CDATA[($V{SUM_LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($V{SUM_LINENETAMT}.negate()):new String(" ")]]></expression>
+			<box style="Total_Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="6fc0e692-3d25-4b87-9ff2-962a2f052f25" key="line-10" x="318" y="3" width="1" height="15"/>
+		<element kind="line" uuid="70391db5-0773-4e51-ad97-0d163d6c9848" key="line-11" x="318" y="17" width="158" height="1"/>
+		<element kind="line" uuid="af9b3a24-32ff-4e65-933a-def068112f68" key="line-12" x="318" y="2" width="158" height="1"/>
+		<element kind="line" uuid="2e6e2715-27bf-47ee-a387-cc36597f84da" key="line-13" x="475" y="3" width="1" height="15"/>
+		<element kind="staticText" uuid="948a38bc-4637-4fe4-8c01-9bad4c96daa1" key="staticText-5" x="319" y="2" width="78" height="16" hTextAlign="Left" vTextAlign="Middle">
+			<text><![CDATA[TOTAL]]></text>
+			<box leftPadding="2"/>
+		</element>
 	</summary>
 </jasperReport>

--- a/src/org/openbravo/erpReports/ReportRegisterByVatJR.jrxml
+++ b/src/org/openbravo/erpReports/ReportRegisterByVatJR.jrxml
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportRegisterByVatJR" pageWidth="842" pageHeight="1190" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="444015c4-9375-4518-8384-80d58062ffa8">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportRegisterByVatJR" language="java" pageWidth="842" pageHeight="1190" columnWidth="782" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="444015c4-9375-4518-8384-80d58062ffa8">
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
 	<parameter name="invoicedateDA" class="java.lang.String">
-		<parameterDescription><![CDATA[Invoice Date From :]]></parameterDescription>
+		<description><![CDATA[Invoice Date From :]]></description>
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
 	<parameter name="invoicedateA" class="java.lang.String">
-		<parameterDescription><![CDATA[Invoice Date To :]]></parameterDescription>
+		<description><![CDATA[Invoice Date To :]]></description>
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[select taxreg.name, (tax.name||'-'||tax.rate || '%' ) as Aliquota,
+	<query language="sql"><![CDATA[select taxreg.name, (tax.name||'-'||tax.rate || '%' ) as Aliquota,
  coalesce(taxregline.taxbaseamt,0) as Imponibile, coalesce(taxregline.novatamt,0) as NonImponibile, coalesce(taxregline.exemptamt,0) as Esente , 
  coalesce(taxregline.taxundamt,0) as IvaIndeducibile, coalesce(taxregline.taxamt,0) as Iva, coalesce(taxregline.totalamt,0) as Totale,
  coalesce(taxreg.lastregaccumamt,0) as TotalePrecedente,
@@ -31,8 +30,7 @@ case
  and 1=1
  and ( taxregline.invoicedate >= to_date($P{invoicedateDA},'DD/MM/YYYY')  ) 
  and ( taxregline.invoicedate <= to_date($P{invoicedateA},'DD/MM/YYYY')  ) 
- order by  taxreg.name,(tax.name||'-'||tax.rate || '%' )]]>
-	</queryString>
+ order by  taxreg.name,(tax.name||'-'||tax.rate || '%' )]]></query>
 	<field name="NAME" class="java.lang.String"/>
 	<field name="ALIQUOTA" class="java.lang.String"/>
 	<field name="IMPONIBILE" class="java.math.BigDecimal"/>
@@ -43,773 +41,586 @@ case
 	<field name="TOTALE" class="java.math.BigDecimal"/>
 	<field name="TOTALEPRECEDENTE" class="java.math.BigDecimal"/>
 	<field name="ISSALE" class="java.lang.String"/>
-	<variable name="SumImponibile" class="java.math.BigDecimal" resetType="Group" resetGroup="NAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{IMPONIBILE}]]></variableExpression>
+	<variable name="SumImponibile" resetType="Group" calculation="Sum" resetGroup="NAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{IMPONIBILE}]]></expression>
 	</variable>
-	<variable name="SumNonImponibile" class="java.math.BigDecimal" resetType="Group" resetGroup="NAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{NONIMPONIBILE}]]></variableExpression>
+	<variable name="SumNonImponibile" resetType="Group" calculation="Sum" resetGroup="NAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{NONIMPONIBILE}]]></expression>
 	</variable>
-	<variable name="SumEsente" class="java.math.BigDecimal" resetType="Group" resetGroup="NAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{ESENTE}]]></variableExpression>
+	<variable name="SumEsente" resetType="Group" calculation="Sum" resetGroup="NAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{ESENTE}]]></expression>
 	</variable>
-	<variable name="SumIvaIndeducibile" class="java.math.BigDecimal" resetType="Group" resetGroup="NAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{IVAINDEDUCIBILE}]]></variableExpression>
+	<variable name="SumIvaIndeducibile" resetType="Group" calculation="Sum" resetGroup="NAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{IVAINDEDUCIBILE}]]></expression>
 	</variable>
-	<variable name="SumIva" class="java.math.BigDecimal" resetType="Group" resetGroup="NAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{IVA}]]></variableExpression>
+	<variable name="SumIva" resetType="Group" calculation="Sum" resetGroup="NAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{IVA}]]></expression>
 	</variable>
-	<variable name="SumTotale" class="java.math.BigDecimal" resetType="Group" resetGroup="NAME" calculation="Sum">
-		<variableExpression><![CDATA[$F{TOTALE}]]></variableExpression>
+	<variable name="SumTotale" resetType="Group" calculation="Sum" resetGroup="NAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{TOTALE}]]></expression>
 	</variable>
-	<variable name="SumTotalePrec" class="java.math.BigDecimal" resetType="Group" resetGroup="NAME" calculation="First">
-		<variableExpression><![CDATA[$F{TOTALEPRECEDENTE}]]></variableExpression>
+	<variable name="SumTotalePrec" resetType="Group" calculation="First" resetGroup="NAME" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{TOTALEPRECEDENTE}]]></expression>
 	</variable>
-	<variable name="TotIva" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[( $F{ISSALE}.equals( "Purchase" )  ? $F{IVA}.negate() : $F{IVA} )]]></variableExpression>
+	<variable name="TotIva" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[( $F{ISSALE}.equals( "Purchase" )  ? $F{IVA}.negate() : $F{IVA} )]]></expression>
 	</variable>
-	<variable name="TotCredPrec" class="java.math.BigDecimal" incrementType="Group" incrementGroup="NAME" calculation="Sum">
-		<variableExpression><![CDATA[( $F{ISSALE}.equals( "Purchase" )  ? $F{TOTALEPRECEDENTE} : $F{TOTALEPRECEDENTE}.negate() )]]></variableExpression>
+	<variable name="TotCredPrec" incrementType="Group" calculation="Sum" incrementGroup="NAME" class="java.math.BigDecimal">
+		<expression><![CDATA[( $F{ISSALE}.equals( "Purchase" )  ? $F{TOTALEPRECEDENTE} : $F{TOTALEPRECEDENTE}.negate() )]]></expression>
 		<initialValueExpression><![CDATA[new BigDecimal(0)]]></initialValueExpression>
 	</variable>
 	<variable name="TotIvaDaPagare" class="java.math.BigDecimal">
-		<variableExpression><![CDATA[$V{TotIva}.add(  ( $V{TotCredPrec}.doubleValue()<0 ? new BigDecimal(0) :  $V{TotCredPrec}.negate() ))]]></variableExpression>
+		<expression><![CDATA[$V{TotIva}.add(  ( $V{TotCredPrec}.doubleValue()<0 ? new BigDecimal(0) :  $V{TotCredPrec}.negate() ))]]></expression>
 	</variable>
 	<group name="NAME">
-		<groupExpression><![CDATA[$F{NAME}]]></groupExpression>
+		<expression><![CDATA[$F{NAME}]]></expression>
 		<groupHeader>
 			<band height="25" splitType="Stretch">
-				<rectangle radius="0">
-					<reportElement key="rectangle" x="0" y="0" width="782" height="25" forecolor="#8080FF" backcolor="#00CCFF" uuid="53cad48c-4466-4309-8a52-d5d1d885256e"/>
-				</rectangle>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="0" y="2" width="329" height="23" forecolor="#000000" uuid="5d144e5d-9c6c-4b5c-9550-11ed667e80cc"/>
+				<element kind="rectangle" uuid="53cad48c-4466-4309-8a52-d5d1d885256e" key="rectangle" x="0" y="0" width="782" height="25" forecolor="#8080FF" backcolor="#00CCFF" radius="0"/>
+				<element kind="textField" uuid="5d144e5d-9c6c-4b5c-9550-11ed667e80cc" key="textField" x="0" y="2" width="329" height="23" forecolor="#000000" fontSize="18.0" pattern="" blankWhenNull="false">
+					<expression><![CDATA[$F{NAME}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="18"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NAME}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" x="538" y="0" width="86" height="25" forecolor="#000000" uuid="61e08d24-d6e1-43f7-ae85-28537c6654b8"/>
+				</element>
+				<element kind="textField" uuid="61e08d24-d6e1-43f7-ae85-28537c6654b8" key="textField" x="538" y="0" width="86" height="25" forecolor="#000000" fontSize="12.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[$F{ISSALE}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{ISSALE}]]></textFieldExpression>
-				</textField>
-				<textField pattern="#,##0.00" isBlankWhenNull="false">
-					<reportElement key="textField" x="329" y="0" width="86" height="25" uuid="416a2192-9c1e-42dd-b69f-484bc9162d15">
-						<printWhenExpression><![CDATA[new Boolean(false)]]></printWhenExpression>
-					</reportElement>
+				</element>
+				<element kind="textField" uuid="416a2192-9c1e-42dd-b69f-484bc9162d15" key="textField" x="329" y="0" width="86" height="25" fontSize="12.0" pattern="#,##0.00" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+					<printWhenExpression><![CDATA[new Boolean(false)]]></printWhenExpression>
+					<expression><![CDATA[$F{TOTALEPRECEDENTE}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="12"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{TOTALEPRECEDENTE}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="30" splitType="Stretch">
-				<line direction="BottomUp">
-					<reportElement key="line" x="1" y="0" width="781" height="1" forecolor="#000000" backcolor="#FFFFFF" uuid="02682466-f33b-4138-9366-10f3dddcc80d"/>
-				</line>
-				<textField pattern="#,##0.00" isBlankWhenNull="false">
-					<reportElement key="textField" x="86" y="0" width="86" height="18" uuid="da968413-7705-4e38-8888-604efa0a4511"/>
+				<element kind="line" uuid="02682466-f33b-4138-9366-10f3dddcc80d" key="line" x="1" y="0" width="781" height="1" forecolor="#000000" backcolor="#FFFFFF" direction="BottomUp"/>
+				<element kind="textField" uuid="da968413-7705-4e38-8888-604efa0a4511" key="textField" x="86" y="0" width="86" height="18" pattern="#,##0.00" blankWhenNull="false" hTextAlign="Right">
+					<expression><![CDATA[$V{SumImponibile}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[$V{SumImponibile}]]></textFieldExpression>
-				</textField>
-				<textField pattern="#,##0.00" isBlankWhenNull="false">
-					<reportElement key="textField" x="172" y="0" width="86" height="18" uuid="621856f4-c4f1-43b9-95ac-7daf009c8604"/>
+				</element>
+				<element kind="textField" uuid="621856f4-c4f1-43b9-95ac-7daf009c8604" key="textField" x="172" y="0" width="86" height="18" pattern="#,##0.00" blankWhenNull="false" hTextAlign="Right">
+					<expression><![CDATA[$V{SumNonImponibile}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[$V{SumNonImponibile}]]></textFieldExpression>
-				</textField>
-				<textField pattern="#,##0.00" isBlankWhenNull="false">
-					<reportElement key="textField-1" x="258" y="0" width="86" height="18" uuid="73f8908c-d812-4461-a55d-dfc57c775951"/>
+				</element>
+				<element kind="textField" uuid="73f8908c-d812-4461-a55d-dfc57c775951" key="textField-1" x="258" y="0" width="86" height="18" pattern="#,##0.00" blankWhenNull="false" hTextAlign="Right">
+					<expression><![CDATA[$V{SumEsente}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[$V{SumEsente}]]></textFieldExpression>
-				</textField>
-				<textField pattern="#,##0.00" isBlankWhenNull="false">
-					<reportElement key="textField-2" x="344" y="0" width="86" height="18" uuid="ee2b5697-271b-4d24-9db9-1950b7698bd9"/>
+				</element>
+				<element kind="textField" uuid="ee2b5697-271b-4d24-9db9-1950b7698bd9" key="textField-2" x="344" y="0" width="86" height="18" pattern="#,##0.00" blankWhenNull="false" hTextAlign="Right">
+					<expression><![CDATA[$V{SumIvaIndeducibile}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[$V{SumIvaIndeducibile}]]></textFieldExpression>
-				</textField>
-				<textField pattern="#,##0.00" isBlankWhenNull="false">
-					<reportElement key="textField-3" x="430" y="0" width="86" height="18" uuid="94858ae3-9a08-4215-84fd-1ccc6b06da28"/>
+				</element>
+				<element kind="textField" uuid="94858ae3-9a08-4215-84fd-1ccc6b06da28" key="textField-3" x="430" y="0" width="86" height="18" pattern="#,##0.00" blankWhenNull="false" hTextAlign="Right">
+					<expression><![CDATA[$V{SumIva}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[$V{SumIva}]]></textFieldExpression>
-				</textField>
-				<textField pattern="#,##0.00" isBlankWhenNull="false">
-					<reportElement key="textField-4" x="516" y="0" width="86" height="18" uuid="9ca2b6ff-0d9d-4b30-9683-210b766c15eb"/>
+				</element>
+				<element kind="textField" uuid="9ca2b6ff-0d9d-4b30-9683-210b766c15eb" key="textField-4" x="516" y="0" width="86" height="18" pattern="#,##0.00" blankWhenNull="false" hTextAlign="Right">
+					<expression><![CDATA[$V{SumTotale}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[$V{SumTotale}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-1" x="0" y="0" width="86" height="18" uuid="12f5c4df-135e-44e6-bc93-bcb08d780a44"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="12f5c4df-135e-44e6-bc93-bcb08d780a44" key="staticText-1" x="0" y="0" width="86" height="18" pdfFontName="Helvetica-Bold" bold="true">
 					<text><![CDATA[Total :]]></text>
-				</staticText>
-				<textField pattern="##0.00" isBlankWhenNull="false">
-					<reportElement key="textField" x="649" y="0" width="100" height="18" uuid="c973694d-7c2e-4f5b-b703-55a3b2150e9d">
-						<printWhenExpression><![CDATA[new Boolean(false)]]></printWhenExpression>
-					</reportElement>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$V{TotCredPrec}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="c973694d-7c2e-4f5b-b703-55a3b2150e9d" key="textField" x="649" y="0" width="100" height="18" pattern="##0.00" blankWhenNull="false">
+					<printWhenExpression><![CDATA[new Boolean(false)]]></printWhenExpression>
+					<expression><![CDATA[$V{TotCredPrec}]]></expression>
+					<box>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="50" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText" x="158" y="5" width="242" height="40" uuid="d6742bdc-14b5-4df3-8139-a9fe3dcf3550"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="30"/>
-				</textElement>
-				<text><![CDATA[Tax payment]]></text>
-			</staticText>
-			<line>
-				<reportElement key="line" x="0" y="48" width="781" height="1" forecolor="#000000" backcolor="#FFFFFF" uuid="b66906fd-fe51-4d39-aaea-8fd204faad64"/>
-			</line>
-			<line>
-				<reportElement key="line" x="0" y="3" width="781" height="1" forecolor="#000000" backcolor="#FFFFFF" uuid="10533b39-e147-4643-9b2e-472552e99c00"/>
-			</line>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-6" x="400" y="0" width="382" height="50" uuid="e5e75247-8142-4f27-a3c0-103616fd87a1"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font isBold="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Date from:   " +" "+ $P{invoicedateDA}+" "+"   to   "+" "+$P{invoicedateA}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="50" splitType="Stretch">
+		<element kind="staticText" uuid="d6742bdc-14b5-4df3-8139-a9fe3dcf3550" key="staticText" x="158" y="5" width="242" height="40" fontSize="30.0">
+			<text><![CDATA[Tax payment]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="b66906fd-fe51-4d39-aaea-8fd204faad64" key="line" x="0" y="48" width="781" height="1" forecolor="#000000" backcolor="#FFFFFF"/>
+		<element kind="line" uuid="10533b39-e147-4643-9b2e-472552e99c00" key="line" x="0" y="3" width="781" height="1" forecolor="#000000" backcolor="#FFFFFF"/>
+		<element kind="textField" uuid="e5e75247-8142-4f27-a3c0-103616fd87a1" key="textField-6" x="400" y="0" width="382" height="50" pattern="" blankWhenNull="true" bold="true" vTextAlign="Middle">
+			<expression><![CDATA["Date from:   " +" "+ $P{invoicedateDA}+" "+"   to   "+" "+$P{invoicedateA}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</title>
-	<pageHeader>
-		<band height="9" splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band height="18" splitType="Stretch">
-			<rectangle>
-				<reportElement key="rectangle" mode="Opaque" x="0" y="0" width="782" height="17" forecolor="#000000" backcolor="#999999" uuid="610f7981-1af0-40f3-a846-084817915b55"/>
-				<graphicElement>
-					<pen lineWidth="0.0" lineStyle="Solid"/>
-				</graphicElement>
-			</rectangle>
-			<line direction="BottomUp">
-				<reportElement key="line" x="0" y="0" width="782" height="1" forecolor="#000000" backcolor="#999999" uuid="635495d1-5981-4edd-9f94-8f06e8645a0b"/>
-			</line>
-			<line direction="BottomUp">
-				<reportElement key="line" x="0" y="15" width="782" height="1" forecolor="#000000" backcolor="#FFFFFF" uuid="2745c65b-954d-4c9b-b0a7-d97a8e109276"/>
-			</line>
-			<staticText>
-				<reportElement key="staticText" x="0" y="0" width="86" height="17" forecolor="#000000" backcolor="#999999" uuid="66083955-79b5-4013-bfe5-edd8f4dd0ed8"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="12"/>
-				</textElement>
-				<text><![CDATA[Tax rate]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText" x="86" y="0" width="86" height="17" forecolor="#000000" uuid="94909989-beae-4e8d-886a-6af3b5f4a2b2"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="12"/>
-				</textElement>
-				<text><![CDATA[Tax base amount]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText" x="172" y="0" width="86" height="17" forecolor="#000000" uuid="7371fbc7-052b-4217-9a06-f01af2d10969"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="12"/>
-				</textElement>
-				<text><![CDATA[Non taxable]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText" x="258" y="0" width="86" height="17" forecolor="#000000" uuid="cc2ab297-a25f-441b-a261-557f64402794"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="12"/>
-				</textElement>
-				<text><![CDATA[Exempt]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText" x="344" y="0" width="86" height="17" forecolor="#000000" uuid="5808ee7d-b05b-43ca-986e-6a7fe62e82d7"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="12"/>
-				</textElement>
-				<text><![CDATA[No deductable]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText" x="430" y="0" width="86" height="17" forecolor="#000000" uuid="f3cf4d0c-8898-457c-bc37-b9027429957a"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="12"/>
-				</textElement>
-				<text><![CDATA[VAT]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText" x="516" y="0" width="86" height="17" forecolor="#000000" uuid="6a1cb7d7-6c43-4e8e-999c-1f1162485862"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="12"/>
-				</textElement>
-				<text><![CDATA[Total]]></text>
-			</staticText>
-		</band>
+	<pageHeader height="9" splitType="Stretch"/>
+	<columnHeader height="18" splitType="Stretch">
+		<element kind="rectangle" uuid="610f7981-1af0-40f3-a846-084817915b55" key="rectangle" mode="Opaque" x="0" y="0" width="782" height="17" forecolor="#000000" backcolor="#999999">
+			<pen lineWidth="0.0" lineStyle="Solid"/>
+		</element>
+		<element kind="line" uuid="635495d1-5981-4edd-9f94-8f06e8645a0b" key="line" x="0" y="0" width="782" height="1" forecolor="#000000" backcolor="#999999" direction="BottomUp"/>
+		<element kind="line" uuid="2745c65b-954d-4c9b-b0a7-d97a8e109276" key="line" x="0" y="15" width="782" height="1" forecolor="#000000" backcolor="#FFFFFF" direction="BottomUp"/>
+		<element kind="staticText" uuid="66083955-79b5-4013-bfe5-edd8f4dd0ed8" key="staticText" x="0" y="0" width="86" height="17" forecolor="#000000" backcolor="#999999" fontSize="12.0">
+			<text><![CDATA[Tax rate]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="94909989-beae-4e8d-886a-6af3b5f4a2b2" key="staticText" x="86" y="0" width="86" height="17" forecolor="#000000" fontSize="12.0" hTextAlign="Center">
+			<text><![CDATA[Tax base amount]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="7371fbc7-052b-4217-9a06-f01af2d10969" key="staticText" x="172" y="0" width="86" height="17" forecolor="#000000" fontSize="12.0" hTextAlign="Center">
+			<text><![CDATA[Non taxable]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="cc2ab297-a25f-441b-a261-557f64402794" key="staticText" x="258" y="0" width="86" height="17" forecolor="#000000" fontSize="12.0" hTextAlign="Center">
+			<text><![CDATA[Exempt]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="5808ee7d-b05b-43ca-986e-6a7fe62e82d7" key="staticText" x="344" y="0" width="86" height="17" forecolor="#000000" fontSize="12.0" hTextAlign="Center">
+			<text><![CDATA[No deductable]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="f3cf4d0c-8898-457c-bc37-b9027429957a" key="staticText" x="430" y="0" width="86" height="17" forecolor="#000000" fontSize="12.0" hTextAlign="Right">
+			<text><![CDATA[VAT]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="6a1cb7d7-6c43-4e8e-999c-1f1162485862" key="staticText" x="516" y="0" width="86" height="17" forecolor="#000000" fontSize="12.0" hTextAlign="Right">
+			<text><![CDATA[Total]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</columnHeader>
 	<detail>
 		<band height="17" splitType="Stretch">
-			<line>
-				<reportElement key="line" x="0" y="16" width="782" height="1" forecolor="#808080" backcolor="#FFFFFF" uuid="9784a796-b670-4ae4-9918-5af20865c895"/>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="0" y="0" width="86" height="17" forecolor="#000000" uuid="b1b4f2fa-0417-4de3-b925-b135e5fc53c8"/>
+			<element kind="line" uuid="9784a796-b670-4ae4-9918-5af20865c895" key="line" x="0" y="16" width="782" height="1" forecolor="#808080" backcolor="#FFFFFF"/>
+			<element kind="textField" uuid="b1b4f2fa-0417-4de3-b925-b135e5fc53c8" key="textField" x="0" y="0" width="86" height="17" forecolor="#000000" fontSize="12.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false">
+				<expression><![CDATA[$F{ALIQUOTA}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{ALIQUOTA}]]></textFieldExpression>
-			</textField>
-			<textField pattern="#,##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="86" y="0" width="86" height="17" forecolor="#000000" uuid="04ae1650-b4f8-438f-8866-2fb39bf15412"/>
+			</element>
+			<element kind="textField" uuid="04ae1650-b4f8-438f-8866-2fb39bf15412" key="textField" x="86" y="0" width="86" height="17" forecolor="#000000" fontSize="12.0" pattern="#,##0.00" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right">
+				<expression><![CDATA[$F{IMPONIBILE}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{IMPONIBILE}]]></textFieldExpression>
-			</textField>
-			<textField pattern="#,##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="172" y="0" width="86" height="17" forecolor="#000000" uuid="3cde74fe-b842-4d56-be61-4e13cb20b9d3"/>
+			</element>
+			<element kind="textField" uuid="3cde74fe-b842-4d56-be61-4e13cb20b9d3" key="textField" x="172" y="0" width="86" height="17" forecolor="#000000" fontSize="12.0" pattern="#,##0.00" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right">
+				<expression><![CDATA[$F{NONIMPONIBILE}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{NONIMPONIBILE}]]></textFieldExpression>
-			</textField>
-			<textField pattern="#,##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="258" y="0" width="86" height="17" forecolor="#000000" uuid="632eec78-2933-454c-9c56-b473e760dac2"/>
+			</element>
+			<element kind="textField" uuid="632eec78-2933-454c-9c56-b473e760dac2" key="textField" x="258" y="0" width="86" height="17" forecolor="#000000" fontSize="12.0" pattern="#,##0.00" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right">
+				<expression><![CDATA[$F{ESENTE}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{ESENTE}]]></textFieldExpression>
-			</textField>
-			<textField pattern="#,##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="344" y="0" width="86" height="17" forecolor="#000000" uuid="aa68ccea-6d5b-4414-8d02-ae7ee6d608cf"/>
+			</element>
+			<element kind="textField" uuid="aa68ccea-6d5b-4414-8d02-ae7ee6d608cf" key="textField" x="344" y="0" width="86" height="17" forecolor="#000000" fontSize="12.0" pattern="#,##0.00" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right">
+				<expression><![CDATA[$F{IVAINDEDUCIBILE}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{IVAINDEDUCIBILE}]]></textFieldExpression>
-			</textField>
-			<textField pattern="#,##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="430" y="0" width="86" height="17" forecolor="#000000" uuid="55d39862-0d69-4400-9389-e15f3ea1badb"/>
+			</element>
+			<element kind="textField" uuid="55d39862-0d69-4400-9389-e15f3ea1badb" key="textField" x="430" y="0" width="86" height="17" forecolor="#000000" fontSize="12.0" pattern="#,##0.00" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right">
+				<expression><![CDATA[$F{IVA}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{IVA}]]></textFieldExpression>
-			</textField>
-			<textField pattern="#,##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="516" y="0" width="86" height="17" forecolor="#000000" uuid="ffda8318-febe-4621-8e98-59b3dba0fb63"/>
+			</element>
+			<element kind="textField" uuid="ffda8318-febe-4621-8e98-59b3dba0fb63" key="textField" x="516" y="0" width="86" height="17" forecolor="#000000" fontSize="12.0" pattern="#,##0.00" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Right">
+				<expression><![CDATA[$F{TOTALE}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{TOTALE}]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="27" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="573" y="4" width="170" height="19" forecolor="#000000" uuid="d0cdebd8-cd1d-4fbf-a0f6-39f980f3153c"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" mode="Transparent" x="746" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="75727ee3-fccd-4ed7-92f3-ece27b488e58"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="3" width="782" height="1" forecolor="#000000" backcolor="#FFFFFF" uuid="471f64c2-ee6a-4776-9cc3-b52047bdb5e1"/>
-			</line>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" x="1" y="6" width="209" height="19" forecolor="#000000" uuid="f13dcdaf-cc2c-44df-9042-2b9989b8fee0"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="27" splitType="Stretch">
+		<element kind="textField" uuid="d0cdebd8-cd1d-4fbf-a0f6-39f980f3153c" key="textField" x="573" y="4" width="170" height="19" forecolor="#000000" pattern="" blankWhenNull="false" hTextAlign="Right">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="75727ee3-fccd-4ed7-92f3-ece27b488e58" key="textField" mode="Transparent" x="746" y="4" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" fontSize="10.0" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false">
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="471f64c2-ee6a-4776-9cc3-b52047bdb5e1" key="line" x="0" y="3" width="782" height="1" forecolor="#000000" backcolor="#FFFFFF"/>
+		<element kind="textField" uuid="f13dcdaf-cc2c-44df-9042-2b9989b8fee0" key="textField" x="1" y="6" width="209" height="19" forecolor="#000000" blankWhenNull="false">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band height="195" splitType="Stretch">
-			<crosstab>
-				<reportElement key="crosstab-1" x="0" y="4" width="321" height="55" uuid="868c276d-cf30-4ea7-9544-a3f46569d0dc"/>
-				<crosstabHeaderCell>
-					<cellContents mode="Transparent">
+	<summary height="195" splitType="Stretch">
+		<element kind="crosstab" uuid="868c276d-cf30-4ea7-9544-a3f46569d0dc" key="crosstab-1" x="0" y="4" width="321" height="55">
+			<dataset/>
+			<whenNoDataCell mode="Transparent">
+				<box>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</whenNoDataCell>
+			<headerCell mode="Transparent">
+				<box>
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</headerCell>
+			<rowGroup name="ALIQUOTA" totalPosition="End" width="126">
+				<bucket class="java.lang.String">
+					<expression><![CDATA[$F{ALIQUOTA}]]></expression>
+				</bucket>
+				<header mode="Transparent">
+					<element kind="textField" uuid="23830866-466d-47ad-a3d7-694375ae48ba" key="textField" x="0" y="0" width="75" height="30" pdfFontName="Helvetica-Bold" blankWhenNull="false" bold="true" hTextAlign="Center" vTextAlign="Middle">
+						<expression><![CDATA[$V{ALIQUOTA}]]></expression>
+						<box>
+							<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+							<bottomPen lineWidth="0.0" lineColor="#000000"/>
+							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						</box>
+					</element>
+					<element kind="staticText" uuid="e899690d-8104-4983-b9f6-449d3b59d9a9" key="staticText-2" x="76" y="15" width="50" height="15">
+						<text><![CDATA[Und. VAT]]></text>
+						<box>
+							<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+							<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+							<bottomPen lineWidth="0.0" lineColor="#000000"/>
+							<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						</box>
+					</element>
+					<element kind="staticText" uuid="9de270b2-c228-4e91-8fe4-8af40942be1a" key="staticText-2" x="76" y="0" width="50" height="15">
+						<text><![CDATA[VAT]]></text>
+						<box>
+							<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+							<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+							<bottomPen lineWidth="0.0" lineColor="#000000"/>
+							<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						</box>
+					</element>
+					<box>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</header>
+				<totalHeader mode="Transparent">
+					<element kind="textField" uuid="48ccfa9c-47fa-4483-a36f-867d1ebe4bec" key="textField" x="0" y="0" width="75" height="30" pdfFontName="Helvetica-Bold" blankWhenNull="false" bold="true" hTextAlign="Center" vTextAlign="Middle">
+						<expression><![CDATA["Total VAT"]]></expression>
 						<box>
 							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<bottomPen lineWidth="0.0" lineColor="#000000"/>
 							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						</box>
-					</cellContents>
-				</crosstabHeaderCell>
-				<rowGroup name="ALIQUOTA" width="126" totalPosition="End">
-					<bucket class="java.lang.String">
-						<bucketExpression><![CDATA[$F{ALIQUOTA}]]></bucketExpression>
-					</bucket>
-					<crosstabRowHeader>
-						<cellContents mode="Transparent">
-							<box>
-								<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-								<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
-								<bottomPen lineWidth="0.0" lineColor="#000000"/>
-								<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
-							</box>
-							<textField isBlankWhenNull="false">
-								<reportElement key="textField" x="0" y="0" width="75" height="30" uuid="23830866-466d-47ad-a3d7-694375ae48ba"/>
-								<box>
-									<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
-									<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-									<bottomPen lineWidth="0.0" lineColor="#000000"/>
-									<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-								</box>
-								<textElement textAlignment="Center" verticalAlignment="Middle">
-									<font isBold="true" pdfFontName="Helvetica-Bold"/>
-								</textElement>
-								<textFieldExpression><![CDATA[$V{ALIQUOTA}]]></textFieldExpression>
-							</textField>
-							<staticText>
-								<reportElement key="staticText-2" x="76" y="15" width="50" height="15" uuid="e899690d-8104-4983-b9f6-449d3b59d9a9"/>
-								<box>
-									<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
-									<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
-									<bottomPen lineWidth="0.0" lineColor="#000000"/>
-									<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
-								</box>
-								<text><![CDATA[Und. VAT]]></text>
-							</staticText>
-							<staticText>
-								<reportElement key="staticText-2" x="76" y="0" width="50" height="15" uuid="9de270b2-c228-4e91-8fe4-8af40942be1a"/>
-								<box>
-									<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
-									<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
-									<bottomPen lineWidth="0.0" lineColor="#000000"/>
-									<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
-								</box>
-								<text><![CDATA[VAT]]></text>
-							</staticText>
-						</cellContents>
-					</crosstabRowHeader>
-					<crosstabTotalRowHeader>
-						<cellContents mode="Transparent">
-							<box>
-								<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-								<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
-								<bottomPen lineWidth="0.0" lineColor="#000000"/>
-								<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
-							</box>
-							<textField isBlankWhenNull="false">
-								<reportElement key="textField" x="0" y="0" width="75" height="30" uuid="48ccfa9c-47fa-4483-a36f-867d1ebe4bec"/>
-								<box>
-									<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-									<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-									<bottomPen lineWidth="0.0" lineColor="#000000"/>
-									<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-								</box>
-								<textElement textAlignment="Center" verticalAlignment="Middle">
-									<font isBold="true" pdfFontName="Helvetica-Bold"/>
-								</textElement>
-								<textFieldExpression><![CDATA["Total VAT"]]></textFieldExpression>
-							</textField>
-							<staticText>
-								<reportElement key="staticText-2" x="76" y="0" width="50" height="15" uuid="94136489-3241-47be-bfb6-e67e9f079153"/>
-								<box>
-									<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
-									<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
-									<bottomPen lineWidth="0.0" lineColor="#000000"/>
-									<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
-								</box>
-								<text><![CDATA[VAT]]></text>
-							</staticText>
-							<staticText>
-								<reportElement key="staticText-2" x="76" y="16" width="50" height="15" uuid="db565e4e-68db-4e45-afa6-53743d1efb2a"/>
-								<box>
-									<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
-									<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
-									<bottomPen lineWidth="0.0" lineColor="#000000"/>
-									<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
-								</box>
-								<text><![CDATA[Und. VAT]]></text>
-							</staticText>
-						</cellContents>
-					</crosstabTotalRowHeader>
-				</rowGroup>
-				<columnGroup name="ISSALE" height="25" headerPosition="Center">
-					<bucket class="java.lang.String">
-						<bucketExpression><![CDATA[$F{ISSALE}]]></bucketExpression>
-					</bucket>
-					<crosstabColumnHeader>
-						<cellContents mode="Transparent">
-							<box>
-								<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
-								<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-								<bottomPen lineWidth="0.0" lineColor="#000000"/>
-								<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
-							</box>
-							<textField isBlankWhenNull="false">
-								<reportElement key="textField" x="0" y="0" width="50" height="25" uuid="3b03c931-f043-4f96-a178-2715229491a9"/>
-								<box>
-									<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-									<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
-									<bottomPen lineWidth="0.0" lineColor="#000000"/>
-									<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-								</box>
-								<textElement textAlignment="Center" verticalAlignment="Middle">
-									<font isBold="true" pdfFontName="Helvetica-Bold"/>
-								</textElement>
-								<textFieldExpression><![CDATA[$V{ISSALE}]]></textFieldExpression>
-							</textField>
-						</cellContents>
-					</crosstabColumnHeader>
-					<crosstabTotalColumnHeader>
-						<cellContents mode="Transparent">
-							<box>
-								<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
-								<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-								<bottomPen lineWidth="0.0" lineColor="#000000"/>
-								<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
-							</box>
-						</cellContents>
-					</crosstabTotalColumnHeader>
-				</columnGroup>
-				<measure name="IVA_Sum" class="java.math.BigDecimal" calculation="Sum">
-					<measureExpression><![CDATA[$F{IVA}]]></measureExpression>
-				</measure>
-				<measure name="IvaInd_Sum" class="java.math.BigDecimal" calculation="Sum">
-					<measureExpression><![CDATA[$F{IVAINDEDUCIBILE}]]></measureExpression>
-				</measure>
-				<crosstabCell width="50" height="30">
-					<cellContents mode="Transparent">
+					</element>
+					<element kind="staticText" uuid="94136489-3241-47be-bfb6-e67e9f079153" key="staticText-2" x="76" y="0" width="50" height="15">
+						<text><![CDATA[VAT]]></text>
+						<box>
+							<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+							<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+							<bottomPen lineWidth="0.0" lineColor="#000000"/>
+							<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						</box>
+					</element>
+					<element kind="staticText" uuid="db565e4e-68db-4e45-afa6-53743d1efb2a" key="staticText-2" x="76" y="16" width="50" height="15">
+						<text><![CDATA[Und. VAT]]></text>
+						<box>
+							<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+							<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+							<bottomPen lineWidth="0.0" lineColor="#000000"/>
+							<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						</box>
+					</element>
+					<box>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</totalHeader>
+			</rowGroup>
+			<columnGroup name="ISSALE" height="25" position="Center">
+				<bucket class="java.lang.String">
+					<expression><![CDATA[$F{ISSALE}]]></expression>
+				</bucket>
+				<header mode="Transparent">
+					<element kind="textField" uuid="3b03c931-f043-4f96-a178-2715229491a9" key="textField" x="0" y="0" width="50" height="25" pdfFontName="Helvetica-Bold" blankWhenNull="false" bold="true" hTextAlign="Center" vTextAlign="Middle">
+						<expression><![CDATA[$V{ISSALE}]]></expression>
+						<box>
+							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+							<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+							<bottomPen lineWidth="0.0" lineColor="#000000"/>
+							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						</box>
+					</element>
+					<box>
+						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</header>
+				<totalHeader mode="Transparent">
+					<box>
+						<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</totalHeader>
+			</columnGroup>
+			<measure name="IVA_Sum" calculation="Sum" class="java.math.BigDecimal">
+				<expression><![CDATA[$F{IVA}]]></expression>
+			</measure>
+			<measure name="IvaInd_Sum" calculation="Sum" class="java.math.BigDecimal">
+				<expression><![CDATA[$F{IVAINDEDUCIBILE}]]></expression>
+			</measure>
+			<cell width="50" height="30">
+				<contents mode="Transparent">
+					<element kind="textField" uuid="b435a8a4-96bc-48a7-8d8e-4f5c6087c8d8" key="textField" x="0" y="0" width="50" height="15" pattern="#,##0.00" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+						<expression><![CDATA[$V{IVA_Sum}]]></expression>
 						<box>
 							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<bottomPen lineWidth="0.0" lineColor="#000000"/>
-							<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						</box>
-						<textField pattern="#,##0.00" isBlankWhenNull="false">
-							<reportElement key="textField" x="0" y="0" width="50" height="15" uuid="b435a8a4-96bc-48a7-8d8e-4f5c6087c8d8"/>
-							<box>
-								<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-								<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-								<bottomPen lineWidth="0.0" lineColor="#000000"/>
-								<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-							</box>
-							<textElement textAlignment="Right" verticalAlignment="Middle"/>
-							<textFieldExpression><![CDATA[$V{IVA_Sum}]]></textFieldExpression>
-						</textField>
-						<textField pattern="#,##0.00" isBlankWhenNull="false">
-							<reportElement key="textField" x="0" y="15" width="50" height="15" uuid="eb32d192-bcd8-415e-8af1-e917b7c8f567"/>
-							<box>
-								<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-								<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-								<bottomPen lineWidth="0.0" lineColor="#000000"/>
-								<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-							</box>
-							<textElement textAlignment="Right"/>
-							<textFieldExpression><![CDATA[$V{IvaInd_Sum}]]></textFieldExpression>
-						</textField>
-					</cellContents>
-				</crosstabCell>
-				<crosstabCell width="50" height="30" columnTotalGroup="ISSALE">
-					<cellContents mode="Transparent">
+					</element>
+					<element kind="textField" uuid="eb32d192-bcd8-415e-8af1-e917b7c8f567" key="textField" x="0" y="15" width="50" height="15" pattern="#,##0.00" blankWhenNull="false" hTextAlign="Right">
+						<expression><![CDATA[$V{IvaInd_Sum}]]></expression>
 						<box>
 							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<bottomPen lineWidth="0.0" lineColor="#000000"/>
-							<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						</box>
-					</cellContents>
-				</crosstabCell>
-				<crosstabCell width="50" height="31" rowTotalGroup="ALIQUOTA">
-					<cellContents mode="Transparent">
+					</element>
+					<box>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</contents>
+			</cell>
+			<cell width="50" height="30" columnTotalGroup="ISSALE">
+				<contents mode="Transparent">
+					<box>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</contents>
+			</cell>
+			<cell width="50" height="31" rowTotalGroup="ALIQUOTA">
+				<contents mode="Transparent">
+					<element kind="textField" uuid="e9670faf-aba1-4bfc-b647-05acc8ef9cd8" key="textField" x="0" y="0" width="50" height="15" pdfFontName="Helvetica-Bold" pattern="#,##0.00" blankWhenNull="false" bold="true" hTextAlign="Right" vTextAlign="Middle">
+						<expression><![CDATA[$V{IVA_Sum}]]></expression>
 						<box>
 							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<bottomPen lineWidth="0.0" lineColor="#000000"/>
-							<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						</box>
-						<textField pattern="#,##0.00" isBlankWhenNull="false">
-							<reportElement key="textField" x="0" y="0" width="50" height="15" uuid="e9670faf-aba1-4bfc-b647-05acc8ef9cd8"/>
-							<box>
-								<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-								<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-								<bottomPen lineWidth="0.0" lineColor="#000000"/>
-								<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-							</box>
-							<textElement textAlignment="Right" verticalAlignment="Middle">
-								<font isBold="true" pdfFontName="Helvetica-Bold"/>
-							</textElement>
-							<textFieldExpression><![CDATA[$V{IVA_Sum}]]></textFieldExpression>
-						</textField>
-						<textField pattern="#,##0.00" isBlankWhenNull="false">
-							<reportElement key="textField-7" x="0" y="15" width="50" height="15" uuid="44748295-9a6f-4598-9708-d86fce59aede"/>
-							<box>
-								<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-								<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-								<bottomPen lineWidth="0.0" lineColor="#000000"/>
-								<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-							</box>
-							<textElement textAlignment="Right">
-								<font isBold="true" pdfFontName="Helvetica-Bold"/>
-							</textElement>
-							<textFieldExpression><![CDATA[$V{IvaInd_Sum}]]></textFieldExpression>
-						</textField>
-					</cellContents>
-				</crosstabCell>
-				<crosstabCell width="50" height="31" rowTotalGroup="ALIQUOTA" columnTotalGroup="ISSALE">
-					<cellContents mode="Transparent">
+					</element>
+					<element kind="textField" uuid="44748295-9a6f-4598-9708-d86fce59aede" key="textField-7" x="0" y="15" width="50" height="15" pdfFontName="Helvetica-Bold" pattern="#,##0.00" blankWhenNull="false" bold="true" hTextAlign="Right">
+						<expression><![CDATA[$V{IvaInd_Sum}]]></expression>
 						<box>
 							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 							<bottomPen lineWidth="0.0" lineColor="#000000"/>
-							<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+							<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						</box>
-					</cellContents>
-				</crosstabCell>
-				<whenNoDataCell>
-					<cellContents mode="Transparent">
-						<box>
-							<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-							<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-							<bottomPen lineWidth="0.0" lineColor="#000000"/>
-							<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
-						</box>
-					</cellContents>
-				</whenNoDataCell>
-			</crosstab>
-			<staticText>
-				<reportElement key="staticText-3" x="321" y="22" width="122" height="20" uuid="126ee43a-7f6f-4e31-b9ea-e90b290ae613"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="12" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Total payment]]></text>
-			</staticText>
-			<textField pattern="#,##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="443" y="22" width="100" height="20" uuid="43a3c64f-8009-44c6-908b-6b1f7bff7c68"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[$V{TotIvaDaPagare}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-4" x="321" y="2" width="122" height="20" uuid="00a2612f-086d-4dfc-884d-d39fe8adb6e3"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="12" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Previous credit.]]></text>
-			</staticText>
-			<textField pattern="#,##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="443" y="2" width="100" height="20" uuid="b4b098e5-6acf-4459-a530-e667368d39ba"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA[( $V{TotCredPrec}.doubleValue()<0 ? new BigDecimal(0) :  $V{TotCredPrec} )]]></textFieldExpression>
-			</textField>
-		</band>
+					</element>
+					<box>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</contents>
+			</cell>
+			<cell width="50" height="31" rowTotalGroup="ALIQUOTA" columnTotalGroup="ISSALE">
+				<contents mode="Transparent">
+					<box>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</contents>
+			</cell>
+		</element>
+		<element kind="staticText" uuid="126ee43a-7f6f-4e31-b9ea-e90b290ae613" key="staticText-3" x="321" y="22" width="122" height="20" fontSize="12.0" pdfFontName="Helvetica-Bold" bold="true" vTextAlign="Middle">
+			<text><![CDATA[Total payment]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="43a3c64f-8009-44c6-908b-6b1f7bff7c68" key="textField" x="443" y="22" width="100" height="20" pattern="#,##0.00" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[$V{TotIvaDaPagare}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="00a2612f-086d-4dfc-884d-d39fe8adb6e3" key="staticText-4" x="321" y="2" width="122" height="20" fontSize="12.0" pdfFontName="Helvetica-Bold" bold="true" vTextAlign="Middle">
+			<text><![CDATA[Previous credit.]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="b4b098e5-6acf-4459-a530-e667368d39ba" key="textField" x="443" y="2" width="100" height="20" pattern="#,##0.00" blankWhenNull="false" hTextAlign="Right">
+			<expression><![CDATA[( $V{TotCredPrec}.doubleValue()<0 ? new BigDecimal(0) :  $V{TotCredPrec} )]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</summary>
 </jasperReport>

--- a/src/org/openbravo/erpReports/ReportRegisterLineJR.jrxml
+++ b/src/org/openbravo/erpReports/ReportRegisterLineJR.jrxml
@@ -1,24 +1,23 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="ReportRegisterLineJR" pageWidth="992" pageHeight="595" orientation="Landscape" columnWidth="932" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="7ef73577-0c62-445e-9f29-a906fde0d16a">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="ReportRegisterLineJR" language="java" pageWidth="992" pageHeight="595" orientation="Landscape" columnWidth="932" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="7ef73577-0c62-445e-9f29-a906fde0d16a">
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
 	<parameter name="invoicedateDA" class="java.lang.String">
-		<parameterDescription><![CDATA[Invoice Date From :]]></parameterDescription>
+		<description><![CDATA[Invoice Date From :]]></description>
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
 	<parameter name="invoicedateA" class="java.lang.String">
-		<parameterDescription><![CDATA[Invoice Date To :]]></parameterDescription>
+		<description><![CDATA[Invoice Date To :]]></description>
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="StartPageNo" class="java.lang.Integer" isForPrompting="false">
-		<parameterDescription><![CDATA[Start Page No]]></parameterDescription>
+	<parameter name="StartPageNo" forPrompting="false" class="java.lang.Integer">
+		<description><![CDATA[Start Page No]]></description>
 		<defaultValueExpression><![CDATA[new Integer(0)]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[select taxreg.name,taxregline.documentno as DocNum,taxregline.created as RegDate , inv.documentno as DocInv, bp.name as RagSoc,
+	<query language="sql"><![CDATA[select taxreg.name,taxregline.documentno as DocNum,taxregline.created as RegDate , inv.documentno as DocInv, bp.name as RagSoc,
  coalesce(taxregline.totalamt,0) as TotAmt, coalesce(taxregline.taxbaseamt,0) as TaxBaseAmt, coalesce(taxregline.exemptamt,0) as ExemptAmt , coalesce(taxregline.taxundamt,0) as TaxUndAmt,
  coalesce(taxregline.taxamt,0) as TaxAmt , (tax.name||'-'||tax.rate || '%') as aliquota
  from c_taxregister taxreg , c_taxregisterline taxregline , c_invoicetax invtax, c_invoice inv ,c_bpartner bp, c_tax tax
@@ -30,8 +29,7 @@
  and 1=1
  and ( taxregline.invoicedate >= to_date($P{invoicedateDA},'DD/MM/YYYY')  ) 
  and ( taxregline.invoicedate <= to_date($P{invoicedateA},'DD/MM/YYYY')  )
- order by taxreg.name]]>
-	</queryString>
+ order by taxreg.name]]></query>
 	<field name="NAME" class="java.lang.String"/>
 	<field name="DOCNUM" class="java.lang.String"/>
 	<field name="REGDATE" class="java.util.Date"/>
@@ -44,7 +42,7 @@
 	<field name="TAXAMT" class="java.math.BigDecimal"/>
 	<field name="ALIQUOTA" class="java.lang.String"/>
 	<group name="RegName">
-		<groupExpression><![CDATA[$F{NAME}]]></groupExpression>
+		<expression><![CDATA[$F{NAME}]]></expression>
 		<groupHeader>
 			<band height="19" splitType="Stretch"/>
 		</groupHeader>
@@ -52,357 +50,241 @@
 			<band height="24" splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="50" splitType="Stretch">
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" x="0" y="3" width="365" height="45" uuid="5c720c1d-dd24-40dd-8899-4d92e53c0fe1"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="12" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{NAME}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="48" width="932" height="1" forecolor="#000000" backcolor="#FFFFFF" uuid="b36ba2f8-942d-46c6-b296-d868f00f52ea"/>
-			</line>
-			<line>
-				<reportElement key="line" x="0" y="3" width="932" height="1" forecolor="#000000" backcolor="#FFFFFF" uuid="3ffa6fc7-468a-40a6-beb7-fa808781458b"/>
-			</line>
-			<textField pattern="" isBlankWhenNull="true">
-				<reportElement key="textField-1" x="365" y="0" width="567" height="50" uuid="da5a0b26-5bc4-4171-bb37-42072b998396"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font isBold="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Date from :    " + $P{invoicedateDA}+"   to    "+$P{invoicedateA}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title height="50" splitType="Stretch">
+		<element kind="textField" uuid="5c720c1d-dd24-40dd-8899-4d92e53c0fe1" key="textField" x="0" y="3" width="365" height="45" fontSize="12.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" bold="true" vTextAlign="Middle">
+			<expression><![CDATA[$F{NAME}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="b36ba2f8-942d-46c6-b296-d868f00f52ea" key="line" x="0" y="48" width="932" height="1" forecolor="#000000" backcolor="#FFFFFF"/>
+		<element kind="line" uuid="3ffa6fc7-468a-40a6-beb7-fa808781458b" key="line" x="0" y="3" width="932" height="1" forecolor="#000000" backcolor="#FFFFFF"/>
+		<element kind="textField" uuid="da5a0b26-5bc4-4171-bb37-42072b998396" key="textField-1" x="365" y="0" width="567" height="50" pattern="" blankWhenNull="true" bold="true" vTextAlign="Middle">
+			<expression><![CDATA["Date from :    " + $P{invoicedateDA}+"   to    "+$P{invoicedateA}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band height="23" splitType="Stretch">
-			<rectangle>
-				<reportElement key="rectangle" mode="Opaque" x="0" y="0" width="782" height="23" forecolor="#000000" uuid="68975f94-14f3-4d63-9b6c-7ed035a6ec02"/>
-				<graphicElement>
-					<pen lineWidth="0.0" lineStyle="Solid"/>
-				</graphicElement>
-			</rectangle>
-			<staticText>
-				<reportElement key="staticText" mode="Transparent" x="0" y="0" width="86" height="23" forecolor="#000000" uuid="a6e829b0-8f6b-4435-8abd-775daba58627"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="12" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Doc No]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText" x="86" y="0" width="86" height="23" forecolor="#000000" uuid="d81ff10c-a171-494a-8f53-636145c62aba"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="12" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Register Date]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText" x="172" y="0" width="86" height="23" forecolor="#000000" uuid="12808066-dcdb-4587-86e3-2ac4666c57e3"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="12" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Invoice Doc No]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText" x="258" y="0" width="86" height="23" forecolor="#000000" uuid="2bb65d42-aa70-4a08-8214-0259a6288a71"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="12" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[B. Partner]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText" x="344" y="0" width="86" height="23" forecolor="#000000" uuid="890ee16c-ccee-4de8-ba58-5707951de58d"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="12" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Tot. Amount]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText" x="430" y="0" width="86" height="23" forecolor="#000000" uuid="ce0857fb-927a-4bde-abac-4dc325d160aa"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="12" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Base Amount]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText" x="516" y="0" width="86" height="23" forecolor="#000000" uuid="a54392b0-10b8-4d3a-823a-c3c690ead5e2"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="12" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Exempt Amount]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText" x="602" y="0" width="86" height="23" forecolor="#000000" uuid="cf02be65-6e84-4b06-a14c-2263cce57864"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="12" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Tax Und. Amount]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText" x="688" y="0" width="86" height="23" forecolor="#000000" uuid="455e62d3-d6e6-479b-b9db-6cd1be13e0cb"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="12" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Tax Amount]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-1" x="774" y="0" width="158" height="23" forecolor="#000000" uuid="11b24ffe-6201-4c95-a57d-af38cc5536cf"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Center">
-					<font size="12" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Tax Name]]></text>
-			</staticText>
-		</band>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader height="23" splitType="Stretch">
+		<element kind="rectangle" uuid="68975f94-14f3-4d63-9b6c-7ed035a6ec02" key="rectangle" mode="Opaque" x="0" y="0" width="782" height="23" forecolor="#000000">
+			<pen lineWidth="0.0" lineStyle="Solid"/>
+		</element>
+		<element kind="staticText" uuid="a6e829b0-8f6b-4435-8abd-775daba58627" key="staticText" mode="Transparent" x="0" y="0" width="86" height="23" forecolor="#000000" fontSize="12.0" bold="true">
+			<text><![CDATA[Doc No]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="d81ff10c-a171-494a-8f53-636145c62aba" key="staticText" x="86" y="0" width="86" height="23" forecolor="#000000" fontSize="12.0" bold="true">
+			<text><![CDATA[Register Date]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="12808066-dcdb-4587-86e3-2ac4666c57e3" key="staticText" x="172" y="0" width="86" height="23" forecolor="#000000" fontSize="12.0" bold="true">
+			<text><![CDATA[Invoice Doc No]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="2bb65d42-aa70-4a08-8214-0259a6288a71" key="staticText" x="258" y="0" width="86" height="23" forecolor="#000000" fontSize="12.0" pdfFontName="Helvetica-Bold" bold="true">
+			<text><![CDATA[B. Partner]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="890ee16c-ccee-4de8-ba58-5707951de58d" key="staticText" x="344" y="0" width="86" height="23" forecolor="#000000" fontSize="12.0" pdfFontName="Helvetica-Bold" bold="true">
+			<text><![CDATA[Tot. Amount]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="ce0857fb-927a-4bde-abac-4dc325d160aa" key="staticText" x="430" y="0" width="86" height="23" forecolor="#000000" fontSize="12.0" bold="true">
+			<text><![CDATA[Base Amount]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="a54392b0-10b8-4d3a-823a-c3c690ead5e2" key="staticText" x="516" y="0" width="86" height="23" forecolor="#000000" fontSize="12.0" bold="true">
+			<text><![CDATA[Exempt Amount]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="cf02be65-6e84-4b06-a14c-2263cce57864" key="staticText" x="602" y="0" width="86" height="23" forecolor="#000000" fontSize="12.0" bold="true">
+			<text><![CDATA[Tax Und. Amount]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="455e62d3-d6e6-479b-b9db-6cd1be13e0cb" key="staticText" x="688" y="0" width="86" height="23" forecolor="#000000" fontSize="12.0" bold="true">
+			<text><![CDATA[Tax Amount]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="11b24ffe-6201-4c95-a57d-af38cc5536cf" key="staticText-1" x="774" y="0" width="158" height="23" forecolor="#000000" fontSize="12.0" bold="true" hTextAlign="Center">
+			<text><![CDATA[Tax Name]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</columnHeader>
 	<detail>
 		<band height="17" splitType="Stretch">
-			<line>
-				<reportElement key="line" x="0" y="16" width="932" height="1" forecolor="#808080" backcolor="#FFFFFF" uuid="9742fd3a-0642-4885-837f-3f94c90b6b73"/>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="0" y="0" width="86" height="17" forecolor="#000000" uuid="106e2087-7686-4ba9-a2ae-188cd9e19111"/>
+			<element kind="line" uuid="9742fd3a-0642-4885-837f-3f94c90b6b73" key="line" x="0" y="16" width="932" height="1" forecolor="#808080" backcolor="#FFFFFF"/>
+			<element kind="textField" uuid="106e2087-7686-4ba9-a2ae-188cd9e19111" key="textField" x="0" y="0" width="86" height="17" forecolor="#000000" fontSize="12.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false">
+				<expression><![CDATA[$F{DOCNUM}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DOCNUM}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="86" y="0" width="86" height="17" forecolor="#000000" uuid="4d66cf03-ac8e-4ee0-9dc5-c539a97ebd3e"/>
+			</element>
+			<element kind="textField" uuid="4d66cf03-ac8e-4ee0-9dc5-c539a97ebd3e" key="textField" x="86" y="0" width="86" height="17" forecolor="#000000" fontSize="12.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false">
+				<expression><![CDATA[$F{REGDATE}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{REGDATE}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="172" y="0" width="86" height="17" forecolor="#000000" uuid="880b18aa-f548-4efa-bb68-a95c5f1dd110"/>
+			</element>
+			<element kind="textField" uuid="880b18aa-f548-4efa-bb68-a95c5f1dd110" key="textField" x="172" y="0" width="86" height="17" forecolor="#000000" fontSize="12.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false">
+				<expression><![CDATA[$F{DOCINV}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{DOCINV}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="258" y="0" width="86" height="17" forecolor="#000000" uuid="3f366a43-6a93-48e2-aade-56ff736294d3"/>
+			</element>
+			<element kind="textField" uuid="3f366a43-6a93-48e2-aade-56ff736294d3" key="textField" x="258" y="0" width="86" height="17" forecolor="#000000" fontSize="12.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false">
+				<expression><![CDATA[$F{RAGSOC}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{RAGSOC}]]></textFieldExpression>
-			</textField>
-			<textField pattern="#,##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="344" y="0" width="86" height="17" forecolor="#000000" uuid="f91091c5-c53d-4575-aa54-7f39cae673f5"/>
+			</element>
+			<element kind="textField" uuid="f91091c5-c53d-4575-aa54-7f39cae673f5" key="textField" x="344" y="0" width="86" height="17" forecolor="#000000" fontSize="12.0" pattern="#,##0.00" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left">
+				<expression><![CDATA[$F{TOTAMT}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left">
-					<font size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{TOTAMT}]]></textFieldExpression>
-			</textField>
-			<textField pattern="#,##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="430" y="0" width="86" height="17" forecolor="#000000" uuid="c78500a6-40df-48ee-81c6-fc307e3e28fe"/>
+			</element>
+			<element kind="textField" uuid="c78500a6-40df-48ee-81c6-fc307e3e28fe" key="textField" x="430" y="0" width="86" height="17" forecolor="#000000" fontSize="12.0" pattern="#,##0.00" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left">
+				<expression><![CDATA[$F{TAXBASEAMT}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left">
-					<font size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{TAXBASEAMT}]]></textFieldExpression>
-			</textField>
-			<textField pattern="#,##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="516" y="0" width="86" height="17" forecolor="#000000" uuid="d8949692-db5a-41f2-b07a-c47873d608c6"/>
+			</element>
+			<element kind="textField" uuid="d8949692-db5a-41f2-b07a-c47873d608c6" key="textField" x="516" y="0" width="86" height="17" forecolor="#000000" fontSize="12.0" pattern="#,##0.00" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left">
+				<expression><![CDATA[$F{EXEMPTAMT}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left">
-					<font size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{EXEMPTAMT}]]></textFieldExpression>
-			</textField>
-			<textField pattern="#,##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="602" y="0" width="86" height="17" forecolor="#000000" uuid="38945438-ba59-451e-af6a-01bf9fb99835"/>
+			</element>
+			<element kind="textField" uuid="38945438-ba59-451e-af6a-01bf9fb99835" key="textField" x="602" y="0" width="86" height="17" forecolor="#000000" fontSize="12.0" pattern="#,##0.00" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left">
+				<expression><![CDATA[$F{TAXUNDAMT}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left">
-					<font size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{TAXUNDAMT}]]></textFieldExpression>
-			</textField>
-			<textField pattern="#,##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="688" y="0" width="86" height="17" forecolor="#000000" uuid="d54a48ee-ae77-414a-a8cc-f2202dab3392"/>
+			</element>
+			<element kind="textField" uuid="d54a48ee-ae77-414a-a8cc-f2202dab3392" key="textField" x="688" y="0" width="86" height="17" forecolor="#000000" fontSize="12.0" pattern="#,##0.00" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left">
+				<expression><![CDATA[$F{TAXAMT}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left">
-					<font size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{TAXAMT}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-2" x="774" y="0" width="158" height="17" forecolor="#000000" uuid="961afa3c-2459-4abf-9af3-7b117a89a308"/>
+			</element>
+			<element kind="textField" uuid="961afa3c-2459-4abf-9af3-7b117a89a308" key="textField-2" x="774" y="0" width="158" height="17" forecolor="#000000" fontSize="12.0" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Center">
+				<expression><![CDATA[$F{ALIQUOTA}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Center">
-					<font size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" isPdfEmbedded="false"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{ALIQUOTA}]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="27" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="719" y="4" width="170" height="19" forecolor="#000000" uuid="a87a8439-8341-4973-ab54-5ed917c57b71"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA["Page   " +(new Integer($V{PAGE_NUMBER}.intValue()+ $P{StartPageNo}.intValue()))]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="3" width="932" height="1" forecolor="#000000" backcolor="#FFFFFF" uuid="6147186a-96c5-4624-b1cf-924305f28162"/>
-			</line>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" x="1" y="6" width="209" height="19" forecolor="#000000" uuid="e76cfe11-e6b3-4d66-8ee3-c3d543d41b79"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="27" splitType="Stretch">
+		<element kind="textField" uuid="a87a8439-8341-4973-ab54-5ed917c57b71" key="textField" x="719" y="4" width="170" height="19" forecolor="#000000" pattern="" blankWhenNull="false" hTextAlign="Right">
+			<expression><![CDATA["Page   " +(new Integer($V{PAGE_NUMBER}.intValue()+ $P{StartPageNo}.intValue()))]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="6147186a-96c5-4624-b1cf-924305f28162" key="line" x="0" y="3" width="932" height="1" forecolor="#000000" backcolor="#FFFFFF"/>
+		<element kind="textField" uuid="e76cfe11-e6b3-4d66-8ee3-c3d543d41b79" key="textField" x="1" y="6" width="209" height="19" forecolor="#000000" blankWhenNull="false">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/RptC_Invoice.jrxml
+++ b/src/org/openbravo/erpReports/RptC_Invoice.jrxml
@@ -1,68 +1,66 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptC_Invoice" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="52d15ca7-c92a-4919-99b9-90d43b194bbd">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="RptC_Invoice" language="java" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="52d15ca7-c92a-4919-99b9-90d43b194bbd">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="160"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
 	<parameter name="DOCUMENT_ID" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'1000032'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DOCUMENT_NAME" class="java.lang.String" isForPrompting="false">
+	<parameter name="DOCUMENT_NAME" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'INVOICE'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/home/openbravo/src/openbravo/erp/devel/bttCourse/pi/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["('1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["('0')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="SUBREPORT_DIR" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{BASE_DESIGN}+"/org/openbravo/erpReports/"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="SUBREP_RptC_Invoice_Lines" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="SUBREP_RptC_Invoice_TaxLines" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT C_INVOICE.C_INVOICE_ID, C_BPARTNER.NAME, C_BPARTNER.TAXID AS CIF, AD_USER.NAME AS CONTACT_NAME, C_LOCATION.ADDRESS1,
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="SUBREP_RptC_Invoice_Lines" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="SUBREP_RptC_Invoice_TaxLines" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<query language="sql"><![CDATA[SELECT C_INVOICE.C_INVOICE_ID, C_BPARTNER.NAME, C_BPARTNER.TAXID AS CIF, AD_USER.NAME AS CONTACT_NAME, C_LOCATION.ADDRESS1,
 C_LOCATION.POSTAL, C_LOCATION.CITY, C_REGION.NAME AS REGION,C_COUNTRY.NAME AS COUNTRY,C_BPARTNER_LOCATION.PHONE AS PHONE, C_BPARTNER_LOCATION.FAX AS FAX,
 C_INVOICE.DATEINVOICED, C_INVOICE.DOCUMENTNO, C_BPARTNER.VALUE AS CODE_BPARTNER,
 AD_CLIENT.DESCRIPTION AS ENTITY, C_Location_Description(AD_ORGINFO.C_LOCATION_ID) AS LOCATION, C_CURRENCY.ISO_CODE AS CURRENCY_CODE,C_CURRENCY.CURSYMBOL AS SYMBOL,
@@ -90,8 +88,7 @@ AND AD_ORG.ad_org_id = AD_ORGINFO.ad_org_id
 AND AD_ORG.ad_org_id = (SELECT o.AD_ORG_ID
                         FROM AD_ORG o JOIN AD_OrgType t USING (AD_ORGTYPE_ID)
                         WHERE AD_ISORGINCLUDED(C_INVOICE.AD_ORG_ID, o.ad_org_id, C_INVOICE.ad_client_id)<>-1
-                              AND (t.IsLegalEntity='Y' OR t.IsAcctLegalEntity='Y'))]]>
-	</queryString>
+                              AND (t.IsLegalEntity='Y' OR t.IsAcctLegalEntity='Y'))]]></query>
 	<field name="C_INVOICE_ID" class="java.lang.String"/>
 	<field name="NAME" class="java.lang.String"/>
 	<field name="CIF" class="java.lang.String"/>
@@ -122,12 +119,12 @@ AND AD_ORG.ad_org_id = (SELECT o.AD_ORG_ID
 	<field name="HEADERMARGIN" class="java.lang.String"/>
 	<field name="ISSOTRX" class="java.lang.String"/>
 	<field name="ISTAXINCLUDED" class="java.lang.String"/>
-	<variable name="TOTAL_LINENETAMT" class="java.math.BigDecimal" resetType="Group" resetGroup="C_INVOICE_ID"/>
-	<variable name="TOTAL_TAXAMT" class="java.math.BigDecimal" resetType="Group" resetGroup="C_INVOICE_ID"/>
+	<variable name="TOTAL_LINENETAMT" resetType="Group" resetGroup="C_INVOICE_ID" class="java.math.BigDecimal"/>
+	<variable name="TOTAL_TAXAMT" resetType="Group" resetGroup="C_INVOICE_ID" class="java.math.BigDecimal"/>
 	<variable name="SHOWLOGO" class="java.lang.String"/>
 	<variable name="SHOWCOMPANYDATA" class="java.lang.String"/>
-	<group name="PrintLarge" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintLarge" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="120" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{HEADERMARGIN}.equalsIgnoreCase("large"))]]></printWhenExpression>
@@ -137,8 +134,8 @@ AND AD_ORG.ad_org_id = (SELECT o.AD_ORG_ID
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="PrintMedium" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintMedium" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="80" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{HEADERMARGIN}.equalsIgnoreCase("medium"))]]></printWhenExpression>
@@ -148,8 +145,8 @@ AND AD_ORG.ad_org_id = (SELECT o.AD_ORG_ID
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="PrintSmall" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintSmall" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="50" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{HEADERMARGIN}.equalsIgnoreCase("small"))]]></printWhenExpression>
@@ -159,150 +156,99 @@ AND AD_ORG.ad_org_id = (SELECT o.AD_ORG_ID
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="C_INVOICE_ID" isStartNewPage="true">
-		<groupExpression><![CDATA[$F{C_INVOICE_ID}]]></groupExpression>
+	<group name="C_INVOICE_ID" startNewPage="true">
+		<expression><![CDATA[$F{C_INVOICE_ID}]]></expression>
 		<groupHeader>
 			<band height="255" splitType="Stretch">
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="Group_Data_Field" x="-3" y="235" width="149" height="18" uuid="f5f705ea-188f-416b-a161-06f420f09ea8"/>
-					<box topPadding="2" leftPadding="5">
+				<element kind="textField" uuid="f5f705ea-188f-416b-a161-06f420f09ea8" key="textField" x="-3" y="235" width="149" height="18" fontSize="10.0" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" style="Group_Data_Field">
+					<expression><![CDATA[$F{DOCUMENTNO}]]></expression>
+					<box topPadding="2" leftPadding="5" style="Group_Data_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left">
-						<font size="10" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{DOCUMENTNO}]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField" style="default" x="387" y="235" width="96" height="18" uuid="9aa91426-cfd4-4f56-b004-0c34f7f56479"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9aa91426-cfd4-4f56-b004-0c34f7f56479" key="textField" x="387" y="235" width="96" height="18" fontName="Times-Roman" fontSize="10.0" textAdjust="StretchHeight" blankWhenNull="true" hTextAlign="Right" style="default">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.applyCountryDateFormat($F{DATEINVOICED},$F{ORGANIZATIONID})]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font fontName="Times-Roman" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.applyCountryDateFormat($F{DATEINVOICED},$F{ORGANIZATIONID})]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-90" style="Group_Data_Label" mode="Transparent" x="-3" y="217" width="149" height="18" forecolor="#999999" backcolor="#FFFFFF" uuid="bb74e183-1e39-4d9b-9002-f163befcc7f6"/>
-					<box leftPadding="5" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Left">
-						<font pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="bb74e183-1e39-4d9b-9002-f163befcc7f6" key="element-90" mode="Transparent" x="-3" y="217" width="149" height="18" forecolor="#999999" backcolor="#FFFFFF" pdfFontName="Helvetica" hTextAlign="Left" style="Group_Data_Label">
 					<text><![CDATA[Invoice Number]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-91" style="Group_Data_Label" mode="Transparent" x="387" y="217" width="96" height="18" forecolor="#999999" backcolor="#FFFFFF" uuid="428cae1c-1470-4e33-a8b9-5d65f3c492a6"/>
-					<box leftPadding="5" rightPadding="2">
+					<box leftPadding="5" rightPadding="2" style="Group_Data_Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="428cae1c-1470-4e33-a8b9-5d65f3c492a6" key="element-91" mode="Transparent" x="387" y="217" width="96" height="18" forecolor="#999999" backcolor="#FFFFFF" pdfFontName="Helvetica" hTextAlign="Right" style="Group_Data_Label">
 					<text><![CDATA[Date]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-35" style="Detail_Data_Field" x="1" y="234" width="482" height="1" uuid="fa8ff49c-a15c-46d4-bd6e-2579adce7f8a"/>
-				</line>
-				<image scaleImage="RetainShape" hAlign="Right" vAlign="Top" isUsingCache="true">
-					<reportElement key="image-1" style="Report_Footer" x="306" y="0" width="176" height="91" uuid="a4b3b256-d5ba-42e3-bd23-44b729f8b418">
-						<printWhenExpression><![CDATA[new Boolean($F{SHOWLOGO}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<box>
+					<box leftPadding="5" rightPadding="2" style="Group_Data_Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<imageExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylegal", $F{ORGANIZATIONID})]]></imageExpression>
-				</image>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-					<reportElement key="textField-9" style="Report_Footer" positionType="Float" x="125" y="169" width="275" height="55" isPrintWhenDetailOverflows="true" forecolor="#FF0000" uuid="a618173f-0bb0-4165-9145-5195ac8c3a80"/>
-					<box>
+				</element>
+				<element kind="line" uuid="fa8ff49c-a15c-46d4-bd6e-2579adce7f8a" key="line-35" x="1" y="234" width="482" height="1" style="Detail_Data_Field"/>
+				<element kind="image" uuid="a4b3b256-d5ba-42e3-bd23-44b729f8b418" key="image-1" x="306" y="0" width="176" height="91" scaleImage="RetainShape" usingCache="true" hImageAlign="Right" vImageAlign="Top" style="Report_Footer">
+					<printWhenExpression><![CDATA[new Boolean($F{SHOWLOGO}.equalsIgnoreCase("Y"))]]></printWhenExpression>
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylegal", $F{ORGANIZATIONID})]]></expression>
+					<box style="Report_Footer">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font size="36"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($F{STATUS}.compareTo("VO")==0) ? "VOIDED" : " ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-14" style="Report_Footer" x="0" y="93" width="285" height="110" isPrintWhenDetailOverflows="true" uuid="accbef2c-cc94-4bd4-884d-87f36e4fbe40"/>
-					<textElement verticalAlignment="Top">
-						<font size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NAME} + "\n" + $F{BP_DATA}]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-					<reportElement key="textField-15" style="Report_Footer" x="307" y="93" width="176" height="42" isPrintWhenDetailOverflows="true" uuid="ad3a5f4d-826a-4d10-910b-ba3dd52d5fff">
-						<printWhenExpression><![CDATA[new Boolean($F{SHOWCOMPANYDATA}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<textElement textAlignment="Right">
-						<font size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{LOCATION}==null ? $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" : $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" + $F{LOCATION})]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-92" style="Group_Data_Label" mode="Transparent" x="210" y="217" width="149" height="18" forecolor="#999999" backcolor="#FFFFFF" uuid="235062e1-4c27-4e80-89e8-72b82a717ad7"/>
-					<box leftPadding="5" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a618173f-0bb0-4165-9145-5195ac8c3a80" key="textField-9" positionType="Float" x="125" y="169" width="275" height="55" forecolor="#FF0000" fontSize="36.0" textAdjust="StretchHeight" blankWhenNull="false" printWhenDetailOverflows="true" hTextAlign="Center" vTextAlign="Middle" style="Report_Footer">
+					<expression><![CDATA[(($F{STATUS}.compareTo("VO")==0) ? "VOIDED" : " ")]]></expression>
+					<box style="Report_Footer">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left">
-						<font pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="textField" uuid="accbef2c-cc94-4bd4-884d-87f36e4fbe40" key="textField-14" x="0" y="93" width="285" height="110" fontSize="10.0" blankWhenNull="false" printWhenDetailOverflows="true" vTextAlign="Top" style="Report_Footer">
+					<expression><![CDATA[$F{NAME} + "\n" + $F{BP_DATA}]]></expression>
+				</element>
+				<element kind="textField" uuid="ad3a5f4d-826a-4d10-910b-ba3dd52d5fff" key="textField-15" x="307" y="93" width="176" height="42" fontSize="10.0" textAdjust="StretchHeight" blankWhenNull="false" printWhenDetailOverflows="true" hTextAlign="Right" style="Report_Footer">
+					<printWhenExpression><![CDATA[new Boolean($F{SHOWCOMPANYDATA}.equalsIgnoreCase("Y"))]]></printWhenExpression>
+					<expression><![CDATA[($F{LOCATION}==null ? $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" : $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" + $F{LOCATION})]]></expression>
+				</element>
+				<element kind="staticText" uuid="235062e1-4c27-4e80-89e8-72b82a717ad7" key="element-92" mode="Transparent" x="210" y="217" width="149" height="18" forecolor="#999999" backcolor="#FFFFFF" pdfFontName="Helvetica" hTextAlign="Left" style="Group_Data_Label">
 					<text><![CDATA[Currency]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField-16" style="Group_Data_Field" x="210" y="235" width="149" height="18" uuid="bd5b35c6-27d3-432e-9fe3-a11459d12c07"/>
-					<box topPadding="2" leftPadding="5">
+					<box leftPadding="5" rightPadding="2" style="Group_Data_Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left">
-						<font size="10" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CURRENCY_CODE}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-15" style="Report_Footer" x="0" y="6" width="310" height="37" uuid="efcbd21a-f97c-4fa9-8228-276e04efc3b7">
-						<printWhenExpression><![CDATA[new Boolean($F{ISSOTRX}.equalsIgnoreCase("N"))]]></printWhenExpression>
-					</reportElement>
-					<textElement>
-						<font size="26"/>
-					</textElement>
+				</element>
+				<element kind="textField" uuid="bd5b35c6-27d3-432e-9fe3-a11459d12c07" key="textField-16" x="210" y="235" width="149" height="18" fontSize="10.0" pdfFontName="Helvetica" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Left" style="Group_Data_Field">
+					<expression><![CDATA[$F{CURRENCY_CODE}]]></expression>
+					<box topPadding="2" leftPadding="5" style="Group_Data_Field">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="efcbd21a-f97c-4fa9-8228-276e04efc3b7" key="staticText-15" x="0" y="6" width="310" height="37" fontSize="26.0" style="Report_Footer">
+					<printWhenExpression><![CDATA[new Boolean($F{ISSOTRX}.equalsIgnoreCase("N"))]]></printWhenExpression>
 					<text><![CDATA[PURCHASE INVOICE]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-16" style="Report_Footer" x="0" y="6" width="310" height="37" uuid="11801970-1d8e-4310-9be2-c615eef79cec">
-						<printWhenExpression><![CDATA[new Boolean($F{ISSOTRX}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<textElement>
-						<font size="26"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="11801970-1d8e-4310-9be2-c615eef79cec" key="staticText-16" x="0" y="6" width="310" height="37" fontSize="26.0" style="Report_Footer">
+					<printWhenExpression><![CDATA[new Boolean($F{ISSOTRX}.equalsIgnoreCase("Y"))]]></printWhenExpression>
 					<text><![CDATA[SALES INVOICE]]></text>
-				</staticText>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -315,127 +261,95 @@ AND AD_ORG.ad_org_id = (SELECT o.AD_ORG_ID
 		</groupHeader>
 		<groupFooter>
 			<band height="16" splitType="Prevent">
-				<subreport isUsingCache="true">
-					<reportElement key="subreport-2" style="Report_Footer" positionType="Float" x="0" y="0" width="482" height="16" uuid="96b39459-a25e-4fc9-9216-59130614421f"/>
-					<subreportParameter name="NUMBERFORMAT">
-						<subreportParameterExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="LOCALE">
-						<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="ISTAXINCLUDED">
-						<subreportParameterExpression><![CDATA[$F{ISTAXINCLUDED}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="TOTAL_LINENET">
-						<subreportParameterExpression><![CDATA[$V{TOTAL_LINENETAMT}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="C_INVOICE_ID">
-						<subreportParameterExpression><![CDATA[$F{C_INVOICE_ID}]]></subreportParameterExpression>
-					</subreportParameter>
+				<element kind="subreport" uuid="96b39459-a25e-4fc9-9216-59130614421f" key="subreport-2" positionType="Float" x="0" y="0" width="482" height="16" usingCache="true" style="Report_Footer">
 					<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-					<returnValue subreportVariable="TOTAL_TAXAMT" toVariable="TOTAL_TAXAMT"/>
-					<subreportExpression><![CDATA[$P{SUBREP_RptC_Invoice_TaxLines}]]></subreportExpression>
-				</subreport>
+					<expression><![CDATA[$P{SUBREP_RptC_Invoice_TaxLines}]]></expression>
+					<returnValue toVariable="TOTAL_TAXAMT" subreportVariable="TOTAL_TAXAMT"/>
+					<parameter name="NUMBERFORMAT">
+						<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></expression>
+					</parameter>
+					<parameter name="LOCALE">
+						<expression><![CDATA[$P{LOCALE}]]></expression>
+					</parameter>
+					<parameter name="ISTAXINCLUDED">
+						<expression><![CDATA[$F{ISTAXINCLUDED}]]></expression>
+					</parameter>
+					<parameter name="TOTAL_LINENET">
+						<expression><![CDATA[$V{TOTAL_LINENETAMT}]]></expression>
+					</parameter>
+					<parameter name="C_INVOICE_ID">
+						<expression><![CDATA[$F{C_INVOICE_ID}]]></expression>
+					</parameter>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="27" splitType="Stretch">
-			<subreport isUsingCache="true">
-				<reportElement key="subreport-3" style="Report_Footer" x="0" y="0" width="482" height="16" uuid="d628a0b3-7269-43bd-a24d-ef01419f19ef"/>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LOCALE">
-					<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="ISTAXINCLUDED">
-					<subreportParameterExpression><![CDATA[$F{ISTAXINCLUDED}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="C_INVOICE_ID">
-					<subreportParameterExpression><![CDATA[$F{C_INVOICE_ID}]]></subreportParameterExpression>
-				</subreportParameter>
+			<element kind="subreport" uuid="d628a0b3-7269-43bd-a24d-ef01419f19ef" key="subreport-3" x="0" y="0" width="482" height="16" usingCache="true" style="Report_Footer">
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<returnValue subreportVariable="TOTAL_LINENETAMT" toVariable="TOTAL_LINENETAMT"/>
-				<subreportExpression><![CDATA[$P{SUBREP_RptC_Invoice_Lines}]]></subreportExpression>
-			</subreport>
+				<expression><![CDATA[$P{SUBREP_RptC_Invoice_Lines}]]></expression>
+				<returnValue toVariable="TOTAL_LINENETAMT" subreportVariable="TOTAL_LINENETAMT"/>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></expression>
+				</parameter>
+				<parameter name="LOCALE">
+					<expression><![CDATA[$P{LOCALE}]]></expression>
+				</parameter>
+				<parameter name="ISTAXINCLUDED">
+					<expression><![CDATA[$F{ISTAXINCLUDED}]]></expression>
+				</parameter>
+				<parameter name="C_INVOICE_ID">
+					<expression><![CDATA[$F{C_INVOICE_ID}]]></expression>
+				</parameter>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="72" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="344" y="49" width="95" height="19" uuid="0d7836d8-7ccd-4e1c-890e-3f8b4e946e8e"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="443" y="49" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="a6523444-dba0-438e-9d97-f5b44581382b"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-13" style="default" x="-1" y="6" width="89" height="18" forecolor="#999999" uuid="17f6e23a-d850-400a-96fd-1609fd315482"/>
-				<box leftPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left"/>
-				<text><![CDATA[Payment Terms]]></text>
-			</staticText>
-			<line>
-				<reportElement key="line-36" style="Report_Footer" x="0" y="25" width="483" height="1" uuid="158b18a7-f580-476b-a975-dd1bb4e3062d"/>
-			</line>
-			<line>
-				<reportElement key="line-38" x="0" y="49" width="483" height="1" uuid="17718ab7-cca2-4b3d-9dea-8a300b20737c"/>
-			</line>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" x="1" y="24" width="89" height="18" uuid="a3560b45-f854-44d4-9e32-7cb27c80033d"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PAYTERM}]]></textFieldExpression>
-			</textField>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="72" splitType="Stretch">
+		<element kind="textField" uuid="0d7836d8-7ccd-4e1c-890e-3f8b4e946e8e" key="textField" x="344" y="49" width="95" height="19" pattern="" blankWhenNull="false" hTextAlign="Right" style="default">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box style="default">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="a6523444-dba0-438e-9d97-f5b44581382b" key="textField" x="443" y="49" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle" style="default">
+			<paragraph lineSpacing="Single" style="default"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box style="default">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="17f6e23a-d850-400a-96fd-1609fd315482" key="staticText-13" x="-1" y="6" width="89" height="18" forecolor="#999999" hTextAlign="Left" style="default">
+			<text><![CDATA[Payment Terms]]></text>
+			<box leftPadding="2" style="default">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="158b18a7-f580-476b-a975-dd1bb4e3062d" key="line-36" x="0" y="25" width="483" height="1" style="Report_Footer"/>
+		<element kind="line" uuid="17718ab7-cca2-4b3d-9dea-8a300b20737c" key="line-38" x="0" y="49" width="483" height="1"/>
+		<element kind="textField" uuid="a3560b45-f854-44d4-9e32-7cb27c80033d" key="textField" x="1" y="24" width="89" height="18" fontSize="8.0" blankWhenNull="false" vTextAlign="Middle">
+			<expression><![CDATA[$F{PAYTERM}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/RptC_Invoice_Lines.jrxml
+++ b/src/org/openbravo/erpReports/RptC_Invoice_Lines.jrxml
@@ -1,41 +1,39 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptC_Invoice_Lines" pageWidth="482" pageHeight="842" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="914f920f-ee82-4deb-a352-2a441707699d">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="RptC_Invoice_Lines" language="java" pageWidth="482" pageHeight="842" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="914f920f-ee82-4deb-a352-2a441707699d">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
 	<parameter name="C_INVOICE_ID" class="java.lang.String"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
 	<parameter name="ISTAXINCLUDED" class="java.lang.String"/>
-	<queryString>
-		<![CDATA[SELECT C_INVOICE.C_INVOICE_ID, COALESCE(M_PRODUCT.NAME, C_INVOICELINE.DESCRIPTION) AS NAME_PRODUCT, C_INVOICELINE.QTYINVOICED,
+	<query language="sql"><![CDATA[SELECT C_INVOICE.C_INVOICE_ID, COALESCE(M_PRODUCT.NAME, C_INVOICELINE.DESCRIPTION) AS NAME_PRODUCT, C_INVOICELINE.QTYINVOICED,
      C_UOM.NAME AS UOMNAME, C_INVOICELINE.DESCRIPTION,
         CASE WHEN $P{ISTAXINCLUDED}='Y' THEN C_INVOICELINE.LINE_GROSS_AMOUNT ELSE C_INVOICELINE.LINENETAMT END AS LINENETAMT,
         CASE WHEN $P{ISTAXINCLUDED}='Y' THEN C_INVOICELINE.GROSS_UNIT_PRICE ELSE C_INVOICELINE.PRICEACTUAL END AS PRICEACTUAL,
@@ -49,8 +47,7 @@
            C_INVOICE
         WHERE C_INVOICELINE.C_INVOICE_ID = C_INVOICE.C_INVOICE_ID
         AND C_INVOICE.C_INVOICE_ID = $P{C_INVOICE_ID}
-        ORDER BY C_INVOICELINE.LINE]]>
-	</queryString>
+        ORDER BY C_INVOICELINE.LINE]]></query>
 	<field name="C_INVOICE_ID" class="java.lang.String"/>
 	<field name="NAME_PRODUCT" class="java.lang.String"/>
 	<field name="QTYINVOICED" class="java.math.BigDecimal"/>
@@ -61,272 +58,178 @@
 	<field name="INOUTNO" class="java.lang.String"/>
 	<field name="ORDERNO" class="java.lang.String"/>
 	<field name="REFERENCE" class="java.lang.String"/>
-	<variable name="TOTAL_LINENETAMT" class="java.math.BigDecimal" resetType="Group" resetGroup="C_INVOICE_ID" calculation="Sum">
-		<variableExpression><![CDATA[$F{LINENETAMT}]]></variableExpression>
+	<variable name="TOTAL_LINENETAMT" resetType="Group" calculation="Sum" resetGroup="C_INVOICE_ID" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{LINENETAMT}]]></expression>
 	</variable>
-	<group name="C_INVOICE_ID" isResetPageNumber="true">
-		<groupExpression><![CDATA[$F{C_INVOICE_ID}]]></groupExpression>
+	<group name="C_INVOICE_ID" resetPageNumber="true">
+		<expression><![CDATA[$F{C_INVOICE_ID}]]></expression>
 		<groupHeader>
 			<band height="16" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText-1" style="Detail_Header" x="0" y="0" width="72" height="16" uuid="032950d0-dda4-4748-9b61-2d135ad35ba2"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font isBold="false"/>
-					</textElement>
+				<element kind="staticText" uuid="032950d0-dda4-4748-9b61-2d135ad35ba2" key="staticText-1" x="0" y="0" width="72" height="16" bold="false" style="Detail_Header">
 					<text><![CDATA[REFERENCE]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-2" style="Detail_Header" x="72" y="0" width="140" height="16" uuid="74171317-5a1f-4ec9-b5eb-556dc7c26bac"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font isBold="false"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="74171317-5a1f-4ec9-b5eb-556dc7c26bac" key="staticText-2" x="72" y="0" width="140" height="16" bold="false" style="Detail_Header">
 					<text><![CDATA[PRODUCT NAME]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-3" style="Detail_Header" x="212" y="0" width="50" height="16" uuid="47aff974-f658-4425-afa9-a4b3331a8566"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font isBold="false"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="47aff974-f658-4425-afa9-a4b3331a8566" key="staticText-3" x="212" y="0" width="50" height="16" bold="false" style="Detail_Header">
 					<text><![CDATA[UOM]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-4" style="Detail_Header" x="262" y="0" width="58" height="16" uuid="a6f23bf4-304f-4d31-94c5-47feb1152d12"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="a6f23bf4-304f-4d31-94c5-47feb1152d12" key="staticText-4" x="262" y="0" width="58" height="16" pdfFontName="Helvetica" bold="false" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[QUANTITY]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-8" style="Detail_Header" x="321" y="0" width="79" height="16" uuid="8c8f8efa-7d68-42e8-a185-03e782b4b8cb"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font isBold="false"/>
-					</textElement>
+					<box leftPadding="5" style="Detail_Header">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="8c8f8efa-7d68-42e8-a185-03e782b4b8cb" key="staticText-8" x="321" y="0" width="79" height="16" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[PRICE]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-9" style="Detail_Header" x="401" y="0" width="81" height="16" uuid="75c97737-44b0-462b-87a3-a21b8cd6ad3a"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font size="10" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="75c97737-44b0-462b-87a3-a21b8cd6ad3a" key="staticText-9" x="401" y="0" width="81" height="16" fontSize="10.0" pdfFontName="Helvetica" bold="false" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[TOTAL]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-9" style="Report_Footer" x="400" y="0" width="1" height="16" forecolor="#FFFFFF" uuid="11c386a7-70e6-4afb-9380-9571fd8e932b"/>
-				</line>
-				<line>
-					<reportElement key="line-10" style="Report_Footer" x="482" y="0" width="1" height="16" forecolor="#FFFFFF" uuid="9f9dcafe-75f7-4f59-9f24-0dc850bd1ada"/>
-				</line>
-				<line>
-					<reportElement key="line-11" style="Report_Footer" x="321" y="0" width="1" height="16" forecolor="#FFFFFF" uuid="39ba6e6f-4e17-407e-be2a-02ac7f5ca1d0"/>
-				</line>
-				<line>
-					<reportElement key="line-12" style="Report_Footer" x="262" y="0" width="1" height="16" forecolor="#FFFFFF" uuid="10fd74ea-dc17-4f7f-9387-d9982e975f9f"/>
-				</line>
-				<line>
-					<reportElement key="line-13" style="Report_Footer" x="211" y="0" width="1" height="16" forecolor="#FFFFFF" uuid="2f854796-10cb-481e-abd7-488327a4aa96"/>
-				</line>
-				<line>
-					<reportElement key="line-14" style="Report_Footer" x="72" y="0" width="1" height="16" forecolor="#FFFFFF" uuid="c5ead66a-680d-4411-b076-0adcb830636f"/>
-				</line>
-				<line>
-					<reportElement key="line-15" style="Report_Footer" x="0" y="0" width="1" height="16" forecolor="#FFFFFF" uuid="f02f3672-d565-48a3-b629-103491ede736"/>
-				</line>
-				<line>
-					<reportElement key="line-16" style="Report_Footer" x="0" y="0" width="482" height="1" forecolor="#FFFFFF" uuid="e82a1599-6eef-4219-888b-16f889e0d5c3"/>
-				</line>
+				</element>
+				<element kind="line" uuid="11c386a7-70e6-4afb-9380-9571fd8e932b" key="line-9" x="400" y="0" width="1" height="16" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="line" uuid="9f9dcafe-75f7-4f59-9f24-0dc850bd1ada" key="line-10" x="482" y="0" width="1" height="16" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="line" uuid="39ba6e6f-4e17-407e-be2a-02ac7f5ca1d0" key="line-11" x="321" y="0" width="1" height="16" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="line" uuid="10fd74ea-dc17-4f7f-9387-d9982e975f9f" key="line-12" x="262" y="0" width="1" height="16" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="line" uuid="2f854796-10cb-481e-abd7-488327a4aa96" key="line-13" x="211" y="0" width="1" height="16" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="line" uuid="c5ead66a-680d-4411-b076-0adcb830636f" key="line-14" x="72" y="0" width="1" height="16" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="line" uuid="f02f3672-d565-48a3-b629-103491ede736" key="line-15" x="0" y="0" width="1" height="16" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="line" uuid="e82a1599-6eef-4219-888b-16f889e0d5c3" key="line-16" x="0" y="0" width="482" height="1" forecolor="#FFFFFF" style="Report_Footer"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="27" splitType="Stretch">
-				<line>
-					<reportElement key="line-1" style="Report_Footer" x="0" y="0" width="482" height="1" uuid="a358614c-50aa-4150-ba2b-1bfe9d525459"/>
-				</line>
-				<staticText>
-					<reportElement key="staticText-7" style="default" x="262" y="1" width="138" height="16" uuid="5d5d4b31-535c-48bb-97cf-cd4243502779">
-						<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("N")]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Left">
-						<font size="10"/>
-					</textElement>
+				<element kind="line" uuid="a358614c-50aa-4150-ba2b-1bfe9d525459" key="line-1" x="0" y="0" width="482" height="1" style="Report_Footer"/>
+				<element kind="staticText" uuid="5d5d4b31-535c-48bb-97cf-cd4243502779" key="staticText-7" x="262" y="1" width="138" height="16" fontSize="10.0" hTextAlign="Left" style="default">
+					<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("N")]]></printWhenExpression>
 					<text><![CDATA[TOTAL (WITHOUT TAXES):]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Total_Gray" x="400" y="1" width="81" height="16" uuid="10f2085e-a2a6-4335-a83c-8e2f78b21d15"/>
-					<box leftPadding="2" rightPadding="2">
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[($V{TOTAL_LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($V{TOTAL_LINENETAMT}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-7" style="default" x="351" y="1" width="49" height="16" uuid="a4946fc4-1359-4985-94d6-c9ff4d112ba8">
-						<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("Y")]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="10f2085e-a2a6-4335-a83c-8e2f78b21d15" key="textField" x="400" y="1" width="81" height="16" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Total_Gray">
+					<expression><![CDATA[($V{TOTAL_LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($V{TOTAL_LINENETAMT}):new String(" ")]]></expression>
+					<box leftPadding="2" rightPadding="2" style="Total_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left">
-						<font size="10"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="a4946fc4-1359-4985-94d6-c9ff4d112ba8" key="staticText-7" x="351" y="1" width="49" height="16" fontSize="10.0" hTextAlign="Left" style="default">
+					<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("Y")]]></printWhenExpression>
 					<text><![CDATA[TOTAL :]]></text>
-				</staticText>
+					<box leftPadding="2" rightPadding="2" style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<frame>
-				<reportElement key="frame-1" style="Detail_Line" x="0" y="0" width="482" height="16" uuid="1b4579c4-f435-4a8b-aa5b-a99ba03213a7"/>
-				<box>
+			<element kind="frame" uuid="1b4579c4-f435-4a8b-aa5b-a99ba03213a7" key="frame-1" x="0" y="0" width="482" height="16" style="Detail_Line">
+				<element kind="textField" uuid="01ffc676-67b8-4494-8bfa-3e017e5bd464" key="textField-1" x="0" y="0" width="72" height="16" forecolor="#000000" blankWhenNull="true" vTextAlign="Middle" style="default">
+					<expression><![CDATA[$F{REFERENCE}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="0f1a35b8-ade6-4cc3-af4c-ebb438ef47f2" key="textField-2" x="400" y="0" width="81" height="16" forecolor="#000000" pattern="" blankWhenNull="false" hTextAlign="Right" style="default">
+					<expression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}):new String(" ")]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="73ae64dc-9c08-4f5b-8ce5-c9dc7d3200db" key="textField-3" x="320" y="0" width="79" height="16" forecolor="#000000" pattern="" blankWhenNull="false" hTextAlign="Right" style="default">
+					<expression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}):new String(" ")]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="b1f08bf8-6457-42f2-8000-8a8d3e6384d0" key="textField-4" x="262" y="0" width="58" height="16" forecolor="#000000" pattern="" blankWhenNull="false" hTextAlign="Right" style="default">
+					<expression><![CDATA[($F{QTYINVOICED}!=null)?$P{NUMBERFORMAT}.format($F{QTYINVOICED}):new String(" ")]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="e2398455-9920-4975-b127-e2467b31f88d" key="textField-5" x="212" y="0" width="50" height="16" forecolor="#000000" blankWhenNull="true" style="default">
+					<expression><![CDATA[$F{UOMNAME}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="ed65c968-41b0-4222-bd96-bd441c3db882" key="textField-6" x="72" y="0" width="140" height="16" forecolor="#000000" blankWhenNull="true" vTextAlign="Middle" style="default">
+					<expression><![CDATA[$F{NAME_PRODUCT}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<box style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-1" style="default" x="0" y="0" width="72" height="16" forecolor="#000000" uuid="01ffc676-67b8-4494-8bfa-3e017e5bd464"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{REFERENCE}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-2" style="default" x="400" y="0" width="81" height="16" forecolor="#000000" uuid="0f1a35b8-ade6-4cc3-af4c-ebb438ef47f2"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-3" style="default" x="320" y="0" width="79" height="16" forecolor="#000000" uuid="73ae64dc-9c08-4f5b-8ce5-c9dc7d3200db"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-4" style="default" x="262" y="0" width="58" height="16" forecolor="#000000" uuid="b1f08bf8-6457-42f2-8000-8a8d3e6384d0"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($F{QTYINVOICED}!=null)?$P{NUMBERFORMAT}.format($F{QTYINVOICED}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-5" style="default" x="212" y="0" width="50" height="16" forecolor="#000000" uuid="e2398455-9920-4975-b127-e2467b31f88d"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textFieldExpression><![CDATA[$F{UOMNAME}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-6" style="default" x="72" y="0" width="140" height="16" forecolor="#000000" uuid="ed65c968-41b0-4222-bd96-bd441c3db882"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{NAME_PRODUCT}]]></textFieldExpression>
-				</textField>
-			</frame>
-			<line>
-				<reportElement key="line-2" style="Report_Footer" stretchType="RelativeToBandHeight" x="72" y="0" width="1" height="16" uuid="a6ca3022-36c4-4a09-b5d0-dfb737daebee"/>
-			</line>
-			<line>
-				<reportElement key="line-3" style="Report_Footer" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="16" uuid="2f915de9-0ca2-4189-bf97-3417c2bf4755"/>
-			</line>
-			<line>
-				<reportElement key="line-4" style="Report_Footer" stretchType="RelativeToBandHeight" x="211" y="0" width="1" height="16" uuid="e70d1970-275e-42e3-9c0d-bef956c836fc"/>
-			</line>
-			<line>
-				<reportElement key="line-5" style="Report_Footer" stretchType="RelativeToBandHeight" x="262" y="0" width="1" height="16" uuid="a2de6d10-e122-416e-9ca4-572d97340d25"/>
-			</line>
-			<line>
-				<reportElement key="line-6" style="Report_Footer" stretchType="RelativeToBandHeight" x="321" y="0" width="1" height="16" uuid="8884f20f-d680-476f-bcb2-e13c509e076d"/>
-			</line>
-			<line>
-				<reportElement key="line-7" style="Report_Footer" stretchType="RelativeToBandHeight" x="400" y="0" width="1" height="16" uuid="b2a25a54-ce87-4cfb-af6e-36478c4557c1"/>
-			</line>
-			<line>
-				<reportElement key="line-8" style="Report_Footer" stretchType="RelativeToBandHeight" x="482" y="0" width="1" height="16" uuid="c4573fb9-de01-4cd7-8f38-f2567f3e07b5"/>
-			</line>
+			</element>
+			<element kind="line" uuid="a6ca3022-36c4-4a09-b5d0-dfb737daebee" key="line-2" stretchType="ContainerHeight" x="72" y="0" width="1" height="16" style="Report_Footer"/>
+			<element kind="line" uuid="2f915de9-0ca2-4189-bf97-3417c2bf4755" key="line-3" stretchType="ContainerHeight" x="0" y="0" width="1" height="16" style="Report_Footer"/>
+			<element kind="line" uuid="e70d1970-275e-42e3-9c0d-bef956c836fc" key="line-4" stretchType="ContainerHeight" x="211" y="0" width="1" height="16" style="Report_Footer"/>
+			<element kind="line" uuid="a2de6d10-e122-416e-9ca4-572d97340d25" key="line-5" stretchType="ContainerHeight" x="262" y="0" width="1" height="16" style="Report_Footer"/>
+			<element kind="line" uuid="8884f20f-d680-476f-bcb2-e13c509e076d" key="line-6" stretchType="ContainerHeight" x="321" y="0" width="1" height="16" style="Report_Footer"/>
+			<element kind="line" uuid="b2a25a54-ce87-4cfb-af6e-36478c4557c1" key="line-7" stretchType="ContainerHeight" x="400" y="0" width="1" height="16" style="Report_Footer"/>
+			<element kind="line" uuid="c4573fb9-de01-4cd7-8f38-f2567f3e07b5" key="line-8" stretchType="ContainerHeight" x="482" y="0" width="1" height="16" style="Report_Footer"/>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/RptC_Invoice_Lines_new.jrxml
+++ b/src/org/openbravo/erpReports/RptC_Invoice_Lines_new.jrxml
@@ -1,41 +1,39 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptC_Invoice_Lines_new" pageWidth="482" pageHeight="842" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="ba4d8f44-3c1b-454b-bcd0-f125d06a7071">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="RptC_Invoice_Lines_new" language="java" pageWidth="482" pageHeight="842" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="ba4d8f44-3c1b-454b-bcd0-f125d06a7071">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.5"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
 	<parameter name="C_INVOICE_ID" class="java.lang.String"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
 	<parameter name="ISTAXINCLUDED" class="java.lang.String"/>
-	<queryString>
-		<![CDATA[SELECT C_INVOICE.C_INVOICE_ID, COALESCE(M_PRODUCT.NAME, COALESCE(C_GLITEM.NAME, C_INVOICELINE.DESCRIPTION)) AS NAME_PRODUCT, C_INVOICELINE.QTYINVOICED,
+	<query language="sql"><![CDATA[SELECT C_INVOICE.C_INVOICE_ID, COALESCE(M_PRODUCT.NAME, COALESCE(C_GLITEM.NAME, C_INVOICELINE.DESCRIPTION)) AS NAME_PRODUCT, C_INVOICELINE.QTYINVOICED,
      C_UOM.NAME AS UOMNAME, C_INVOICELINE.DESCRIPTION,
         CASE WHEN $P{ISTAXINCLUDED}='Y' THEN C_INVOICELINE.LINE_GROSS_AMOUNT ELSE C_INVOICELINE.LINENETAMT END AS LINENETAMT,
         CASE WHEN $P{ISTAXINCLUDED}='Y' THEN C_INVOICELINE.GROSS_UNIT_PRICE ELSE C_INVOICELINE.PRICEACTUAL END AS PRICEACTUAL,
@@ -50,8 +48,7 @@
            C_INVOICE
         WHERE C_INVOICELINE.C_INVOICE_ID = C_INVOICE.C_INVOICE_ID
         AND C_INVOICE.C_INVOICE_ID = $P{C_INVOICE_ID}
-        ORDER BY C_INVOICELINE.LINE]]>
-	</queryString>
+        ORDER BY C_INVOICELINE.LINE]]></query>
 	<field name="C_INVOICE_ID" class="java.lang.String"/>
 	<field name="NAME_PRODUCT" class="java.lang.String"/>
 	<field name="QTYINVOICED" class="java.math.BigDecimal"/>
@@ -62,283 +59,184 @@
 	<field name="INOUTNO" class="java.lang.String"/>
 	<field name="ORDERNO" class="java.lang.String"/>
 	<field name="REFERENCE" class="java.lang.String"/>
-	<variable name="TOTAL_LINENETAMT" class="java.math.BigDecimal" resetType="Group" resetGroup="C_INVOICE_ID" calculation="Sum">
-		<variableExpression><![CDATA[$F{LINENETAMT}]]></variableExpression>
+	<variable name="TOTAL_LINENETAMT" resetType="Group" calculation="Sum" resetGroup="C_INVOICE_ID" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{LINENETAMT}]]></expression>
 	</variable>
-	<group name="C_INVOICE_ID" isResetPageNumber="true">
-		<groupExpression><![CDATA[$F{C_INVOICE_ID}]]></groupExpression>
+	<group name="C_INVOICE_ID" resetPageNumber="true">
+		<expression><![CDATA[$F{C_INVOICE_ID}]]></expression>
 		<groupHeader>
 			<band height="25" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText-1" style="Detail_Header" mode="Transparent" x="0" y="2" width="72" height="22" forecolor="#7E7979" backcolor="#FFFFFF" uuid="73133fd4-c020-492e-987f-816c28b9d448"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font fontName="DejaVu Sans" isBold="true"/>
-					</textElement>
+				<element kind="staticText" uuid="73133fd4-c020-492e-987f-816c28b9d448" key="staticText-1" mode="Transparent" x="0" y="2" width="72" height="22" forecolor="#7E7979" backcolor="#FFFFFF" fontName="DejaVu Sans" bold="true" style="Detail_Header">
 					<text><![CDATA[Reference]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-2" style="Detail_Header" mode="Transparent" x="72" y="2" width="140" height="22" forecolor="#7E7979" backcolor="#FFFFFF" uuid="250930ee-741e-4c4f-a699-113d795add9a"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="DejaVu Sans" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="250930ee-741e-4c4f-a699-113d795add9a" key="staticText-2" mode="Transparent" x="72" y="2" width="140" height="22" forecolor="#7E7979" backcolor="#FFFFFF" fontName="DejaVu Sans" bold="true" style="Detail_Header">
 					<text><![CDATA[Product name]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-3" style="Detail_Header" mode="Transparent" x="212" y="2" width="50" height="22" forecolor="#7E7979" backcolor="#FFFFFF" uuid="6fe364d9-193f-4f8b-a0d1-27f3386f98b0"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="DejaVu Sans" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="6fe364d9-193f-4f8b-a0d1-27f3386f98b0" key="staticText-3" mode="Transparent" x="212" y="2" width="50" height="22" forecolor="#7E7979" backcolor="#FFFFFF" fontName="DejaVu Sans" bold="true" style="Detail_Header">
 					<text><![CDATA[Uom]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-4" style="Detail_Header" mode="Transparent" x="262" y="2" width="58" height="22" forecolor="#7E7979" backcolor="#FFFFFF" uuid="d1db2827-0fbe-44a5-a76a-6d01c4644520"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font fontName="DejaVu Sans" isBold="true" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="d1db2827-0fbe-44a5-a76a-6d01c4644520" key="staticText-4" mode="Transparent" x="262" y="2" width="58" height="22" forecolor="#7E7979" backcolor="#FFFFFF" fontName="DejaVu Sans" pdfFontName="Helvetica" bold="true" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-8" style="Detail_Header" mode="Transparent" x="321" y="2" width="79" height="22" forecolor="#7E7979" backcolor="#FFFFFF" uuid="cd90eabc-d174-43fb-9b6d-ad6e6af0e8fe"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" isBold="true"/>
-					</textElement>
+					<box leftPadding="5" style="Detail_Header">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="cd90eabc-d174-43fb-9b6d-ad6e6af0e8fe" key="staticText-8" mode="Transparent" x="321" y="2" width="79" height="22" forecolor="#7E7979" backcolor="#FFFFFF" fontName="DejaVu Sans" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Price]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-9" style="Detail_Header" mode="Transparent" x="401" y="2" width="81" height="22" forecolor="#7E7979" backcolor="#FFFFFF" uuid="8b85962a-807f-42c4-93e0-2acf5e294480"/>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="10" isBold="true" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="8b85962a-807f-42c4-93e0-2acf5e294480" key="staticText-9" mode="Transparent" x="401" y="2" width="81" height="22" forecolor="#7E7979" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="10.0" pdfFontName="Helvetica" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Total]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-1" x="0" y="23" width="482" height="1" forecolor="#CCCCCC" uuid="7b2064dc-4184-438e-9b6f-01e2f1e3e677"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Double" lineColor="#A3A1A1"/>
-					</graphicElement>
-				</line>
+				</element>
+				<element kind="line" uuid="7b2064dc-4184-438e-9b6f-01e2f1e3e677" key="line-1" x="0" y="23" width="482" height="1" forecolor="#CCCCCC">
+					<pen lineWidth="2.0" lineStyle="Double" lineColor="#A3A1A1"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="39" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText-7" style="default" x="251" y="17" width="149" height="21" forecolor="#7E7979" uuid="801f62b7-4ac4-49cf-b888-d7efb917a192">
-						<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("N")]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font fontName="DejaVu Sans" size="12" isBold="true"/>
-					</textElement>
+				<element kind="staticText" uuid="801f62b7-4ac4-49cf-b888-d7efb917a192" key="staticText-7" x="251" y="17" width="149" height="21" forecolor="#7E7979" fontName="DejaVu Sans" fontSize="12.0" bold="true" hTextAlign="Right" style="default">
+					<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("N")]]></printWhenExpression>
 					<text><![CDATA[Total (without taxes)]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Total_Gray" x="400" y="17" width="81" height="21" backcolor="#FFFFFF" uuid="2b21559e-2ef9-4787-bcf6-155adf08293f"/>
-					<box leftPadding="2" rightPadding="2">
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" isBold="true"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($V{TOTAL_LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($V{TOTAL_LINENETAMT}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-7" style="default" x="351" y="17" width="49" height="21" forecolor="#7E7979" uuid="2cfc942f-f848-4b9f-8110-3058a431808d">
-						<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("Y")]]></printWhenExpression>
-					</reportElement>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="2b21559e-2ef9-4787-bcf6-155adf08293f" key="textField" x="400" y="17" width="81" height="21" backcolor="#FFFFFF" fontName="DejaVu Sans" pattern="" blankWhenNull="false" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Total_Gray">
+					<expression><![CDATA[($V{TOTAL_LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($V{TOTAL_LINENETAMT}):new String(" ")]]></expression>
+					<box leftPadding="2" rightPadding="2" style="Total_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left">
-						<font fontName="DejaVu Sans" size="12" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="2cfc942f-f848-4b9f-8110-3058a431808d" key="staticText-7" x="351" y="17" width="49" height="21" forecolor="#7E7979" fontName="DejaVu Sans" fontSize="12.0" bold="true" hTextAlign="Left" style="default">
+					<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("Y")]]></printWhenExpression>
 					<text><![CDATA[Total]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-12" x="251" y="17" width="231" height="1" forecolor="#CCCCCC" uuid="4dc5ad01-9251-441d-83fd-0139da3159d1">
-						<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("N")]]></printWhenExpression>
-					</reportElement>
-					<graphicElement>
-						<pen lineWidth="2.0"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-12" x="251" y="37" width="231" height="1" forecolor="#CCCCCC" uuid="8fad398d-4031-4516-b541-2b0f0b841a19">
-						<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("N")]]></printWhenExpression>
-					</reportElement>
-					<graphicElement>
-						<pen lineWidth="2.0"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-12" x="351" y="17" width="130" height="1" forecolor="#CCCCCC" uuid="4781b54b-935d-439a-9721-596c3c7c01e9">
-						<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("Y")]]></printWhenExpression>
-					</reportElement>
-					<graphicElement>
-						<pen lineWidth="2.0"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-12" x="351" y="37" width="129" height="1" forecolor="#CCCCCC" uuid="3881eb1f-706d-4e1a-9776-39f5a8f52589">
-						<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("Y")]]></printWhenExpression>
-					</reportElement>
-					<graphicElement>
-						<pen lineWidth="2.0"/>
-					</graphicElement>
-				</line>
+					<box leftPadding="2" rightPadding="2" style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="4dc5ad01-9251-441d-83fd-0139da3159d1" key="line-12" x="251" y="17" width="231" height="1" forecolor="#CCCCCC">
+					<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("N")]]></printWhenExpression>
+					<pen lineWidth="2.0"/>
+				</element>
+				<element kind="line" uuid="8fad398d-4031-4516-b541-2b0f0b841a19" key="line-12" x="251" y="37" width="231" height="1" forecolor="#CCCCCC">
+					<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("N")]]></printWhenExpression>
+					<pen lineWidth="2.0"/>
+				</element>
+				<element kind="line" uuid="4781b54b-935d-439a-9721-596c3c7c01e9" key="line-12" x="351" y="17" width="130" height="1" forecolor="#CCCCCC">
+					<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("Y")]]></printWhenExpression>
+					<pen lineWidth="2.0"/>
+				</element>
+				<element kind="line" uuid="3881eb1f-706d-4e1a-9776-39f5a8f52589" key="line-12" x="351" y="37" width="129" height="1" forecolor="#CCCCCC">
+					<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("Y")]]></printWhenExpression>
+					<pen lineWidth="2.0"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="25" splitType="Stretch">
-			<frame>
-				<reportElement key="frame-1" style="default" x="0" y="0" width="482" height="21" uuid="09a53eab-acc6-453e-8c39-afeed300751a"/>
-				<box>
+			<element kind="frame" uuid="09a53eab-acc6-453e-8c39-afeed300751a" key="frame-1" x="0" y="0" width="482" height="21" style="default">
+				<element kind="textField" uuid="007bdd88-9a4c-456f-8e25-47d0b5ccf5e6" key="textField-1" x="0" y="0" width="72" height="21" forecolor="#000000" fontName="DejaVu Sans" blankWhenNull="true" vTextAlign="Middle" style="default">
+					<expression><![CDATA[$F{REFERENCE}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="0bdc6fd4-1443-44f4-ae70-ff1779709073" key="textField-2" x="400" y="0" width="81" height="21" forecolor="#000000" fontName="DejaVu Sans" pattern="" blankWhenNull="false" hTextAlign="Right" style="default">
+					<expression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}):new String(" ")]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="5ee4a098-7ca4-4803-9c86-298792bb4bfe" key="textField-3" x="320" y="0" width="79" height="21" forecolor="#000000" fontName="DejaVu Sans" pattern="" blankWhenNull="false" hTextAlign="Right" style="default">
+					<expression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}):new String(" ")]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="684bf28c-4665-4cc4-b945-881db3df1ab4" key="textField-4" x="262" y="0" width="58" height="21" forecolor="#000000" fontName="DejaVu Sans" pattern="" blankWhenNull="false" hTextAlign="Right" style="default">
+					<expression><![CDATA[($F{QTYINVOICED}!=null)?$P{NUMBERFORMAT}.format($F{QTYINVOICED}):new String(" ")]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="d36c0148-820c-46bd-928f-1930f3b8fe96" key="textField-5" x="212" y="0" width="50" height="21" forecolor="#000000" fontName="DejaVu Sans" blankWhenNull="true" style="default">
+					<expression><![CDATA[$F{UOMNAME}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="c68abc85-f707-472f-bc1c-50b089f44e9b" key="textField-6" x="72" y="0" width="140" height="21" forecolor="#000000" fontName="DejaVu Sans" blankWhenNull="true" vTextAlign="Middle" style="default">
+					<expression><![CDATA[$F{NAME_PRODUCT}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<box style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-1" style="default" x="0" y="0" width="72" height="21" forecolor="#000000" uuid="007bdd88-9a4c-456f-8e25-47d0b5ccf5e6"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="DejaVu Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{REFERENCE}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-2" style="default" x="400" y="0" width="81" height="21" forecolor="#000000" uuid="0bdc6fd4-1443-44f4-ae70-ff1779709073"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font fontName="DejaVu Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-3" style="default" x="320" y="0" width="79" height="21" forecolor="#000000" uuid="5ee4a098-7ca4-4803-9c86-298792bb4bfe"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font fontName="DejaVu Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-4" style="default" x="262" y="0" width="58" height="21" forecolor="#000000" uuid="684bf28c-4665-4cc4-b945-881db3df1ab4"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font fontName="DejaVu Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{QTYINVOICED}!=null)?$P{NUMBERFORMAT}.format($F{QTYINVOICED}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-5" style="default" x="212" y="0" width="50" height="21" forecolor="#000000" uuid="d36c0148-820c-46bd-928f-1930f3b8fe96"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font fontName="DejaVu Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{UOMNAME}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-6" style="default" x="72" y="0" width="140" height="21" forecolor="#000000" uuid="c68abc85-f707-472f-bc1c-50b089f44e9b"/>
-					<box leftPadding="2" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement verticalAlignment="Middle">
-						<font fontName="DejaVu Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NAME_PRODUCT}]]></textFieldExpression>
-				</textField>
-			</frame>
-			<line>
-				<reportElement key="line-1" x="0" y="22" width="482" height="1" forecolor="#CCCCCC" uuid="505095a5-efa1-4bd5-bced-9df7a8ecaf23"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
-				</graphicElement>
-			</line>
+			</element>
+			<element kind="line" uuid="505095a5-efa1-4bd5-bced-9df7a8ecaf23" key="line-1" x="0" y="22" width="482" height="1" forecolor="#CCCCCC">
+				<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/RptC_Invoice_TaxLines.jrxml
+++ b/src/org/openbravo/erpReports/RptC_Invoice_TaxLines.jrxml
@@ -1,158 +1,111 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptC_Invoice_TaxLines" pageWidth="482" pageHeight="842" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="9d194431-1513-4b4e-9cb7-66fdacf30268">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="RptC_Invoice_TaxLines" language="java" pageWidth="482" pageHeight="842" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="9d194431-1513-4b4e-9cb7-66fdacf30268">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
 	<parameter name="C_INVOICE_ID" class="java.lang.String"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
 	<parameter name="ISTAXINCLUDED" class="java.lang.String"/>
 	<parameter name="TOTAL_LINENET" class="java.math.BigDecimal"/>
-	<queryString>
-		<![CDATA[SELECT C_INVOICE_ID, C_TAX.NAME, C_INVOICETAX.TAXBASEAMT, C_INVOICETAX.TAXAMT
+	<query language="sql"><![CDATA[SELECT C_INVOICE_ID, C_TAX.NAME, C_INVOICETAX.TAXBASEAMT, C_INVOICETAX.TAXAMT
         FROM C_INVOICETAX, C_TAX
         WHERE C_INVOICETAX.C_TAX_ID = C_TAX.C_TAX_ID
         AND C_INVOICETAX.C_INVOICE_ID = $P{C_INVOICE_ID}
-        ORDER BY C_INVOICETAX.LINE, C_TAX.RATE]]>
-	</queryString>
+        ORDER BY C_INVOICETAX.LINE, C_TAX.RATE]]></query>
 	<field name="C_INVOICE_ID" class="java.lang.String"/>
 	<field name="NAME" class="java.lang.String"/>
 	<field name="TAXBASEAMT" class="java.math.BigDecimal"/>
 	<field name="TAXAMT" class="java.math.BigDecimal"/>
-	<variable name="TOTAL_TAXAMT" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{TAXAMT}]]></variableExpression>
+	<variable name="TOTAL_TAXAMT" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{TAXAMT}]]></expression>
 	</variable>
 	<group name="C_INVOICE_ID">
-		<groupExpression><![CDATA[$F{C_INVOICE_ID}]]></groupExpression>
+		<expression><![CDATA[$F{C_INVOICE_ID}]]></expression>
 		<groupHeader>
 			<band splitType="Stretch"/>
 		</groupHeader>
 		<groupFooter>
 			<band height="5" splitType="Stretch">
-				<line>
-					<reportElement key="line-1" x="0" y="0" width="482" height="1" uuid="5008f953-da31-4ca1-a36c-fdfca574357d"/>
-				</line>
+				<element kind="line" uuid="5008f953-da31-4ca1-a36c-fdfca574357d" key="line-1" x="0" y="0" width="482" height="1"/>
 			</band>
 			<band height="27">
 				<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("N")]]></printWhenExpression>
-				<textField evaluationTime="Band" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" mode="Opaque" x="399" y="6" width="82" height="17" backcolor="#CCCCCC" uuid="111e6ae2-636b-48da-8da4-8a4600bd5cb2"/>
+				<element kind="textField" uuid="111e6ae2-636b-48da-8da4-8a4600bd5cb2" key="textField" mode="Opaque" x="399" y="6" width="82" height="17" backcolor="#CCCCCC" fontName="SansSerif" fontSize="10.0" evaluationTime="Band" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($P{TOTAL_LINENET}.add($V{TOTAL_TAXAMT})!=null)?$P{NUMBERFORMAT}.format($P{TOTAL_LINENET}.add($V{TOTAL_TAXAMT})):new String(" ")]]></expression>
 					<box>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="SansSerif" size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($P{TOTAL_LINENET}.add($V{TOTAL_TAXAMT})!=null)?$P{NUMBERFORMAT}.format($P{TOTAL_LINENET}.add($V{TOTAL_TAXAMT})):new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-14" style="Report_Footer" x="315" y="6" width="84" height="17" uuid="b36c7cef-ba9c-4fcc-b5ff-170d2afe5076"/>
-					<textElement textAlignment="Right"/>
+				</element>
+				<element kind="staticText" uuid="b36c7cef-ba9c-4fcc-b5ff-170d2afe5076" key="staticText-14" x="315" y="6" width="84" height="17" hTextAlign="Right" style="Report_Footer">
 					<text><![CDATA[TOTAL:]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-39" style="Report_Footer" x="315" y="5" width="167" height="1" uuid="b8b9f9e4-0e6d-4a73-85ac-51e0b686d31e"/>
-				</line>
-				<line>
-					<reportElement key="line-40" style="Report_Footer" x="315" y="23" width="167" height="1" uuid="68c2e748-b119-4de4-96b7-5edcd34ce7a5"/>
-				</line>
-				<line>
-					<reportElement key="line-41" style="Report_Footer" x="315" y="5" width="1" height="19" uuid="0177d4b3-e901-4cc1-969e-a9d3aba65b7b"/>
-				</line>
-				<line>
-					<reportElement key="line-42" style="Report_Footer" x="481" y="6" width="1" height="18" uuid="ff05513f-3bb2-43fa-8291-4bd4460e92ee"/>
-				</line>
+				</element>
+				<element kind="line" uuid="b8b9f9e4-0e6d-4a73-85ac-51e0b686d31e" key="line-39" x="315" y="5" width="167" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="68c2e748-b119-4de4-96b7-5edcd34ce7a5" key="line-40" x="315" y="23" width="167" height="1" style="Report_Footer"/>
+				<element kind="line" uuid="0177d4b3-e901-4cc1-969e-a9d3aba65b7b" key="line-41" x="315" y="5" width="1" height="19" style="Report_Footer"/>
+				<element kind="line" uuid="ff05513f-3bb2-43fa-8291-4bd4460e92ee" key="line-42" x="481" y="6" width="1" height="18" style="Report_Footer"/>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<line>
-				<reportElement key="line-2" style="Report_Footer" x="0" y="0" width="482" height="1" uuid="860332fc-b280-41f8-a229-85f17b480f4f"/>
-			</line>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="0" y="0" width="400" height="16" forecolor="#000000" uuid="cb1c590e-e0ab-418d-8e26-55538c19aa01"/>
-				<box>
+			<element kind="line" uuid="860332fc-b280-41f8-a229-85f17b480f4f" key="line-2" x="0" y="0" width="482" height="1" style="Report_Footer"/>
+			<element kind="textField" uuid="cb1c590e-e0ab-418d-8e26-55538c19aa01" key="textField" x="0" y="0" width="400" height="16" forecolor="#000000" blankWhenNull="false" style="default">
+				<expression><![CDATA[" " + $F{NAME}]]></expression>
+				<box style="default">
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[" " + $F{NAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="400" y="0" width="82" height="16" forecolor="#000000" uuid="93f930bf-5af3-4a20-a12d-df775f6d0605"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="93f930bf-5af3-4a20-a12d-df775f6d0605" key="textField" x="400" y="0" width="82" height="16" forecolor="#000000" pattern="" blankWhenNull="false" hTextAlign="Right" style="default">
+				<expression><![CDATA[($F{TAXAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXAMT}):new String(" ")]]></expression>
+				<box style="default">
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA[($F{TAXAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXAMT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-3" style="Report_Footer" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="16" uuid="718ea088-d6bd-46b6-8a1f-9e75f37eecc1"/>
-			</line>
-			<line>
-				<reportElement key="line-4" style="Report_Footer" stretchType="RelativeToBandHeight" x="482" y="0" width="1" height="16" uuid="3524c562-1c0c-441b-a178-1ec05ab3f195"/>
-			</line>
-			<textField>
-				<reportElement x="310" y="0" width="82" height="16" uuid="27150cfc-8671-435f-b874-3994a5978091">
-					<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("Y")]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{TAXBASEAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXBASEAMT}):new String(" ")]]></textFieldExpression>
-			</textField>
+			</element>
+			<element kind="line" uuid="718ea088-d6bd-46b6-8a1f-9e75f37eecc1" key="line-3" stretchType="ContainerHeight" x="0" y="0" width="1" height="16" style="Report_Footer"/>
+			<element kind="line" uuid="3524c562-1c0c-441b-a178-1ec05ab3f195" key="line-4" stretchType="ContainerHeight" x="482" y="0" width="1" height="16" style="Report_Footer"/>
+			<element kind="textField" uuid="27150cfc-8671-435f-b874-3994a5978091" x="310" y="0" width="82" height="16" fontSize="8.0" hTextAlign="Right">
+				<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("Y")]]></printWhenExpression>
+				<expression><![CDATA[($F{TAXBASEAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXBASEAMT}):new String(" ")]]></expression>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/RptC_Invoice_TaxLines_new.jrxml
+++ b/src/org/openbravo/erpReports/RptC_Invoice_TaxLines_new.jrxml
@@ -1,56 +1,53 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptC_Invoice_TaxLines_new" pageWidth="482" pageHeight="842" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="30435b90-1203-4280-bc9c-7050905cab87">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="RptC_Invoice_TaxLines_new" language="java" pageWidth="482" pageHeight="842" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="30435b90-1203-4280-bc9c-7050905cab87">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.5"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
 	<parameter name="C_INVOICE_ID" class="java.lang.String"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
 	<parameter name="ISTAXINCLUDED" class="java.lang.String"/>
 	<parameter name="TOTAL_LINENET" class="java.math.BigDecimal"/>
-	<queryString>
-		<![CDATA[SELECT C_INVOICE_ID, C_TAX.NAME, C_INVOICETAX.TAXBASEAMT, C_INVOICETAX.TAXAMT
+	<query language="sql"><![CDATA[SELECT C_INVOICE_ID, C_TAX.NAME, C_INVOICETAX.TAXBASEAMT, C_INVOICETAX.TAXAMT
         FROM C_INVOICETAX, C_TAX
         WHERE C_INVOICETAX.C_TAX_ID = C_TAX.C_TAX_ID
         AND C_INVOICETAX.C_INVOICE_ID = $P{C_INVOICE_ID}
-        ORDER BY C_INVOICETAX.LINE, C_TAX.RATE]]>
-	</queryString>
+        ORDER BY C_INVOICETAX.LINE, C_TAX.RATE]]></query>
 	<field name="C_INVOICE_ID" class="java.lang.String"/>
 	<field name="NAME" class="java.lang.String"/>
 	<field name="TAXBASEAMT" class="java.math.BigDecimal"/>
 	<field name="TAXAMT" class="java.math.BigDecimal"/>
-	<variable name="TOTAL_TAXAMT" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{TAXAMT}]]></variableExpression>
+	<variable name="TOTAL_TAXAMT" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{TAXAMT}]]></expression>
 	</variable>
 	<group name="C_INVOICE_ID">
-		<groupExpression><![CDATA[$F{C_INVOICE_ID}]]></groupExpression>
+		<expression><![CDATA[$F{C_INVOICE_ID}]]></expression>
 		<groupHeader>
 			<band splitType="Stretch"/>
 		</groupHeader>
@@ -58,95 +55,52 @@
 			<band height="5" splitType="Stretch"/>
 			<band height="40">
 				<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("N")]]></printWhenExpression>
-				<textField evaluationTime="Band" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" mode="Opaque" x="399" y="18" width="82" height="21" backcolor="#FFFFFF" uuid="efde9531-b570-4d98-85b0-00cba4acd9ab"/>
+				<element kind="textField" uuid="efde9531-b570-4d98-85b0-00cba4acd9ab" key="textField" mode="Opaque" x="399" y="18" width="82" height="21" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="10.0" evaluationTime="Band" pattern="" blankWhenNull="true" bold="true" hTextAlign="Right" vTextAlign="Middle">
+					<expression><![CDATA[($P{TOTAL_LINENET}.add($V{TOTAL_TAXAMT})!=null)?$P{NUMBERFORMAT}.format($P{TOTAL_LINENET}.add($V{TOTAL_TAXAMT})):new String(" ")]]></expression>
 					<box>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="10" isBold="true"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($P{TOTAL_LINENET}.add($V{TOTAL_TAXAMT})!=null)?$P{NUMBERFORMAT}.format($P{TOTAL_LINENET}.add($V{TOTAL_TAXAMT})):new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-14" style="Report_Footer" x="355" y="18" width="44" height="21" forecolor="#7E7979" uuid="f8b8ec4c-d56c-4a76-8275-fe032145325d"/>
-					<textElement textAlignment="Right">
-						<font fontName="DejaVu Sans" size="12" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="f8b8ec4c-d56c-4a76-8275-fe032145325d" key="staticText-14" x="355" y="18" width="44" height="21" forecolor="#7E7979" fontName="DejaVu Sans" fontSize="12.0" bold="true" hTextAlign="Right" style="Report_Footer">
 					<text><![CDATA[Total]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-39" style="Report_Footer" x="355" y="18" width="127" height="1" forecolor="#CCCCCC" uuid="1e401f76-2ceb-4859-9e4c-bc7a148dd807"/>
-				</line>
-				<line>
-					<reportElement key="line-40" style="Report_Footer" x="355" y="38" width="127" height="1" forecolor="#CCCCCC" uuid="34f523e9-ff52-4a82-b418-373701f030ef"/>
-				</line>
+				</element>
+				<element kind="line" uuid="1e401f76-2ceb-4859-9e4c-bc7a148dd807" key="line-39" x="355" y="18" width="127" height="1" forecolor="#CCCCCC" style="Report_Footer"/>
+				<element kind="line" uuid="34f523e9-ff52-4a82-b418-373701f030ef" key="line-40" x="355" y="38" width="127" height="1" forecolor="#CCCCCC" style="Report_Footer"/>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="25" splitType="Stretch">
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="0" y="2" width="400" height="21" forecolor="#000000" uuid="8dd5151e-210d-492e-8d71-25ffd4185dfd"/>
-				<box>
+			<element kind="textField" uuid="8dd5151e-210d-492e-8d71-25ffd4185dfd" key="textField" x="0" y="2" width="400" height="21" forecolor="#000000" fontName="DejaVu Sans" blankWhenNull="false" style="default">
+				<expression><![CDATA[" " + $F{NAME}]]></expression>
+				<box style="default">
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font fontName="DejaVu Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[" " + $F{NAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="400" y="2" width="82" height="21" forecolor="#000000" uuid="24849b48-0240-4332-ab32-98f843de63c3"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="24849b48-0240-4332-ab32-98f843de63c3" key="textField" x="400" y="2" width="82" height="21" forecolor="#000000" fontName="DejaVu Sans" pattern="" blankWhenNull="false" hTextAlign="Right" style="default">
+				<expression><![CDATA[($F{TAXAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXAMT}):new String(" ")]]></expression>
+				<box style="default">
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="DejaVu Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{TAXAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXAMT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="310" y="2" width="82" height="21" uuid="cde860d4-59dc-4680-a831-b79da757f02b">
-					<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("Y")]]></printWhenExpression>
-				</reportElement>
-				<textElement textAlignment="Right">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{TAXBASEAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXBASEAMT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="21" width="481" height="1" forecolor="#CCCCCC" uuid="a1f12390-4d9a-4e83-8b1b-9b612613ff6a"/>
-			</line>
-			<line>
-				<reportElement key="line-2" style="Report_Footer" x="0" y="0" width="481" height="1" forecolor="#CCCCCC" uuid="b080f40b-2b38-4721-ac4d-e957d0809dbe"/>
-			</line>
+			</element>
+			<element kind="textField" uuid="cde860d4-59dc-4680-a831-b79da757f02b" x="310" y="2" width="82" height="21" fontName="DejaVu Sans" fontSize="8.0" hTextAlign="Right">
+				<printWhenExpression><![CDATA[$P{ISTAXINCLUDED}.equals("Y")]]></printWhenExpression>
+				<expression><![CDATA[($F{TAXBASEAMT}!=null)?$P{NUMBERFORMAT}.format($F{TAXBASEAMT}):new String(" ")]]></expression>
+			</element>
+			<element kind="line" uuid="a1f12390-4d9a-4e83-8b1b-9b612613ff6a" key="line-1" x="0" y="21" width="481" height="1" forecolor="#CCCCCC"/>
+			<element kind="line" uuid="b080f40b-2b38-4721-ac4d-e957d0809dbe" key="line-2" x="0" y="0" width="481" height="1" forecolor="#CCCCCC" style="Report_Footer"/>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/RptC_Invoice_new.jrxml
+++ b/src/org/openbravo/erpReports/RptC_Invoice_new.jrxml
@@ -1,71 +1,69 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptC_Invoice_new" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="f2b40577-1272-4849-ad1a-f97e1bd41b41">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="RptC_Invoice_new" language="java" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="f2b40577-1272-4849-ad1a-f97e1bd41b41">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="136"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
 	<parameter name="DOCUMENT_ID" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'1000032'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="DOCUMENT_NAME" class="java.lang.String" isForPrompting="false">
+	<parameter name="DOCUMENT_NAME" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["'INVOICE'"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/home/openbravo/src/openbravo/erp/devel/bttCourse/pi/src"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["('1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["('0')"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="SUBREPORT_DIR" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{BASE_DESIGN}+"/org/openbravo/erpReports/"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="SUBREP_RptC_Invoice_Lines_new" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="SUBREP_RptC_Invoice_TaxLines_new" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="SUBREP_RptC_Invoice_Lines_new" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="SUBREP_RptC_Invoice_TaxLines_new" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
 	<parameter name="SHOW_LOGO" class="java.lang.String"/>
-	<parameter name="SHOW_COMPANYDATA" class="java.lang.String" isForPrompting="false"/>
+	<parameter name="SHOW_COMPANYDATA" forPrompting="false" class="java.lang.String"/>
 	<parameter name="HEADER_MARGIN" class="java.lang.String"/>
-	<queryString>
-		<![CDATA[SELECT C_INVOICE.C_INVOICE_ID, C_BPARTNER.NAME, C_BPARTNER.TAXID AS CIF, AD_USER.NAME AS CONTACT_NAME, C_LOCATION.ADDRESS1,
+	<query language="sql"><![CDATA[SELECT C_INVOICE.C_INVOICE_ID, C_BPARTNER.NAME, C_BPARTNER.TAXID AS CIF, AD_USER.NAME AS CONTACT_NAME, C_LOCATION.ADDRESS1,
 C_LOCATION.POSTAL, C_LOCATION.CITY, C_REGION.NAME AS REGION,C_COUNTRY.NAME AS COUNTRY,C_BPARTNER_LOCATION.PHONE AS PHONE, C_BPARTNER_LOCATION.FAX AS FAX,
 C_INVOICE.DATEINVOICED, C_INVOICE.DOCUMENTNO, C_BPARTNER.VALUE AS CODE_BPARTNER,
 AD_CLIENT.DESCRIPTION AS ENTITY, C_Location_Description(AD_ORGINFO.C_LOCATION_ID) AS LOCATION, C_CURRENCY.ISO_CODE AS CURRENCY_CODE,C_CURRENCY.CURSYMBOL AS SYMBOL,
@@ -93,8 +91,7 @@ AND AD_ORG.ad_org_id = AD_ORGINFO.ad_org_id
 AND AD_ORG.ad_org_id = (SELECT o.AD_ORG_ID
                         FROM AD_ORG o JOIN AD_OrgType t USING (AD_ORGTYPE_ID)
                         WHERE AD_ISORGINCLUDED(C_INVOICE.AD_ORG_ID, o.ad_org_id, C_INVOICE.ad_client_id)<>-1
-                              AND (t.IsLegalEntity='Y' OR t.IsAcctLegalEntity='Y'))]]>
-	</queryString>
+                              AND (t.IsLegalEntity='Y' OR t.IsAcctLegalEntity='Y'))]]></query>
 	<field name="C_INVOICE_ID" class="java.lang.String"/>
 	<field name="NAME" class="java.lang.String"/>
 	<field name="CIF" class="java.lang.String"/>
@@ -126,12 +123,12 @@ AND AD_ORG.ad_org_id = (SELECT o.AD_ORG_ID
 	<field name="ISSOTRX" class="java.lang.String"/>
 	<field name="ISTAXINCLUDED" class="java.lang.String"/>
 	<field name="ISCASHVAT" class="java.lang.String"/>
-	<variable name="TOTAL_LINENETAMT" class="java.math.BigDecimal" resetType="Group" resetGroup="C_INVOICE_ID"/>
-	<variable name="TOTAL_TAXAMT" class="java.math.BigDecimal" resetType="Group" resetGroup="C_INVOICE_ID"/>
+	<variable name="TOTAL_LINENETAMT" resetType="Group" resetGroup="C_INVOICE_ID" class="java.math.BigDecimal"/>
+	<variable name="TOTAL_TAXAMT" resetType="Group" resetGroup="C_INVOICE_ID" class="java.math.BigDecimal"/>
 	<variable name="SHOWLOGO" class="java.lang.String"/>
 	<variable name="SHOWCOMPANYDATA" class="java.lang.String"/>
-	<group name="PrintLarge" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintLarge" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="120" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{HEADERMARGIN}.equalsIgnoreCase("large"))]]></printWhenExpression>
@@ -141,8 +138,8 @@ AND AD_ORG.ad_org_id = (SELECT o.AD_ORG_ID
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="PrintMedium" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintMedium" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="80" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{HEADERMARGIN}.equalsIgnoreCase("medium"))]]></printWhenExpression>
@@ -152,8 +149,8 @@ AND AD_ORG.ad_org_id = (SELECT o.AD_ORG_ID
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="PrintSmall" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintSmall" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="50" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{HEADERMARGIN}.equalsIgnoreCase("small"))]]></printWhenExpression>
@@ -163,183 +160,116 @@ AND AD_ORG.ad_org_id = (SELECT o.AD_ORG_ID
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="C_INVOICE_ID" isStartNewPage="true">
-		<groupExpression><![CDATA[$F{C_INVOICE_ID}]]></groupExpression>
+	<group name="C_INVOICE_ID" startNewPage="true">
+		<expression><![CDATA[$F{C_INVOICE_ID}]]></expression>
 		<groupHeader>
 			<band height="255" splitType="Stretch">
-				<image scaleImage="RetainShape" hAlign="Right" vAlign="Top" isUsingCache="true">
-					<reportElement key="image-1" style="Report_Footer" x="0" y="13" width="153" height="78" uuid="938e0575-3a04-438c-bc84-4b77fe82b4a0">
-						<printWhenExpression><![CDATA[new Boolean($F{SHOWLOGO}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<box>
+				<element kind="image" uuid="938e0575-3a04-438c-bc84-4b77fe82b4a0" key="image-1" x="0" y="13" width="153" height="78" scaleImage="RetainShape" usingCache="true" hImageAlign="Right" vImageAlign="Top" style="Report_Footer">
+					<printWhenExpression><![CDATA[new Boolean($F{SHOWLOGO}.equalsIgnoreCase("Y"))]]></printWhenExpression>
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylegal", $F{ORGANIZATIONID})]]></expression>
+					<box style="Report_Footer">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<imageExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylegal", $F{ORGANIZATIONID})]]></imageExpression>
-				</image>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-					<reportElement key="textField-9" style="Report_Footer" positionType="Float" x="314" y="18" width="168" height="27" isPrintWhenDetailOverflows="true" forecolor="#FF0000" uuid="daa0dc12-8785-4592-b3ec-da4365b38803"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="daa0dc12-8785-4592-b3ec-da4365b38803" key="textField-9" positionType="Float" x="314" y="18" width="168" height="27" forecolor="#FF0000" fontName="DejaVu Sans" fontSize="22.0" textAdjust="StretchHeight" blankWhenNull="false" printWhenDetailOverflows="true" hTextAlign="Center" vTextAlign="Middle" style="Report_Footer">
+					<expression><![CDATA[(($F{STATUS}.compareTo("VO")==0) ? "VOIDED" : " ")]]></expression>
+					<box style="Report_Footer">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="22"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($F{STATUS}.compareTo("VO")==0) ? "VOIDED" : " ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-14" x="1" y="137" width="188" height="57" isPrintWhenDetailOverflows="true" uuid="b566b47f-703a-4f1a-ac77-15e47fe2ce13"/>
-					<textElement verticalAlignment="Top">
-						<font fontName="DejaVu Sans" size="9" isBold="true"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{NAME} + "\n" + $F{BP_DATA}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-15" style="Report_Footer" x="165" y="2" width="155" height="91" isPrintInFirstWholeBand="true" isPrintWhenDetailOverflows="true" uuid="74ec69eb-168f-4e91-9bcd-4d10da0c2323">
-						<printWhenExpression><![CDATA[new Boolean($F{SHOWCOMPANYDATA}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<textElement verticalAlignment="Top">
-						<font fontName="DejaVu Sans" size="9"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{LOCATION}==null ? $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" : $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" + $F{LOCATION})]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-15" style="Report_Footer" x="235" y="96" width="247" height="25" uuid="d84dfc67-930c-4a0f-bdc7-e915cbdbcc74">
-						<printWhenExpression><![CDATA[new Boolean($F{ISSOTRX}.equalsIgnoreCase("N"))]]></printWhenExpression>
-					</reportElement>
-					<textElement textAlignment="Right" verticalAlignment="Top">
-						<font fontName="DejaVu Sans" size="16"/>
-					</textElement>
+				</element>
+				<element kind="textField" uuid="b566b47f-703a-4f1a-ac77-15e47fe2ce13" key="textField-14" x="1" y="137" width="188" height="57" fontName="DejaVu Sans" fontSize="9.0" blankWhenNull="false" printWhenDetailOverflows="true" bold="true" vTextAlign="Top">
+					<expression><![CDATA[$F{NAME} + "\n" + $F{BP_DATA}]]></expression>
+				</element>
+				<element kind="textField" uuid="74ec69eb-168f-4e91-9bcd-4d10da0c2323" key="textField-15" x="165" y="2" width="155" height="91" fontName="DejaVu Sans" fontSize="9.0" blankWhenNull="false" printInFirstWholeBand="true" printWhenDetailOverflows="true" vTextAlign="Top" style="Report_Footer">
+					<printWhenExpression><![CDATA[new Boolean($F{SHOWCOMPANYDATA}.equalsIgnoreCase("Y"))]]></printWhenExpression>
+					<expression><![CDATA[($F{LOCATION}==null ? $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" : $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" + $F{LOCATION})]]></expression>
+				</element>
+				<element kind="staticText" uuid="d84dfc67-930c-4a0f-bdc7-e915cbdbcc74" key="staticText-15" x="235" y="96" width="247" height="25" fontName="DejaVu Sans" fontSize="16.0" hTextAlign="Right" vTextAlign="Top" style="Report_Footer">
+					<printWhenExpression><![CDATA[new Boolean($F{ISSOTRX}.equalsIgnoreCase("N"))]]></printWhenExpression>
 					<text><![CDATA[This is a Purchase invoice]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-16" style="Report_Footer" x="235" y="96" width="247" height="25" uuid="74b0da43-4596-45ad-b0ec-030aa7740d5b">
-						<printWhenExpression><![CDATA[new Boolean($F{ISSOTRX}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<textElement textAlignment="Right" verticalAlignment="Top">
-						<font fontName="DejaVu Sans" size="16"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="74b0da43-4596-45ad-b0ec-030aa7740d5b" key="staticText-16" x="235" y="96" width="247" height="25" fontName="DejaVu Sans" fontSize="16.0" hTextAlign="Right" vTextAlign="Top" style="Report_Footer">
+					<printWhenExpression><![CDATA[new Boolean($F{ISSOTRX}.equalsIgnoreCase("Y"))]]></printWhenExpression>
 					<text><![CDATA[This is a Sales invoice]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-8" style="Group_Data_Label" x="425" y="134" width="57" height="18" forecolor="#7E7979" backcolor="#FFFFFF" uuid="3da73b73-eafc-41fa-99fe-2edcf08c98c8"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="9" isBold="true" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="3da73b73-eafc-41fa-99fe-2edcf08c98c8" key="staticText-8" x="425" y="134" width="57" height="18" forecolor="#7E7979" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="9.0" pdfFontName="Helvetica" bold="true" hTextAlign="Center" vTextAlign="Middle" style="Group_Data_Label">
 					<text><![CDATA[Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-6" style="Group_Data_Label" x="305" y="134" width="57" height="18" forecolor="#7E7979" backcolor="#FFFFFF" uuid="0ac35f0f-fece-4326-b315-2010bb2c926f"/>
-					<box>
+					<box style="Group_Data_Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="9"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="0ac35f0f-fece-4326-b315-2010bb2c926f" key="staticText-6" x="305" y="134" width="57" height="18" forecolor="#7E7979" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="9.0" hTextAlign="Center" vTextAlign="Middle" style="Group_Data_Label">
 					<text><![CDATA[Invoice Nº]]></text>
-				</staticText>
-				<line direction="BottomUp">
-					<reportElement key="line-1" x="363" y="131" width="1" height="46" forecolor="#CCCCCC" uuid="fb10e6a5-eab2-4f7d-a7ea-1dbd677f4754"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
-					</graphicElement>
-				</line>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-8" x="305" y="154" width="57" height="20" uuid="bf76682c-7a45-4b86-adc1-79f54b63724b"/>
+					<box style="Group_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="fb10e6a5-eab2-4f7d-a7ea-1dbd677f4754" key="line-1" x="363" y="131" width="1" height="46" forecolor="#CCCCCC" direction="BottomUp">
+					<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
+				</element>
+				<element kind="textField" uuid="bf76682c-7a45-4b86-adc1-79f54b63724b" key="textField-8" x="305" y="154" width="57" height="20" fontName="DejaVu Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Center">
+					<expression><![CDATA[$F{DOCUMENTNO}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{DOCUMENTNO}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-11" style="Group_Data_Label" x="365" y="134" width="57" height="18" forecolor="#7E7979" backcolor="#FFFFFF" uuid="d4685419-4980-44b2-8597-0ef9431b599b"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="9" isBold="true" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="d4685419-4980-44b2-8597-0ef9431b599b" key="staticText-11" x="365" y="134" width="57" height="18" forecolor="#7E7979" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="9.0" pdfFontName="Helvetica" bold="true" hTextAlign="Center" vTextAlign="Middle" style="Group_Data_Label">
 					<text><![CDATA[Currency]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-1" x="1" y="130" width="482" height="1" forecolor="#CCCCCC" uuid="86ba1390-5730-4186-8836-dc9fd3f751b3"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
-					</graphicElement>
-				</line>
-				<line direction="BottomUp">
-					<reportElement key="line-1" x="303" y="131" width="1" height="46" forecolor="#CCCCCC" uuid="f8af6931-41bf-4daf-ad08-1ec6d3eaae1b"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-1" x="304" y="177" width="179" height="1" forecolor="#CCCCCC" uuid="35f9cb30-a77d-4908-81e6-e0ee7a7a8135"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
-					</graphicElement>
-				</line>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-24" x="365" y="154" width="57" height="20" uuid="18f95886-ba5c-4b97-ac46-a10fcccafe9e"/>
+					<box style="Group_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="86ba1390-5730-4186-8836-dc9fd3f751b3" key="line-1" x="1" y="130" width="482" height="1" forecolor="#CCCCCC">
+					<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
+				</element>
+				<element kind="line" uuid="f8af6931-41bf-4daf-ad08-1ec6d3eaae1b" key="line-1" x="303" y="131" width="1" height="46" forecolor="#CCCCCC" direction="BottomUp">
+					<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
+				</element>
+				<element kind="line" uuid="35f9cb30-a77d-4908-81e6-e0ee7a7a8135" key="line-1" x="304" y="177" width="179" height="1" forecolor="#CCCCCC">
+					<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
+				</element>
+				<element kind="textField" uuid="18f95886-ba5c-4b97-ac46-a10fcccafe9e" key="textField-24" x="365" y="154" width="57" height="20" fontName="DejaVu Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Center">
+					<expression><![CDATA[$F{CURRENCY_CODE}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{CURRENCY_CODE}]]></textFieldExpression>
-				</textField>
-				<line direction="BottomUp">
-					<reportElement key="line-1" x="483" y="131" width="1" height="46" forecolor="#CCCCCC" uuid="7f6f21c6-72e0-483d-97a6-82b29886dfbc"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
-					</graphicElement>
-				</line>
-				<line direction="BottomUp">
-					<reportElement key="line-1" x="423" y="131" width="1" height="46" forecolor="#CCCCCC" uuid="9c3bcad2-d595-4644-8e97-79d235dc0a23"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
-					</graphicElement>
-				</line>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField" x="425" y="154" width="57" height="20" uuid="c8f79167-d64b-4656-9412-42038ff48610"/>
+				</element>
+				<element kind="line" uuid="7f6f21c6-72e0-483d-97a6-82b29886dfbc" key="line-1" x="483" y="131" width="1" height="46" forecolor="#CCCCCC" direction="BottomUp">
+					<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
+				</element>
+				<element kind="line" uuid="9c3bcad2-d595-4644-8e97-79d235dc0a23" key="line-1" x="423" y="131" width="1" height="46" forecolor="#CCCCCC" direction="BottomUp">
+					<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
+				</element>
+				<element kind="textField" uuid="c8f79167-d64b-4656-9412-42038ff48610" key="textField" x="425" y="154" width="57" height="20" fontName="DejaVu Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Center">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.applyCountryDateFormat($F{DATEINVOICED},$F{ORGANIZATIONID})]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.applyCountryDateFormat($F{DATEINVOICED},$F{ORGANIZATIONID})]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -347,146 +277,103 @@ AND AD_ORG.ad_org_id = (SELECT o.AD_ORG_ID
 		</groupFooter>
 	</group>
 	<group name="tax" minHeightToStartNewPage="300">
-		<groupExpression><![CDATA[]]></groupExpression>
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band splitType="Stretch"/>
 		</groupHeader>
 		<groupFooter>
 			<band height="16" splitType="Stretch">
-				<subreport isUsingCache="true">
-					<reportElement key="subreport-2" style="Report_Footer" positionType="Float" x="0" y="0" width="482" height="16" uuid="8be68be6-758f-48a9-afb5-10d50cfacd15"/>
-					<subreportParameter name="NUMBERFORMAT">
-						<subreportParameterExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="LOCALE">
-						<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="ISTAXINCLUDED">
-						<subreportParameterExpression><![CDATA[$F{ISTAXINCLUDED}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="TOTAL_LINENET">
-						<subreportParameterExpression><![CDATA[$V{TOTAL_LINENETAMT}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="C_INVOICE_ID">
-						<subreportParameterExpression><![CDATA[$F{C_INVOICE_ID}]]></subreportParameterExpression>
-					</subreportParameter>
+				<element kind="subreport" uuid="8be68be6-758f-48a9-afb5-10d50cfacd15" key="subreport-2" positionType="Float" x="0" y="0" width="482" height="16" usingCache="true" style="Report_Footer">
 					<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-					<returnValue subreportVariable="TOTAL_TAXAMT" toVariable="TOTAL_TAXAMT"/>
-					<subreportExpression><![CDATA[$P{SUBREP_RptC_Invoice_TaxLines_new}]]></subreportExpression>
-				</subreport>
+					<expression><![CDATA[$P{SUBREP_RptC_Invoice_TaxLines_new}]]></expression>
+					<returnValue toVariable="TOTAL_TAXAMT" subreportVariable="TOTAL_TAXAMT"/>
+					<parameter name="NUMBERFORMAT">
+						<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></expression>
+					</parameter>
+					<parameter name="LOCALE">
+						<expression><![CDATA[$P{LOCALE}]]></expression>
+					</parameter>
+					<parameter name="ISTAXINCLUDED">
+						<expression><![CDATA[$F{ISTAXINCLUDED}]]></expression>
+					</parameter>
+					<parameter name="TOTAL_LINENET">
+						<expression><![CDATA[$V{TOTAL_LINENETAMT}]]></expression>
+					</parameter>
+					<parameter name="C_INVOICE_ID">
+						<expression><![CDATA[$F{C_INVOICE_ID}]]></expression>
+					</parameter>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="27" splitType="Stretch">
-			<subreport isUsingCache="true">
-				<reportElement key="subreport-3" style="Report_Footer" x="0" y="0" width="482" height="16" uuid="51e01625-89c7-4bc0-9c86-cac9a26d86c8"/>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LOCALE">
-					<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="ISTAXINCLUDED">
-					<subreportParameterExpression><![CDATA[$F{ISTAXINCLUDED}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="C_INVOICE_ID">
-					<subreportParameterExpression><![CDATA[$F{C_INVOICE_ID}]]></subreportParameterExpression>
-				</subreportParameter>
+			<element kind="subreport" uuid="51e01625-89c7-4bc0-9c86-cac9a26d86c8" key="subreport-3" x="0" y="0" width="482" height="16" usingCache="true" style="Report_Footer">
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<returnValue subreportVariable="TOTAL_LINENETAMT" toVariable="TOTAL_LINENETAMT"/>
-				<subreportExpression><![CDATA[$P{SUBREP_RptC_Invoice_Lines_new}]]></subreportExpression>
-			</subreport>
+				<expression><![CDATA[$P{SUBREP_RptC_Invoice_Lines_new}]]></expression>
+				<returnValue toVariable="TOTAL_LINENETAMT" subreportVariable="TOTAL_LINENETAMT"/>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></expression>
+				</parameter>
+				<parameter name="LOCALE">
+					<expression><![CDATA[$P{LOCALE}]]></expression>
+				</parameter>
+				<parameter name="ISTAXINCLUDED">
+					<expression><![CDATA[$F{ISTAXINCLUDED}]]></expression>
+				</parameter>
+				<parameter name="C_INVOICE_ID">
+					<expression><![CDATA[$F{C_INVOICE_ID}]]></expression>
+				</parameter>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="90" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-9" style="default" x="304" y="8" width="171" height="32" forecolor="#7E7979" uuid="bd6dd473-b902-4088-a17f-6388c111d5f4"/>
-				<box leftPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left">
-					<font fontName="DejaVu Sans" size="9" isBold="true"/>
-				</textElement>
-				<text><![CDATA[Payment Terms]]></text>
-			</staticText>
-			<line>
-				<reportElement key="line-3" style="default" x="0" y="42" width="483" height="1" forecolor="#CCCCCC" uuid="82ddaffa-23ac-4869-b332-27125c88842e"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-22" x="308" y="45" width="89" height="18" isPrintWhenDetailOverflows="true" uuid="5aa4b73a-1ac1-4f94-ba9c-79eba2396a68"/>
-				<textElement>
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{PAYTERM}]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-9" x="439" y="64" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="58c3d0df-761c-4e27-96e2-17001b3d5432"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-10" x="340" y="64" width="95" height="19" uuid="c1bb140c-1041-404f-b142-458e3cfe0ea0"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-2" x="0" y="61" width="483" height="1" forecolor="#CCCCCC" uuid="2125f6b1-ebbe-483c-a41e-395b5be269ef"/>
-				<graphicElement>
-					<pen lineWidth="0.25" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<staticText>
-				<reportElement key="staticText" x="1" y="45" width="307" height="19" uuid="2663ca4e-294d-4491-8390-1c4013cf118d">
-					<printWhenExpression><![CDATA["Y".equals($F{ISCASHVAT})]]></printWhenExpression>
-				</reportElement>
-				<textElement>
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<text><![CDATA[Cash VAT Invoice]]></text>
-			</staticText>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="90" splitType="Stretch">
+		<element kind="staticText" uuid="bd6dd473-b902-4088-a17f-6388c111d5f4" key="staticText-9" x="304" y="8" width="171" height="32" forecolor="#7E7979" fontName="DejaVu Sans" fontSize="9.0" bold="true" hTextAlign="Left" style="default">
+			<text><![CDATA[Payment Terms]]></text>
+			<box leftPadding="2" style="default">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="82ddaffa-23ac-4869-b332-27125c88842e" key="line-3" x="0" y="42" width="483" height="1" forecolor="#CCCCCC" style="default">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="5aa4b73a-1ac1-4f94-ba9c-79eba2396a68" key="textField-22" x="308" y="45" width="89" height="18" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="false" printWhenDetailOverflows="true">
+			<expression><![CDATA[$F{PAYTERM}]]></expression>
+		</element>
+		<element kind="textField" uuid="58c3d0df-761c-4e27-96e2-17001b3d5432" key="textField-9" x="439" y="64" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="DejaVu Sans" fontSize="8.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="c1bb140c-1041-404f-b142-458e3cfe0ea0" key="textField-10" x="340" y="64" width="95" height="19" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="2125f6b1-ebbe-483c-a41e-395b5be269ef" key="line-2" x="0" y="61" width="483" height="1" forecolor="#CCCCCC">
+			<pen lineWidth="0.25" lineStyle="Solid"/>
+		</element>
+		<element kind="staticText" uuid="2663ca4e-294d-4491-8390-1c4013cf118d" key="staticText" x="1" y="45" width="307" height="19" fontName="DejaVu Sans" fontSize="8.0">
+			<printWhenExpression><![CDATA["Y".equals($F{ISCASHVAT})]]></printWhenExpression>
+			<text><![CDATA[Cash VAT Invoice]]></text>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/RptC_Order_TaxLines.jrxml
+++ b/src/org/openbravo/erpReports/RptC_Order_TaxLines.jrxml
@@ -1,117 +1,87 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptC_Invoice_TaxLines" pageWidth="477" pageHeight="842" columnWidth="477" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d50afc0b-3968-43b0-aef7-067dd7188433">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="RptC_Invoice_TaxLines" language="java" pageWidth="477" pageHeight="842" columnWidth="477" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d50afc0b-3968-43b0-aef7-067dd7188433">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
 	<parameter name="C_ORDER_ID" class="java.lang.String"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT C_TAX.C_TAX_ID,C_TAX.NAME, C_ORDERTAX.TAXBASEAMT as BASE, TAXAMT as SUM
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT C_TAX.C_TAX_ID,C_TAX.NAME, C_ORDERTAX.TAXBASEAMT as BASE, TAXAMT as SUM
         FROM C_TAX, C_ORDERTAX
         WHERE C_ORDERTAX.C_TAX_ID = C_TAX.C_TAX_ID
-        AND C_ORDERTAX.C_ORDER_ID = $P{C_ORDER_ID}]]>
-	</queryString>
+        AND C_ORDERTAX.C_ORDER_ID = $P{C_ORDER_ID}]]></query>
 	<field name="C_TAX_ID" class="java.lang.String"/>
 	<field name="NAME" class="java.lang.String"/>
 	<field name="BASE" class="java.math.BigDecimal"/>
 	<field name="SUM" class="java.math.BigDecimal"/>
 	<group name="C_ORDER_ID">
-		<groupExpression><![CDATA[]]></groupExpression>
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band splitType="Stretch"/>
 		</groupHeader>
 		<groupFooter>
 			<band height="2" splitType="Stretch">
-				<line>
-					<reportElement key="line-1" x="0" y="0" width="477" height="2" uuid="ba78d4b5-c748-4e73-83bc-50f84cbe1d75"/>
-				</line>
+				<element kind="line" uuid="ba78d4b5-c748-4e73-83bc-50f84cbe1d75" key="line-1" x="0" y="0" width="477" height="2"/>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<line>
-				<reportElement key="line-2" style="Report_Footer" x="0" y="0" width="477" height="1" uuid="6a06d485-bdab-4403-aebe-568e72c9f55d"/>
-			</line>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="0" y="0" width="400" height="16" forecolor="#000000" uuid="30fae226-a4e3-4750-8fbc-ff67d3da27fa"/>
-				<box>
+			<element kind="line" uuid="6a06d485-bdab-4403-aebe-568e72c9f55d" key="line-2" x="0" y="0" width="477" height="1" style="Report_Footer"/>
+			<element kind="textField" uuid="30fae226-a4e3-4750-8fbc-ff67d3da27fa" key="textField" x="0" y="0" width="400" height="16" forecolor="#000000" blankWhenNull="false" style="default">
+				<expression><![CDATA[" " + $F{NAME}]]></expression>
+				<box style="default">
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[" " + $F{NAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="395" y="0" width="82" height="16" forecolor="#000000" uuid="3c3393d0-7679-45c7-a7fe-176386054a3a"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="3c3393d0-7679-45c7-a7fe-176386054a3a" key="textField" x="395" y="0" width="82" height="16" forecolor="#000000" pattern="" blankWhenNull="false" hTextAlign="Right" style="default">
+				<expression><![CDATA[($F{SUM}!=null)?$P{NUMBERFORMAT}.format($F{SUM}):new String(" ")]]></expression>
+				<box style="default">
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA[($F{SUM}!=null)?$P{NUMBERFORMAT}.format($F{SUM}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="textField" style="default" x="287" y="0" width="82" height="16" uuid="1bada3bb-f345-46b4-8184-b2b1ded27d17"/>
-				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA[($F{BASE}!=null)?$P{NUMBERFORMAT}.format($F{BASE}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-3" style="Report_Footer" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="16" uuid="7a604cd7-82c3-482e-ba48-b73958f18df1"/>
-			</line>
-			<line>
-				<reportElement key="line-4" style="Report_Footer" stretchType="RelativeToBandHeight" x="477" y="0" width="1" height="16" uuid="25f0c9ae-c601-498c-80d3-a78cb1cf65f6"/>
-			</line>
+			</element>
+			<element kind="textField" uuid="1bada3bb-f345-46b4-8184-b2b1ded27d17" key="textField" x="287" y="0" width="82" height="16" hTextAlign="Right" style="default">
+				<expression><![CDATA[($F{BASE}!=null)?$P{NUMBERFORMAT}.format($F{BASE}):new String(" ")]]></expression>
+			</element>
+			<element kind="line" uuid="7a604cd7-82c3-482e-ba48-b73958f18df1" key="line-3" stretchType="ContainerHeight" x="0" y="0" width="1" height="16" style="Report_Footer"/>
+			<element kind="line" uuid="25f0c9ae-c601-498c-80d3-a78cb1cf65f6" key="line-4" stretchType="ContainerHeight" x="477" y="0" width="1" height="16" style="Report_Footer"/>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/RptC_Order_TaxLines_new.jrxml
+++ b/src/org/openbravo/erpReports/RptC_Order_TaxLines_new.jrxml
@@ -1,50 +1,47 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptC_Order_TaxLines_new" pageWidth="477" pageHeight="842" columnWidth="477" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="de218178-592d-49dc-9d13-5adf61b856d4">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="RptC_Order_TaxLines_new" language="java" pageWidth="477" pageHeight="842" columnWidth="477" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="de218178-592d-49dc-9d13-5adf61b856d4">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.5"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
 	<parameter name="C_ORDER_ID" class="java.lang.String"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT C_TAX.C_TAX_ID,C_TAX.NAME, C_ORDERTAX.TAXBASEAMT as BASE, TAXAMT as SUM
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT C_TAX.C_TAX_ID,C_TAX.NAME, C_ORDERTAX.TAXBASEAMT as BASE, TAXAMT as SUM
         FROM C_TAX, C_ORDERTAX
         WHERE C_ORDERTAX.C_TAX_ID = C_TAX.C_TAX_ID
-        AND C_ORDERTAX.C_ORDER_ID = $P{C_ORDER_ID}]]>
-	</queryString>
+        AND C_ORDERTAX.C_ORDER_ID = $P{C_ORDER_ID}]]></query>
 	<field name="C_TAX_ID" class="java.lang.String"/>
 	<field name="NAME" class="java.lang.String"/>
 	<field name="BASE" class="java.math.BigDecimal"/>
 	<field name="SUM" class="java.math.BigDecimal"/>
 	<group name="C_ORDER_ID">
-		<groupExpression><![CDATA[]]></groupExpression>
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band splitType="Stretch"/>
 		</groupHeader>
@@ -52,66 +49,36 @@
 			<band height="2" splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="25" splitType="Stretch">
-			<line>
-				<reportElement key="line-2" style="Report_Footer" x="0" y="21" width="477" height="1" forecolor="#CCCCCC" uuid="4d13a96d-2b66-4af4-96f6-cc57ad726e64"/>
-			</line>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="0" y="0" width="400" height="21" forecolor="#000000" uuid="7d386eb5-4ad1-418e-b47c-79554a69ddfc"/>
-				<box>
+			<element kind="line" uuid="4d13a96d-2b66-4af4-96f6-cc57ad726e64" key="line-2" x="0" y="21" width="477" height="1" forecolor="#CCCCCC" style="Report_Footer"/>
+			<element kind="textField" uuid="7d386eb5-4ad1-418e-b47c-79554a69ddfc" key="textField" x="0" y="0" width="400" height="21" forecolor="#000000" fontName="DejaVu Sans" blankWhenNull="false" style="default">
+				<expression><![CDATA[" " + $F{NAME}]]></expression>
+				<box style="default">
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement>
-					<font fontName="DejaVu Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[" " + $F{NAME}]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="395" y="0" width="82" height="21" forecolor="#000000" uuid="3b426abf-2475-45d4-8a86-2e978c5e9628"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="3b426abf-2475-45d4-8a86-2e978c5e9628" key="textField" x="395" y="0" width="82" height="21" forecolor="#000000" fontName="DejaVu Sans" pattern="" blankWhenNull="false" hTextAlign="Right" style="default">
+				<expression><![CDATA[($F{SUM}!=null)?$P{NUMBERFORMAT}.format($F{SUM}):new String(" ")]]></expression>
+				<box style="default">
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right">
-					<font fontName="DejaVu Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{SUM}!=null)?$P{NUMBERFORMAT}.format($F{SUM}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement key="textField" style="default" x="287" y="0" width="82" height="21" uuid="6d62f0be-e777-40c1-8e9f-46b44f2dcc62"/>
-				<textElement textAlignment="Right">
-					<font fontName="DejaVu Sans"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{BASE}!=null)?$P{NUMBERFORMAT}.format($F{BASE}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="0" width="477" height="2" forecolor="#CCCCCC" uuid="2d9980b3-0111-4451-b4b7-66ce4c05d922"/>
-			</line>
+			</element>
+			<element kind="textField" uuid="6d62f0be-e777-40c1-8e9f-46b44f2dcc62" key="textField" x="287" y="0" width="82" height="21" fontName="DejaVu Sans" hTextAlign="Right" style="default">
+				<expression><![CDATA[($F{BASE}!=null)?$P{NUMBERFORMAT}.format($F{BASE}):new String(" ")]]></expression>
+			</element>
+			<element kind="line" uuid="2d9980b3-0111-4451-b4b7-66ce4c05d922" key="line-1" x="0" y="0" width="477" height="2" forecolor="#CCCCCC"/>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/RptC_ProposalJr.jrxml
+++ b/src/org/openbravo/erpReports/RptC_ProposalJr.jrxml
@@ -1,62 +1,60 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptC_ProposalJr" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="28b4a0d6-1dd4-4ec8-b30c-c2b1c8977b27">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="RptC_ProposalJr" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="28b4a0d6-1dd4-4ec8-b30c-c2b1c8977b27">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="SUBREPORT_DIR" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{BASE_DESIGN}+"/org/openbravo/erpReports/"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="C_PROJECTPROPOSAL_ID" class="java.lang.String"/>
-	<parameter name="SR_LINES" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT DISTINCT REPLACE(table3.HEADERNOTE, CHR(10), '') AS headernote, table3.C_PROJECTPROPOSAL_ID,
+	<parameter name="SR_LINES" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<query language="sql"><![CDATA[SELECT DISTINCT REPLACE(table3.HEADERNOTE, CHR(10), '') AS headernote, table3.C_PROJECTPROPOSAL_ID,
 table7.C_BPARTNER_ID, TO_CHAR(table8.address1) AS address1, to_char(table8.address2) as address2,
         TO_CHAR(table5.DESCRIPTION )  AS proposal, table5.VALUE AS reference,
         TO_CHAR(table8.POSTAL)||' '|| TO_CHAR(table8.CITY)||' ('||TO_CHAR(table9.description)||')' AS localidad, 
@@ -81,8 +79,7 @@ table7.C_BPARTNER_ID, TO_CHAR(table8.address1) AS address1, to_char(table8.addre
         AND table5.C_CURRENCY_ID = table15.C_CURRENCY_ID
         AND C_PROJECTPROPOSALLINE.IsActive = 'Y'
         AND table13.AD_ORG_ID = C_PROJECTPROPOSALLINE.AD_ORG_ID
-        AND table14.C_LOCATION_ID= table13.C_LOCATION_ID]]>
-	</queryString>
+        AND table14.C_LOCATION_ID= table13.C_LOCATION_ID]]></query>
 	<field name="HEADERNOTE" class="java.lang.String"/>
 	<field name="C_PROJECTPROPOSAL_ID" class="java.lang.String"/>
 	<field name="C_BPARTNER_ID" class="java.lang.String"/>
@@ -103,273 +100,194 @@ table7.C_BPARTNER_ID, TO_CHAR(table8.address1) AS address1, to_char(table8.addre
 	<field name="GREETAUX" class="java.lang.String"/>
 	<field name="FOOTNOTE" class="java.lang.String"/>
 	<field name="NAME" class="java.lang.String"/>
-	<background>
-		<band height="14" splitType="Stretch"/>
-	</background>
-	<title>
-		<band height="250" splitType="Stretch">
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" x="-1" y="64" width="234" height="16" uuid="399b2c33-520d-42c7-9cdc-ecdce012f0df"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="12"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{BPNAME}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" x="-1" y="80" width="234" height="36" uuid="83f87e2f-84f4-4ede-8455-ade097f69848"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="12"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{ADDRESS}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" x="296" y="70" width="82" height="15" uuid="a4fbe355-50a1-4755-9f5f-5550ad14a243"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{FECHA}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-8" x="-1" y="5" width="120" height="26" uuid="1b180f1a-2a7c-4b72-bad7-74fb4c96fc83"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="20"/>
-				</textElement>
-				<text><![CDATA[PROPOSAL]]></text>
-			</staticText>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-4" x="-2" y="116" width="86" height="15" uuid="6bb27fd1-82bd-4ec9-bb46-8aa2cb49c933"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PHONE} == null ? "" : $F{PHONE})]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-5" x="-2" y="132" width="87" height="17" uuid="50cde23a-998f-4624-be90-4f2bab3c197c"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{FAX} == null ? "" : $F{FAX})]]></textFieldExpression>
-			</textField>
-			<image isLazy="true">
-				<reportElement key="image-1" x="302" y="5" width="197" height="55" uuid="abc4da37-23a2-4faf-88f7-b806aec38d79"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<imageExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylogin")]]></imageExpression>
-			</image>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField" x="-1" y="202" width="490" height="41" uuid="4eeeef14-67c9-4979-8b47-f3a4b6954674"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="12"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{HEADERNOTE}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-11" x="234" y="72" width="62" height="16" forecolor="#666666" uuid="3b87a816-cb4f-4494-92e4-63f8601a9970"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left">
-					<font size="10" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Date Sent:]]></text>
-			</staticText>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-6" x="296" y="87" width="100" height="15" uuid="bb7357b4-0d2d-4409-a637-363d70b61474"/>
-				<box leftPadding="2" rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{NAME}]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-13" x="234" y="89" width="62" height="16" forecolor="#666666" uuid="c9516d0e-5800-43c3-b0e9-a45a63e21a05"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left">
-					<font size="10" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<text><![CDATA[Project:]]></text>
-			</staticText>
-			<line>
-				<reportElement key="line-2" x="162" y="164" width="148" height="1" uuid="3d1b7593-9293-4fe8-ace7-0009bdb1cd02"/>
-			</line>
-		</band>
+	<background height="14" splitType="Stretch"/>
+	<title height="250" splitType="Stretch">
+		<element kind="textField" uuid="399b2c33-520d-42c7-9cdc-ecdce012f0df" key="textField" x="-1" y="64" width="234" height="16" fontName="Times-Roman" fontSize="12.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle">
+			<expression><![CDATA[$F{BPNAME}]]></expression>
+			<box leftPadding="2" rightPadding="2">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="83f87e2f-84f4-4ede-8455-ade097f69848" key="textField" x="-1" y="80" width="234" height="36" fontName="Times-Roman" fontSize="12.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle">
+			<expression><![CDATA[$F{ADDRESS}]]></expression>
+			<box leftPadding="2" rightPadding="2">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="a4fbe355-50a1-4755-9f5f-5550ad14a243" key="textField" x="296" y="70" width="82" height="15" fontSize="10.0" blankWhenNull="false" vTextAlign="Middle">
+			<expression><![CDATA[$F{FECHA}]]></expression>
+			<box leftPadding="2" rightPadding="2">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="1b180f1a-2a7c-4b72-bad7-74fb4c96fc83" key="staticText-8" x="-1" y="5" width="120" height="26" fontSize="20.0">
+			<text><![CDATA[PROPOSAL]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="6bb27fd1-82bd-4ec9-bb46-8aa2cb49c933" key="textField-4" x="-2" y="116" width="86" height="15" fontSize="10.0" blankWhenNull="false">
+			<expression><![CDATA[($F{PHONE} == null ? "" : $F{PHONE})]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="50cde23a-998f-4624-be90-4f2bab3c197c" key="textField-5" x="-2" y="132" width="87" height="17" fontSize="10.0" blankWhenNull="false">
+			<expression><![CDATA[($F{FAX} == null ? "" : $F{FAX})]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="image" uuid="abc4da37-23a2-4faf-88f7-b806aec38d79" key="image-1" x="302" y="5" width="197" height="55" lazy="true">
+			<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylogin")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="4eeeef14-67c9-4979-8b47-f3a4b6954674" key="textField" x="-1" y="202" width="490" height="41" fontSize="12.0" blankWhenNull="true">
+			<expression><![CDATA[$F{HEADERNOTE}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="3b87a816-cb4f-4494-92e4-63f8601a9970" key="staticText-11" x="234" y="72" width="62" height="16" forecolor="#666666" fontSize="10.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left">
+			<text><![CDATA[Date Sent:]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="bb7357b4-0d2d-4409-a637-363d70b61474" key="textField-6" x="296" y="87" width="100" height="15" fontSize="10.0" blankWhenNull="false" vTextAlign="Middle">
+			<expression><![CDATA[$F{NAME}]]></expression>
+			<box leftPadding="2" rightPadding="2">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="c9516d0e-5800-43c3-b0e9-a45a63e21a05" key="staticText-13" x="234" y="89" width="62" height="16" forecolor="#666666" fontSize="10.0" pdfFontName="Helvetica-Bold" bold="true" hTextAlign="Left">
+			<text><![CDATA[Project:]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="3d1b7593-9293-4fe8-ace7-0009bdb1cd02" key="line-2" x="162" y="164" width="148" height="1"/>
 	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="43" splitType="Stretch">
-			<subreport isUsingCache="true">
-				<reportElement key="subreport-1" x="0" y="7" width="535" height="26" uuid="01ba794b-2aea-4ae2-9b2d-9cf6da879348"/>
-				<subreportParameter name="ATTACH">
-					<subreportParameterExpression><![CDATA[$P{ATTACH}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="BASE_WEB">
-					<subreportParameterExpression><![CDATA[$P{BASE_WEB}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="BASE_DESIGN">
-					<subreportParameterExpression><![CDATA[$P{BASE_DESIGN}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LANGUAGE">
-					<subreportParameterExpression><![CDATA[$P{LANGUAGE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="USER_CLIENT">
-					<subreportParameterExpression><![CDATA[$P{USER_CLIENT}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[$P{NUMBERFORMAT}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="USER_ORG">
-					<subreportParameterExpression><![CDATA[$P{USER_ORG}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="C_PROJECTPROPOSAL_ID">
-					<subreportParameterExpression><![CDATA[$F{C_PROJECTPROPOSAL_ID}.toString()]]></subreportParameterExpression>
-				</subreportParameter>
+			<element kind="subreport" uuid="01ba794b-2aea-4ae2-9b2d-9cf6da879348" key="subreport-1" x="0" y="7" width="535" height="26" usingCache="true">
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{SR_LINES}]]></subreportExpression>
-			</subreport>
+				<expression><![CDATA[$P{SR_LINES}]]></expression>
+				<parameter name="ATTACH">
+					<expression><![CDATA[$P{ATTACH}]]></expression>
+				</parameter>
+				<parameter name="BASE_WEB">
+					<expression><![CDATA[$P{BASE_WEB}]]></expression>
+				</parameter>
+				<parameter name="BASE_DESIGN">
+					<expression><![CDATA[$P{BASE_DESIGN}]]></expression>
+				</parameter>
+				<parameter name="LANGUAGE">
+					<expression><![CDATA[$P{LANGUAGE}]]></expression>
+				</parameter>
+				<parameter name="USER_CLIENT">
+					<expression><![CDATA[$P{USER_CLIENT}]]></expression>
+				</parameter>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[$P{NUMBERFORMAT}]]></expression>
+				</parameter>
+				<parameter name="USER_ORG">
+					<expression><![CDATA[$P{USER_ORG}]]></expression>
+				</parameter>
+				<parameter name="C_PROJECTPROPOSAL_ID">
+					<expression><![CDATA[$F{C_PROJECTPROPOSAL_ID}.toString()]]></expression>
+				</parameter>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="131" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-1" x="401" y="110" width="95" height="19" uuid="9fda906a-9c44-4724-917d-62aac6833d29"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-2" x="498" y="110" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="17c92492-aff6-440e-8580-3cb52b79b5e4"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="158" y="8" width="175" height="1" forecolor="#000000" uuid="ce0cee72-0b35-4d72-8df9-fca2c3bfe1e4"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-3" x="278" y="110" width="116" height="19" uuid="06da1923-64ea-4c5b-85b4-754f88e68718"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-5" x="199" y="111" width="78" height="19" uuid="9afc9d62-2f0a-41ad-8dab-90667051e9f3"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-			<textField isBlankWhenNull="true">
-				<reportElement key="textField" x="0" y="17" width="535" height="60" uuid="0e036abd-acd6-4d13-be09-4d30b98441d5"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="12"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{FOOTNOTE}]]></textFieldExpression>
-			</textField>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="131" splitType="Stretch">
+		<element kind="textField" uuid="9fda906a-9c44-4724-917d-62aac6833d29" key="textField-1" x="401" y="110" width="95" height="19" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="17c92492-aff6-440e-8580-3cb52b79b5e4" key="textField-2" x="498" y="110" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="ce0cee72-0b35-4d72-8df9-fca2c3bfe1e4" key="line-1" x="158" y="8" width="175" height="1" forecolor="#000000">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="06da1923-64ea-4c5b-85b4-754f88e68718" key="textField-3" x="278" y="110" width="116" height="19" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="9afc9d62-2f0a-41ad-8dab-90667051e9f3" key="staticText-5" x="199" y="111" width="78" height="19" hTextAlign="Right">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="0e036abd-acd6-4d13-be09-4d30b98441d5" key="textField" x="0" y="17" width="535" height="60" fontSize="12.0" blankWhenNull="true">
+			<expression><![CDATA[$F{FOOTNOTE}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/RptC_Remittance.jrxml
+++ b/src/org/openbravo/erpReports/RptC_Remittance.jrxml
@@ -1,76 +1,74 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptC_Remittance" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="01ea3c5d-131a-403c-a8ed-a27b41cf0f4c">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="RptC_Remittance" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="01ea3c5d-131a-403c-a8ed-a27b41cf0f4c">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true">
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="REPORT_TITLE" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="ReportData" class="java.lang.String" isForPrompting="false">
+	<parameter name="ReportData" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
 	<parameter name="SUBREPORT_DIR" class="java.lang.String">
 		<defaultValueExpression><![CDATA[$P{BASE_DESIGN}+"/org/openbravo/erpReports/"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false">
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale">
 		<defaultValueExpression><![CDATA[new Locale("en","US")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="SR_LINES" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT DISTINCT CS.C_REMITTANCE_ID, CS.DOCUMENTNO, CS.DATETRX, CS.DUEDATE AS dateacct, AD_CLIENT.NAME AS ENTITY, AD_ORGINFO.TAXID AS CIF, C_BANK.NAME AS NAME_BANK, 
+	<parameter name="SR_LINES" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<query language="sql"><![CDATA[SELECT DISTINCT CS.C_REMITTANCE_ID, CS.DOCUMENTNO, CS.DATETRX, CS.DUEDATE AS dateacct, AD_CLIENT.NAME AS ENTITY, AD_ORGINFO.TAXID AS CIF, C_BANK.NAME AS NAME_BANK, 
       C_BANK.CODEBANK||' '||C_BANK.CODEBRANCH||' '||C_BANK.DIGITCONTROL||' '||C_BANKACCOUNT.DIGITCONTROL||' '||C_BANKACCOUNT.CODEACCOUNT AS ACCOUNT, CS.NAME
 				FROM C_REMITTANCE CS left join C_REMITTANCELINE RL on CS.C_REMITTANCE_ID = RL.C_REMITTANCE_ID
 				                     left join C_DEBT_PAYMENT CDG on RL.C_DEBT_PAYMENT_ID = CDG.C_DEBT_PAYMENT_ID
@@ -80,8 +78,7 @@
 				     AD_CLIENT, AD_ORGINFO
         WHERE CS.AD_CLIENT_ID = AD_CLIENT.AD_CLIENT_ID
         AND CS.AD_ORG_ID = AD_ORGINFO.AD_ORG_ID
-        AND CS.C_REMITTANCE_ID = 1000011]]>
-	</queryString>
+        AND CS.C_REMITTANCE_ID = 1000011]]></query>
 	<field name="C_REMITTANCE_ID" class="java.lang.String"/>
 	<field name="DOCUMENTNO" class="java.lang.String"/>
 	<field name="DATETRX" class="java.util.Date"/>
@@ -92,333 +89,256 @@
 	<field name="ACCOUNT" class="java.lang.String"/>
 	<field name="NAME" class="java.lang.String"/>
 	<variable name="DetailFieldTotal" class="java.lang.String"/>
-	<variable name="REMITTANCE_AMOUNT" class="java.math.BigDecimal" resetType="Group" resetGroup="C_REMITTANCE_ID"/>
-	<group name="C_REMITTANCE_ID" isResetPageNumber="true">
-		<groupExpression><![CDATA[$F{C_REMITTANCE_ID}]]></groupExpression>
+	<variable name="REMITTANCE_AMOUNT" resetType="Group" resetGroup="C_REMITTANCE_ID" class="java.math.BigDecimal"/>
+	<group name="C_REMITTANCE_ID" resetPageNumber="true">
+		<expression><![CDATA[$F{C_REMITTANCE_ID}]]></expression>
 		<groupHeader>
 			<band height="80" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText" style="GroupHeader_DarkGray" x="0" y="0" width="120" height="18" uuid="051bfab0-3e92-4433-8a96-f151699fe181"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
+				<element kind="staticText" uuid="051bfab0-3e92-4433-8a96-f151699fe181" key="staticText" x="0" y="0" width="120" height="18" style="GroupHeader_DarkGray">
 					<text><![CDATA[Remittance No:]]></text>
-				</staticText>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="120" y="0" width="415" height="18" uuid="f8285b0f-61b4-46b0-aad4-dbafd32b9c8f"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{DOCUMENTNO}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-2" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="80" forecolor="#555555" uuid="934ddb3f-e2ab-44e7-aec3-2f704582ca84"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-3" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="80" forecolor="#555555" uuid="a9ec5958-b035-4a5f-bde0-3090294a09ec"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField" style="Group_Data_Field" x="130" y="26" width="140" height="16" uuid="b43a0b81-6226-4a34-b4a5-d35c27e7897b"/>
-					<box leftPadding="4" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="f8285b0f-61b4-46b0-aad4-dbafd32b9c8f" key="textField" x="120" y="0" width="415" height="18" textAdjust="StretchHeight" pattern="" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{DOCUMENTNO}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
+						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{DATETRX}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-90" style="Group_Data_Label" x="10" y="26" width="120" height="16" uuid="9e2508ce-8064-4866-b791-af8e4b3c33e1"/>
-					<box leftPadding="4" rightPadding="2">
+				</element>
+				<element kind="line" uuid="934ddb3f-e2ab-44e7-aec3-2f704582ca84" key="line-2" stretchType="ContainerHeight" x="0" y="0" width="1" height="80" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="a9ec5958-b035-4a5f-bde0-3090294a09ec" key="line-3" stretchType="ContainerHeight" x="535" y="0" width="1" height="80" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="textField" uuid="b43a0b81-6226-4a34-b4a5-d35c27e7897b" key="textField" x="130" y="26" width="140" height="16" blankWhenNull="false" style="Group_Data_Field">
+					<expression><![CDATA[$F{DATETRX}]]></expression>
+					<box leftPadding="4" rightPadding="2" style="Group_Data_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="9e2508ce-8064-4866-b791-af8e4b3c33e1" key="element-90" x="10" y="26" width="120" height="16" style="Group_Data_Label">
 					<text><![CDATA[Drawing up Date:]]></text>
-				</staticText>
-				<textField pattern="dd-MM-yyyyy" isBlankWhenNull="false">
-					<reportElement key="textField" style="Group_Data_Field" x="369" y="26" width="134" height="16" uuid="6188f3fd-c5f3-4a46-b4c9-3cbecd488d9b"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textFieldExpression><![CDATA[$F{DATEACCT}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-90" style="Group_Data_Label" x="270" y="26" width="100" height="16" uuid="a12268c1-9ccf-4f63-bab0-95bb8e3e6591"/>
-					<box leftPadding="5">
+					<box leftPadding="4" rightPadding="2" style="Group_Data_Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
+				</element>
+				<element kind="textField" uuid="6188f3fd-c5f3-4a46-b4c9-3cbecd488d9b" key="textField" x="369" y="26" width="134" height="16" pattern="dd-MM-yyyyy" blankWhenNull="false" style="Group_Data_Field">
+					<expression><![CDATA[$F{DATEACCT}]]></expression>
+					<box leftPadding="5" style="Group_Data_Field">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="a12268c1-9ccf-4f63-bab0-95bb8e3e6591" key="element-90" x="270" y="26" width="100" height="16" style="Group_Data_Label">
 					<text><![CDATA[Charge Date:]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField" x="70" y="58" width="200" height="16" uuid="b6eae6f9-ed74-403f-acd4-d5be5b3d99be"/>
+					<box leftPadding="5" style="Group_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="b6eae6f9-ed74-403f-acd4-d5be5b3d99be" key="textField" x="70" y="58" width="200" height="16" blankWhenNull="false">
+					<expression><![CDATA[$F{CIF}]]></expression>
 					<box leftPadding="4">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{CIF}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-90" style="Group_Data_Label" x="10" y="58" width="60" height="16" uuid="48de462e-8b43-4aff-bbbf-de8276223f18"/>
-					<box leftPadding="4" rightPadding="2">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
+				</element>
+				<element kind="staticText" uuid="48de462e-8b43-4aff-bbbf-de8276223f18" key="element-90" x="10" y="58" width="60" height="16" style="Group_Data_Label">
 					<text><![CDATA[Tax ID:]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField" style="Group_Data_Field" x="323" y="42" width="180" height="16" uuid="306ce774-482b-476c-ba38-36c34f4c07ca"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textFieldExpression><![CDATA[$F{NAME_BANK}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-90" style="Group_Data_Label" x="270" y="42" width="50" height="16" uuid="573581fa-c554-420e-844d-688cf4f9af0a"/>
-					<box leftPadding="5">
+					<box leftPadding="4" rightPadding="2" style="Group_Data_Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
+				</element>
+				<element kind="textField" uuid="306ce774-482b-476c-ba38-36c34f4c07ca" key="textField" x="323" y="42" width="180" height="16" blankWhenNull="false" style="Group_Data_Field">
+					<expression><![CDATA[$F{NAME_BANK}]]></expression>
+					<box leftPadding="5" style="Group_Data_Field">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="573581fa-c554-420e-844d-688cf4f9af0a" key="element-90" x="270" y="42" width="50" height="16" style="Group_Data_Label">
 					<text><![CDATA[Bank:]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField" style="Group_Data_Field" x="110" y="42" width="160" height="16" uuid="b4a138cc-36f7-4382-ad01-9e403b3750d1"/>
-					<box leftPadding="4">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textFieldExpression><![CDATA[$F{ACCOUNT}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-90" style="Report_Data_Label" x="10" y="42" width="100" height="16" uuid="ff8d388e-6408-4f10-b0ef-8d6c23d8f3f8"/>
-					<box leftPadding="4" rightPadding="2">
+					<box leftPadding="5" style="Group_Data_Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
+				</element>
+				<element kind="textField" uuid="b4a138cc-36f7-4382-ad01-9e403b3750d1" key="textField" x="110" y="42" width="160" height="16" blankWhenNull="false" style="Group_Data_Field">
+					<expression><![CDATA[$F{ACCOUNT}]]></expression>
+					<box leftPadding="4" style="Group_Data_Field">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="ff8d388e-6408-4f10-b0ef-8d6c23d8f3f8" key="element-90" x="10" y="42" width="100" height="16" style="Report_Data_Label">
 					<text><![CDATA[Bank Account:]]></text>
-				</staticText>
+					<box leftPadding="4" rightPadding="2" style="Report_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="24" splitType="Stretch">
-				<line>
-					<reportElement key="line-32" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="22" forecolor="#555555" uuid="1ac8af8a-dc50-4e8e-bde0-4e71c2d0d629"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-33" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="22" forecolor="#555555" uuid="6edd093c-604c-4524-acfb-0c1d607b75e3"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-34" x="0" y="22" width="535" height="1" forecolor="#555555" uuid="182be86a-43a6-42f5-9432-5bb01d2bdce0"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<textField evaluationTime="Group" evaluationGroup="C_REMITTANCE_ID" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Total_Field" x="430" y="2" width="100" height="16" uuid="b34c1d7b-f9d6-4ed0-89fe-5650db27fcc8"/>
-					<box leftPadding="5">
+				<element kind="line" uuid="1ac8af8a-dc50-4e8e-bde0-4e71c2d0d629" key="line-32" stretchType="ContainerHeight" x="0" y="0" width="1" height="22" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="6edd093c-604c-4524-acfb-0c1d607b75e3" key="line-33" stretchType="ContainerHeight" x="535" y="0" width="1" height="22" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="182be86a-43a6-42f5-9432-5bb01d2bdce0" key="line-34" x="0" y="22" width="535" height="1" forecolor="#555555">
+					<pen lineWidth="1.0" lineStyle="Solid"/>
+				</element>
+				<element kind="textField" uuid="b34c1d7b-f9d6-4ed0-89fe-5650db27fcc8" key="textField" x="430" y="2" width="100" height="16" evaluationTime="Group" pattern="" evaluationGroup="C_REMITTANCE_ID" blankWhenNull="false" hTextAlign="Right" style="Total_Field">
+					<expression><![CDATA[($V{REMITTANCE_AMOUNT}!=null)?$P{NUMBERFORMAT}.format($V{REMITTANCE_AMOUNT}):new String(" ")]]></expression>
+					<box leftPadding="5" style="Total_Field">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{REMITTANCE_AMOUNT}!=null)?$P{NUMBERFORMAT}.format($V{REMITTANCE_AMOUNT}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-91" style="Group_Data_Label" x="370" y="2" width="60" height="16" uuid="fb10da34-3c7e-4f4c-a9cd-9c7db7c2d606"/>
-					<box leftPadding="4" rightPadding="4">
+				</element>
+				<element kind="staticText" uuid="fb10da34-3c7e-4f4c-a9cd-9c7db7c2d606" key="element-91" x="370" y="2" width="60" height="16" pdfFontName="Helvetica-Bold" hTextAlign="Right" style="Group_Data_Label">
+					<text><![CDATA[Total:]]></text>
+					<box leftPadding="4" rightPadding="4" style="Group_Data_Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<text><![CDATA[Total:]]></text>
-				</staticText>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band height="62" splitType="Stretch">
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Title" mode="Transparent" x="0" y="0" width="535" height="24" uuid="9c93b873-c294-4237-8865-366b63ae89ad"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$P{REPORT_TITLE}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="24" width="535" height="1" uuid="e9f2c1a4-2e4d-4a8a-a783-4f90d78cfda0"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Subtitle" x="0" y="26" width="535" height="20" uuid="3688d5bb-35c5-4fcd-a9dc-3bf14f9aed5b"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="14"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{REPORT_SUBTITLE}]]></textFieldExpression>
-			</textField>
-		</band>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader height="62" splitType="Stretch">
+		<element kind="textField" uuid="9c93b873-c294-4237-8865-366b63ae89ad" key="textField" mode="Transparent" x="0" y="0" width="535" height="24" blankWhenNull="false" style="Report_Title">
+			<expression><![CDATA[$P{REPORT_TITLE}]]></expression>
+			<box leftPadding="5" style="Report_Title">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="e9f2c1a4-2e4d-4a8a-a783-4f90d78cfda0" key="line-1" x="0" y="24" width="535" height="1">
+			<pen lineWidth="1.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="3688d5bb-35c5-4fcd-a9dc-3bf14f9aed5b" key="textField" x="0" y="26" width="535" height="20" fontSize="14.0" textAdjust="StretchHeight" blankWhenNull="false" style="Report_Subtitle">
+			<expression><![CDATA[$P{REPORT_SUBTITLE}]]></expression>
+			<box leftPadding="5" style="Report_Subtitle">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageHeader>
-	<columnHeader>
-		<band height="16" splitType="Stretch"/>
-	</columnHeader>
+	<columnHeader height="16" splitType="Stretch"/>
 	<detail>
 		<band height="48" splitType="Stretch">
-			<line>
-				<reportElement key="line-16" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="48" forecolor="#555555" uuid="d6198fd7-855d-4ec4-9c6e-b55efbdedfce"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<subreport isUsingCache="true">
-				<reportElement key="subreport-1" style="default" x="10" y="0" width="519" height="48" uuid="a3b6fa36-3622-48b2-9e4f-366c783e96f0"/>
-				<subreportParameter name="C_REMITTANCE_ID">
-					<subreportParameterExpression><![CDATA[$F{C_REMITTANCE_ID}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LOCALE">
-					<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[$P{NUMBERFORMAT}]]></subreportParameterExpression>
-				</subreportParameter>
+			<element kind="line" uuid="d6198fd7-855d-4ec4-9c6e-b55efbdedfce" key="line-16" stretchType="ContainerHeight" x="535" y="0" width="1" height="48" forecolor="#555555">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
+			<element kind="subreport" uuid="a3b6fa36-3622-48b2-9e4f-366c783e96f0" key="subreport-1" x="10" y="0" width="519" height="48" usingCache="true" style="default">
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<returnValue subreportVariable="REMITTANCE_AMOUNT" toVariable="REMITTANCE_AMOUNT"/>
-				<subreportExpression><![CDATA[$P{SR_LINES}]]></subreportExpression>
-			</subreport>
-			<line>
-				<reportElement key="line-35" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="48" forecolor="#555555" uuid="69cc9ff2-6ec1-4560-a36a-45277570e1cb"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
+				<expression><![CDATA[$P{SR_LINES}]]></expression>
+				<returnValue toVariable="REMITTANCE_AMOUNT" subreportVariable="REMITTANCE_AMOUNT"/>
+				<parameter name="C_REMITTANCE_ID">
+					<expression><![CDATA[$F{C_REMITTANCE_ID}]]></expression>
+				</parameter>
+				<parameter name="LOCALE">
+					<expression><![CDATA[$P{LOCALE}]]></expression>
+				</parameter>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[$P{NUMBERFORMAT}]]></expression>
+				</parameter>
+			</element>
+			<element kind="line" uuid="69cc9ff2-6ec1-4560-a36a-45277570e1cb" key="line-35" stretchType="ContainerHeight" x="0" y="0" width="1" height="48" forecolor="#555555">
+				<pen lineWidth="1.0" lineStyle="Solid"/>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="16" splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="20" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="402" y="4" width="95" height="16" uuid="dc778401-7683-4d75-9a07-9b1401ca02c6"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Report_Footer" x="499" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" uuid="172e575e-4eda-4a15-b5d2-02ad36de7c61"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" x="0" y="1" width="535" height="1" forecolor="#000000" uuid="d67da4b3-637d-46a4-86f6-89086e80602f"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="277" y="4" width="69" height="16" uuid="de13f005-5eed-4e7e-a3cd-31871badaed4"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle"/>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" style="default" x="195" y="4" width="78" height="16" uuid="c74d794a-1ff0-4641-8ebd-357993b11be5"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-		</band>
+	<columnFooter height="16" splitType="Stretch"/>
+	<pageFooter height="20" splitType="Stretch">
+		<element kind="textField" uuid="dc778401-7683-4d75-9a07-9b1401ca02c6" key="textField" x="402" y="4" width="95" height="16" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="Report_Footer">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="172e575e-4eda-4a15-b5d2-02ad36de7c61" key="textField" x="499" y="4" width="36" height="16" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle" style="Report_Footer">
+			<paragraph lineSpacing="Single" style="Report_Footer"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box style="Report_Footer">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="d67da4b3-637d-46a4-86f6-89086e80602f" key="line" x="0" y="1" width="535" height="1" forecolor="#000000">
+			<pen lineWidth="1.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="de13f005-5eed-4e7e-a3cd-31871badaed4" key="textField" x="277" y="4" width="69" height="16" blankWhenNull="false" vTextAlign="Middle" style="default">
+			<expression><![CDATA[new Date()]]></expression>
+			<box style="default">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="c74d794a-1ff0-4641-8ebd-357993b11be5" key="staticText-1" x="195" y="4" width="78" height="16" hTextAlign="Right" style="default">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5" style="default">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/RptC_Remittance_Lines.jrxml
+++ b/src/org/openbravo/erpReports/RptC_Remittance_Lines.jrxml
@@ -1,64 +1,63 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptC_Remittance_Lines" pageWidth="524" pageHeight="842" columnWidth="524" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d905da12-5f12-4447-b9f6-959e2eca8a31">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="RptC_Remittance_Lines" language="java" pageWidth="524" pageHeight="842" columnWidth="524" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="d905da12-5f12-4447-b9f6-959e2eca8a31">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true">
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="ReportData" class="java.lang.String" isForPrompting="false">
+	<parameter name="ReportData" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
 	<parameter name="C_REMITTANCE_ID" class="java.lang.String">
@@ -67,9 +66,8 @@
 	<parameter name="LOCALE" class="java.util.Locale">
 		<defaultValueExpression><![CDATA[new Locale("en","US")]]></defaultValueExpression>
 	</parameter>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT D.DATEPLANNED, B.NAME, D.AMOUNT, COALESCE(I.DOCUMENTNO, O.DOCUMENTNO, S.DOCUMENTNO) AS  DESCRIPTION, BPB.ACCOUNTNO
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<query language="sql"><![CDATA[SELECT D.DATEPLANNED, B.NAME, D.AMOUNT, COALESCE(I.DOCUMENTNO, O.DOCUMENTNO, S.DOCUMENTNO) AS  DESCRIPTION, BPB.ACCOUNTNO
         FROM C_REMITTANCELINE RL,
         C_BPARTNER     B  LEFT JOIN C_BP_BANKACCOUNT BPB ON B.C_BPARTNER_ID = BPB.C_BPARTNER_ID,
         C_DEBT_PAYMENT   D  LEFT JOIN C_INVOICE I ON D.C_INVOICE_ID = I.C_INVOICE_ID
@@ -78,152 +76,123 @@
         WHERE RL.C_REMITTANCE_ID = $P{C_REMITTANCE_ID}
         AND RL.C_DEBT_PAYMENT_ID = D.C_DEBT_PAYMENT_ID
         AND D.C_BPARTNER_ID   = B.C_BPARTNER_ID
-        ORDER BY DATEPLANNED, RL.LINE]]>
-	</queryString>
+        ORDER BY DATEPLANNED, RL.LINE]]></query>
 	<field name="DATEPLANNED" class="java.sql.Timestamp"/>
 	<field name="NAME" class="java.lang.String"/>
 	<field name="AMOUNT" class="java.math.BigDecimal"/>
 	<field name="DESCRIPTION" class="java.lang.String"/>
 	<field name="ACCOUNTNO" class="java.lang.String"/>
 	<variable name="DetailFieldTotal" class="java.lang.String"/>
-	<variable name="REMITTANCE_AMOUNT" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="REMITTANCE_AMOUNT" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band height="16" splitType="Stretch">
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="0" y="0" width="90" height="16" uuid="794f2c3f-8837-4298-897a-fdfdf98a4f7c"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<text><![CDATA[Maturity Date]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="90" y="0" width="106" height="16" uuid="0f69930a-a513-459c-8377-9d753fda92c5"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<text><![CDATA[Customer]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="414" y="0" width="108" height="16" uuid="f7dcff1c-841b-4302-afc2-6997732c68d3"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Amount]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="306" y="0" width="108" height="16" uuid="44b4f106-6e9e-45ea-9d69-1e7fdc7279c3"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<text><![CDATA[Inv/Debt-Pay/Ord No]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="196" y="0" width="110" height="16" uuid="bb743fee-9bae-4543-bb6c-deda3195f77e"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<text><![CDATA[Account No.]]></text>
-			</staticText>
-		</band>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader height="16" splitType="Stretch">
+		<element kind="staticText" uuid="794f2c3f-8837-4298-897a-fdfdf98a4f7c" key="element-90" x="0" y="0" width="90" height="16" style="Detail_Header">
+			<text><![CDATA[Maturity Date]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="0f69930a-a513-459c-8377-9d753fda92c5" key="element-90" x="90" y="0" width="106" height="16" style="Detail_Header">
+			<text><![CDATA[Customer]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="f7dcff1c-841b-4302-afc2-6997732c68d3" key="element-90" x="414" y="0" width="108" height="16" hTextAlign="Right" style="Detail_Header">
+			<text><![CDATA[Amount]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="44b4f106-6e9e-45ea-9d69-1e7fdc7279c3" key="element-90" x="306" y="0" width="108" height="16" style="Detail_Header">
+			<text><![CDATA[Inv/Debt-Pay/Ord No]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="bb743fee-9bae-4543-bb6c-deda3195f77e" key="element-90" x="196" y="0" width="110" height="16" style="Detail_Header">
+			<text><![CDATA[Account No.]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
 	</columnHeader>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="0" y="0" width="90" height="16" uuid="54e2c643-978e-459f-896f-80ef95c1f25d"/>
-				<box leftPadding="4" rightPadding="4">
+			<element kind="textField" uuid="54e2c643-978e-459f-896f-80ef95c1f25d" key="textField" x="0" y="0" width="90" height="16" blankWhenNull="false" style="Detail_Line">
+				<expression><![CDATA[$F{DATEPLANNED}]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$F{DATEPLANNED}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="90" y="0" width="106" height="16" uuid="291f3f9a-b58d-4476-856b-aebef07fbebc"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="291f3f9a-b58d-4476-856b-aebef07fbebc" key="textField" x="90" y="0" width="106" height="16" blankWhenNull="false" style="Detail_Line">
+				<expression><![CDATA[($F{NAME}!=null)?$F{NAME}:new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[($F{NAME}!=null)?$F{NAME}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="414" y="0" width="108" height="16" uuid="7f4c8a6d-20d3-44c7-9630-64b83ead8db1"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="7f4c8a6d-20d3-44c7-9630-64b83ead8db1" key="textField" x="414" y="0" width="108" height="16" pattern="" blankWhenNull="false" hTextAlign="Right" style="Detail_Line">
+				<expression><![CDATA[($F{AMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{AMOUNT}):new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 				</box>
-				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA[($F{AMOUNT}!=null)?$P{NUMBERFORMAT}.format($F{AMOUNT}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="306" y="0" width="108" height="16" uuid="b585a6b7-cf5c-482b-acb1-d0a789c01b17"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="b585a6b7-cf5c-482b-acb1-d0a789c01b17" key="textField" x="306" y="0" width="108" height="16" blankWhenNull="false" style="Detail_Line">
+				<expression><![CDATA[($F{DESCRIPTION}!=null)?$F{DESCRIPTION}:new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[($F{DESCRIPTION}!=null)?$F{DESCRIPTION}:new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="Detail_Line" x="196" y="0" width="110" height="16" uuid="eb40c262-cc85-4e89-8a16-6e4b5535b76a"/>
-				<box leftPadding="4" rightPadding="4">
+			</element>
+			<element kind="textField" uuid="eb40c262-cc85-4e89-8a16-6e4b5535b76a" key="textField" x="196" y="0" width="110" height="16" blankWhenNull="false" style="Detail_Line">
+				<expression><![CDATA[($F{ACCOUNTNO}!=null)?$F{ACCOUNTNO}:new String(" ")]]></expression>
+				<box leftPadding="4" rightPadding="4" style="Detail_Line">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#555555"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[($F{ACCOUNTNO}!=null)?$F{ACCOUNTNO}:new String(" ")]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="6" splitType="Stretch">
-			<line>
-				<reportElement key="line-1" style="Report_Footer" x="0" y="0" width="522" height="1" forecolor="#555555" uuid="b5d8d130-d714-4af8-9652-9a8a67c0b272"/>
-			</line>
-		</band>
+	<columnFooter height="6" splitType="Stretch">
+		<element kind="line" uuid="b5d8d130-d714-4af8-9652-9a8a67c0b272" key="line-1" x="0" y="0" width="522" height="1" forecolor="#555555" style="Report_Footer"/>
 	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/RptFIN_Payment.jrxml
+++ b/src/org/openbravo/erpReports/RptFIN_Payment.jrxml
@@ -1,26 +1,25 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptFIN_Payment" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="bd802b78-4f3c-4bd9-a6b7-1974b3ca5536">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="RptFIN_Payment" language="java" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="bd802b78-4f3c-4bd9-a6b7-1974b3ca5536">
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="200"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="Label" forecolor="#999999" fontSize="14" isBold="true"/>
-	<parameter name="SUBREP_RptFIN_PaymentLines" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="DOCUMENT_ID" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="DOCUMENT_NAME" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="SHOW_LOGO" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="SHOW_COMPANYDATA" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="HEADER_MARGIN" class="java.lang.String" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT p.documentno as PAYMENTNO, bp.name AS BUSINESSPARTNER, p.paymentdate as PAYMENT_DATE,
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="Label" forecolor="#999999" fontSize="14.0" bold="true"/>
+	<parameter name="SUBREP_RptFIN_PaymentLines" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="DOCUMENT_ID" forPrompting="false" class="java.lang.String"/>
+	<parameter name="DOCUMENT_NAME" forPrompting="false" class="java.lang.String"/>
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="SHOW_LOGO" forPrompting="false" class="java.lang.String"/>
+	<parameter name="SHOW_COMPANYDATA" forPrompting="false" class="java.lang.String"/>
+	<parameter name="HEADER_MARGIN" forPrompting="false" class="java.lang.String"/>
+	<query language="sql"><![CDATA[SELECT p.documentno as PAYMENTNO, bp.name AS BUSINESSPARTNER, p.paymentdate as PAYMENT_DATE,
        p.amount as TOTAL, pm.name as PAYMENT_METHOD, cur.cursymbol as CURRENCY, p.isreceipt as ISRECEIPT,
        org.ad_org_id as legalentity, org.name as LE_NAME, ad_orginfo.taxid as LE_TAXID,
        c_location_description(ad_orginfo.c_location_id) as LE_LOCATION
@@ -32,8 +31,7 @@ WHERE p.fin_payment_id=$P{DOCUMENT_ID}
       and org.ad_org_id = (select o.ad_org_id
                            from ad_org o join ad_orgtype t on (o.ad_orgtype_id=t.ad_orgtype_id)
                            where ad_isorgincluded(p.ad_org_id, o.ad_org_id, p.ad_client_id)<>-1
-                                 and (t.islegalentity='Y' OR t.isacctlegalentity='Y'))]]>
-	</queryString>
+                                 and (t.islegalentity='Y' OR t.isacctlegalentity='Y'))]]></query>
 	<field name="PAYMENTNO" class="java.lang.String"/>
 	<field name="BUSINESSPARTNER" class="java.lang.String"/>
 	<field name="PAYMENT_DATE" class="java.util.Date"/>
@@ -46,7 +44,7 @@ WHERE p.fin_payment_id=$P{DOCUMENT_ID}
 	<field name="LE_TAXID" class="java.lang.String"/>
 	<field name="LE_LOCATION" class="java.lang.String"/>
 	<group name="LargeHeader">
-		<groupExpression><![CDATA[]]></groupExpression>
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="120" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{HEADER_MARGIN}.equalsIgnoreCase("large"))]]></printWhenExpression>
@@ -57,7 +55,7 @@ WHERE p.fin_payment_id=$P{DOCUMENT_ID}
 		</groupFooter>
 	</group>
 	<group name="MediumHeader">
-		<groupExpression><![CDATA[]]></groupExpression>
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="80" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{HEADER_MARGIN}.equalsIgnoreCase("medium"))]]></printWhenExpression>
@@ -68,7 +66,7 @@ WHERE p.fin_payment_id=$P{DOCUMENT_ID}
 		</groupFooter>
 	</group>
 	<group name="SmallHeader">
-		<groupExpression><![CDATA[]]></groupExpression>
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="50" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($P{HEADER_MARGIN}.equalsIgnoreCase("small"))]]></printWhenExpression>
@@ -79,328 +77,234 @@ WHERE p.fin_payment_id=$P{DOCUMENT_ID}
 		</groupFooter>
 	</group>
 	<group name="Payment">
-		<groupExpression><![CDATA[]]></groupExpression>
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="180" splitType="Stretch">
-				<staticText>
-					<reportElement key="label_payment_number" style="Label" x="0" y="92" width="125" height="13" uuid="2be49a8f-6ebc-4093-a4df-036bd5020cf3"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement verticalAlignment="Middle">
-						<font size="10"/>
-					</textElement>
+				<element kind="staticText" uuid="2be49a8f-6ebc-4093-a4df-036bd5020cf3" key="label_payment_number" x="0" y="92" width="125" height="13" fontSize="10.0" vTextAlign="Middle" style="Label">
 					<text><![CDATA[Payment Number:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="label_receivedfrom" style="Label" x="0" y="105" width="125" height="13" uuid="cc23f02a-d7b5-4a8e-91f9-a787f60e9486">
-						<printWhenExpression><![CDATA[new Boolean($F{ISRECEIPT}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<box>
+					<box style="Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font size="10"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="cc23f02a-d7b5-4a8e-91f9-a787f60e9486" key="label_receivedfrom" x="0" y="105" width="125" height="13" fontSize="10.0" vTextAlign="Middle" style="Label">
+					<printWhenExpression><![CDATA[new Boolean($F{ISRECEIPT}.equalsIgnoreCase("Y"))]]></printWhenExpression>
 					<text><![CDATA[Received From:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="label_paidto" style="Label" x="0" y="105" width="125" height="13" uuid="46231fd1-7f8d-437c-861a-fb02fcd43966">
-						<printWhenExpression><![CDATA[new Boolean($F{ISRECEIPT}.equalsIgnoreCase("N"))]]></printWhenExpression>
-					</reportElement>
-					<box>
+					<box style="Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font size="10"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="46231fd1-7f8d-437c-861a-fb02fcd43966" key="label_paidto" x="0" y="105" width="125" height="13" fontSize="10.0" vTextAlign="Middle" style="Label">
+					<printWhenExpression><![CDATA[new Boolean($F{ISRECEIPT}.equalsIgnoreCase("N"))]]></printWhenExpression>
 					<text><![CDATA[Paid To:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="label_receiveddate" style="Label" x="0" y="118" width="125" height="13" uuid="a77b083c-eba8-40fa-b58c-a95ffa5378ae">
-						<printWhenExpression><![CDATA[new Boolean($F{ISRECEIPT}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<box>
+					<box style="Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font size="10"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="a77b083c-eba8-40fa-b58c-a95ffa5378ae" key="label_receiveddate" x="0" y="118" width="125" height="13" fontSize="10.0" vTextAlign="Middle" style="Label">
+					<printWhenExpression><![CDATA[new Boolean($F{ISRECEIPT}.equalsIgnoreCase("Y"))]]></printWhenExpression>
 					<text><![CDATA[Receipt Date:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="label_paymentdate" style="Label" x="0" y="118" width="125" height="13" uuid="42ebf0e7-6600-44dd-a1a8-96acb40f6be1">
-						<printWhenExpression><![CDATA[new Boolean($F{ISRECEIPT}.equalsIgnoreCase("N"))]]></printWhenExpression>
-					</reportElement>
-					<box>
+					<box style="Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font size="10"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="42ebf0e7-6600-44dd-a1a8-96acb40f6be1" key="label_paymentdate" x="0" y="118" width="125" height="13" fontSize="10.0" vTextAlign="Middle" style="Label">
+					<printWhenExpression><![CDATA[new Boolean($F{ISRECEIPT}.equalsIgnoreCase("N"))]]></printWhenExpression>
 					<text><![CDATA[Payment Date:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="label_paymentmethod-1" style="Label" x="0" y="144" width="125" height="13" uuid="a95d5600-fcee-4cfc-bfe7-49b62c46e0e7"/>
-					<box>
+					<box style="Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font size="10"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="a95d5600-fcee-4cfc-bfe7-49b62c46e0e7" key="label_paymentmethod-1" x="0" y="144" width="125" height="13" fontSize="10.0" vTextAlign="Middle" style="Label">
 					<text><![CDATA[Payment Method:]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="label_paidamt" style="Label" x="0" y="131" width="125" height="13" uuid="f140556b-e2d3-4cd9-b777-274a9c5d44bd">
-						<printWhenExpression><![CDATA[new Boolean($F{ISRECEIPT}.equalsIgnoreCase("N"))]]></printWhenExpression>
-					</reportElement>
+					<box style="Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="f140556b-e2d3-4cd9-b777-274a9c5d44bd" key="label_paidamt" x="0" y="131" width="125" height="13" fontSize="10.0" blankWhenNull="false" vTextAlign="Middle" style="Label">
+					<printWhenExpression><![CDATA[new Boolean($F{ISRECEIPT}.equalsIgnoreCase("N"))]]></printWhenExpression>
+					<expression><![CDATA["Paid Amount (" + $F{CURRENCY} + "): "]]></expression>
+					<box style="Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="d4e2381a-e86f-4bf1-b294-19928cf2b0b0" key="label_receivedamt" x="0" y="131" width="125" height="13" fontSize="10.0" blankWhenNull="false" vTextAlign="Middle" style="Label">
+					<printWhenExpression><![CDATA[new Boolean($F{ISRECEIPT}.equalsIgnoreCase("Y"))]]></printWhenExpression>
+					<expression><![CDATA["Received Amount (" + $F{CURRENCY} + "): "]]></expression>
+					<box style="Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="f13e8b45-5357-4f90-bff3-f0f14de2f672" key="textField-3" x="125" y="92" width="136" height="13" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[$F{PAYMENTNO}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA["Paid Amount (" + $F{CURRENCY} + "): "]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="label_receivedamt" style="Label" x="0" y="131" width="125" height="13" uuid="d4e2381a-e86f-4bf1-b294-19928cf2b0b0">
-						<printWhenExpression><![CDATA[new Boolean($F{ISRECEIPT}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
+				</element>
+				<element kind="textField" uuid="fd67c56d-13c0-4c06-87d7-747f682e17c5" key="textField-4" x="125" y="118" width="136" height="13" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.applyCountryDateFormat($F{PAYMENT_DATE},$F{LEGALENTITY})]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle">
-						<font size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA["Received Amount (" + $F{CURRENCY} + "): "]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-3" x="125" y="92" width="136" height="13" uuid="f13e8b45-5357-4f90-bff3-f0f14de2f672"/>
+				</element>
+				<element kind="textField" uuid="26725711-7869-45e0-9f03-e4e5a7326477" key="textField-5" x="125" y="131" width="136" height="13" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{LEGALENTITY},$P{NUMBERFORMAT}).format($F{TOTAL}).toString()]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{PAYMENTNO}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-4" x="125" y="118" width="136" height="13" uuid="fd67c56d-13c0-4c06-87d7-747f682e17c5"/>
+				</element>
+				<element kind="textField" uuid="4a3a4dcf-d28e-4825-aa80-3fb836d045cb" key="textField-9" x="125" y="105" width="136" height="13" blankWhenNull="true" vTextAlign="Middle">
+					<expression><![CDATA[$F{BUSINESSPARTNER}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.applyCountryDateFormat($F{PAYMENT_DATE},$F{LEGALENTITY})]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-5" x="125" y="131" width="136" height="13" uuid="26725711-7869-45e0-9f03-e4e5a7326477"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{LEGALENTITY},$P{NUMBERFORMAT}).format($F{TOTAL}).toString()]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-9" x="125" y="105" width="136" height="13" uuid="4a3a4dcf-d28e-4825-aa80-3fb836d045cb"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{BUSINESSPARTNER}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-10" x="286" y="92" width="197" height="80" uuid="457f748c-21ef-46b1-b526-90b9be027037">
-						<printWhenExpression><![CDATA[new Boolean($P{SHOW_COMPANYDATA}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
+				</element>
+				<element kind="textField" uuid="457f748c-21ef-46b1-b526-90b9be027037" key="textField-10" x="286" y="92" width="197" height="80" blankWhenNull="false" hTextAlign="Right">
+					<printWhenExpression><![CDATA[new Boolean($P{SHOW_COMPANYDATA}.equalsIgnoreCase("Y"))]]></printWhenExpression>
+					<expression><![CDATA[($F{LE_LOCATION}==null ? $F{LE_NAME} + "\n" + $F{LE_TAXID} + "\n" : $F{LE_NAME} + "\n" + $F{LE_TAXID} + "\n" + $F{LE_LOCATION})]]></expression>
 					<box rightPadding="10">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($F{LE_LOCATION}==null ? $F{LE_NAME} + "\n" + $F{LE_TAXID} + "\n" : $F{LE_NAME} + "\n" + $F{LE_TAXID} + "\n" + $F{LE_LOCATION})]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-11" x="125" y="144" width="136" height="13" uuid="dd8ae872-ba77-41af-94a3-6a979cd541b0"/>
+				</element>
+				<element kind="textField" uuid="dd8ae872-ba77-41af-94a3-6a979cd541b0" key="textField-11" x="125" y="144" width="136" height="13" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[$F{PAYMENT_METHOD}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{PAYMENT_METHOD}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="title_receipt" x="0" y="0" width="145" height="35" uuid="2de08d71-273a-4434-8588-8b0debc65158">
-						<printWhenExpression><![CDATA[new Boolean($F{ISRECEIPT}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font size="24" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="2de08d71-273a-4434-8588-8b0debc65158" key="title_receipt" x="0" y="0" width="145" height="35" fontSize="24.0" bold="true">
+					<printWhenExpression><![CDATA[new Boolean($F{ISRECEIPT}.equalsIgnoreCase("Y"))]]></printWhenExpression>
 					<text><![CDATA[Receipt]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="title_payment" x="0" y="0" width="145" height="35" uuid="c6069c81-3685-4c26-bfae-d374c1c00e2e">
-						<printWhenExpression><![CDATA[new Boolean($F{ISRECEIPT}.equalsIgnoreCase("N"))]]></printWhenExpression>
-					</reportElement>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="24" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="c6069c81-3685-4c26-bfae-d374c1c00e2e" key="title_payment" x="0" y="0" width="145" height="35" fontSize="24.0" bold="true">
+					<printWhenExpression><![CDATA[new Boolean($F{ISRECEIPT}.equalsIgnoreCase("N"))]]></printWhenExpression>
 					<text><![CDATA[Payment]]></text>
-				</staticText>
-				<image scaleImage="RetainShape" hAlign="Right" isUsingCache="true">
-					<reportElement key="image-1" x="307" y="0" width="176" height="91" uuid="99cb5294-6698-4837-a50b-23d66c3119c1">
-						<printWhenExpression><![CDATA[new Boolean($P{SHOW_LOGO}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<imageExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylegal", $F{LEGALENTITY})]]></imageExpression>
-				</image>
+				</element>
+				<element kind="image" uuid="99cb5294-6698-4837-a50b-23d66c3119c1" key="image-1" x="307" y="0" width="176" height="91" scaleImage="RetainShape" usingCache="true" hImageAlign="Right">
+					<printWhenExpression><![CDATA[new Boolean($P{SHOW_LOGO}.equalsIgnoreCase("Y"))]]></printWhenExpression>
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylegal", $F{LEGALENTITY})]]></expression>
+					<box>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="20" splitType="Stretch">
-			<subreport isUsingCache="true">
-				<reportElement key="subreport-1" x="0" y="0" width="483" height="20" uuid="419fcde7-c943-49ef-b8fe-90a7f56b5b58"/>
-				<subreportParameter name="FIN_PAYMENT_ID">
-					<subreportParameterExpression><![CDATA[$P{DOCUMENT_ID}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{LEGALENTITY},$P{NUMBERFORMAT})]]></subreportParameterExpression>
-				</subreportParameter>
+			<element kind="subreport" uuid="419fcde7-c943-49ef-b8fe-90a7f56b5b58" key="subreport-1" x="0" y="0" width="483" height="20" usingCache="true">
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{SUBREP_RptFIN_PaymentLines}]]></subreportExpression>
-			</subreport>
+				<expression><![CDATA[$P{SUBREP_RptFIN_PaymentLines}]]></expression>
+				<parameter name="FIN_PAYMENT_ID">
+					<expression><![CDATA[$P{DOCUMENT_ID}]]></expression>
+				</parameter>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{LEGALENTITY},$P{NUMBERFORMAT})]]></expression>
+				</parameter>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="20" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-1" x="145" y="5" width="84" height="10" uuid="68b460da-aeb7-4ca6-9f97-6d31333f663c"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<text><![CDATA[Printed on]]></text>
-			</staticText>
-			<textField pattern="dd/MM/yyyy" isBlankWhenNull="false">
-				<reportElement key="textField-6" x="233" y="5" width="84" height="10" uuid="b4e1e6f6-4451-4ffc-aa36-59ac66397429"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-7" x="348" y="5" width="95" height="10" uuid="e1ff49e9-af07-4bba-bf91-02399e852d9a"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" isBlankWhenNull="false">
-				<reportElement key="textField-8" x="447" y="5" width="36" height="10" uuid="e5ced833-39ef-4f4d-b89c-d19ac8fefdf8"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="20" splitType="Stretch">
+		<element kind="staticText" uuid="68b460da-aeb7-4ca6-9f97-6d31333f663c" key="staticText-1" x="145" y="5" width="84" height="10" fontSize="8.0" hTextAlign="Right">
+			<text><![CDATA[Printed on]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="b4e1e6f6-4451-4ffc-aa36-59ac66397429" key="textField-6" x="233" y="5" width="84" height="10" fontSize="8.0" pattern="dd/MM/yyyy" blankWhenNull="false">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="e1ff49e9-af07-4bba-bf91-02399e852d9a" key="textField-7" x="348" y="5" width="95" height="10" fontSize="8.0" blankWhenNull="false" hTextAlign="Right">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="e5ced833-39ef-4f4d-b89c-d19ac8fefdf8" key="textField-8" x="447" y="5" width="36" height="10" fontSize="8.0" evaluationTime="Report" blankWhenNull="false">
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/RptFIN_PaymentLines.jrxml
+++ b/src/org/openbravo/erpReports/RptFIN_PaymentLines.jrxml
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptFIN_PaymentLines" pageWidth="483" pageHeight="802" columnWidth="483" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="8ff0fb53-ffd8-4a35-a22c-2d1b2defed19">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="RptFIN_PaymentLines" language="java" pageWidth="483" pageHeight="802" columnWidth="483" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="8ff0fb53-ffd8-4a35-a22c-2d1b2defed19">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18" isBold="true">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="18.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
 	<style name="Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="FIN_PAYMENT_ID" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT LINE_DOCUMENTTYPE, LINE_DOCUMENTNO, LINE_DATE, LINE_CURRENCY ,SUM(A.LINE_AMOUNT) AS AMOUNT
+	<parameter name="FIN_PAYMENT_ID" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT LINE_DOCUMENTTYPE, LINE_DOCUMENTNO, LINE_DATE, LINE_CURRENCY ,SUM(A.LINE_AMOUNT) AS AMOUNT
 FROM
   (SELECT
      case when psd.fin_payment_schedule_order is not null and psd.fin_payment_schedule_invoice is null then 'O'
@@ -37,199 +36,122 @@ FROM
         left outer join c_currency cur on (p.c_currency_id = cur.c_currency_id)
    WHERE p.fin_payment_id=$P{FIN_PAYMENT_ID}) A
 GROUP BY LINE_DOCUMENTTYPE, LINE_DOCUMENTNO, LINE_DATE, LINE_CURRENCY
-ORDER BY LINE_DOCUMENTTYPE,LINE_DATE, LINE_DOCUMENTNO]]>
-	</queryString>
+ORDER BY LINE_DOCUMENTTYPE,LINE_DATE, LINE_DOCUMENTNO]]></query>
 	<field name="LINE_DOCUMENTTYPE" class="java.lang.String"/>
 	<field name="LINE_DOCUMENTNO" class="java.lang.String"/>
 	<field name="LINE_DATE" class="java.lang.String"/>
 	<field name="LINE_CURRENCY" class="java.lang.String"/>
 	<field name="AMOUNT" class="java.math.BigDecimal"/>
-	<variable name="SUM_LINEAMT" class="java.math.BigDecimal" calculation="Sum">
-		<variableExpression><![CDATA[$F{AMOUNT}]]></variableExpression>
+	<variable name="SUM_LINEAMT" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{AMOUNT}]]></expression>
 	</variable>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band height="15" splitType="Stretch">
-			<staticText>
-				<reportElement key="staticText-1" style="GroupHeader_DarkGray" x="0" y="0" width="346" height="15" uuid="b38f1088-a59a-44a7-bef5-48b1bc2b48e3"/>
-				<box leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="12"/>
-				</textElement>
-				<text><![CDATA[Justification]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="staticText-2" style="GroupHeader_DarkGray" x="346" y="0" width="137" height="15" uuid="882fe54e-192a-4119-b4ce-305ea81d5f9b"/>
-				<box rightPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right">
-					<font size="12"/>
-				</textElement>
-				<text><![CDATA[Amount]]></text>
-			</staticText>
-			<line>
-				<reportElement key="line-8" x="483" y="0" width="1" height="15" uuid="39f798aa-f72c-45f9-9ee3-fc35ccdd27ea"/>
-			</line>
-			<line>
-				<reportElement key="line-9" x="0" y="0" width="1" height="15" uuid="674f979e-95f3-4dd0-bc40-27046abfcb0a"/>
-			</line>
-			<line>
-				<reportElement key="line-11" x="0" y="14" width="483" height="1" uuid="c7be5471-e337-4d51-8a66-5859a937d390"/>
-			</line>
-			<line>
-				<reportElement key="line-12" x="346" y="0" width="1" height="15" uuid="40ecbf01-3f38-4596-a465-80a9089cccca"/>
-			</line>
-		</band>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader height="15" splitType="Stretch">
+		<element kind="staticText" uuid="b38f1088-a59a-44a7-bef5-48b1bc2b48e3" key="staticText-1" x="0" y="0" width="346" height="15" fontSize="12.0" style="GroupHeader_DarkGray">
+			<text><![CDATA[Justification]]></text>
+			<box leftPadding="5" style="GroupHeader_DarkGray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="882fe54e-192a-4119-b4ce-305ea81d5f9b" key="staticText-2" x="346" y="0" width="137" height="15" fontSize="12.0" hTextAlign="Right" style="GroupHeader_DarkGray">
+			<text><![CDATA[Amount]]></text>
+			<box rightPadding="5" style="GroupHeader_DarkGray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="39f798aa-f72c-45f9-9ee3-fc35ccdd27ea" key="line-8" x="483" y="0" width="1" height="15"/>
+		<element kind="line" uuid="674f979e-95f3-4dd0-bc40-27046abfcb0a" key="line-9" x="0" y="0" width="1" height="15"/>
+		<element kind="line" uuid="c7be5471-e337-4d51-8a66-5859a937d390" key="line-11" x="0" y="14" width="483" height="1"/>
+		<element kind="line" uuid="40ecbf01-3f38-4596-a465-80a9089cccca" key="line-12" x="346" y="0" width="1" height="15"/>
 	</columnHeader>
 	<detail>
 		<band height="13" splitType="Stretch">
-			<line>
-				<reportElement key="line-1" x="0" y="12" width="483" height="1" uuid="10f174f5-d9fe-459c-b1ae-4bfe0f3f297f"/>
-			</line>
-			<line>
-				<reportElement key="line-2" x="0" y="0" width="1" height="13" uuid="b1e3695b-c8db-4d69-9a64-e9ec37120df6"/>
-			</line>
-			<line>
-				<reportElement key="line-3" x="483" y="0" width="1" height="13" uuid="a5a5e9ef-0e63-48a2-83ef-d6ae8b17528b"/>
-			</line>
-			<line>
-				<reportElement key="line-4" x="346" y="0" width="1" height="13" uuid="85c96a13-4a76-44a3-8fef-a8a7995a0a2d"/>
-			</line>
-			<textField isBlankWhenNull="false">
-				<reportElement key="invoice" x="1" y="0" width="346" height="12" uuid="36ffa608-ebbf-4c4d-ab3b-93aaa7dad5ad">
-					<printWhenExpression><![CDATA[new Boolean($F{LINE_DOCUMENTTYPE}.equalsIgnoreCase("I"))]]></printWhenExpression>
-				</reportElement>
+			<element kind="line" uuid="10f174f5-d9fe-459c-b1ae-4bfe0f3f297f" key="line-1" x="0" y="12" width="483" height="1"/>
+			<element kind="line" uuid="b1e3695b-c8db-4d69-9a64-e9ec37120df6" key="line-2" x="0" y="0" width="1" height="13"/>
+			<element kind="line" uuid="a5a5e9ef-0e63-48a2-83ef-d6ae8b17528b" key="line-3" x="483" y="0" width="1" height="13"/>
+			<element kind="line" uuid="85c96a13-4a76-44a3-8fef-a8a7995a0a2d" key="line-4" x="346" y="0" width="1" height="13"/>
+			<element kind="textField" uuid="36ffa608-ebbf-4c4d-ab3b-93aaa7dad5ad" key="invoice" x="1" y="0" width="346" height="12" fontSize="8.0" blankWhenNull="false" vTextAlign="Middle">
+				<printWhenExpression><![CDATA[new Boolean($F{LINE_DOCUMENTTYPE}.equalsIgnoreCase("I"))]]></printWhenExpression>
+				<expression><![CDATA["Invoice" + "   " + (($F{LINE_DOCUMENTNO}!=null) ? $F{LINE_DOCUMENTNO} : new String("")) + "   " + (($F{LINE_DATE}!=null) ? $F{LINE_DATE} : new String(""))]]></expression>
 				<box leftPadding="5">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Invoice" + "   " + (($F{LINE_DOCUMENTNO}!=null) ? $F{LINE_DOCUMENTNO} : new String("")) + "   " + (($F{LINE_DATE}!=null) ? $F{LINE_DATE} : new String(""))]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="order" x="1" y="0" width="346" height="12" uuid="56be77db-4fe7-4f52-ae96-f738f4cdbd0e">
-					<printWhenExpression><![CDATA[new Boolean($F{LINE_DOCUMENTTYPE}.equalsIgnoreCase("O"))]]></printWhenExpression>
-				</reportElement>
+			</element>
+			<element kind="textField" uuid="56be77db-4fe7-4f52-ae96-f738f4cdbd0e" key="order" x="1" y="0" width="346" height="12" fontSize="8.0" blankWhenNull="false" vTextAlign="Middle">
+				<printWhenExpression><![CDATA[new Boolean($F{LINE_DOCUMENTTYPE}.equalsIgnoreCase("O"))]]></printWhenExpression>
+				<expression><![CDATA["Order" + "   " + (($F{LINE_DOCUMENTNO}!=null) ? $F{LINE_DOCUMENTNO} : new String("")) + "   " + (($F{LINE_DATE}!=null) ? $F{LINE_DATE} : new String(""))]]></expression>
 				<box leftPadding="5">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Order" + "   " + (($F{LINE_DOCUMENTNO}!=null) ? $F{LINE_DOCUMENTNO} : new String("")) + "   " + (($F{LINE_DATE}!=null) ? $F{LINE_DATE} : new String(""))]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="others" x="1" y="0" width="346" height="12" uuid="4769b6a9-fc0d-4f56-bb8e-837fb7a55046">
-					<printWhenExpression><![CDATA[new Boolean($F{LINE_DOCUMENTTYPE}.equalsIgnoreCase("GL"))]]></printWhenExpression>
-				</reportElement>
+			</element>
+			<element kind="textField" uuid="4769b6a9-fc0d-4f56-bb8e-837fb7a55046" key="others" x="1" y="0" width="346" height="12" fontSize="8.0" blankWhenNull="false" vTextAlign="Middle">
+				<printWhenExpression><![CDATA[new Boolean($F{LINE_DOCUMENTTYPE}.equalsIgnoreCase("GL"))]]></printWhenExpression>
+				<expression><![CDATA["Others" + "   " + (($F{LINE_DOCUMENTNO}!=null) ? $F{LINE_DOCUMENTNO} : new String("")) + "   " + (($F{LINE_DATE}!=null) ? $F{LINE_DATE} : new String(""))]]></expression>
 				<box leftPadding="5">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Others" + "   " + (($F{LINE_DOCUMENTNO}!=null) ? $F{LINE_DOCUMENTNO} : new String("")) + "   " + (($F{LINE_DATE}!=null) ? $F{LINE_DATE} : new String(""))]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="unapplied" x="-1" y="0" width="346" height="12" uuid="e242ac50-6d51-42f2-b1f6-20a520082136">
-					<printWhenExpression><![CDATA[new Boolean($F{LINE_DOCUMENTTYPE}.equalsIgnoreCase("U"))]]></printWhenExpression>
-				</reportElement>
+			</element>
+			<element kind="textField" uuid="e242ac50-6d51-42f2-b1f6-20a520082136" key="unapplied" x="-1" y="0" width="346" height="12" fontSize="8.0" blankWhenNull="false" vTextAlign="Middle">
+				<printWhenExpression><![CDATA[new Boolean($F{LINE_DOCUMENTTYPE}.equalsIgnoreCase("U"))]]></printWhenExpression>
+				<expression><![CDATA["Unapplied" + "   " + (($F{LINE_DOCUMENTNO}!=null) ? $F{LINE_DOCUMENTNO} : new String("")) + "   " + (($F{LINE_DATE}!=null) ? $F{LINE_DATE} : new String(""))]]></expression>
 				<box leftPadding="5">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Unapplied" + "   " + (($F{LINE_DOCUMENTNO}!=null) ? $F{LINE_DOCUMENTNO} : new String("")) + "   " + (($F{LINE_DATE}!=null) ? $F{LINE_DATE} : new String(""))]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-2" x="347" y="0" width="136" height="13" uuid="d868d9e2-bbe5-4e58-a8d1-44fd8a1a741f"/>
+			</element>
+			<element kind="textField" uuid="d868d9e2-bbe5-4e58-a8d1-44fd8a1a741f" key="textField-2" x="347" y="0" width="136" height="13" fontSize="8.0" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{AMOUNT}!=null) ? $P{NUMBERFORMAT}.format($F{AMOUNT}).toString() : new String(" ")]]></expression>
 				<box rightPadding="5">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{AMOUNT}!=null) ? $P{NUMBERFORMAT}.format($F{AMOUNT}).toString() : new String(" ")]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band height="28" splitType="Stretch">
-			<line>
-				<reportElement key="line-5" x="346" y="-1" width="1" height="29" uuid="e7a9ce64-ac93-4349-b58f-22e542f076d8"/>
-			</line>
-			<line>
-				<reportElement key="line-6" x="483" y="0" width="1" height="28" uuid="c5e2911b-d8d1-4caa-a879-4ced0787fafd"/>
-			</line>
-			<line>
-				<reportElement key="line-7" x="347" y="27" width="136" height="1" uuid="d627d24e-ffcb-4dd3-9e94-fb05b68f36c0"/>
-			</line>
-			<textField evaluationTime="Report" isBlankWhenNull="false">
-				<reportElement key="textField-3" style="Gray" x="347" y="0" width="136" height="27" uuid="54edc464-96e2-4cf2-8b2a-a2c13364a69a"/>
-				<box rightPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="10" isBold="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($V{SUM_LINEAMT}!=null) ? $P{NUMBERFORMAT}.format($V{SUM_LINEAMT}).toString() : new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-4" x="200" y="0" width="145" height="28" uuid="a70d0b76-e649-49c8-9f19-2797eeff94d8"/>
-				<box rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="10" isBold="true" pdfFontName="Helvetica-Bold"/>
-				</textElement>
-				<textFieldExpression><![CDATA[" TOTAL (" + $F{LINE_CURRENCY}.toString() + "): "]]></textFieldExpression>
-			</textField>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary height="28" splitType="Stretch">
+		<element kind="line" uuid="e7a9ce64-ac93-4349-b58f-22e542f076d8" key="line-5" x="346" y="-1" width="1" height="29"/>
+		<element kind="line" uuid="c5e2911b-d8d1-4caa-a879-4ced0787fafd" key="line-6" x="483" y="0" width="1" height="28"/>
+		<element kind="line" uuid="d627d24e-ffcb-4dd3-9e94-fb05b68f36c0" key="line-7" x="347" y="27" width="136" height="1"/>
+		<element kind="textField" uuid="54edc464-96e2-4cf2-8b2a-a2c13364a69a" key="textField-3" x="347" y="0" width="136" height="27" fontSize="10.0" evaluationTime="Report" blankWhenNull="false" bold="true" hTextAlign="Right" vTextAlign="Middle" style="Gray">
+			<expression><![CDATA[($V{SUM_LINEAMT}!=null) ? $P{NUMBERFORMAT}.format($V{SUM_LINEAMT}).toString() : new String(" ")]]></expression>
+			<box rightPadding="5" style="Gray">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="a70d0b76-e649-49c8-9f19-2797eeff94d8" key="textField-4" x="200" y="0" width="145" height="28" fontSize="10.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" bold="true" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA[" TOTAL (" + $F{LINE_CURRENCY}.toString() + "): "]]></expression>
+			<box rightPadding="2">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</summary>
 </jasperReport>

--- a/src/org/openbravo/erpReports/RptMA_ProcessPlan.jrxml
+++ b/src/org/openbravo/erpReports/RptMA_ProcessPlan.jrxml
@@ -1,58 +1,56 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptMA_ProcessPlan" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="fc05e8ca-705f-4a94-b629-affee9f7cfd8">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="RptMA_ProcessPlan" language="java" pageWidth="595" pageHeight="842" columnWidth="535" leftMargin="30" rightMargin="30" topMargin="20" bottomMargin="20" uuid="fc05e8ca-705f-4a94-b629-affee9f7cfd8">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="9.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{SECUENCIA_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT pp.NAME as processplan, pp.CONVERSIONRATE as ratio, pp.SECONDARYUNIT as secud, v.DATEFROM as desde, 
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<query language="sql"><![CDATA[SELECT pp.NAME as processplan, pp.CONVERSIONRATE as ratio, pp.SECONDARYUNIT as secud, v.DATEFROM as desde, 
               v.DATETO as hasta, s.NAME as secuencia, s.VALUE as sec, s.DESCRIPTION, pr.NAME as proceso,
               s.SEQNO, (CASE s.GROUPUSE WHEN 'Y' THEN 'SI' ELSE 'NO' END) as groupuse, (CASE s.NOQTY WHEN 'Y' THEN 'SI' ELSE 'NO' END) as vacio,
               p.name as producto, sp.PRODUCTIONTYPE as tipo, (CASE sp.PRODUCTIONTYPE WHEN '+' THEN 'bold' ELSE 'normal' END) as bold,
@@ -69,8 +67,7 @@
             and v.DATEFROM <= now()
             and v.DATETO > now()
             and 1=1
-          order by pp.ma_processplan_id, pp.NAME, s.seqno, sp.productiontype, p.name]]>
-	</queryString>
+          order by pp.ma_processplan_id, pp.NAME, s.seqno, sp.productiontype, p.name]]></query>
 	<field name="PROCESSPLAN" class="java.lang.String"/>
 	<field name="RATIO" class="java.math.BigDecimal"/>
 	<field name="SECUD" class="java.lang.String"/>
@@ -94,157 +91,113 @@
 	<field name="MA_PROCESSPLAN_ID" class="java.lang.String"/>
 	<field name="MA_SEQUENCE_ID" class="java.lang.String"/>
 	<field name="EXPLODEPHASES" class="java.lang.String"/>
-	<group name="PRODUCTION PLAN" isStartNewPage="true">
-		<groupExpression><![CDATA[$F{MA_PROCESSPLAN_ID}]]></groupExpression>
+	<group name="PRODUCTION PLAN" startNewPage="true">
+		<expression><![CDATA[$F{MA_PROCESSPLAN_ID}]]></expression>
 		<groupHeader>
 			<band height="86" splitType="Stretch">
-				<textField isStretchWithOverflow="true" evaluationTime="Group" evaluationGroup="PRODUCTION PLAN" isBlankWhenNull="true">
-					<reportElement key="textField" style="default" x="120" y="63" width="78" height="18" uuid="d1e2badb-e0ab-422c-99f3-53cc6b760c0c"/>
-					<box>
+				<element kind="textField" uuid="d1e2badb-e0ab-422c-99f3-53cc6b760c0c" key="textField" x="120" y="63" width="78" height="18" fontSize="10.0" textAdjust="StretchHeight" evaluationTime="Group" evaluationGroup="PRODUCTION PLAN" blankWhenNull="true" style="default">
+					<expression><![CDATA[$F{SECUD}]]></expression>
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{SECUD}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="PRODUCTION PLAN" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="default" x="335" y="63" width="78" height="18" uuid="8834196c-b49f-4887-a47a-1a42c921cc47"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="8834196c-b49f-4887-a47a-1a42c921cc47" key="textField" x="335" y="63" width="78" height="18" fontSize="10.0" evaluationTime="Group" pattern="" evaluationGroup="PRODUCTION PLAN" blankWhenNull="true" style="default">
+					<expression><![CDATA[($F{RATIO}!=null)?$P{NUMBERFORMAT}.format($F{RATIO}):new String(" ")]]></expression>
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{RATIO}!=null)?$P{NUMBERFORMAT}.format($F{RATIO}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-93" style="default" x="11" y="63" width="109" height="18" uuid="edf4eaf3-2129-4e98-b838-9badf55466b3"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="edf4eaf3-2129-4e98-b838-9badf55466b3" key="element-93" x="11" y="63" width="109" height="18" fontSize="10.0" bold="true" style="default">
 					<text><![CDATA[Secondary Unit: ]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-94" style="default" x="205" y="63" width="130" height="18" uuid="30a5c270-a061-4a7a-97b0-1ef1538529cd"/>
-					<box>
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="30a5c270-a061-4a7a-97b0-1ef1538529cd" key="element-94" x="205" y="63" width="130" height="18" fontSize="10.0" bold="true" style="default">
 					<text><![CDATA[Conversion ratio:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-95" style="default" x="358" y="40" width="99" height="18" uuid="12a12293-c856-4cbe-9bc9-05ad9954807a"/>
-					<box>
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="12a12293-c856-4cbe-9bc9-05ad9954807a" key="element-95" x="358" y="40" width="99" height="18" fontSize="10.0" bold="true" style="default">
 					<text><![CDATA[Explode: phases:]]></text>
-				</staticText>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField" style="default" x="457" y="40" width="69" height="18" uuid="d128a525-60bb-4a6f-ac57-633a35fbe599"/>
-					<box>
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{EXPLODEPHASES}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-96" style="default" x="11" y="40" width="44" height="18" uuid="66d3939c-3091-47d9-9bdc-83286de3f235"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="d128a525-60bb-4a6f-ac57-633a35fbe599" key="textField" x="457" y="40" width="69" height="18" fontSize="10.0" blankWhenNull="true" style="default">
+					<expression><![CDATA[$F{EXPLODEPHASES}]]></expression>
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="66d3939c-3091-47d9-9bdc-83286de3f235" key="element-96" x="11" y="40" width="44" height="18" fontSize="10.0" bold="true" style="default">
 					<text><![CDATA[From:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-97" style="default" x="205" y="40" width="44" height="18" uuid="0a63918b-fad8-4ad8-904c-b26f5a6327e5"/>
-					<box>
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="0a63918b-fad8-4ad8-904c-b26f5a6327e5" key="element-97" x="205" y="40" width="44" height="18" fontSize="10.0" bold="true" style="default">
 					<text><![CDATA[To:]]></text>
-				</staticText>
-				<textField evaluationTime="Group" evaluationGroup="PRODUCTION PLAN" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="default" x="55" y="40" width="100" height="18" uuid="08f02f39-4bf8-4f45-a72e-031530cdd123"/>
-					<box>
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{DESDE}]]></textFieldExpression>
-				</textField>
-				<textField evaluationTime="Group" evaluationGroup="PRODUCTION PLAN" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="default" x="249" y="40" width="100" height="18" uuid="bf801424-6214-4af8-b0b1-eca4914f7186"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="08f02f39-4bf8-4f45-a72e-031530cdd123" key="textField" x="55" y="40" width="100" height="18" fontSize="10.0" evaluationTime="Group" pattern="" evaluationGroup="PRODUCTION PLAN" blankWhenNull="true" style="default">
+					<expression><![CDATA[$F{DESDE}]]></expression>
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{HASTA}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField" style="Report_Title" x="1" y="0" width="534" height="25" uuid="ebd1f55a-9ae9-473a-a5db-84b935184b9f"/>
-					<box leftPadding="5">
+				</element>
+				<element kind="textField" uuid="bf801424-6214-4af8-b0b1-eca4914f7186" key="textField" x="249" y="40" width="100" height="18" fontSize="10.0" evaluationTime="Group" pattern="" evaluationGroup="PRODUCTION PLAN" blankWhenNull="true" style="default">
+					<expression><![CDATA[$F{HASTA}]]></expression>
+					<box style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="textField" uuid="ebd1f55a-9ae9-473a-a5db-84b935184b9f" key="textField" x="1" y="0" width="534" height="25" blankWhenNull="true" style="Report_Title">
+					<expression><![CDATA[$F{PROCESSPLAN}]]></expression>
+					<box leftPadding="5" style="Report_Title">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{PROCESSPLAN}]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-18" stretchType="RelativeToBandHeight" x="0" y="29" width="535" height="1" forecolor="#000000" uuid="f038538f-d6b3-4346-8062-f5390480139f"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				</element>
+				<element kind="line" uuid="f038538f-d6b3-4346-8062-f5390480139f" key="line-18" stretchType="ContainerHeight" x="0" y="29" width="535" height="1" forecolor="#000000">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
@@ -252,406 +205,292 @@
 		</groupFooter>
 	</group>
 	<group name="SECUENCIA">
-		<groupExpression><![CDATA[$F{SECUENCIA}]]></groupExpression>
+		<expression><![CDATA[$F{SECUENCIA}]]></expression>
 		<groupHeader>
 			<band height="51" splitType="Stretch">
-				<textField isStretchWithOverflow="true" evaluationTime="Group" evaluationGroup="SECUENCIA" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="GroupHeader_DarkGray" x="98" y="0" width="437" height="20" uuid="1a3ca1b8-00b7-48d9-867a-945b4d6a0b86"/>
-					<box leftPadding="5">
+				<element kind="textField" uuid="1a3ca1b8-00b7-48d9-867a-945b4d6a0b86" key="textField" x="98" y="0" width="437" height="20" pdfFontName="Helvetica" textAdjust="StretchHeight" evaluationTime="Group" pattern="" evaluationGroup="SECUENCIA" blankWhenNull="true" style="GroupHeader_DarkGray">
+					<expression><![CDATA[$F{SECUENCIA}]]></expression>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{SECUENCIA}]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" evaluationTime="Group" evaluationGroup="PROCESO" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField" style="default" mode="Opaque" x="78" y="28" width="95" height="18" uuid="85b3b148-9963-4669-9b52-4077f4e6e124"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="85b3b148-9963-4669-9b52-4077f4e6e124" key="textField" mode="Opaque" x="78" y="28" width="95" height="18" fontSize="10.0" textAdjust="StretchHeight" evaluationTime="Group" pattern="" evaluationGroup="PROCESO" blankWhenNull="true" style="default">
+					<expression><![CDATA[$F{PROCESO}]]></expression>
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{PROCESO}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField" style="default" mode="Opaque" x="334" y="28" width="24" height="18" uuid="97148a39-9226-4e4d-8c46-d0e2fd220212"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="97148a39-9226-4e4d-8c46-d0e2fd220212" key="textField" mode="Opaque" x="334" y="28" width="24" height="18" fontSize="10.0" blankWhenNull="true" style="default">
+					<expression><![CDATA[$F{GROUPUSE}]]></expression>
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{GROUPUSE}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField" style="default" mode="Opaque" x="469" y="28" width="22" height="18" uuid="ca7c85f5-fa28-4083-be92-fd41f272d03a"/>
-					<box>
+				</element>
+				<element kind="textField" uuid="ca7c85f5-fa28-4083-be92-fd41f272d03a" key="textField" mode="Opaque" x="469" y="28" width="22" height="18" fontSize="10.0" blankWhenNull="true" style="default">
+					<expression><![CDATA[$F{VACIO}]]></expression>
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="10"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{VACIO}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="element-91" style="default" mode="Opaque" x="234" y="28" width="98" height="18" uuid="53f2f8e6-fe63-4842-a08e-c03280a2fa43"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="53f2f8e6-fe63-4842-a08e-c03280a2fa43" key="element-91" mode="Opaque" x="234" y="28" width="98" height="18" fontSize="10.0" bold="true" style="default">
 					<text><![CDATA[Global consume:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-92" style="default" mode="Opaque" x="370" y="28" width="99" height="18" uuid="764fcb2b-552e-46d5-9f58-66f40340af64"/>
-					<box>
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="10" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="764fcb2b-552e-46d5-9f58-66f40340af64" key="element-92" mode="Opaque" x="370" y="28" width="99" height="18" fontSize="10.0" bold="true" style="default">
 					<text><![CDATA[Empty qty:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-3" style="GroupHeader_DarkGray" x="1" y="0" width="97" height="20" uuid="e1526096-3f2b-418d-a703-b9c72cc2c272"/>
-					<box leftPadding="5">
+					<box style="default">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="staticText" uuid="e1526096-3f2b-418d-a703-b9c72cc2c272" key="staticText-3" x="1" y="0" width="97" height="20" pdfFontName="Helvetica" style="GroupHeader_DarkGray">
+					<text><![CDATA[Sequence:]]></text>
+					<box leftPadding="5" style="GroupHeader_DarkGray">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font pdfFontName="Helvetica"/>
-					</textElement>
-					<text><![CDATA[Sequence:]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-98" style="default" x="13" y="28" width="65" height="18" uuid="ae0e1790-dc4c-477b-93ae-0a90f8c1c63d"/>
-					<box>
+				</element>
+				<element kind="staticText" uuid="ae0e1790-dc4c-477b-93ae-0a90f8c1c63d" key="element-98" x="13" y="28" width="65" height="18" fontSize="10.0" bold="true" style="default">
+					<text><![CDATA[Process:]]></text>
+					<box style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="10" isBold="true"/>
-					</textElement>
-					<text><![CDATA[Process:]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-21" style="default" stretchType="RelativeToBandHeight" x="1" y="1" width="1" height="50" forecolor="#555555" uuid="76322462-1f7c-45cf-be58-aa8ecad95119"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-28" style="default" stretchType="RelativeToBandHeight" x="535" y="1" width="1" height="50" forecolor="#555555" uuid="ae79feac-c5a8-4944-9512-21f1c42d60f1"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				</element>
+				<element kind="line" uuid="76322462-1f7c-45cf-be58-aa8ecad95119" key="line-21" stretchType="ContainerHeight" x="1" y="1" width="1" height="50" forecolor="#555555" style="default">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="ae79feac-c5a8-4944-9512-21f1c42d60f1" key="line-28" stretchType="ContainerHeight" x="535" y="1" width="1" height="50" forecolor="#555555" style="default">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="19" splitType="Stretch">
-				<line>
-					<reportElement key="line-25" stretchType="RelativeToBandHeight" x="1" y="11" width="534" height="1" forecolor="#555555" uuid="b06a29a6-c357-4354-9308-02b900fae0aa"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-24" style="default" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="10" forecolor="#555555" uuid="ed5bd9da-510c-4323-9a32-2a3cf2f4cde1"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-35" style="default" stretchType="RelativeToBandHeight" x="535" y="1" width="1" height="10" forecolor="#555555" uuid="a43bea35-66a4-44c5-9dd2-f59fbaa3fa59"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-36" stretchType="RelativeToBandHeight" x="10" y="0" width="512" height="1" forecolor="#666666" uuid="055adaf1-d880-4c98-9e38-94f58910fe73"/>
-					<graphicElement>
-						<pen lineWidth="0.25" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+				<element kind="line" uuid="b06a29a6-c357-4354-9308-02b900fae0aa" key="line-25" stretchType="ContainerHeight" x="1" y="11" width="534" height="1" forecolor="#555555">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="ed5bd9da-510c-4323-9a32-2a3cf2f4cde1" key="line-24" stretchType="ContainerHeight" x="1" y="0" width="1" height="10" forecolor="#555555" style="default">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="a43bea35-66a4-44c5-9dd2-f59fbaa3fa59" key="line-35" stretchType="ContainerHeight" x="535" y="1" width="1" height="10" forecolor="#555555" style="default">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="055adaf1-d880-4c98-9e38-94f58910fe73" key="line-36" stretchType="ContainerHeight" x="10" y="0" width="512" height="1" forecolor="#666666">
+					<pen lineWidth="0.25" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
 	<group name="PROCESO">
-		<groupExpression><![CDATA[$F{PROCESO}]]></groupExpression>
+		<expression><![CDATA[$F{PROCESO}]]></expression>
 		<groupHeader>
 			<band height="18" splitType="Stretch">
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="10" y="0" width="143" height="18" uuid="884333a7-be44-49a7-8f93-db443e8d5d24"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
+				<element kind="staticText" uuid="884333a7-be44-49a7-8f93-db443e8d5d24" key="element-90" x="10" y="0" width="143" height="18" style="Detail_Header">
 					<text><![CDATA[Product]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="153" y="0" width="46" height="18" uuid="b24d8154-d293-47ac-b18e-d977eb9781f1"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
+				</element>
+				<element kind="staticText" uuid="b24d8154-d293-47ac-b18e-d977eb9781f1" key="element-90" x="153" y="0" width="46" height="18" style="Detail_Header">
 					<text><![CDATA[Type]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="199" y="0" width="96" height="18" uuid="bfec095f-2dc6-4406-a881-1bad7cf70294"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right"/>
+				</element>
+				<element kind="staticText" uuid="bfec095f-2dc6-4406-a881-1bad7cf70294" key="element-90" x="199" y="0" width="96" height="18" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="295" y="0" width="53" height="18" uuid="e16b444c-81b2-4c05-b881-c4f14d5c0e15"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right"/>
+				</element>
+				<element kind="staticText" uuid="e16b444c-81b2-4c05-b881-c4f14d5c0e15" key="element-90" x="295" y="0" width="53" height="18" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[Decrease]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-90" style="Detail_Header" x="348" y="0" width="66" height="18" uuid="7182e359-4097-4ec4-b085-452500a11e97"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right"/>
+				</element>
+				<element kind="staticText" uuid="7182e359-4097-4ec4-b085-452500a11e97" key="element-90" x="348" y="0" width="66" height="18" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[Rejected]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-22" style="default" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="18" forecolor="#555555" uuid="d5393458-ec2a-4872-aaad-887170238999"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-30" style="default" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="18" forecolor="#555555" uuid="c0c0012b-c113-47e9-a3a6-a764f409c9d4"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
+				<element kind="line" uuid="d5393458-ec2a-4872-aaad-887170238999" key="line-22" stretchType="ContainerHeight" x="1" y="0" width="1" height="18" forecolor="#555555" style="default">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
+				<element kind="line" uuid="c0c0012b-c113-47e9-a3a6-a764f409c9d4" key="line-30" stretchType="ContainerHeight" x="535" y="0" width="1" height="18" forecolor="#555555" style="default">
+					<pen lineWidth="2.0" lineStyle="Solid"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<frame>
-				<reportElement key="frame-2" style="Detail_Line" stretchType="RelativeToBandHeight" x="10" y="0" width="512" height="16" uuid="3c658b0c-1adb-40a4-bc28-4de28d9f40aa"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField-1" style="default" stretchType="RelativeToBandHeight" x="0" y="0" width="143" height="16" uuid="705e9675-4570-43ed-b953-dffc1cbceb86"/>
-					<box leftPadding="2" rightPadding="2">
+			<element kind="frame" uuid="3c658b0c-1adb-40a4-bc28-4de28d9f40aa" key="frame-2" stretchType="ContainerHeight" x="10" y="0" width="512" height="16" style="Detail_Line">
+				<element kind="textField" uuid="705e9675-4570-43ed-b953-dffc1cbceb86" key="textField-1" stretchType="ContainerHeight" x="0" y="0" width="143" height="16" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="default">
+					<expression><![CDATA[$F{PRODUCTO}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{PRODUCTO}]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField-2" style="default" stretchType="RelativeToBandHeight" x="143" y="0" width="46" height="16" uuid="4af73c63-3214-4c0f-a526-9023c02a7697"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4af73c63-3214-4c0f-a526-9023c02a7697" key="textField-2" stretchType="ContainerHeight" x="143" y="0" width="46" height="16" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="default">
+					<expression><![CDATA[$F{TIPO}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{TIPO}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-3" style="default" stretchType="RelativeToBandHeight" x="189" y="0" width="66" height="16" uuid="9c63f267-987f-4782-af7d-5126e9d467b7"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="9c63f267-987f-4782-af7d-5126e9d467b7" key="textField-3" stretchType="ContainerHeight" x="189" y="0" width="66" height="16" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+					<expression><![CDATA[($F{QUANTITY}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITY}):new String(" ")]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[($F{QUANTITY}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITY}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-					<reportElement key="textField-4" style="default" stretchType="RelativeToBandHeight" x="255" y="0" width="30" height="16" uuid="e9b57b07-c622-4e6e-bdfc-bb5e755c24c8"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="e9b57b07-c622-4e6e-bdfc-bb5e755c24c8" key="textField-4" stretchType="ContainerHeight" x="255" y="0" width="30" height="16" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle" style="default">
+					<expression><![CDATA[$F{UD}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#666666"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[$F{UD}]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-5" style="default" stretchType="RelativeToBandHeight" x="285" y="0" width="53" height="16" uuid="8d6ead9e-38c9-42ee-ab7e-2202a9a54760"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="8d6ead9e-38c9-42ee-ab7e-2202a9a54760" key="textField-5" stretchType="ContainerHeight" x="285" y="0" width="53" height="16" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+					<expression><![CDATA[($F{DECREASE}!=null)?$P{NUMBERFORMAT}.format($F{DECREASE}):new String(" ")]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[($F{DECREASE}!=null)?$P{NUMBERFORMAT}.format($F{DECREASE}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-6" style="default" stretchType="RelativeToBandHeight" x="338" y="0" width="66" height="16" uuid="255dee82-1b9b-4a23-b0cf-a9ffa8988423"/>
-					<box leftPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="255dee82-1b9b-4a23-b0cf-a9ffa8988423" key="textField-6" stretchType="ContainerHeight" x="338" y="0" width="66" height="16" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+					<expression><![CDATA[($F{REJECTED}!=null)?$P{NUMBERFORMAT}.format($F{REJECTED}):new String(" ")]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#666666"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle"/>
-					<textFieldExpression><![CDATA[($F{REJECTED}!=null)?$P{NUMBERFORMAT}.format($F{REJECTED}):new String(" ")]]></textFieldExpression>
-				</textField>
-			</frame>
-			<line>
-				<reportElement key="line-23" style="default" stretchType="RelativeToBandHeight" x="1" y="0" width="1" height="16" forecolor="#555555" uuid="76d082ed-ec6f-4a36-9736-b35344d06813"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<line>
-				<reportElement key="line-32" style="default" stretchType="RelativeToBandHeight" x="535" y="0" width="1" height="16" forecolor="#555555" uuid="cfaefa58-bce9-4be2-8834-01f4d659dbee"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
+				</element>
+				<box style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="line" uuid="76d082ed-ec6f-4a36-9736-b35344d06813" key="line-23" stretchType="ContainerHeight" x="1" y="0" width="1" height="16" forecolor="#555555" style="default">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
+			<element kind="line" uuid="cfaefa58-bce9-4be2-8834-01f4d659dbee" key="line-32" stretchType="ContainerHeight" x="535" y="0" width="1" height="16" forecolor="#555555" style="default">
+				<pen lineWidth="2.0" lineStyle="Solid"/>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="28" splitType="Stretch">
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="398" y="7" width="95" height="19" uuid="87fa8295-0d0b-4702-89b1-6122888ad543"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Helvetica" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="497" y="7" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="948c9a2b-986e-486f-8274-a959a8d09734"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="Helvetica" size="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line" stretchType="RelativeToBandHeight" x="0" y="4" width="535" height="1" forecolor="#000000" uuid="4ccc77f5-9f5f-42f8-999a-1335597202ee"/>
-				<graphicElement>
-					<pen lineWidth="2.0" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField" x="275" y="7" width="69" height="19" uuid="75fc4294-ee2f-46f9-a5b1-159241a93b4b"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="10"/>
-				</textElement>
-				<textFieldExpression><![CDATA[new Date()]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-1" x="195" y="7" width="78" height="19" uuid="00f12f38-b7b4-4721-98df-c4e666cd206e"/>
-				<box topPadding="2" leftPadding="5">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="28" splitType="Stretch">
+		<element kind="textField" uuid="87fa8295-0d0b-4702-89b1-6122888ad543" key="textField" x="398" y="7" width="95" height="19" fontName="Helvetica" fontSize="10.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="948c9a2b-986e-486f-8274-a959a8d09734" key="textField" x="497" y="7" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="Helvetica" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="4ccc77f5-9f5f-42f8-999a-1335597202ee" key="line" stretchType="ContainerHeight" x="0" y="4" width="535" height="1" forecolor="#000000">
+			<pen lineWidth="2.0" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="75fc4294-ee2f-46f9-a5b1-159241a93b4b" key="textField" x="275" y="7" width="69" height="19" fontName="Times-Roman" fontSize="10.0" pattern="" blankWhenNull="false" vTextAlign="Middle">
+			<expression><![CDATA[new Date()]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="00f12f38-b7b4-4721-98df-c4e666cd206e" key="staticText-1" x="195" y="7" width="78" height="19" hTextAlign="Right">
+			<text><![CDATA[Generated on]]></text>
+			<box topPadding="2" leftPadding="5">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/RptM_InOut.jrxml
+++ b/src/org/openbravo/erpReports/RptM_InOut.jrxml
@@ -1,43 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptM_InOut" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="d5dfe95f-ae06-4f79-81e9-d0b17882de12">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="RptM_InOut" language="java" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="d5dfe95f-ae06-4f79-81e9-d0b17882de12">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="57"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<parameter name="DOCUMENT_ID" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="SUBREP_Rptm_InOut_Lines" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false">
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<parameter name="DOCUMENT_ID" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="SUBREP_Rptm_InOut_Lines" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["http://localhost/openbravo"]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[SELECT M_INOUT.M_INOUT_ID, M_INOUT.ISSOTRX, C_BPARTNER_LOCATION.NAME, COALESCE(TO_CHAR(C_LOCATION.ADDRESS1),'')||COALESCE(TO_CHAR(C_LOCATION.ADDRESS2),'') AS ADDRESS,
+	<query language="sql"><![CDATA[SELECT M_INOUT.M_INOUT_ID, M_INOUT.ISSOTRX, C_BPARTNER_LOCATION.NAME, COALESCE(TO_CHAR(C_LOCATION.ADDRESS1),'')||COALESCE(TO_CHAR(C_LOCATION.ADDRESS2),'') AS ADDRESS,
 COALESCE(TO_CHAR(C_LOCATION.POSTAL),'')||' - '||COALESCE(TO_CHAR(C_LOCATION.CITY),'') AS POSTAL,
 C_REGION.NAME AS REGION, M_INOUT.DOCUMENTNO, M_INOUT.MOVEMENTDATE, C_BPARTNER.VALUE AS PARTNER_VALUE, C_BPARTNER.TAXID,
 MAX(C_ORDER.POREFERENCE) AS POREFERENCE, AD_CLIENT.DESCRIPTION AS ENTITY, C_LOCATION_DESCRIPTION(AD_ORGINFO.C_LOCATION_ID) AS ENTITY_LOCATION,
@@ -67,8 +65,7 @@ AND M_INOUT.M_INOUT_ID IN ($P{DOCUMENT_ID})
 AND AD_ORGINFO.AD_ORG_ID = AD_ORG.AD_ORG_ID
 GROUP BY M_INOUT.M_INOUT_ID, M_INOUT.ISSOTRX, C_BPARTNER.NAME, C_BPARTNER_LOCATION.NAME, C_LOCATION.ADDRESS1, C_LOCATION.ADDRESS2, C_LOCATION.POSTAL, C_LOCATION.CITY, C_REGION.NAME,
 M_INOUT.DOCUMENTNO, M_INOUT.MOVEMENTDATE, C_BPARTNER.VALUE, C_BPARTNER.TAXID, AD_CLIENT.DESCRIPTION, AD_ORGINFO.C_LOCATION_ID, C_ORDER.DATEPROMISED, AD_ORGINFO.ad_org_id, M_INOUT.docstatus,
-AD_ORG.NAME, AD_ORGINFO.TAXID, AD_USER.NAME, C_BPARTNER_LOCATION.PHONE, C_BPARTNER_LOCATION.FAX, SHOWLOGO, SHOWCOMPANYDATA, HEADERMARGIN, AD_ORGINFO.ad_client_id, C_COUNTRY.NAME]]>
-	</queryString>
+AD_ORG.NAME, AD_ORGINFO.TAXID, AD_USER.NAME, C_BPARTNER_LOCATION.PHONE, C_BPARTNER_LOCATION.FAX, SHOWLOGO, SHOWCOMPANYDATA, HEADERMARGIN, AD_ORGINFO.ad_client_id, C_COUNTRY.NAME]]></query>
 	<field name="m_inout_id" class="java.lang.String"/>
 	<field name="issotrx" class="java.lang.String"/>
 	<field name="name" class="java.lang.String"/>
@@ -93,8 +90,8 @@ AD_ORG.NAME, AD_ORGINFO.TAXID, AD_USER.NAME, C_BPARTNER_LOCATION.PHONE, C_BPARTN
 	<field name="SHOWLOGO" class="java.lang.String"/>
 	<field name="SHOWCOMPANYDATA" class="java.lang.String"/>
 	<field name="HEADERMARGIN" class="java.lang.String"/>
-	<group name="PrintLarge" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintLarge" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="120" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{HEADERMARGIN}.equalsIgnoreCase("large"))]]></printWhenExpression>
@@ -104,8 +101,8 @@ AD_ORG.NAME, AD_ORGINFO.TAXID, AD_USER.NAME, C_BPARTNER_LOCATION.PHONE, C_BPARTN
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="PrintMedium" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintMedium" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="80" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{HEADERMARGIN}.equalsIgnoreCase("medium"))]]></printWhenExpression>
@@ -115,8 +112,8 @@ AD_ORG.NAME, AD_ORGINFO.TAXID, AD_USER.NAME, C_BPARTNER_LOCATION.PHONE, C_BPARTN
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="PrintSmall" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintSmall" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="50" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{HEADERMARGIN}.equalsIgnoreCase("small"))]]></printWhenExpression>
@@ -126,176 +123,100 @@ AD_ORG.NAME, AD_ORGINFO.TAXID, AD_USER.NAME, C_BPARTNER_LOCATION.PHONE, C_BPARTN
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="M_INOUT_ID" isStartNewPage="true">
-		<groupExpression><![CDATA[$F{m_inout_id}]]></groupExpression>
+	<group name="M_INOUT_ID" startNewPage="true">
+		<expression><![CDATA[$F{m_inout_id}]]></expression>
 		<groupHeader>
 			<band height="255" splitType="Stretch">
-				<line>
-					<reportElement key="line-2" x="250" y="233" width="233" height="1" uuid="1828a822-5220-4f13-ad6f-f6f736dbfdf2"/>
-				</line>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-18" stretchType="RelativeToTallestObject" x="250" y="238" width="108" height="16" isPrintWhenDetailOverflows="true" uuid="ba61bca4-094e-49f5-8e32-264d0e3fb25d"/>
+				<element kind="line" uuid="1828a822-5220-4f13-ad6f-f6f736dbfdf2" key="line-2" x="250" y="233" width="233" height="1"/>
+				<element kind="textField" uuid="ba61bca4-094e-49f5-8e32-264d0e3fb25d" key="textField-18" stretchType="ElementGroupHeight" x="250" y="238" width="108" height="16" fontName="Arial" fontSize="10.0" blankWhenNull="false" printWhenDetailOverflows="true" bold="false">
+					<expression><![CDATA[$F{documentno}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Arial" size="10" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{documentno}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-19" stretchType="RelativeToTallestObject" x="358" y="238" width="125" height="16" isPrintWhenDetailOverflows="true" uuid="17c2a483-4644-4617-a57a-469fc9d2bcac"/>
+				</element>
+				<element kind="textField" uuid="17c2a483-4644-4617-a57a-469fc9d2bcac" key="textField-19" stretchType="ElementGroupHeight" x="358" y="238" width="125" height="16" fontName="Arial" fontSize="10.0" blankWhenNull="false" printWhenDetailOverflows="true" bold="false">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.applyCountryDateFormat($F{movementdate},$F{organizationid})]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Arial" size="10" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.applyCountryDateFormat($F{movementdate},$F{organizationid})]]></textFieldExpression>
-				</textField>
-				<image scaleImage="RetainShape" hAlign="Right" vAlign="Top" isUsingCache="true">
-					<reportElement key="image-1" x="307" y="0" width="176" height="91" uuid="7ead9fc2-efc5-4e5b-9bfd-715cdafc91db">
-						<printWhenExpression><![CDATA[new Boolean($F{SHOWLOGO}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<imageExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylegal", $F{organizationid})]]></imageExpression>
-				</image>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-22" x="128" y="168" width="239" height="56" forecolor="#FF0000" uuid="1c3e81eb-a5d2-4189-8074-55a67ecc5937"/>
-					<textElement verticalAlignment="Middle">
-						<font size="36"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($F{status}.compareTo("VO")==0) ? "VOIDED" : " ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-27" x="0" y="94" width="260" height="110" isPrintWhenDetailOverflows="true" uuid="55377e82-5d90-47de-9481-e588aad30690"/>
-					<textElement textAlignment="Left" verticalAlignment="Top"/>
-					<textFieldExpression><![CDATA[$F{BP_NAME} + "\n" + $F{BP_DATA}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-28" x="271" y="94" width="212" height="42" isPrintWhenDetailOverflows="true" uuid="49e85e51-a3cd-4d37-9460-6980c2b5217e">
-						<printWhenExpression><![CDATA[new Boolean($F{SHOWCOMPANYDATA}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<textElement textAlignment="Right" verticalAlignment="Top"/>
-					<textFieldExpression><![CDATA[($F{LOCATION}==null ? $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" : $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" + $F{LOCATION})]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-1" x="0" y="6" width="320" height="37" uuid="08c54537-996c-4393-89a3-f6e148eef471">
-						<printWhenExpression><![CDATA[new Boolean($F{issotrx}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<textElement verticalAlignment="Middle">
-						<font size="26"/>
-					</textElement>
+				</element>
+				<element kind="image" uuid="7ead9fc2-efc5-4e5b-9bfd-715cdafc91db" key="image-1" x="307" y="0" width="176" height="91" scaleImage="RetainShape" usingCache="true" hImageAlign="Right" vImageAlign="Top">
+					<printWhenExpression><![CDATA[new Boolean($F{SHOWLOGO}.equalsIgnoreCase("Y"))]]></printWhenExpression>
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylegal", $F{organizationid})]]></expression>
+				</element>
+				<element kind="textField" uuid="1c3e81eb-a5d2-4189-8074-55a67ecc5937" key="textField-22" x="128" y="168" width="239" height="56" forecolor="#FF0000" fontSize="36.0" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[(($F{status}.compareTo("VO")==0) ? "VOIDED" : " ")]]></expression>
+				</element>
+				<element kind="textField" uuid="55377e82-5d90-47de-9481-e588aad30690" key="textField-27" x="0" y="94" width="260" height="110" blankWhenNull="false" printWhenDetailOverflows="true" hTextAlign="Left" vTextAlign="Top">
+					<expression><![CDATA[$F{BP_NAME} + "\n" + $F{BP_DATA}]]></expression>
+				</element>
+				<element kind="textField" uuid="49e85e51-a3cd-4d37-9460-6980c2b5217e" key="textField-28" x="271" y="94" width="212" height="42" blankWhenNull="false" printWhenDetailOverflows="true" hTextAlign="Right" vTextAlign="Top">
+					<printWhenExpression><![CDATA[new Boolean($F{SHOWCOMPANYDATA}.equalsIgnoreCase("Y"))]]></printWhenExpression>
+					<expression><![CDATA[($F{LOCATION}==null ? $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" : $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" + $F{LOCATION})]]></expression>
+				</element>
+				<element kind="staticText" uuid="08c54537-996c-4393-89a3-f6e148eef471" key="staticText-1" x="0" y="6" width="320" height="37" fontSize="26.0" vTextAlign="Middle">
+					<printWhenExpression><![CDATA[new Boolean($F{issotrx}.equalsIgnoreCase("Y"))]]></printWhenExpression>
 					<text><![CDATA[GOODS SHIPMENT]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-2" x="0" y="6" width="320" height="37" uuid="d434d3cc-b9cd-49ce-98e2-95d79b2a2c50">
-						<printWhenExpression><![CDATA[new Boolean($F{issotrx}.equalsIgnoreCase("N"))]]></printWhenExpression>
-					</reportElement>
-					<textElement verticalAlignment="Middle">
-						<font size="26"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="d434d3cc-b9cd-49ce-98e2-95d79b2a2c50" key="staticText-2" x="0" y="6" width="320" height="37" fontSize="26.0" vTextAlign="Middle">
+					<printWhenExpression><![CDATA[new Boolean($F{issotrx}.equalsIgnoreCase("N"))]]></printWhenExpression>
 					<text><![CDATA[GOODS RECEIPT]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-3" x="250" y="217" width="108" height="15" uuid="8a33a629-6e0a-406f-8756-97f1acd3dbd1">
-						<printWhenExpression><![CDATA[new Boolean($F{issotrx}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<textElement>
-						<font size="10" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="8a33a629-6e0a-406f-8756-97f1acd3dbd1" key="staticText-3" x="250" y="217" width="108" height="15" fontSize="10.0" pdfFontName="Helvetica-Bold" bold="true">
+					<printWhenExpression><![CDATA[new Boolean($F{issotrx}.equalsIgnoreCase("Y"))]]></printWhenExpression>
 					<text><![CDATA[Shipment No.]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-4" x="250" y="217" width="108" height="15" uuid="b737bced-051a-48da-854e-f88497087928">
-						<printWhenExpression><![CDATA[new Boolean($F{issotrx}.equalsIgnoreCase("N"))]]></printWhenExpression>
-					</reportElement>
-					<textElement>
-						<font size="10" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="b737bced-051a-48da-854e-f88497087928" key="staticText-4" x="250" y="217" width="108" height="15" fontSize="10.0" pdfFontName="Helvetica-Bold" bold="true">
+					<printWhenExpression><![CDATA[new Boolean($F{issotrx}.equalsIgnoreCase("N"))]]></printWhenExpression>
 					<text><![CDATA[Receipt No.]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-5" x="358" y="217" width="125" height="16" uuid="6084394d-0c92-416f-9d63-534c0464c80e">
-						<printWhenExpression><![CDATA[new Boolean($F{issotrx}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<textElement>
-						<font size="10" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="6084394d-0c92-416f-9d63-534c0464c80e" key="staticText-5" x="358" y="217" width="125" height="16" fontSize="10.0" pdfFontName="Helvetica-Bold" bold="true">
+					<printWhenExpression><![CDATA[new Boolean($F{issotrx}.equalsIgnoreCase("Y"))]]></printWhenExpression>
 					<text><![CDATA[Shipment Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-6" x="358" y="217" width="125" height="16" uuid="7488bd72-b29a-4bbc-9c13-a932fff8c5dd">
-						<printWhenExpression><![CDATA[new Boolean($F{issotrx}.equalsIgnoreCase("N"))]]></printWhenExpression>
-					</reportElement>
-					<textElement>
-						<font size="10" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="7488bd72-b29a-4bbc-9c13-a932fff8c5dd" key="staticText-6" x="358" y="217" width="125" height="16" fontSize="10.0" pdfFontName="Helvetica-Bold" bold="true">
+					<printWhenExpression><![CDATA[new Boolean($F{issotrx}.equalsIgnoreCase("N"))]]></printWhenExpression>
 					<text><![CDATA[Receipt Date]]></text>
-				</staticText>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="35" splitType="Stretch">
-			<subreport isUsingCache="true">
-				<reportElement key="subreport-1" x="0" y="0" width="483" height="35" uuid="97d6e866-44e2-4083-bfec-7226b85a1777"/>
-				<subreportParameter name="M_INOUT_ID">
-					<subreportParameterExpression><![CDATA[$F{m_inout_id}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{organizationid},$P{NUMBERFORMAT})]]></subreportParameterExpression>
-				</subreportParameter>
+			<element kind="subreport" uuid="97d6e866-44e2-4083-bfec-7226b85a1777" key="subreport-1" x="0" y="0" width="483" height="35" usingCache="true">
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{SUBREP_Rptm_InOut_Lines}]]></subreportExpression>
-			</subreport>
+				<expression><![CDATA[$P{SUBREP_Rptm_InOut_Lines}]]></expression>
+				<parameter name="M_INOUT_ID">
+					<expression><![CDATA[$F{m_inout_id}]]></expression>
+				</parameter>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{organizationid},$P{NUMBERFORMAT})]]></expression>
+				</parameter>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="53" splitType="Stretch">
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-33" x="359" y="31" width="100" height="18" uuid="2ec9f942-39e6-4cea-af86-4d44944538f4"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" isBlankWhenNull="false">
-				<reportElement key="textField-34" style="default" x="461" y="31" width="18" height="18" uuid="f1b21094-fb8d-4e85-a0d2-c6d7114a7ca9"/>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-3" x="0" y="27" width="483" height="1" uuid="241d2f54-7e9f-4021-85d1-bb2788ccb25d"/>
-			</line>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="53" splitType="Stretch">
+		<element kind="textField" uuid="2ec9f942-39e6-4cea-af86-4d44944538f4" key="textField-33" x="359" y="31" width="100" height="18" fontSize="8.0" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+		</element>
+		<element kind="textField" uuid="f1b21094-fb8d-4e85-a0d2-c6d7114a7ca9" key="textField-34" x="461" y="31" width="18" height="18" fontSize="8.0" evaluationTime="Report" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="default">
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+		</element>
+		<element kind="line" uuid="241d2f54-7e9f-4021-85d1-bb2788ccb25d" key="line-3" x="0" y="27" width="483" height="1"/>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/RptM_InOut_new.jrxml
+++ b/src/org/openbravo/erpReports/RptM_InOut_new.jrxml
@@ -1,43 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptM_InOut_new" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="d6963708-dc40-4b85-aab0-775de682be29">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="RptM_InOut_new" language="java" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="d6963708-dc40-4b85-aab0-775de682be29">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="257"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<parameter name="DOCUMENT_ID" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="SUBREP_Rptm_InOut_Lines_new" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false">
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<parameter name="DOCUMENT_ID" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="SUBREP_Rptm_InOut_Lines_new" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["http://localhost/openbravo"]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[SELECT M_INOUT.M_INOUT_ID, M_INOUT.ISSOTRX, C_BPARTNER_LOCATION.NAME, COALESCE(TO_CHAR(C_LOCATION.ADDRESS1),'')||COALESCE(TO_CHAR(C_LOCATION.ADDRESS2),'') AS ADDRESS,
+	<query language="sql"><![CDATA[SELECT M_INOUT.M_INOUT_ID, M_INOUT.ISSOTRX, C_BPARTNER_LOCATION.NAME, COALESCE(TO_CHAR(C_LOCATION.ADDRESS1),'')||COALESCE(TO_CHAR(C_LOCATION.ADDRESS2),'') AS ADDRESS,
 COALESCE(TO_CHAR(C_LOCATION.POSTAL),'')||' - '||COALESCE(TO_CHAR(C_LOCATION.CITY),'') AS POSTAL,
 C_REGION.NAME AS REGION, M_INOUT.DOCUMENTNO, M_INOUT.MOVEMENTDATE, C_BPARTNER.VALUE AS PARTNER_VALUE, C_BPARTNER.TAXID,
 MAX(C_ORDER.POREFERENCE) AS POREFERENCE, AD_CLIENT.DESCRIPTION AS ENTITY, C_LOCATION_DESCRIPTION(AD_ORGINFO.C_LOCATION_ID) AS ENTITY_LOCATION,
@@ -67,8 +65,7 @@ AND M_INOUT.M_INOUT_ID IN ($P{DOCUMENT_ID})
 AND AD_ORGINFO.AD_ORG_ID = AD_ORG.AD_ORG_ID
 GROUP BY M_INOUT.M_INOUT_ID, M_INOUT.ISSOTRX, C_BPARTNER.NAME, C_BPARTNER_LOCATION.NAME, C_LOCATION.ADDRESS1, C_LOCATION.ADDRESS2, C_LOCATION.POSTAL, C_LOCATION.CITY, C_REGION.NAME,
 M_INOUT.DOCUMENTNO, M_INOUT.MOVEMENTDATE, C_BPARTNER.VALUE, C_BPARTNER.TAXID, AD_CLIENT.DESCRIPTION, AD_ORGINFO.C_LOCATION_ID, C_ORDER.DATEPROMISED, AD_ORGINFO.ad_org_id, M_INOUT.docstatus,
-AD_ORG.NAME, AD_ORGINFO.TAXID, AD_USER.NAME, C_BPARTNER_LOCATION.PHONE, C_BPARTNER_LOCATION.FAX, SHOWLOGO, SHOWCOMPANYDATA, HEADERMARGIN, AD_ORGINFO.ad_client_id, C_COUNTRY.NAME]]>
-	</queryString>
+AD_ORG.NAME, AD_ORGINFO.TAXID, AD_USER.NAME, C_BPARTNER_LOCATION.PHONE, C_BPARTNER_LOCATION.FAX, SHOWLOGO, SHOWCOMPANYDATA, HEADERMARGIN, AD_ORGINFO.ad_client_id, C_COUNTRY.NAME]]></query>
 	<field name="m_inout_id" class="java.lang.String"/>
 	<field name="issotrx" class="java.lang.String"/>
 	<field name="name" class="java.lang.String"/>
@@ -93,8 +90,8 @@ AD_ORG.NAME, AD_ORGINFO.TAXID, AD_USER.NAME, C_BPARTNER_LOCATION.PHONE, C_BPARTN
 	<field name="SHOWLOGO" class="java.lang.String"/>
 	<field name="SHOWCOMPANYDATA" class="java.lang.String"/>
 	<field name="HEADERMARGIN" class="java.lang.String"/>
-	<group name="PrintLarge" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintLarge" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="120" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{HEADERMARGIN}.equalsIgnoreCase("large"))]]></printWhenExpression>
@@ -104,8 +101,8 @@ AD_ORG.NAME, AD_ORGINFO.TAXID, AD_USER.NAME, C_BPARTNER_LOCATION.PHONE, C_BPARTN
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="PrintMedium" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintMedium" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="80" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{HEADERMARGIN}.equalsIgnoreCase("medium"))]]></printWhenExpression>
@@ -115,8 +112,8 @@ AD_ORG.NAME, AD_ORGINFO.TAXID, AD_USER.NAME, C_BPARTNER_LOCATION.PHONE, C_BPARTN
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="PrintSmall" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintSmall" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="50" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{HEADERMARGIN}.equalsIgnoreCase("small"))]]></printWhenExpression>
@@ -126,213 +123,131 @@ AD_ORG.NAME, AD_ORGINFO.TAXID, AD_USER.NAME, C_BPARTNER_LOCATION.PHONE, C_BPARTN
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="M_INOUT_ID" isStartNewPage="true">
-		<groupExpression><![CDATA[$F{m_inout_id}]]></groupExpression>
+	<group name="M_INOUT_ID" startNewPage="true">
+		<expression><![CDATA[$F{m_inout_id}]]></expression>
 		<groupHeader>
 			<band height="255" splitType="Stretch">
-				<image scaleImage="RetainShape" hAlign="Right" vAlign="Top" isUsingCache="true">
-					<reportElement key="image-1" x="0" y="13" width="153" height="78" uuid="e2a42cb6-9e11-4a52-a2c6-ee7cfe492484">
-						<printWhenExpression><![CDATA[new Boolean($F{SHOWLOGO}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<imageExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylegal", $F{organizationid})]]></imageExpression>
-				</image>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-22" x="314" y="18" width="168" height="27" forecolor="#FF0000" uuid="0a101abd-3805-4eac-9ae6-d0ff0e641177"/>
-					<textElement verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="22"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($F{status}.compareTo("VO")==0) ? "VOIDED" : " ")]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-27" x="1" y="137" width="188" height="57" isPrintWhenDetailOverflows="true" uuid="d2e84f96-2ff9-44ca-b087-bcd41da3c096"/>
-					<textElement textAlignment="Left" verticalAlignment="Top">
-						<font fontName="DejaVu Sans" size="9" isBold="true"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{BP_NAME} + "\n" + $F{BP_DATA}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-28" x="165" y="2" width="155" height="91" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" uuid="b418a35b-16d9-45fc-8bbd-76c65ee29f34">
-						<printWhenExpression><![CDATA[new Boolean($F{SHOWCOMPANYDATA}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<textElement verticalAlignment="Top">
-						<font fontName="DejaVu Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[($F{LOCATION}==null ? $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" : $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" + $F{LOCATION})]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-1" x="260" y="94" width="222" height="25" uuid="4150d44c-4074-4ab7-80b6-72874a02432f">
-						<printWhenExpression><![CDATA[new Boolean($F{issotrx}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<textElement textAlignment="Right" verticalAlignment="Top">
-						<font fontName="DejaVu Sans" size="16"/>
-					</textElement>
+				<element kind="image" uuid="e2a42cb6-9e11-4a52-a2c6-ee7cfe492484" key="image-1" x="0" y="13" width="153" height="78" scaleImage="RetainShape" usingCache="true" hImageAlign="Right" vImageAlign="Top">
+					<printWhenExpression><![CDATA[new Boolean($F{SHOWLOGO}.equalsIgnoreCase("Y"))]]></printWhenExpression>
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylegal", $F{organizationid})]]></expression>
+				</element>
+				<element kind="textField" uuid="0a101abd-3805-4eac-9ae6-d0ff0e641177" key="textField-22" x="314" y="18" width="168" height="27" forecolor="#FF0000" fontName="DejaVu Sans" fontSize="22.0" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[(($F{status}.compareTo("VO")==0) ? "VOIDED" : " ")]]></expression>
+				</element>
+				<element kind="textField" uuid="d2e84f96-2ff9-44ca-b087-bcd41da3c096" key="textField-27" x="1" y="137" width="188" height="57" fontName="DejaVu Sans" fontSize="9.0" blankWhenNull="false" printWhenDetailOverflows="true" bold="true" hTextAlign="Left" vTextAlign="Top">
+					<expression><![CDATA[$F{BP_NAME} + "\n" + $F{BP_DATA}]]></expression>
+				</element>
+				<element kind="textField" uuid="b418a35b-16d9-45fc-8bbd-76c65ee29f34" key="textField-28" x="165" y="2" width="155" height="91" fontName="DejaVu Sans" blankWhenNull="false" removeLineWhenBlank="true" printWhenDetailOverflows="true" vTextAlign="Top">
+					<printWhenExpression><![CDATA[new Boolean($F{SHOWCOMPANYDATA}.equalsIgnoreCase("Y"))]]></printWhenExpression>
+					<expression><![CDATA[($F{LOCATION}==null ? $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" : $F{ORG_NAME} + "\n" + $F{ORG_TAXID} + "\n" + $F{LOCATION})]]></expression>
+				</element>
+				<element kind="staticText" uuid="4150d44c-4074-4ab7-80b6-72874a02432f" key="staticText-1" x="260" y="94" width="222" height="25" fontName="DejaVu Sans" fontSize="16.0" hTextAlign="Right" vTextAlign="Top">
+					<printWhenExpression><![CDATA[new Boolean($F{issotrx}.equalsIgnoreCase("Y"))]]></printWhenExpression>
 					<text><![CDATA[This is a Goods shipment]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-2" x="260" y="94" width="222" height="25" uuid="c7aa5074-14e4-421f-b4d7-ddbd04674f60">
-						<printWhenExpression><![CDATA[new Boolean($F{issotrx}.equalsIgnoreCase("N"))]]></printWhenExpression>
-					</reportElement>
-					<textElement textAlignment="Right" verticalAlignment="Top">
-						<font fontName="DejaVu Sans" size="16" isBold="true"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="c7aa5074-14e4-421f-b4d7-ddbd04674f60" key="staticText-2" x="260" y="94" width="222" height="25" fontName="DejaVu Sans" fontSize="16.0" bold="true" hTextAlign="Right" vTextAlign="Top">
+					<printWhenExpression><![CDATA[new Boolean($F{issotrx}.equalsIgnoreCase("N"))]]></printWhenExpression>
 					<text><![CDATA[This is a Goods receipt]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField" x="427" y="154" width="57" height="20" uuid="393a08d2-6138-4b73-9e6b-dd86f65d7c8e"/>
+				</element>
+				<element kind="textField" uuid="393a08d2-6138-4b73-9e6b-dd86f65d7c8e" key="textField" x="427" y="154" width="57" height="20" fontName="DejaVu Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Center">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.applyCountryDateFormat($F{movementdate},$F{organizationid})]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.applyCountryDateFormat($F{movementdate},$F{organizationid})]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-1" x="365" y="177" width="120" height="1" forecolor="#CCCCCC" uuid="738c5f88-63ab-4d9f-9624-484192ba787a"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
-					</graphicElement>
-				</line>
-				<line direction="BottomUp">
-					<reportElement key="line-1" x="425" y="131" width="1" height="46" forecolor="#CCCCCC" uuid="0b6e9ddd-8c93-42bb-a27d-272743f19d38"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
-					</graphicElement>
-				</line>
-				<line direction="BottomUp">
-					<reportElement key="line-1" x="485" y="131" width="1" height="46" forecolor="#CCCCCC" uuid="350aa256-bcd5-44b0-986a-78f2fb609b3b"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
-					</graphicElement>
-				</line>
-				<line direction="BottomUp">
-					<reportElement key="line-1" x="365" y="131" width="1" height="46" forecolor="#CCCCCC" uuid="494d25da-f436-4d6e-a54d-30a17c353f55"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
-					</graphicElement>
-				</line>
-				<line>
-					<reportElement key="line-1" x="3" y="130" width="482" height="1" forecolor="#CCCCCC" uuid="1c7c492c-6772-477a-9759-4cf33eb2a402"/>
-					<graphicElement>
-						<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
-					</graphicElement>
-				</line>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-24" x="367" y="154" width="57" height="20" uuid="711f86ad-cafd-46e9-a18c-f9061726caa9"/>
+				</element>
+				<element kind="line" uuid="738c5f88-63ab-4d9f-9624-484192ba787a" key="line-1" x="365" y="177" width="120" height="1" forecolor="#CCCCCC">
+					<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
+				</element>
+				<element kind="line" uuid="0b6e9ddd-8c93-42bb-a27d-272743f19d38" key="line-1" x="425" y="131" width="1" height="46" forecolor="#CCCCCC" direction="BottomUp">
+					<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
+				</element>
+				<element kind="line" uuid="350aa256-bcd5-44b0-986a-78f2fb609b3b" key="line-1" x="485" y="131" width="1" height="46" forecolor="#CCCCCC" direction="BottomUp">
+					<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
+				</element>
+				<element kind="line" uuid="494d25da-f436-4d6e-a54d-30a17c353f55" key="line-1" x="365" y="131" width="1" height="46" forecolor="#CCCCCC" direction="BottomUp">
+					<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
+				</element>
+				<element kind="line" uuid="1c7c492c-6772-477a-9759-4cf33eb2a402" key="line-1" x="3" y="130" width="482" height="1" forecolor="#CCCCCC">
+					<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
+				</element>
+				<element kind="textField" uuid="711f86ad-cafd-46e9-a18c-f9061726caa9" key="textField-24" x="367" y="154" width="57" height="20" fontName="DejaVu Sans" fontSize="8.0" blankWhenNull="false" hTextAlign="Center">
+					<expression><![CDATA[$F{documentno}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{documentno}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-8" style="Group_Data_Label" x="427" y="134" width="57" height="18" forecolor="#7E7979" backcolor="#FFFFFF" uuid="273b5dfc-7a44-417a-9b07-f43cd5f8760b"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="9" isBold="true" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="273b5dfc-7a44-417a-9b07-f43cd5f8760b" key="staticText-8" x="427" y="134" width="57" height="18" forecolor="#7E7979" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="9.0" pdfFontName="Helvetica" bold="true" hTextAlign="Center" vTextAlign="Middle" style="Group_Data_Label">
 					<text><![CDATA[Date]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-11" style="Group_Data_Label" x="367" y="134" width="57" height="18" forecolor="#7E7979" backcolor="#FFFFFF" uuid="5f083f4b-d387-46f8-a679-d502ae4b2fdc"/>
-					<box>
+					<box style="Group_Data_Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Center" verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="9" isBold="true" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="5f083f4b-d387-46f8-a679-d502ae4b2fdc" key="staticText-11" x="367" y="134" width="57" height="18" forecolor="#7E7979" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="9.0" pdfFontName="Helvetica" bold="true" hTextAlign="Center" vTextAlign="Middle" style="Group_Data_Label">
 					<text><![CDATA[Receipt Nº]]></text>
-				</staticText>
+					<box style="Group_Data_Label">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="35" splitType="Stretch">
-			<subreport isUsingCache="true">
-				<reportElement key="subreport-1" x="0" y="0" width="483" height="35" uuid="a18f9b12-ae27-4a6b-a3a9-e4f26041fd14"/>
-				<subreportParameter name="M_INOUT_ID">
-					<subreportParameterExpression><![CDATA[$F{m_inout_id}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{organizationid},$P{NUMBERFORMAT})]]></subreportParameterExpression>
-				</subreportParameter>
+			<element kind="subreport" uuid="a18f9b12-ae27-4a6b-a3a9-e4f26041fd14" key="subreport-1" x="0" y="0" width="483" height="35" usingCache="true">
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{SUBREP_Rptm_InOut_Lines_new}]]></subreportExpression>
-			</subreport>
+				<expression><![CDATA[$P{SUBREP_Rptm_InOut_Lines_new}]]></expression>
+				<parameter name="M_INOUT_ID">
+					<expression><![CDATA[$F{m_inout_id}]]></expression>
+				</parameter>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{organizationid},$P{NUMBERFORMAT})]]></expression>
+				</parameter>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="53" splitType="Stretch">
-			<line>
-				<reportElement key="line-2" x="0" y="28" width="483" height="1" forecolor="#CCCCCC" uuid="819391a6-bae6-4501-b5dd-5bb36d760b3d"/>
-				<graphicElement>
-					<pen lineWidth="0.25" lineStyle="Solid"/>
-				</graphicElement>
-			</line>
-			<textField pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-10" x="340" y="31" width="95" height="19" uuid="95a98a5b-a7c5-4791-9a6c-9b3701898fdf"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Report" pattern="" isBlankWhenNull="false">
-				<reportElement key="textField-9" x="439" y="31" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" uuid="518cc5b7-8f75-4029-b5ec-a42b1ef66e0f"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle" rotation="None">
-					<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" pdfFontName="Helvetica" pdfEncoding="CP1252" isPdfEmbedded="false"/>
-					<paragraph lineSpacing="Single"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="53" splitType="Stretch">
+		<element kind="line" uuid="819391a6-bae6-4501-b5dd-5bb36d760b3d" key="line-2" x="0" y="28" width="483" height="1" forecolor="#CCCCCC">
+			<pen lineWidth="0.25" lineStyle="Solid"/>
+		</element>
+		<element kind="textField" uuid="95a98a5b-a7c5-4791-9a6c-9b3701898fdf" key="textField-10" x="340" y="31" width="95" height="19" fontName="DejaVu Sans" fontSize="8.0" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="518cc5b7-8f75-4029-b5ec-a42b1ef66e0f" key="textField-9" x="439" y="31" width="36" height="19" forecolor="#000000" backcolor="#FFFFFF" rotation="None" fontName="DejaVu Sans" fontSize="8.0" pdfFontName="Helvetica" pdfEncoding="CP1252" evaluationTime="Report" pattern="" blankWhenNull="false" pdfEmbedded="false" underline="false" strikeThrough="false" bold="false" italic="false" hTextAlign="Left" vTextAlign="Middle">
+			<paragraph lineSpacing="Single"/>
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/RptM_RMInOut.jrxml
+++ b/src/org/openbravo/erpReports/RptM_RMInOut.jrxml
@@ -1,40 +1,38 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptM_InOut" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="fc7ba0c1-1bf9-4c95-8069-b6d4fa637b88">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="RptM_InOut" language="java" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="fc7ba0c1-1bf9-4c95-8069-b6d4fa637b88">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<parameter name="DOCUMENT_ID" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="SUBREP_RptM_RMInOut_Lines" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false">
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<parameter name="DOCUMENT_ID" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<parameter name="SUBREP_RptM_RMInOut_Lines" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["http://localhost/openbravo"]]></defaultValueExpression>
 	</parameter>
-	<queryString>
-		<![CDATA[SELECT M_INOUT.M_INOUT_ID, M_INOUT.ISSOTRX, C_BPARTNER_LOCATION.NAME, COALESCE(TO_CHAR(C_LOCATION.ADDRESS1),'')||COALESCE(TO_CHAR(C_LOCATION.ADDRESS2),'') AS ADDRESS,
+	<query language="sql"><![CDATA[SELECT M_INOUT.M_INOUT_ID, M_INOUT.ISSOTRX, C_BPARTNER_LOCATION.NAME, COALESCE(TO_CHAR(C_LOCATION.ADDRESS1),'')||COALESCE(TO_CHAR(C_LOCATION.ADDRESS2),'') AS ADDRESS,
 COALESCE(TO_CHAR(C_LOCATION.POSTAL),'')||' - '||COALESCE(TO_CHAR(C_LOCATION.CITY),'') AS POSTAL,
 C_REGION.NAME AS REGION, M_INOUT.DOCUMENTNO, M_INOUT.MOVEMENTDATE, C_BPARTNER.VALUE AS PARTNER_VALUE, C_BPARTNER.TAXID,
 MAX(C_ORDER.POREFERENCE) AS POREFERENCE, AD_CLIENT.DESCRIPTION AS ENTITY, C_LOCATION_DESCRIPTION(AD_ORGINFO.C_LOCATION_ID) AS ENTITY_LOCATION,
@@ -64,8 +62,7 @@ AND M_INOUT.M_INOUT_ID IN ($P{DOCUMENT_ID})
 AND AD_ORGINFO.AD_ORG_ID = AD_ORG.AD_ORG_ID
 GROUP BY M_INOUT.M_INOUT_ID, M_INOUT.ISSOTRX, C_BPARTNER.NAME, C_BPARTNER_LOCATION.NAME, C_LOCATION.ADDRESS1, C_LOCATION.ADDRESS2, C_LOCATION.POSTAL, C_LOCATION.CITY, C_REGION.NAME,
 M_INOUT.DOCUMENTNO, M_INOUT.MOVEMENTDATE, C_BPARTNER.VALUE, C_BPARTNER.TAXID, AD_CLIENT.DESCRIPTION, AD_ORGINFO.C_LOCATION_ID, C_ORDER.DATEPROMISED, AD_ORGINFO.ad_org_id, M_INOUT.docstatus,
-AD_ORG.NAME, AD_ORGINFO.TAXID, AD_USER.NAME, C_BPARTNER_LOCATION.PHONE, C_BPARTNER_LOCATION.FAX, SHOWLOGO, SHOWCOMPANYDATA, HEADERMARGIN, AD_ORGINFO.ad_client_id, C_COUNTRY.NAME, M_INOUT.POREFERENCE]]>
-	</queryString>
+AD_ORG.NAME, AD_ORGINFO.TAXID, AD_USER.NAME, C_BPARTNER_LOCATION.PHONE, C_BPARTNER_LOCATION.FAX, SHOWLOGO, SHOWCOMPANYDATA, HEADERMARGIN, AD_ORGINFO.ad_client_id, C_COUNTRY.NAME, M_INOUT.POREFERENCE]]></query>
 	<field name="m_inout_id" class="java.lang.String"/>
 	<field name="issotrx" class="java.lang.String"/>
 	<field name="name" class="java.lang.String"/>
@@ -91,8 +88,8 @@ AD_ORG.NAME, AD_ORGINFO.TAXID, AD_USER.NAME, C_BPARTNER_LOCATION.PHONE, C_BPARTN
 	<field name="showcompanydata" class="java.lang.String"/>
 	<field name="headermargin" class="java.lang.String"/>
 	<field name="inoutreference" class="java.lang.String"/>
-	<group name="PrintLarge" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintLarge" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="120" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{headermargin}.equalsIgnoreCase("large"))]]></printWhenExpression>
@@ -102,8 +99,8 @@ AD_ORG.NAME, AD_ORGINFO.TAXID, AD_USER.NAME, C_BPARTNER_LOCATION.PHONE, C_BPARTN
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="PrintMedium" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintMedium" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="80" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{headermargin}.equalsIgnoreCase("medium"))]]></printWhenExpression>
@@ -113,8 +110,8 @@ AD_ORG.NAME, AD_ORGINFO.TAXID, AD_USER.NAME, C_BPARTNER_LOCATION.PHONE, C_BPARTN
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="PrintSmall" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[]]></groupExpression>
+	<group name="PrintSmall" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[]]></expression>
 		<groupHeader>
 			<band height="50" splitType="Stretch">
 				<printWhenExpression><![CDATA[new Boolean($F{headermargin}.equalsIgnoreCase("small"))]]></printWhenExpression>
@@ -124,188 +121,122 @@ AD_ORG.NAME, AD_ORGINFO.TAXID, AD_USER.NAME, C_BPARTNER_LOCATION.PHONE, C_BPARTN
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<group name="M_INOUT_ID" isStartNewPage="true">
-		<groupExpression><![CDATA[$F{m_inout_id}]]></groupExpression>
+	<group name="M_INOUT_ID" startNewPage="true">
+		<expression><![CDATA[$F{m_inout_id}]]></expression>
 		<groupHeader>
 			<band height="195" splitType="Stretch">
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-14" x="0" y="6" width="300" height="37" uuid="75b36d8a-371b-4a6d-b6fd-759ded492c11"/>
+				<element kind="textField" uuid="75b36d8a-371b-4a6d-b6fd-759ded492c11" key="textField-14" x="0" y="6" width="300" height="37" fontSize="26.0" pdfFontName="Helvetica" blankWhenNull="false" bold="false" hTextAlign="Left" vTextAlign="Middle">
+					<expression><![CDATA[$F{issotrx}.equals("Y") ? "Return Receipt" : "Return Shipment"]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font size="26" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{issotrx}.equals("Y") ? "Return Receipt" : "Return Shipment"]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-29" positionType="FixRelativeToBottom" x="180" y="160" width="100" height="16" uuid="845a96bb-5146-4455-82fa-d2d065690a75"/>
+				</element>
+				<element kind="textField" uuid="845a96bb-5146-4455-82fa-d2d065690a75" key="textField-29" positionType="FixRelativeToBottom" x="180" y="160" width="100" height="16" fontSize="9.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" bold="true">
+					<expression><![CDATA[$F{issotrx}.equals("N") ? "RTV Shipment No." : "RFC Receipt No."]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="9" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{issotrx}.equals("N") ? "RTV Shipment No." : "RFC Receipt No."]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-30" positionType="FixRelativeToBottom" x="380" y="160" width="100" height="16" uuid="116930f7-3e51-4654-ae1d-0bdd5319bdb5"/>
+				</element>
+				<element kind="textField" uuid="116930f7-3e51-4654-ae1d-0bdd5319bdb5" key="textField-30" positionType="FixRelativeToBottom" x="380" y="160" width="100" height="16" fontSize="9.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" bold="true">
+					<expression><![CDATA[$F{issotrx}.equals("N") ? "RTV Shipment Date" : "RFC Receipt Date"]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="9" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{issotrx}.equals("N") ? "RTV Shipment Date" : "RFC Receipt Date"]]></textFieldExpression>
-				</textField>
-				<line>
-					<reportElement key="line-2" positionType="FixRelativeToBottom" x="180" y="177" width="300" height="1" uuid="bec357a6-ed84-43e0-81c3-cedbf7ec08ee"/>
-				</line>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-18" positionType="FixRelativeToBottom" stretchType="RelativeToTallestObject" x="180" y="178" width="100" height="16" isPrintWhenDetailOverflows="true" uuid="c6074637-b8a3-44e8-90eb-f59a4ab0c169"/>
+				</element>
+				<element kind="line" uuid="bec357a6-ed84-43e0-81c3-cedbf7ec08ee" key="line-2" positionType="FixRelativeToBottom" x="180" y="177" width="300" height="1"/>
+				<element kind="textField" uuid="c6074637-b8a3-44e8-90eb-f59a4ab0c169" key="textField-18" positionType="FixRelativeToBottom" stretchType="ElementGroupHeight" x="180" y="178" width="100" height="16" fontName="Arial" fontSize="9.0" blankWhenNull="false" printWhenDetailOverflows="true" bold="false">
+					<expression><![CDATA[$F{documentno}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Arial" size="9" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{documentno}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-19" positionType="FixRelativeToBottom" stretchType="RelativeToTallestObject" x="380" y="178" width="100" height="16" isPrintWhenDetailOverflows="true" uuid="9470efcb-6705-47c8-9210-0b3a859fd041"/>
+				</element>
+				<element kind="textField" uuid="9470efcb-6705-47c8-9210-0b3a859fd041" key="textField-19" positionType="FixRelativeToBottom" stretchType="ElementGroupHeight" x="380" y="178" width="100" height="16" fontName="Arial" fontSize="9.0" blankWhenNull="false" printWhenDetailOverflows="true" bold="false">
+					<expression><![CDATA[$F{movementdate}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Arial" size="9" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{movementdate}]]></textFieldExpression>
-				</textField>
-				<image scaleImage="RetainShape" hAlign="Right" vAlign="Top" isUsingCache="true">
-					<reportElement key="image-1" x="307" y="0" width="176" height="91" uuid="def28c77-45bf-4400-b9c7-4af3842943d6">
-						<printWhenExpression><![CDATA[new Boolean($F{showlogo}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<imageExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylegal", $F{organizationid})]]></imageExpression>
-				</image>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-22" positionType="FixRelativeToBottom" x="126" y="113" width="239" height="56" forecolor="#FF0000" uuid="5fe80267-bafe-47a0-8270-1dbbadf989ff"/>
-					<textElement verticalAlignment="Middle">
-						<font size="36"/>
-					</textElement>
-					<textFieldExpression><![CDATA[(($F{status}.compareTo("VO")==0) ? "VOIDED" : " ")]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-					<reportElement key="textField-27" x="0" y="94" width="260" height="58" isPrintWhenDetailOverflows="true" uuid="a696b6b6-dd73-414b-8f1a-a55ba587c3cf"/>
-					<textElement textAlignment="Left" verticalAlignment="Top"/>
-					<textFieldExpression><![CDATA[$F{bp_name} + "\n" + $F{bp_data}]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-					<reportElement key="textField-28" x="271" y="94" width="212" height="42" isPrintWhenDetailOverflows="true" uuid="f801d65b-c1c0-44bf-8e6b-af7e36799050">
-						<printWhenExpression><![CDATA[new Boolean($F{showcompanydata}.equalsIgnoreCase("Y"))]]></printWhenExpression>
-					</reportElement>
-					<textElement textAlignment="Right" verticalAlignment="Top"/>
-					<textFieldExpression><![CDATA[($F{location}==null ? $F{org_name} + "\n" + $F{org_taxid} + "\n" :
-    $F{org_name} + "\n" + $F{org_taxid} + "\n" + $F{location})]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-18" positionType="FixRelativeToBottom" stretchType="RelativeToTallestObject" x="280" y="178" width="100" height="16" isPrintWhenDetailOverflows="true" uuid="9951fd1e-7fa7-4a16-942d-d82a887766b6"/>
+				</element>
+				<element kind="image" uuid="def28c77-45bf-4400-b9c7-4af3842943d6" key="image-1" x="307" y="0" width="176" height="91" scaleImage="RetainShape" usingCache="true" hImageAlign="Right" vImageAlign="Top">
+					<printWhenExpression><![CDATA[new Boolean($F{showlogo}.equalsIgnoreCase("Y"))]]></printWhenExpression>
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylegal", $F{organizationid})]]></expression>
+				</element>
+				<element kind="textField" uuid="5fe80267-bafe-47a0-8270-1dbbadf989ff" key="textField-22" positionType="FixRelativeToBottom" x="126" y="113" width="239" height="56" forecolor="#FF0000" fontSize="36.0" blankWhenNull="false" vTextAlign="Middle">
+					<expression><![CDATA[(($F{status}.compareTo("VO")==0) ? "VOIDED" : " ")]]></expression>
+				</element>
+				<element kind="textField" uuid="a696b6b6-dd73-414b-8f1a-a55ba587c3cf" key="textField-27" x="0" y="94" width="260" height="58" textAdjust="StretchHeight" blankWhenNull="false" printWhenDetailOverflows="true" hTextAlign="Left" vTextAlign="Top">
+					<expression><![CDATA[$F{bp_name} + "\n" + $F{bp_data}]]></expression>
+				</element>
+				<element kind="textField" uuid="f801d65b-c1c0-44bf-8e6b-af7e36799050" key="textField-28" x="271" y="94" width="212" height="42" textAdjust="StretchHeight" blankWhenNull="false" printWhenDetailOverflows="true" hTextAlign="Right" vTextAlign="Top">
+					<printWhenExpression><![CDATA[new Boolean($F{showcompanydata}.equalsIgnoreCase("Y"))]]></printWhenExpression>
+					<expression><![CDATA[($F{location}==null ? $F{org_name} + "\n" + $F{org_taxid} + "\n" :
+    $F{org_name} + "\n" + $F{org_taxid} + "\n" + $F{location})]]></expression>
+				</element>
+				<element kind="textField" uuid="9951fd1e-7fa7-4a16-942d-d82a887766b6" key="textField-18" positionType="FixRelativeToBottom" stretchType="ElementGroupHeight" x="280" y="178" width="100" height="16" fontName="Arial" fontSize="9.0" blankWhenNull="true" printWhenDetailOverflows="true" bold="false">
+					<expression><![CDATA[$F{inoutreference}]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Arial" size="9" isBold="false"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{inoutreference}]]></textFieldExpression>
-				</textField>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-29" positionType="FixRelativeToBottom" x="280" y="160" width="100" height="16" uuid="b5342784-2e9a-4def-a911-75646beb3d77"/>
+				</element>
+				<element kind="textField" uuid="b5342784-2e9a-4def-a911-75646beb3d77" key="textField-29" positionType="FixRelativeToBottom" x="280" y="160" width="100" height="16" fontSize="9.0" pdfFontName="Helvetica-Bold" blankWhenNull="false" bold="true">
+					<expression><![CDATA[$F{issotrx}.equals("Y") ? "" : "RMA Vendor Ref."]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="9" isBold="true" pdfFontName="Helvetica-Bold"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{issotrx}.equals("Y") ? "" : "RMA Vendor Ref."]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="35" splitType="Stretch">
-			<subreport isUsingCache="true">
-				<reportElement key="subreport-1" x="0" y="0" width="483" height="35" uuid="51827544-418d-4b8f-8ad8-b46a06243701"/>
-				<subreportParameter name="M_INOUT_ID">
-					<subreportParameterExpression><![CDATA[$F{m_inout_id}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[$P{NUMBERFORMAT}]]></subreportParameterExpression>
-				</subreportParameter>
+			<element kind="subreport" uuid="51827544-418d-4b8f-8ad8-b46a06243701" key="subreport-1" x="0" y="0" width="483" height="35" usingCache="true">
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{SUBREP_RptM_RMInOut_Lines}]]></subreportExpression>
-			</subreport>
+				<expression><![CDATA[$P{SUBREP_RptM_RMInOut_Lines}]]></expression>
+				<parameter name="M_INOUT_ID">
+					<expression><![CDATA[$F{m_inout_id}]]></expression>
+				</parameter>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[$P{NUMBERFORMAT}]]></expression>
+				</parameter>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="53" splitType="Stretch">
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-33" x="359" y="31" width="100" height="18" uuid="90da121b-2e25-4b89-bf7b-39cf7564298f"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-34" style="default" x="461" y="31" width="18" height="18" uuid="9b987210-5d82-4d0d-84c0-b30089a18a79"/>
-				<textElement textAlignment="Left" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER}]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-3" x="0" y="27" width="483" height="1" uuid="d419192a-7f4e-492a-ac3d-1f1a11a362c4"/>
-			</line>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="53" splitType="Stretch">
+		<element kind="textField" uuid="90da121b-2e25-4b89-bf7b-39cf7564298f" key="textField-33" x="359" y="31" width="100" height="18" fontSize="8.0" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle">
+			<expression><![CDATA["Page " + $V{PAGE_NUMBER} + " of "]]></expression>
+		</element>
+		<element kind="textField" uuid="9b987210-5d82-4d0d-84c0-b30089a18a79" key="textField-34" x="461" y="31" width="18" height="18" fontSize="8.0" blankWhenNull="false" hTextAlign="Left" vTextAlign="Middle" style="default">
+			<expression><![CDATA["" + $V{PAGE_NUMBER}]]></expression>
+		</element>
+		<element kind="line" uuid="d419192a-7f4e-492a-ac3d-1f1a11a362c4" key="line-3" x="0" y="27" width="483" height="1"/>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/RptM_RMInOut_Lines.jrxml
+++ b/src/org/openbravo/erpReports/RptM_RMInOut_Lines.jrxml
@@ -1,36 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Rptm_InOut_Lines" pageWidth="482" pageHeight="842" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="27655561-7568-4958-8021-a69a0b19e797">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="Rptm_InOut_Lines" language="java" pageWidth="482" pageHeight="842" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="27655561-7568-4958-8021-a69a0b19e797">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<parameter name="M_INOUT_ID" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT M_PRODUCT.VALUE,
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<parameter name="M_INOUT_ID" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<query language="sql"><![CDATA[SELECT M_PRODUCT.VALUE,
         COALESCE((SELECT M_PRODUCT_CUSTOMER.NAME
             FROM M_PRODUCT_CUSTOMER
             WHERE M_PRODUCT_CUSTOMER.M_PRODUCT_ID=M_INOUTLINE.M_PRODUCT_ID
@@ -47,8 +45,7 @@
         AND M_PRODUCT.C_UOM_ID = C_UOM.C_UOM_ID
         GROUP BY C_ORDER.DOCUMENTNO, M_INOUT.C_BPARTNER_ID, C_ORDER.POREFERENCE, M_PRODUCT.VALUE, M_INOUTLINE.M_PRODUCT_ID, M_PRODUCT.NAME, M_ATTRIBUTESETINSTANCE.DESCRIPTION,
         M_ATTRIBUTESETINSTANCE.GUARANTEEDATE, M_INOUT.DESCRIPTION, M_INOUTLINE.DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME
-        ORDER BY C_ORDER.DOCUMENTNO, M_PRODUCT.NAME]]>
-	</queryString>
+        ORDER BY C_ORDER.DOCUMENTNO, M_PRODUCT.NAME]]></query>
 	<field name="value" class="java.lang.String"/>
 	<field name="name" class="java.lang.String"/>
 	<field name="movementqty" class="java.math.BigDecimal"/>
@@ -58,196 +55,109 @@
 	<field name="upc" class="java.lang.String"/>
 	<field name="uom" class="java.lang.String"/>
 	<group name="M_INOUT_ID">
-		<groupExpression><![CDATA[$P{M_INOUT_ID}]]></groupExpression>
+		<expression><![CDATA[$P{M_INOUT_ID}]]></expression>
 		<groupHeader>
 			<band height="14" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText-1" style="Detail_Header" x="0" y="0" width="90" height="14" uuid="60e86668-585a-451f-916c-ed5fe12b20c0"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font size="10" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="60e86668-585a-451f-916c-ed5fe12b20c0" key="staticText-1" x="0" y="0" width="90" height="14" fontSize="10.0" pdfFontName="Helvetica" bold="false" style="Detail_Header">
 					<text><![CDATA[ REFERENCE]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-2" style="Detail_Header" x="90" y="0" width="165" height="14" uuid="2ae536cb-2ddf-4d23-91b1-aa328862cc82"/>
-					<box>
+					<box style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="10" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="2ae536cb-2ddf-4d23-91b1-aa328862cc82" key="staticText-2" x="90" y="0" width="165" height="14" fontSize="10.0" pdfFontName="Helvetica" bold="false" style="Detail_Header">
 					<text><![CDATA[PRODUCT]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-8" style="Detail_Header" x="423" y="0" width="59" height="14" uuid="df065f03-714e-4182-8284-93d7b8532b12"/>
-					<box>
+					<box style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="10" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="df065f03-714e-4182-8284-93d7b8532b12" key="staticText-8" x="423" y="0" width="59" height="14" fontSize="10.0" pdfFontName="Helvetica" bold="false" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-4" style="Detail_Header" x="422" y="0" width="59" height="14" uuid="05b35178-fc9b-4676-88f1-c952228af6ca"/>
-					<box>
+					<box style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="10" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="05b35178-fc9b-4676-88f1-c952228af6ca" key="staticText-4" x="422" y="0" width="59" height="14" fontSize="10.0" pdfFontName="Helvetica" bold="false" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[QUANTITY ]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-5" style="Detail_Header" x="255" y="0" width="130" height="14" uuid="bd68184a-f357-4a6d-abe0-aa3d734f143b"/>
-					<box>
+					<box style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="10" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="bd68184a-f357-4a6d-abe0-aa3d734f143b" key="staticText-5" x="255" y="0" width="130" height="14" fontSize="10.0" pdfFontName="Helvetica" bold="false" style="Detail_Header">
 					<text><![CDATA[ ATTRIBUTES]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-7" style="Report_Footer" x="0" y="0" width="1" height="14" forecolor="#FFFFFF" uuid="07ac439b-d4f9-4fe9-aa57-178d68575228"/>
-				</line>
-				<line>
-					<reportElement key="line-8" style="Report_Footer" x="89" y="0" width="1" height="14" forecolor="#FFFFFF" uuid="93b10497-2a7b-45c4-b221-87c6ad1ea7f9"/>
-				</line>
-				<line>
-					<reportElement key="line-10" style="Report_Footer" x="255" y="0" width="1" height="14" forecolor="#FFFFFF" uuid="64e78b7c-82e9-4f41-88f9-fff1720e78d0"/>
-				</line>
-				<line>
-					<reportElement key="line-11" style="Report_Footer" x="482" y="0" width="1" height="14" forecolor="#FFFFFF" uuid="20b6ad6f-2980-4749-b05b-9f60a2b9a91c"/>
-				</line>
-				<staticText>
-					<reportElement key="staticText-7" style="Detail_Header" x="386" y="0" width="35" height="14" uuid="68cbe281-907c-422c-8f70-8959e7bf604c"/>
-					<textElement>
-						<font size="10" isBold="false"/>
-					</textElement>
+					<box style="Detail_Header">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="07ac439b-d4f9-4fe9-aa57-178d68575228" key="line-7" x="0" y="0" width="1" height="14" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="line" uuid="93b10497-2a7b-45c4-b221-87c6ad1ea7f9" key="line-8" x="89" y="0" width="1" height="14" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="line" uuid="64e78b7c-82e9-4f41-88f9-fff1720e78d0" key="line-10" x="255" y="0" width="1" height="14" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="line" uuid="20b6ad6f-2980-4749-b05b-9f60a2b9a91c" key="line-11" x="482" y="0" width="1" height="14" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="staticText" uuid="68cbe281-907c-422c-8f70-8959e7bf604c" key="staticText-7" x="386" y="0" width="35" height="14" fontSize="10.0" bold="false" style="Detail_Header">
 					<text><![CDATA[ UOM]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-12" style="Report_Footer" x="0" y="0" width="482" height="1" forecolor="#FFFFFF" uuid="3b402c2e-6042-4dba-adb9-460dfa92cbcf"/>
-				</line>
-				<line>
-					<reportElement key="line-14" style="Report_Footer" x="385" y="0" width="1" height="14" forecolor="#FFFFFF" uuid="4380140e-a72c-498f-bd4b-89f7916cc08d"/>
-				</line>
-				<line>
-					<reportElement key="line-15" style="Report_Footer" x="421" y="0" width="1" height="14" forecolor="#FFFFFF" uuid="1bfc906a-c1b6-4e46-8b82-eddd86098a32"/>
-				</line>
+				</element>
+				<element kind="line" uuid="3b402c2e-6042-4dba-adb9-460dfa92cbcf" key="line-12" x="0" y="0" width="482" height="1" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="line" uuid="4380140e-a72c-498f-bd4b-89f7916cc08d" key="line-14" x="385" y="0" width="1" height="14" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="line" uuid="1bfc906a-c1b6-4e46-8b82-eddd86098a32" key="line-15" x="421" y="0" width="1" height="14" forecolor="#FFFFFF" style="Report_Footer"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="1" splitType="Stretch">
-				<line>
-					<reportElement key="line-13" style="Report_Footer" x="0" y="0" width="482" height="1" uuid="d3de0637-5ebc-47a3-a241-61e29f303a4c"/>
-				</line>
+				<element kind="line" uuid="d3de0637-5ebc-47a3-a241-61e29f303a4c" key="line-13" x="0" y="0" width="482" height="1" style="Report_Footer"/>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<frame>
-				<reportElement key="frame-1" style="Detail_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="482" height="16" uuid="0201eeaf-8b7c-49d3-a3b4-c06edb40f6a6"/>
-				<textField isBlankWhenNull="true">
-					<reportElement key="textField-5" style="default" x="385" y="0" width="35" height="16" forecolor="#000000" uuid="56a36daf-577b-428f-8727-7029ba1e5d5d"/>
-					<box leftPadding="2" rightPadding="2"/>
-					<textElement verticalAlignment="Middle">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{uom}]]></textFieldExpression>
-				</textField>
-			</frame>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField-1" style="default" x="0" y="0" width="90" height="16" forecolor="#000000" uuid="715a9803-e468-46ed-8e1e-4abffe833d03"/>
-				<box leftPadding="2" rightPadding="2"/>
-				<textElement verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{value}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField-2" style="default" x="90" y="0" width="165" height="16" forecolor="#000000" uuid="64f7907f-315a-4fca-a38f-9ce027045eb2"/>
-				<box leftPadding="2" rightPadding="2"/>
-				<textElement verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{name}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField-3" style="default" x="255" y="0" width="130" height="16" forecolor="#000000" uuid="93834014-9b05-4afc-bc4a-408cd6b40cb8"/>
-				<box leftPadding="2" rightPadding="2"/>
-				<textElement verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{attributedesc}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-4" style="default" x="420" y="0" width="60" height="16" forecolor="#000000" uuid="46cfb2a8-96fe-474e-bfa5-be6467a48987"/>
-				<box leftPadding="2" rightPadding="2"/>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{movementqty}!=null)?$P{NUMBERFORMAT}.format($F{movementqty}.negate()) + " " :new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" style="Report_Footer" stretchType="RelativeToBandHeight" x="89" y="0" width="1" height="16" uuid="36f08ae2-e1f9-423a-b338-a87ca4bba3e4"/>
-			</line>
-			<line>
-				<reportElement key="line-2" style="Report_Footer" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="16" uuid="efe6a46f-a063-4096-8e44-4c2d4accdb5f"/>
-			</line>
-			<line>
-				<reportElement key="line-4" style="Report_Footer" stretchType="RelativeToBandHeight" x="255" y="0" width="1" height="16" uuid="d482fcd7-9709-4140-9439-973f99f449cc"/>
-			</line>
-			<line>
-				<reportElement key="line-6" style="Report_Footer" stretchType="RelativeToBandHeight" x="482" y="0" width="1" height="16" uuid="8d91ced9-87d7-4425-9897-7893579829ee"/>
-			</line>
-			<line>
-				<reportElement key="line-16" style="Report_Footer" stretchType="RelativeToBandHeight" x="385" y="0" width="1" height="16" uuid="070820fe-b81a-406d-bec5-35fefdd80847"/>
-			</line>
-			<line>
-				<reportElement key="line-17" style="Report_Footer" stretchType="RelativeToBandHeight" x="421" y="0" width="1" height="16" uuid="e0a8b5a7-53ba-4b93-9f1f-01aa3bc1c3e1"/>
-			</line>
+			<element kind="frame" uuid="0201eeaf-8b7c-49d3-a3b4-c06edb40f6a6" key="frame-1" stretchType="ContainerHeight" x="0" y="0" width="482" height="16" style="Detail_Line">
+				<element kind="textField" uuid="56a36daf-577b-428f-8727-7029ba1e5d5d" key="textField-5" x="385" y="0" width="35" height="16" forecolor="#000000" fontSize="8.0" blankWhenNull="true" vTextAlign="Middle" style="default">
+					<expression><![CDATA[$F{uom}]]></expression>
+					<box leftPadding="2" rightPadding="2" style="default"/>
+				</element>
+			</element>
+			<element kind="textField" uuid="715a9803-e468-46ed-8e1e-4abffe833d03" key="textField-1" x="0" y="0" width="90" height="16" forecolor="#000000" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" vTextAlign="Middle" style="default">
+				<expression><![CDATA[$F{value}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default"/>
+			</element>
+			<element kind="textField" uuid="64f7907f-315a-4fca-a38f-9ce027045eb2" key="textField-2" x="90" y="0" width="165" height="16" forecolor="#000000" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" vTextAlign="Middle" style="default">
+				<expression><![CDATA[$F{name}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default"/>
+			</element>
+			<element kind="textField" uuid="93834014-9b05-4afc-bc4a-408cd6b40cb8" key="textField-3" x="255" y="0" width="130" height="16" forecolor="#000000" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="true" vTextAlign="Middle" style="default">
+				<expression><![CDATA[$F{attributedesc}]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default"/>
+			</element>
+			<element kind="textField" uuid="46cfb2a8-96fe-474e-bfa5-be6467a48987" key="textField-4" x="420" y="0" width="60" height="16" forecolor="#000000" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{movementqty}!=null)?$P{NUMBERFORMAT}.format($F{movementqty}.negate()) + " " :new String(" ")]]></expression>
+				<box leftPadding="2" rightPadding="2" style="default"/>
+			</element>
+			<element kind="line" uuid="36f08ae2-e1f9-423a-b338-a87ca4bba3e4" key="line-1" stretchType="ContainerHeight" x="89" y="0" width="1" height="16" style="Report_Footer"/>
+			<element kind="line" uuid="efe6a46f-a063-4096-8e44-4c2d4accdb5f" key="line-2" stretchType="ContainerHeight" x="0" y="0" width="1" height="16" style="Report_Footer"/>
+			<element kind="line" uuid="d482fcd7-9709-4140-9439-973f99f449cc" key="line-4" stretchType="ContainerHeight" x="255" y="0" width="1" height="16" style="Report_Footer"/>
+			<element kind="line" uuid="8d91ced9-87d7-4425-9897-7893579829ee" key="line-6" stretchType="ContainerHeight" x="482" y="0" width="1" height="16" style="Report_Footer"/>
+			<element kind="line" uuid="070820fe-b81a-406d-bec5-35fefdd80847" key="line-16" stretchType="ContainerHeight" x="385" y="0" width="1" height="16" style="Report_Footer"/>
+			<element kind="line" uuid="e0a8b5a7-53ba-4b93-9f1f-01aa3bc1c3e1" key="line-17" stretchType="ContainerHeight" x="421" y="0" width="1" height="16" style="Report_Footer"/>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/RptM_Requisition.jrxml
+++ b/src/org/openbravo/erpReports/RptM_Requisition.jrxml
@@ -1,49 +1,48 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptM_Requisition" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="6be99697-9c45-4a7c-92c2-903e691d1041">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="RptM_Requisition" language="java" pageWidth="595" pageHeight="842" columnWidth="483" leftMargin="56" rightMargin="56" topMargin="56" bottomMargin="56" uuid="6be99697-9c45-4a7c-92c2-903e691d1041">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.0"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true">
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false">
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/usr/local/src/AppsOpenbravo/web"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="REQUISITION_ID" class="java.lang.String">
@@ -52,213 +51,170 @@
 	<parameter name="SUBREPORT_DIR" class="java.lang.String">
 		<defaultValueExpression><![CDATA["/usr/local/src/AppsOpenbravo/src/erpReports/"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="SR_LINES" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<parameter name="DATEPATTERN" class="java.lang.String" isForPrompting="false">
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="SR_LINES" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<parameter name="DATEPATTERN" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["dd-MM-yyyy"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
 	<parameter name="LANGUAGE" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="SUBREP_RptM_Requisition_Lines" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT M_REQUISITION.M_REQUISITION_ID, M_REQUISITION.DOCUMENTNO,
+	<parameter name="SUBREP_RptM_Requisition_Lines" forPrompting="false" class="net.sf.jasperreports.engine.JasperReport"/>
+	<query language="sql"><![CDATA[SELECT M_REQUISITION.M_REQUISITION_ID, M_REQUISITION.DOCUMENTNO,
        AD_COLUMN_IDENTIFIER(to_char('AD_User'), to_char(M_REQUISITION.AD_USER_ID), $P{LANGUAGE}) AS REQUESTER,
        REPLACE(M_REQUISITION.DESCRIPTION, CHR(10), '') AS DESCRIPTION, M_REQUISITION.AD_ORG_ID AS ORGANIZATIONID
        FROM M_REQUISITION
-       WHERE M_REQUISITION.M_REQUISITION_ID IN $P!{REQUISITION_ID}]]>
-	</queryString>
+       WHERE M_REQUISITION.M_REQUISITION_ID IN $P!{REQUISITION_ID}]]></query>
 	<field name="M_REQUISITION_ID" class="java.lang.String">
-		<fieldDescription><![CDATA[]]></fieldDescription>
+		<description><![CDATA[]]></description>
 	</field>
 	<field name="DOCUMENTNO" class="java.lang.String">
-		<fieldDescription><![CDATA[]]></fieldDescription>
+		<description><![CDATA[]]></description>
 	</field>
 	<field name="REQUESTER" class="java.lang.String">
-		<fieldDescription><![CDATA[]]></fieldDescription>
+		<description><![CDATA[]]></description>
 	</field>
 	<field name="DESCRIPTION" class="java.lang.String">
-		<fieldDescription><![CDATA[]]></fieldDescription>
+		<description><![CDATA[]]></description>
 	</field>
 	<field name="ORGANIZATIONID" class="java.lang.String"/>
-	<group name="M_REQUISITION_ID" isStartNewPage="true" isResetPageNumber="true" isReprintHeaderOnEachPage="true">
-		<groupExpression><![CDATA[$F{M_REQUISITION_ID}]]></groupExpression>
+	<group name="M_REQUISITION_ID" startNewPage="true" resetPageNumber="true" reprintHeaderOnEachPage="true">
+		<expression><![CDATA[$F{M_REQUISITION_ID}]]></expression>
 		<groupHeader>
 			<band height="124" splitType="Stretch">
-				<image isLazy="true">
-					<reportElement key="image-2" x="286" y="0" width="197" height="55" uuid="da60585b-48fd-47e3-9655-30baac3e2b8e"/>
+				<element kind="image" uuid="da60585b-48fd-47e3-9655-30baac3e2b8e" key="image-2" x="286" y="0" width="197" height="55" lazy="true">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylogin")]]></expression>
 					<box>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<imageExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.showImageLogo("yourcompanylogin")]]></imageExpression>
-				</image>
-				<line>
-					<reportElement key="line-2" x="1" y="96" width="482" height="1" uuid="5d19a24b-7b86-438b-9265-bc8b9e2cdbdd"/>
-				</line>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-4" style="Report_Data_Field" x="0" y="98" width="152" height="18" uuid="a7a9501e-fece-4cda-bc2b-9fe85348e830"/>
-					<box>
+				</element>
+				<element kind="line" uuid="5d19a24b-7b86-438b-9265-bc8b9e2cdbdd" key="line-2" x="1" y="96" width="482" height="1"/>
+				<element kind="textField" uuid="a7a9501e-fece-4cda-bc2b-9fe85348e830" key="textField-4" x="0" y="98" width="152" height="18" fontName="Bitstream Vera Sans" blankWhenNull="false" style="Report_Data_Field">
+					<expression><![CDATA[$F{DOCUMENTNO}]]></expression>
+					<box style="Report_Data_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="Bitstream Vera Sans"/>
-					</textElement>
-					<textFieldExpression><![CDATA[$F{DOCUMENTNO}]]></textFieldExpression>
-				</textField>
-				<staticText>
-					<reportElement key="staticText-29" style="Report_Title" x="1" y="1" width="258" height="46" forecolor="#666666" uuid="483c2900-92e4-4725-add4-49048a3f6e22"/>
-					<box leftPadding="5">
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Left">
-						<font fontName="Bitstream Vera Sans" size="36"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="483c2900-92e4-4725-add4-49048a3f6e22" key="staticText-29" x="1" y="1" width="258" height="46" forecolor="#666666" fontName="Bitstream Vera Sans" fontSize="36.0" hTextAlign="Left" style="Report_Title">
 					<text><![CDATA[REQUISITION]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-30" style="Group_Data_Label" x="1" y="75" width="149" height="18" forecolor="#999999" uuid="5981b1ad-9ed3-48f5-a26e-10f6df4c808e"/>
-					<box leftPadding="2">
+					<box leftPadding="5" style="Report_Title">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Middle"/>
+				</element>
+				<element kind="staticText" uuid="5981b1ad-9ed3-48f5-a26e-10f6df4c808e" key="staticText-30" x="1" y="75" width="149" height="18" forecolor="#999999" vTextAlign="Middle" style="Group_Data_Label">
 					<text><![CDATA[Requisition Number]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-31" style="Group_Data_Label" x="359" y="75" width="118" height="18" forecolor="#999999" uuid="07da26bb-862a-4b64-be7f-a229e087fb0f"/>
-					<box leftPadding="2">
+					<box leftPadding="2" style="Group_Data_Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle"/>
+				</element>
+				<element kind="staticText" uuid="07da26bb-862a-4b64-be7f-a229e087fb0f" key="staticText-31" x="359" y="75" width="118" height="18" forecolor="#999999" hTextAlign="Right" vTextAlign="Middle" style="Group_Data_Label">
 					<text><![CDATA[Requester]]></text>
-				</staticText>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField" style="Group_Data_Field" x="359" y="98" width="118" height="18" uuid="3c05813b-4987-474f-a4d3-0578e9ebee4a"/>
-					<box>
+					<box leftPadding="2" style="Group_Data_Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[$F{REQUESTER}]]></textFieldExpression>
-				</textField>
+				</element>
+				<element kind="textField" uuid="3c05813b-4987-474f-a4d3-0578e9ebee4a" key="textField" x="359" y="98" width="118" height="18" blankWhenNull="false" hTextAlign="Right" style="Group_Data_Field">
+					<expression><![CDATA[$F{REQUESTER}]]></expression>
+					<box style="Group_Data_Field">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="20" splitType="Stretch">
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-8" style="Group_Data_Field" x="67" y="0" width="369" height="20" uuid="ed5ba807-412e-4dd0-9923-afd78452f230"/>
-					<box leftPadding="24">
+				<element kind="textField" uuid="ed5ba807-412e-4dd0-9923-afd78452f230" key="textField-8" x="67" y="0" width="369" height="20" textAdjust="StretchHeight" blankWhenNull="true" style="Group_Data_Field">
+					<expression><![CDATA[$F{DESCRIPTION}]]></expression>
+					<box leftPadding="24" style="Group_Data_Field">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textFieldExpression><![CDATA[$F{DESCRIPTION}]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="76" splitType="Stretch">
-			<subreport isUsingCache="true">
-				<reportElement key="subreport-1" x="0" y="0" width="483" height="76" uuid="6a400c78-272a-4b49-8dfa-caa05e3d71bd"/>
-				<subreportParameter name="NUMBERFORMAT">
-					<subreportParameterExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="REQUISITION_ID">
-					<subreportParameterExpression><![CDATA[$F{M_REQUISITION_ID}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="LOCALE">
-					<subreportParameterExpression><![CDATA[$P{LOCALE}]]></subreportParameterExpression>
-				</subreportParameter>
+			<element kind="subreport" uuid="6a400c78-272a-4b49-8dfa-caa05e3d71bd" key="subreport-1" x="0" y="0" width="483" height="76" usingCache="true">
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
-				<subreportExpression><![CDATA[$P{SUBREP_RptM_Requisition_Lines}]]></subreportExpression>
-			</subreport>
+				<expression><![CDATA[$P{SUBREP_RptM_Requisition_Lines}]]></expression>
+				<parameter name="NUMBERFORMAT">
+					<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.getCountryNumberFormat($F{ORGANIZATIONID},$P{NUMBERFORMAT})]]></expression>
+				</parameter>
+				<parameter name="REQUISITION_ID">
+					<expression><![CDATA[$F{M_REQUISITION_ID}]]></expression>
+				</parameter>
+				<parameter name="LOCALE">
+					<expression><![CDATA[$P{LOCALE}]]></expression>
+				</parameter>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band height="34" splitType="Stretch">
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField-6" style="default" x="359" y="11" width="100" height="18" uuid="0fdcfed0-a86a-40cd-8853-68a03a10ba81"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA["PAGE: " + $V{PAGE_NUMBER} + "/"]]></textFieldExpression>
-			</textField>
-			<textField evaluationTime="Group" evaluationGroup="M_REQUISITION_ID" isBlankWhenNull="false">
-				<reportElement key="textField-7" style="default" x="461" y="11" width="18" height="18" uuid="45477bc7-10d1-41a1-863d-efd586c2b0f1"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA["" + $V{PAGE_NUMBER} + ""]]></textFieldExpression>
-			</textField>
-			<staticText>
-				<reportElement key="staticText-28" style="default" x="124" y="11" width="78" height="18" uuid="4ef0ed88-5d44-484d-8b72-c4df021870b3"/>
-				<box rightPadding="2">
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<text><![CDATA[Generated on]]></text>
-			</staticText>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" style="default" x="205" y="11" width="100" height="18" uuid="36817647-22fe-4605-811c-ac53f10168ac"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.applyCountryDateFormat(new java.util.Date(),$F{ORGANIZATIONID})]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-5" x="1" y="6" width="482" height="1" uuid="15fd182d-221b-460a-b823-9fc857a3249e"/>
-			</line>
-		</band>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter height="34" splitType="Stretch">
+		<element kind="textField" uuid="0fdcfed0-a86a-40cd-8853-68a03a10ba81" key="textField-6" x="359" y="11" width="100" height="18" blankWhenNull="false" hTextAlign="Right" style="default">
+			<expression><![CDATA["PAGE: " + $V{PAGE_NUMBER} + "/"]]></expression>
+			<box style="default">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="45477bc7-10d1-41a1-863d-efd586c2b0f1" key="textField-7" x="461" y="11" width="18" height="18" evaluationTime="Group" evaluationGroup="M_REQUISITION_ID" blankWhenNull="false" style="default">
+			<expression><![CDATA["" + $V{PAGE_NUMBER} + ""]]></expression>
+			<box style="default">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="4ef0ed88-5d44-484d-8b72-c4df021870b3" key="staticText-28" x="124" y="11" width="78" height="18" hTextAlign="Right" style="default">
+			<text><![CDATA[Generated on]]></text>
+			<box rightPadding="2" style="default">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="36817647-22fe-4605-811c-ac53f10168ac" key="textField" x="205" y="11" width="100" height="18" blankWhenNull="false" style="default">
+			<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.applyCountryDateFormat(new java.util.Date(),$F{ORGANIZATIONID})]]></expression>
+			<box style="default">
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="15fd182d-221b-460a-b823-9fc857a3249e" key="line-5" x="1" y="6" width="482" height="1"/>
 	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/RptM_Requisition_Lines.jrxml
+++ b/src/org/openbravo/erpReports/RptM_Requisition_Lines.jrxml
@@ -1,52 +1,50 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="RptM_Requisition_Lines" pageWidth="483" pageHeight="842" columnWidth="483" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="5b3bd9f3-8d27-41ab-9a65-993f1b0760f6">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="RptM_Requisition_Lines" language="java" pageWidth="483" pageHeight="842" columnWidth="483" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="5b3bd9f3-8d27-41ab-9a65-993f1b0760f6">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true">
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true">
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<parameter name="REQUISITION_ID" class="java.lang.String" isForPrompting="false">
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<parameter name="REQUISITION_ID" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["1000001"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="LOCALE" class="java.util.Locale" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.NumberFormat" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT M_PRODUCT.VALUE, M_PRODUCT.NAME, M_REQUISITIONLINE.QTY,  
+	<parameter name="LOCALE" forPrompting="false" class="java.util.Locale"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.NumberFormat"/>
+	<query language="sql"><![CDATA[SELECT M_PRODUCT.VALUE, M_PRODUCT.NAME, M_REQUISITIONLINE.QTY,  
        C_UOM.UOMSYMBOL AS UOMSYMBOL, M_REQUISITIONLINE.LINENETAMT, M_REQUISITIONLINE.AD_ORG_ID AS ORGANIZATIONID,  
        M_REQUISITIONLINE.PRICEACTUAL, M_REQUISITIONLINE.NEEDBYDATE,  
           (CASE WHEN M_ATTRIBUTESETINSTANCE.M_ATTRIBUTESET_ID IS NULL THEN ''  
@@ -56,8 +54,7 @@
                left join  M_ATTRIBUTESETINSTANCE on M_REQUISITIONLINE.M_ATTRIBUTESETINSTANCE_ID = M_ATTRIBUTESETINSTANCE.M_ATTRIBUTESETINSTANCE_ID, C_UOM  
 		WHERE M_REQUISITIONLINE.C_UOM_ID = C_UOM.C_UOM_ID 
 		AND M_REQUISITIONLINE.M_REQUISITION_ID = $P{REQUISITION_ID} 
-		ORDER BY M_REQUISITIONLINE.NEEDBYDATE, M_PRODUCT.NAME]]>
-	</queryString>
+		ORDER BY M_REQUISITIONLINE.NEEDBYDATE, M_PRODUCT.NAME]]></query>
 	<field name="VALUE" class="java.lang.String"/>
 	<field name="NAME" class="java.lang.String"/>
 	<field name="QTY" class="java.math.BigDecimal"/>
@@ -67,250 +64,194 @@
 	<field name="NEEDBYDATE" class="java.util.Date"/>
 	<field name="ATTRIBUTE" class="java.lang.String"/>
 	<field name="ORGANIZATIONID" class="java.lang.String"/>
-	<variable name="AMOUNT_SUM" class="java.math.BigDecimal" resetType="Group" resetGroup="REQUISITION_ID" calculation="Sum">
-		<variableExpression><![CDATA[$F{LINENETAMT}]]></variableExpression>
+	<variable name="AMOUNT_SUM" resetType="Group" calculation="Sum" resetGroup="REQUISITION_ID" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{LINENETAMT}]]></expression>
 	</variable>
-	<variable name="AMOUNT_SUM_1" class="java.math.BigDecimal" resetType="Group" resetGroup="REQUISITION_ID" calculation="Sum">
-		<variableExpression><![CDATA[$F{LINENETAMT}]]></variableExpression>
+	<variable name="AMOUNT_SUM_1" resetType="Group" calculation="Sum" resetGroup="REQUISITION_ID" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{LINENETAMT}]]></expression>
 	</variable>
 	<group name="REQUISITION_ID">
-		<groupExpression><![CDATA[$P{REQUISITION_ID}]]></groupExpression>
+		<expression><![CDATA[$P{REQUISITION_ID}]]></expression>
 		<groupHeader>
 			<band height="16" splitType="Stretch">
-				<staticText>
-					<reportElement key="element-1" style="Detail_Header" x="0" y="0" width="50" height="16" uuid="7779509d-97bd-4190-afe8-beb39c30496b"/>
-					<box leftPadding="5">
-						<pen lineWidth="0.0"/>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				<element kind="staticText" uuid="7779509d-97bd-4190-afe8-beb39c30496b" key="element-1" x="0" y="0" width="50" height="16" pdfFontName="Helvetica-Bold" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Ref.]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-3" style="Detail_Header" x="50" y="0" width="138" height="16" uuid="ada64ec7-62ac-4796-870d-4698657b65be"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle"/>
+				</element>
+				<element kind="staticText" uuid="ada64ec7-62ac-4796-870d-4698657b65be" key="element-3" x="50" y="0" width="138" height="16" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Product Name]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-4" style="Detail_Header" x="343" y="0" width="50" height="16" uuid="a07ab159-2013-4e69-8f52-ef5d0a189455"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle"/>
+				</element>
+				<element kind="staticText" uuid="a07ab159-2013-4e69-8f52-ef5d0a189455" key="element-4" x="343" y="0" width="50" height="16" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Qty.]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-5" style="Detail_Header" x="433" y="0" width="50" height="16" uuid="021099f1-85de-4edb-9832-dc917df84730"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle"/>
+				</element>
+				<element kind="staticText" uuid="021099f1-85de-4edb-9832-dc917df84730" key="element-5" x="433" y="0" width="50" height="16" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Amt.]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-6" style="Detail_Header" x="188" y="0" width="75" height="16" uuid="01b057dd-38eb-489c-8890-4f5eb3c8768c"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle"/>
+				</element>
+				<element kind="staticText" uuid="01b057dd-38eb-489c-8890-4f5eb3c8768c" key="element-6" x="188" y="0" width="75" height="16" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Attribute]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-7" style="Detail_Header" x="393" y="0" width="40" height="16" uuid="ac892ae9-c953-45c7-a749-0d728cd12f0d"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Middle"/>
+				</element>
+				<element kind="staticText" uuid="ac892ae9-c953-45c7-a749-0d728cd12f0d" key="element-7" x="393" y="0" width="40" height="16" hTextAlign="Right" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Price]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="element-8" style="Detail_Header" x="263" y="0" width="80" height="16" uuid="2b97ccf6-3a1a-41b5-a689-0cf199a14175"/>
-					<box leftPadding="5">
+					<box leftPadding="5" style="Detail_Header">
 						<pen lineWidth="0.0"/>
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Middle">
-						<font pdfFontName="Helvetica-Bold"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="2b97ccf6-3a1a-41b5-a689-0cf199a14175" key="element-8" x="263" y="0" width="80" height="16" pdfFontName="Helvetica-Bold" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
 					<text><![CDATA[Need by]]></text>
-				</staticText>
+					<box leftPadding="5" style="Detail_Header">
+						<pen lineWidth="0.0"/>
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+					</box>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="17" splitType="Stretch">
-				<line>
-					<reportElement key="line" positionType="FixRelativeToBottom" x="0" y="0" width="483" height="1" forecolor="#000000" uuid="06741801-88ff-4798-81b9-12033ec8f539"/>
-					<graphicElement>
-						<pen lineWidth="0.25" lineStyle="Solid"/>
-					</graphicElement>
-				</line>
-				<staticText>
-					<reportElement key="staticText-2" style="Report_Data_Label" x="355" y="1" width="46" height="16" uuid="bd8d6529-8b2a-43a8-a57c-5f57f87bfb35"/>
-					<box leftPadding="5">
+				<element kind="line" uuid="06741801-88ff-4798-81b9-12033ec8f539" key="line" positionType="FixRelativeToBottom" x="0" y="0" width="483" height="1" forecolor="#000000">
+					<pen lineWidth="0.25" lineStyle="Solid"/>
+				</element>
+				<element kind="staticText" uuid="bd8d6529-8b2a-43a8-a57c-5f57f87bfb35" key="staticText-2" x="355" y="1" width="46" height="16" fontSize="10.0" style="Report_Data_Label">
+					<text><![CDATA[Total:]]></text>
+					<box leftPadding="5" style="Report_Data_Label">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="10"/>
-					</textElement>
-					<text><![CDATA[Total:]]></text>
-				</staticText>
-				<textField pattern="" isBlankWhenNull="false">
-					<reportElement key="textField" style="Total_Gray" x="401" y="1" width="82" height="16" uuid="4b895e91-ff0d-4b55-b24f-d837cbbfac05"/>
-					<box topPadding="2" leftPadding="2" bottomPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4b895e91-ff0d-4b55-b24f-d837cbbfac05" key="textField" x="401" y="1" width="82" height="16" pattern="" blankWhenNull="false" hTextAlign="Right" style="Total_Gray">
+					<expression><![CDATA[($V{AMOUNT_SUM}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM}):new String(" ")]]></expression>
+					<box topPadding="2" leftPadding="2" bottomPadding="2" rightPadding="2" style="Total_Gray">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#FFFFFF"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#FFFFFF"/>
 					</box>
-					<textElement textAlignment="Right"/>
-					<textFieldExpression><![CDATA[($V{AMOUNT_SUM}!=null)?$P{NUMBERFORMAT}.format($V{AMOUNT_SUM}):new String(" ")]]></textFieldExpression>
-				</textField>
+				</element>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="16" splitType="Stretch">
-			<frame>
-				<reportElement key="frame-1" style="Detail_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="483" height="16" uuid="5b0cd77f-dbce-4544-a6fc-9b4452c1c171"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-1" style="default" stretchType="RelativeToBandHeight" x="0" y="0" width="50" height="16" uuid="6516ee69-21f4-4203-b1fa-6d7024814ffb"/>
-					<box topPadding="2" leftPadding="2" bottomPadding="2" rightPadding="2">
+			<element kind="frame" uuid="5b0cd77f-dbce-4544-a6fc-9b4452c1c171" key="frame-1" stretchType="ContainerHeight" x="0" y="0" width="483" height="16" style="Detail_Line">
+				<element kind="textField" uuid="6516ee69-21f4-4203-b1fa-6d7024814ffb" key="textField-1" stretchType="ContainerHeight" x="0" y="0" width="50" height="16" textAdjust="StretchHeight" blankWhenNull="true" hTextAlign="Left" vTextAlign="Top" style="default">
+					<expression><![CDATA[$F{VALUE}]]></expression>
+					<box topPadding="2" leftPadding="2" bottomPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Left" verticalAlignment="Top"/>
-					<textFieldExpression><![CDATA[$F{VALUE}]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-3" style="default" stretchType="RelativeToBandHeight" x="50" y="0" width="138" height="16" uuid="a972de98-127e-4295-bad1-f0702aec8f62"/>
-					<box topPadding="2" leftPadding="2" bottomPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="a972de98-127e-4295-bad1-f0702aec8f62" key="textField-3" stretchType="ContainerHeight" x="50" y="0" width="138" height="16" textAdjust="StretchHeight" blankWhenNull="true" vTextAlign="Top" style="default">
+					<expression><![CDATA[$F{NAME}]]></expression>
+					<box topPadding="2" leftPadding="2" bottomPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Top"/>
-					<textFieldExpression><![CDATA[$F{NAME}]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-					<reportElement key="textField-6" style="default" stretchType="RelativeToBandHeight" x="188" y="0" width="75" height="16" uuid="4b9825f6-e2c3-4234-ba9e-f949e9465a6a"/>
-					<box topPadding="2" leftPadding="2" bottomPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="4b9825f6-e2c3-4234-ba9e-f949e9465a6a" key="textField-6" stretchType="ContainerHeight" x="188" y="0" width="75" height="16" textAdjust="StretchHeight" blankWhenNull="true" vTextAlign="Top" style="default">
+					<expression><![CDATA[$F{ATTRIBUTE}]]></expression>
+					<box topPadding="2" leftPadding="2" bottomPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement verticalAlignment="Top"/>
-					<textFieldExpression><![CDATA[$F{ATTRIBUTE}]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-					<reportElement key="textField-4" style="default" stretchType="RelativeToBandHeight" x="343" y="0" width="50" height="16" uuid="49c21581-18bd-4584-b4bf-f6361fd145c1"/>
-					<box topPadding="2" leftPadding="2" bottomPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="49c21581-18bd-4584-b4bf-f6361fd145c1" key="textField-4" stretchType="ContainerHeight" x="343" y="0" width="50" height="16" textAdjust="StretchHeight" blankWhenNull="false" hTextAlign="Right" vTextAlign="Top" style="default">
+					<expression><![CDATA[($F{QTY}!=null)?$P{NUMBERFORMAT}.format($F{QTY})+" "+$F{UOMSYMBOL}:new String(" ")]]></expression>
+					<box topPadding="2" leftPadding="2" bottomPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Top"/>
-					<textFieldExpression><![CDATA[($F{QTY}!=null)?$P{NUMBERFORMAT}.format($F{QTY})+" "+$F{UOMSYMBOL}:new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-					<reportElement key="textField-7" style="default" stretchType="RelativeToBandHeight" x="393" y="0" width="40" height="16" uuid="3c68e2ef-df60-4e55-b85b-4e789fe6d02c"/>
-					<box topPadding="2" leftPadding="2" bottomPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="3c68e2ef-df60-4e55-b85b-4e789fe6d02c" key="textField-7" stretchType="ContainerHeight" x="393" y="0" width="40" height="16" textAdjust="StretchHeight" blankWhenNull="false" hTextAlign="Right" vTextAlign="Top" style="default">
+					<expression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}):new String(" ")]]></expression>
+					<box topPadding="2" leftPadding="2" bottomPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Top"/>
-					<textFieldExpression><![CDATA[($F{PRICEACTUAL}!=null)?$P{NUMBERFORMAT}.format($F{PRICEACTUAL}):new String(" ")]]></textFieldExpression>
-				</textField>
-				<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="false">
-					<reportElement key="textField-5" style="default" stretchType="RelativeToBandHeight" x="433" y="0" width="50" height="16" uuid="87b51bed-73d8-45fa-943e-3947941bf4e7"/>
-					<box topPadding="2" leftPadding="2" bottomPadding="2" rightPadding="2">
+				</element>
+				<element kind="textField" uuid="87b51bed-73d8-45fa-943e-3947941bf4e7" key="textField-5" stretchType="ContainerHeight" x="433" y="0" width="50" height="16" textAdjust="StretchHeight" pattern="" blankWhenNull="false" hTextAlign="Right" vTextAlign="Top" style="default">
+					<expression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}):new String(" ")]]></expression>
+					<box topPadding="2" leftPadding="2" bottomPadding="2" rightPadding="2" style="default">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right" verticalAlignment="Top"/>
-					<textFieldExpression><![CDATA[($F{LINENETAMT}!=null)?$P{NUMBERFORMAT}.format($F{LINENETAMT}):new String(" ")]]></textFieldExpression>
-				</textField>
-			</frame>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-8" style="default" stretchType="RelativeToBandHeight" x="263" y="0" width="80" height="16" uuid="494f46b4-c650-4656-954d-fae1a2682c32"/>
-				<box topPadding="2" leftPadding="2" bottomPadding="2" rightPadding="2">
+				</element>
+				<box style="Detail_Line">
+					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="0.0" lineColor="#000000"/>
+					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+			</element>
+			<element kind="textField" uuid="494f46b4-c650-4656-954d-fae1a2682c32" key="textField-8" stretchType="ContainerHeight" x="263" y="0" width="80" height="16" textAdjust="StretchHeight" blankWhenNull="false" hTextAlign="Left" vTextAlign="Top" style="default">
+				<expression><![CDATA[org.openbravo.erpCommon.utility.Utility.applyCountryDateFormat($F{NEEDBYDATE},$F{ORGANIZATIONID})]]></expression>
+				<box topPadding="2" leftPadding="2" bottomPadding="2" rightPadding="2" style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.25" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Left" verticalAlignment="Top"/>
-				<textFieldExpression><![CDATA[org.openbravo.erpCommon.utility.Utility.applyCountryDateFormat($F{NEEDBYDATE},$F{ORGANIZATIONID})]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/Rptm_InOut_Lines.jrxml
+++ b/src/org/openbravo/erpReports/Rptm_InOut_Lines.jrxml
@@ -1,36 +1,34 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Rptm_InOut_Lines" pageWidth="482" pageHeight="842" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="1a92b8dd-038c-4fa0-9510-01b7f14a60d3">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="Rptm_InOut_Lines" language="java" pageWidth="482" pageHeight="842" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="1a92b8dd-038c-4fa0-9510-01b7f14a60d3">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<parameter name="M_INOUT_ID" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT M_PRODUCT.VALUE,
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<parameter name="M_INOUT_ID" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<query language="sql"><![CDATA[SELECT M_PRODUCT.VALUE,
         COALESCE((SELECT M_PRODUCT_CUSTOMER.NAME 
             FROM M_PRODUCT_CUSTOMER 
             WHERE M_PRODUCT_CUSTOMER.M_PRODUCT_ID=M_INOUTLINE.M_PRODUCT_ID
@@ -47,8 +45,7 @@
         AND M_PRODUCT.C_UOM_ID = C_UOM.C_UOM_ID
         GROUP BY C_ORDER.DOCUMENTNO, M_INOUT.C_BPARTNER_ID, C_ORDER.POREFERENCE, M_PRODUCT.VALUE, M_INOUTLINE.M_PRODUCT_ID, M_PRODUCT.NAME, M_ATTRIBUTESETINSTANCE.LOT,
         M_ATTRIBUTESETINSTANCE.GUARANTEEDATE, M_INOUT.DESCRIPTION, M_INOUTLINE.DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME
-        ORDER BY C_ORDER.DOCUMENTNO, M_PRODUCT.NAME]]>
-	</queryString>
+        ORDER BY C_ORDER.DOCUMENTNO, M_PRODUCT.NAME]]></query>
 	<field name="value" class="java.lang.String"/>
 	<field name="name" class="java.lang.String"/>
 	<field name="movementqty" class="java.math.BigDecimal"/>
@@ -58,215 +55,128 @@
 	<field name="upc" class="java.lang.String"/>
 	<field name="uom" class="java.lang.String"/>
 	<group name="M_INOUT_ID">
-		<groupExpression><![CDATA[$P{M_INOUT_ID}]]></groupExpression>
+		<expression><![CDATA[$P{M_INOUT_ID}]]></expression>
 		<groupHeader>
 			<band height="14" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText-1" style="Detail_Header" x="0" y="0" width="90" height="14" uuid="fe43bbec-fd5e-43d3-a3ff-5cde56c3623e"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement>
-						<font size="10" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="fe43bbec-fd5e-43d3-a3ff-5cde56c3623e" key="staticText-1" x="0" y="0" width="90" height="14" fontSize="10.0" pdfFontName="Helvetica" bold="false" style="Detail_Header">
 					<text><![CDATA[REFERENCE]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-2" style="Detail_Header" x="90" y="0" width="165" height="14" uuid="a1140e69-42d0-4b5c-867b-086f0424b6e5"/>
-					<box>
+					<box style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="10" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="a1140e69-42d0-4b5c-867b-086f0424b6e5" key="staticText-2" x="90" y="0" width="165" height="14" fontSize="10.0" pdfFontName="Helvetica" bold="false" style="Detail_Header">
 					<text><![CDATA[PRODUCT NAME]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-8" style="Detail_Header" x="423" y="0" width="59" height="14" uuid="c2734190-a712-42ba-b41f-56c28302c170"/>
-					<box>
+					<box style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="10" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="c2734190-a712-42ba-b41f-56c28302c170" key="staticText-8" x="423" y="0" width="59" height="14" fontSize="10.0" pdfFontName="Helvetica" bold="false" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-4" style="Detail_Header" x="422" y="0" width="59" height="14" uuid="2ee13c30-b6b0-4729-be70-1cfe2eb5145e"/>
-					<box>
+					<box style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement textAlignment="Right">
-						<font size="10" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="2ee13c30-b6b0-4729-be70-1cfe2eb5145e" key="staticText-4" x="422" y="0" width="59" height="14" fontSize="10.0" pdfFontName="Helvetica" bold="false" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[QUANTITY]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-5" style="Detail_Header" x="255" y="0" width="130" height="14" uuid="1aa5d082-608b-43e4-aa84-7568e2fa4caa"/>
-					<box>
+					<box style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font size="10" isBold="false" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="1aa5d082-608b-43e4-aa84-7568e2fa4caa" key="staticText-5" x="255" y="0" width="130" height="14" fontSize="10.0" pdfFontName="Helvetica" bold="false" style="Detail_Header">
 					<text><![CDATA[ATTRIBUTES]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-7" style="Report_Footer" x="0" y="0" width="1" height="14" forecolor="#FFFFFF" uuid="744de7bb-ba56-424f-94f5-5d28576d09e0"/>
-				</line>
-				<line>
-					<reportElement key="line-8" style="Report_Footer" x="89" y="0" width="1" height="14" forecolor="#FFFFFF" uuid="603bf3da-f9fd-44f3-8932-9e65d91c91ee"/>
-				</line>
-				<line>
-					<reportElement key="line-10" style="Report_Footer" x="255" y="0" width="1" height="14" forecolor="#FFFFFF" uuid="e395fe88-fcd2-4b46-9a38-19c9f3356878"/>
-				</line>
-				<line>
-					<reportElement key="line-11" style="Report_Footer" x="482" y="0" width="1" height="14" forecolor="#FFFFFF" uuid="099de837-bdc5-4ab8-a5c6-40ffba468318"/>
-				</line>
-				<staticText>
-					<reportElement key="staticText-7" style="Detail_Header" x="386" y="0" width="35" height="14" uuid="b9d6257d-857a-444a-903a-fa1969e95f95"/>
-					<textElement>
-						<font size="10" isBold="false"/>
-					</textElement>
+					<box style="Detail_Header">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="744de7bb-ba56-424f-94f5-5d28576d09e0" key="line-7" x="0" y="0" width="1" height="14" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="line" uuid="603bf3da-f9fd-44f3-8932-9e65d91c91ee" key="line-8" x="89" y="0" width="1" height="14" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="line" uuid="e395fe88-fcd2-4b46-9a38-19c9f3356878" key="line-10" x="255" y="0" width="1" height="14" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="line" uuid="099de837-bdc5-4ab8-a5c6-40ffba468318" key="line-11" x="482" y="0" width="1" height="14" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="staticText" uuid="b9d6257d-857a-444a-903a-fa1969e95f95" key="staticText-7" x="386" y="0" width="35" height="14" fontSize="10.0" bold="false" style="Detail_Header">
 					<text><![CDATA[UOM]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-12" style="Report_Footer" x="0" y="0" width="482" height="1" forecolor="#FFFFFF" uuid="7e655896-4d6c-42ce-b4f7-effdd418000d"/>
-				</line>
-				<line>
-					<reportElement key="line-14" style="Report_Footer" x="385" y="0" width="1" height="14" forecolor="#FFFFFF" uuid="f75248ec-e01d-44ff-95c7-5f231d833b15"/>
-				</line>
-				<line>
-					<reportElement key="line-15" style="Report_Footer" x="421" y="0" width="1" height="14" forecolor="#FFFFFF" uuid="b0b8ee5a-5891-441c-9f22-5f43546177db"/>
-				</line>
+				</element>
+				<element kind="line" uuid="7e655896-4d6c-42ce-b4f7-effdd418000d" key="line-12" x="0" y="0" width="482" height="1" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="line" uuid="f75248ec-e01d-44ff-95c7-5f231d833b15" key="line-14" x="385" y="0" width="1" height="14" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="line" uuid="b0b8ee5a-5891-441c-9f22-5f43546177db" key="line-15" x="421" y="0" width="1" height="14" forecolor="#FFFFFF" style="Report_Footer"/>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="1" splitType="Stretch">
-				<line>
-					<reportElement key="line-13" style="Report_Footer" x="0" y="0" width="482" height="1" uuid="1d2e5a70-07cb-4f2b-bb28-cc66d7436087"/>
-				</line>
+				<element kind="line" uuid="1d2e5a70-07cb-4f2b-bb28-cc66d7436087" key="line-13" x="0" y="0" width="482" height="1" style="Report_Footer"/>
 			</band>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="17" splitType="Stretch">
-			<frame>
-				<reportElement key="frame-1" style="Detail_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="482" height="16" uuid="8402283f-3a9a-424a-8667-2861e3897b51"/>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-5" style="default" x="386" y="0" width="35" height="16" forecolor="#000000" uuid="13597421-9850-4f65-b6d6-e62bfdfed331"/>
-					<textElement verticalAlignment="Middle">
-						<font size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[" " + $F{uom}]]></textFieldExpression>
-				</textField>
-			</frame>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-1" style="default" x="0" y="0" width="90" height="16" forecolor="#000000" uuid="e1ce06e4-4f0e-492f-9efd-779ae7b116a3"/>
-				<box>
+			<element kind="frame" uuid="8402283f-3a9a-424a-8667-2861e3897b51" key="frame-1" stretchType="ContainerHeight" x="0" y="0" width="482" height="16" style="Detail_Line">
+				<element kind="textField" uuid="13597421-9850-4f65-b6d6-e62bfdfed331" key="textField-5" x="386" y="0" width="35" height="16" forecolor="#000000" fontSize="8.0" blankWhenNull="false" vTextAlign="Middle" style="default">
+					<expression><![CDATA[" " + $F{uom}]]></expression>
+				</element>
+			</element>
+			<element kind="textField" uuid="e1ce06e4-4f0e-492f-9efd-779ae7b116a3" key="textField-1" x="0" y="0" width="90" height="16" forecolor="#000000" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="default">
+				<expression><![CDATA[" " + $F{value}]]></expression>
+				<box style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[" " + $F{value}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-2" style="default" x="90" y="0" width="165" height="16" forecolor="#000000" uuid="73641aba-0521-4a97-8337-d2026b604fb3"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="73641aba-0521-4a97-8337-d2026b604fb3" key="textField-2" x="90" y="0" width="165" height="16" forecolor="#000000" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{name}==null ? " " : " " + $F{name})]]></expression>
+				<box style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{name}==null ? " " : " " + $F{name})]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-3" style="default" x="255" y="0" width="130" height="16" forecolor="#000000" uuid="a73b2096-8fd2-4ba9-beef-e1af56e86615"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="a73b2096-8fd2-4ba9-beef-e1af56e86615" key="textField-3" x="255" y="0" width="130" height="16" forecolor="#000000" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{lot}==null ? " " : " " + $F{lot})]]></expression>
+				<box style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{lot}==null ? " " : " " + $F{lot})]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-4" style="default" x="422" y="0" width="59" height="16" forecolor="#000000" uuid="56c70f0a-3b29-4ea6-a473-e51a62588b70"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="56c70f0a-3b29-4ea6-a473-e51a62588b70" key="textField-4" x="422" y="0" width="59" height="16" forecolor="#000000" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{movementqty}!=null)?$P{NUMBERFORMAT}.format($F{movementqty}) + " " :new String(" ")]]></expression>
+				<box style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{movementqty}!=null)?$P{NUMBERFORMAT}.format($F{movementqty}) + " " :new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" style="Report_Footer" stretchType="RelativeToBandHeight" x="89" y="0" width="1" height="17" uuid="bf9ca48b-744a-472b-a202-ebb51cdd6f34"/>
-			</line>
-			<line>
-				<reportElement key="line-2" style="Report_Footer" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="17" uuid="8aef53cb-ac91-4978-a97a-237bda84a4ae"/>
-			</line>
-			<line>
-				<reportElement key="line-4" style="Report_Footer" stretchType="RelativeToBandHeight" x="255" y="0" width="1" height="17" uuid="71a64524-d85d-432f-9cc6-74a9bdd64cb8"/>
-			</line>
-			<line>
-				<reportElement key="line-6" style="Report_Footer" stretchType="RelativeToBandHeight" x="482" y="0" width="1" height="17" uuid="ba7c7a35-e39d-4154-8e59-f1c558c768e5"/>
-			</line>
-			<line>
-				<reportElement key="line-16" style="Report_Footer" stretchType="RelativeToBandHeight" x="385" y="0" width="1" height="17" uuid="fc4a7fda-6121-43d6-a372-ff8e5c0a1552"/>
-			</line>
-			<line>
-				<reportElement key="line-17" style="Report_Footer" stretchType="RelativeToBandHeight" x="421" y="0" width="1" height="17" uuid="f8ca1328-facc-4452-8daf-73d8f905db0f"/>
-			</line>
+			</element>
+			<element kind="line" uuid="bf9ca48b-744a-472b-a202-ebb51cdd6f34" key="line-1" stretchType="ContainerHeight" x="89" y="0" width="1" height="17" style="Report_Footer"/>
+			<element kind="line" uuid="8aef53cb-ac91-4978-a97a-237bda84a4ae" key="line-2" stretchType="ContainerHeight" x="0" y="0" width="1" height="17" style="Report_Footer"/>
+			<element kind="line" uuid="71a64524-d85d-432f-9cc6-74a9bdd64cb8" key="line-4" stretchType="ContainerHeight" x="255" y="0" width="1" height="17" style="Report_Footer"/>
+			<element kind="line" uuid="ba7c7a35-e39d-4154-8e59-f1c558c768e5" key="line-6" stretchType="ContainerHeight" x="482" y="0" width="1" height="17" style="Report_Footer"/>
+			<element kind="line" uuid="fc4a7fda-6121-43d6-a372-ff8e5c0a1552" key="line-16" stretchType="ContainerHeight" x="385" y="0" width="1" height="17" style="Report_Footer"/>
+			<element kind="line" uuid="f8ca1328-facc-4452-8daf-73d8f905db0f" key="line-17" stretchType="ContainerHeight" x="421" y="0" width="1" height="17" style="Report_Footer"/>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/Rptm_InOut_Lines_new.jrxml
+++ b/src/org/openbravo/erpReports/Rptm_InOut_Lines_new.jrxml
@@ -1,39 +1,37 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Rptm_InOut_Lines_new" pageWidth="482" pageHeight="842" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="a4a06de8-2715-48bf-92dd-590febb0d7eb">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="Rptm_InOut_Lines_new" language="java" pageWidth="482" pageHeight="842" columnWidth="482" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="a4a06de8-2715-48bf-92dd-590febb0d7eb">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
 	<property name="ireport.zoom" value="1.5"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18"/>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14"/>
-	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11" isBold="false"/>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12" isBold="true"/>
-	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8">
-		<conditionalStyle>
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="8.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0"/>
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0"/>
+	<style name="Report_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0" bold="false"/>
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="12.0" bold="true"/>
+	<style name="Group_Data_Label" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Group_Data_Field" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#5D5D5D" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Line" fontName="Bitstream Vera Sans" fontSize="8.0">
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==0)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10" isBold="true"/>
-	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11" isBold="true"/>
-	<style name="Report_Footer" isDefault="true" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11"/>
-	<parameter name="M_INOUT_ID" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="NUMBERFORMAT" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT M_PRODUCT.VALUE,
+	<style name="Detail_Data_Label" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0" bold="true"/>
+	<style name="Detail_Data_Field" mode="Opaque" backcolor="#CCCCCC" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Group_Footer" fontName="Bitstream Vera Sans" fontSize="11.0" bold="true"/>
+	<style name="Report_Footer" default="true" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="11.0"/>
+	<parameter name="M_INOUT_ID" forPrompting="false" class="java.lang.String"/>
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.DecimalFormat"/>
+	<query language="sql"><![CDATA[SELECT M_PRODUCT.VALUE,
         COALESCE((SELECT M_PRODUCT_CUSTOMER.NAME
             FROM M_PRODUCT_CUSTOMER
             WHERE M_PRODUCT_CUSTOMER.M_PRODUCT_ID=M_INOUTLINE.M_PRODUCT_ID
@@ -49,8 +47,7 @@
         AND M_INOUT.M_INOUT_ID = '$P!{M_INOUT_ID}'
         AND M_PRODUCT.C_UOM_ID = C_UOM.C_UOM_ID
         GROUP BY C_ORDER.DOCUMENTNO, M_INOUT.C_BPARTNER_ID, C_ORDER.POREFERENCE, M_PRODUCT.VALUE, M_INOUTLINE.M_PRODUCT_ID, M_PRODUCT.NAME, M_ATTRIBUTESETINSTANCE.DESCRIPTION, M_INOUT.DESCRIPTION, M_INOUTLINE.DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME
-        ORDER BY C_ORDER.DOCUMENTNO, M_PRODUCT.NAME]]>
-	</queryString>
+        ORDER BY C_ORDER.DOCUMENTNO, M_PRODUCT.NAME]]></query>
 	<field name="value" class="java.lang.String"/>
 	<field name="name" class="java.lang.String"/>
 	<field name="movementqty" class="java.math.BigDecimal"/>
@@ -60,192 +57,117 @@
 	<field name="upc" class="java.lang.String"/>
 	<field name="uom" class="java.lang.String"/>
 	<group name="M_INOUT_ID">
-		<groupExpression><![CDATA[$P{M_INOUT_ID}]]></groupExpression>
+		<expression><![CDATA[$P{M_INOUT_ID}]]></expression>
 		<groupHeader>
 			<band height="25" splitType="Stretch">
-				<staticText>
-					<reportElement key="staticText-4" style="Detail_Header" mode="Transparent" x="422" y="2" width="59" height="22" forecolor="#7E7979" backcolor="#FFFFFF" uuid="9935afe1-5ee7-4d9a-ac4e-70edaea1a22d"/>
-					<box>
-						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-						<bottomPen lineWidth="0.0" lineColor="#000000"/>
-						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					</box>
-					<textElement textAlignment="Right">
-						<font fontName="DejaVu Sans" size="10" isBold="true" pdfFontName="Helvetica"/>
-					</textElement>
+				<element kind="staticText" uuid="9935afe1-5ee7-4d9a-ac4e-70edaea1a22d" key="staticText-4" mode="Transparent" x="422" y="2" width="59" height="22" forecolor="#7E7979" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="10.0" pdfFontName="Helvetica" bold="true" hTextAlign="Right" style="Detail_Header">
 					<text><![CDATA[Quantity]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-1" style="Detail_Header" mode="Transparent" x="0" y="2" width="90" height="22" forecolor="#7E7979" backcolor="#FFFFFF" uuid="f5fafdcc-3b7b-45e2-ba07-180981d47627"/>
-					<box>
+					<box style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="DejaVu Sans" size="10" isBold="true" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="f5fafdcc-3b7b-45e2-ba07-180981d47627" key="staticText-1" mode="Transparent" x="0" y="2" width="90" height="22" forecolor="#7E7979" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="10.0" pdfFontName="Helvetica" bold="true" style="Detail_Header">
 					<text><![CDATA[Reference]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-2" style="Detail_Header" mode="Transparent" x="90" y="2" width="165" height="22" forecolor="#7E7979" backcolor="#FFFFFF" uuid="f559cbfe-8697-4437-9472-163ab4add55d"/>
-					<box>
+					<box style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="DejaVu Sans" size="10" isBold="true" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="f559cbfe-8697-4437-9472-163ab4add55d" key="staticText-2" mode="Transparent" x="90" y="2" width="165" height="22" forecolor="#7E7979" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="10.0" pdfFontName="Helvetica" bold="true" style="Detail_Header">
 					<text><![CDATA[Product name]]></text>
-				</staticText>
-				<staticText>
-					<reportElement key="staticText-5" style="Detail_Header" mode="Transparent" x="255" y="2" width="130" height="22" forecolor="#7E7979" backcolor="#FFFFFF" uuid="c474c80c-eaea-48d6-8762-8fbb2caa4666"/>
-					<box>
+					<box style="Detail_Header">
 						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 						<bottomPen lineWidth="0.0" lineColor="#000000"/>
 						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					</box>
-					<textElement>
-						<font fontName="DejaVu Sans" size="10" isBold="true" pdfFontName="Helvetica"/>
-					</textElement>
+				</element>
+				<element kind="staticText" uuid="c474c80c-eaea-48d6-8762-8fbb2caa4666" key="staticText-5" mode="Transparent" x="255" y="2" width="130" height="22" forecolor="#7E7979" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="10.0" pdfFontName="Helvetica" bold="true" style="Detail_Header">
 					<text><![CDATA[Attributes]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-7" style="Report_Footer" x="0" y="0" width="1" height="14" forecolor="#FFFFFF" uuid="53a0c53b-86cb-479a-a820-a3ec2cda4369"/>
-				</line>
-				<line>
-					<reportElement key="line-8" style="Report_Footer" x="89" y="0" width="1" height="14" forecolor="#FFFFFF" uuid="05a44a81-e190-4da8-8789-e4ae2cdb2168"/>
-				</line>
-				<line>
-					<reportElement key="line-10" style="Report_Footer" x="255" y="0" width="1" height="14" forecolor="#FFFFFF" uuid="88f3603d-c068-402a-9968-9809e9fb39f1"/>
-				</line>
-				<line>
-					<reportElement key="line-11" style="Report_Footer" x="482" y="0" width="1" height="14" forecolor="#FFFFFF" uuid="034ec948-9882-4a1b-b965-422f1028e283"/>
-				</line>
-				<staticText>
-					<reportElement key="staticText-7" style="Detail_Header" mode="Transparent" x="386" y="2" width="35" height="22" forecolor="#7E7979" backcolor="#FFFFFF" uuid="f0f1bd25-8247-44b2-9efb-aa943cb2e66a"/>
-					<textElement>
-						<font fontName="DejaVu Sans" size="10" isBold="true"/>
-					</textElement>
+					<box style="Detail_Header">
+						<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+						<bottomPen lineWidth="0.0" lineColor="#000000"/>
+						<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+					</box>
+				</element>
+				<element kind="line" uuid="53a0c53b-86cb-479a-a820-a3ec2cda4369" key="line-7" x="0" y="0" width="1" height="14" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="line" uuid="05a44a81-e190-4da8-8789-e4ae2cdb2168" key="line-8" x="89" y="0" width="1" height="14" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="line" uuid="88f3603d-c068-402a-9968-9809e9fb39f1" key="line-10" x="255" y="0" width="1" height="14" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="line" uuid="034ec948-9882-4a1b-b965-422f1028e283" key="line-11" x="482" y="0" width="1" height="14" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="staticText" uuid="f0f1bd25-8247-44b2-9efb-aa943cb2e66a" key="staticText-7" mode="Transparent" x="386" y="2" width="35" height="22" forecolor="#7E7979" backcolor="#FFFFFF" fontName="DejaVu Sans" fontSize="10.0" bold="true" style="Detail_Header">
 					<text><![CDATA[Uom]]></text>
-				</staticText>
-				<line>
-					<reportElement key="line-12" style="Report_Footer" x="0" y="0" width="482" height="1" forecolor="#FFFFFF" uuid="1d0515ac-db76-481f-8f9d-e0f46c47d702"/>
-				</line>
-				<line>
-					<reportElement key="line-14" style="Report_Footer" x="385" y="0" width="1" height="14" forecolor="#FFFFFF" uuid="5229da70-3d35-428f-8a10-f1cea52e149a"/>
-				</line>
-				<line>
-					<reportElement key="line-15" style="Report_Footer" x="421" y="0" width="1" height="14" forecolor="#FFFFFF" uuid="e2ade8d3-c203-4d00-a9c5-5729ee708aaa"/>
-				</line>
-				<line>
-					<reportElement key="line-1" x="0" y="23" width="482" height="1" forecolor="#CCCCCC" uuid="51094600-d724-4b17-89bb-0434d55bbd62"/>
-					<graphicElement>
-						<pen lineWidth="2.0" lineStyle="Double" lineColor="#A3A1A1"/>
-					</graphicElement>
-				</line>
+				</element>
+				<element kind="line" uuid="1d0515ac-db76-481f-8f9d-e0f46c47d702" key="line-12" x="0" y="0" width="482" height="1" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="line" uuid="5229da70-3d35-428f-8a10-f1cea52e149a" key="line-14" x="385" y="0" width="1" height="14" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="line" uuid="e2ade8d3-c203-4d00-a9c5-5729ee708aaa" key="line-15" x="421" y="0" width="1" height="14" forecolor="#FFFFFF" style="Report_Footer"/>
+				<element kind="line" uuid="51094600-d724-4b17-89bb-0434d55bbd62" key="line-1" x="0" y="23" width="482" height="1" forecolor="#CCCCCC">
+					<pen lineWidth="2.0" lineStyle="Double" lineColor="#A3A1A1"/>
+				</element>
 			</band>
 		</groupHeader>
 		<groupFooter>
 			<band height="1" splitType="Stretch"/>
 		</groupFooter>
 	</group>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band splitType="Stretch"/>
-	</columnHeader>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader splitType="Stretch"/>
 	<detail>
 		<band height="25" splitType="Stretch">
-			<frame>
-				<reportElement key="frame-1" style="default" stretchType="RelativeToBandHeight" x="0" y="0" width="482" height="21" uuid="f170c6be-337a-45b9-a5bc-be2c6dd1c874"/>
-				<textField isBlankWhenNull="false">
-					<reportElement key="textField-5" style="default" x="386" y="0" width="35" height="21" forecolor="#000000" uuid="9d25a9eb-1dd0-435b-a89f-3250d84f0c20"/>
-					<textElement verticalAlignment="Middle">
-						<font fontName="DejaVu Sans" size="8"/>
-					</textElement>
-					<textFieldExpression><![CDATA[" " + $F{uom}]]></textFieldExpression>
-				</textField>
-			</frame>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-1" style="default" x="0" y="0" width="90" height="21" forecolor="#000000" uuid="97ea4cd2-7c66-45e8-bbb0-50ae3fdb2bb5"/>
-				<box>
+			<element kind="frame" uuid="f170c6be-337a-45b9-a5bc-be2c6dd1c874" key="frame-1" stretchType="ContainerHeight" x="0" y="0" width="482" height="21" style="default">
+				<element kind="textField" uuid="9d25a9eb-1dd0-435b-a89f-3250d84f0c20" key="textField-5" x="386" y="0" width="35" height="21" forecolor="#000000" fontName="DejaVu Sans" fontSize="8.0" blankWhenNull="false" vTextAlign="Middle" style="default">
+					<expression><![CDATA[" " + $F{uom}]]></expression>
+				</element>
+			</element>
+			<element kind="textField" uuid="97ea4cd2-7c66-45e8-bbb0-50ae3fdb2bb5" key="textField-1" x="0" y="0" width="90" height="21" forecolor="#000000" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="default">
+				<expression><![CDATA[" " + $F{value}]]></expression>
+				<box style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[" " + $F{value}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-2" style="default" x="90" y="0" width="165" height="21" forecolor="#000000" uuid="514da93d-ecdb-48b3-96bc-3ce11c483b53"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="514da93d-ecdb-48b3-96bc-3ce11c483b53" key="textField-2" x="90" y="0" width="165" height="21" forecolor="#000000" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{name}==null ? " " : " " + $F{name})]]></expression>
+				<box style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{name}==null ? " " : " " + $F{name})]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-3" style="default" x="255" y="0" width="130" height="21" forecolor="#000000" uuid="cd437130-1b14-4955-8887-17835e8d310f"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="cd437130-1b14-4955-8887-17835e8d310f" key="textField-3" x="255" y="0" width="130" height="21" forecolor="#000000" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="false" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{lot}==null ? " " : " " + $F{lot})]]></expression>
+				<box style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{lot}==null ? " " : " " + $F{lot})]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-4" style="default" x="422" y="0" width="59" height="21" forecolor="#000000" uuid="5e627541-5158-4d30-8185-b2a0dcc1eac5"/>
-				<box>
+			</element>
+			<element kind="textField" uuid="5e627541-5158-4d30-8185-b2a0dcc1eac5" key="textField-4" x="422" y="0" width="59" height="21" forecolor="#000000" fontName="DejaVu Sans" fontSize="8.0" textAdjust="StretchHeight" blankWhenNull="false" hTextAlign="Right" vTextAlign="Middle" style="default">
+				<expression><![CDATA[($F{movementqty}!=null)?$P{NUMBERFORMAT}.format($F{movementqty}) + " " :new String(" ")]]></expression>
+				<box style="default">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="DejaVu Sans" size="8"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{movementqty}!=null)?$P{NUMBERFORMAT}.format($F{movementqty}) + " " :new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="0" y="22" width="482" height="1" forecolor="#CCCCCC" uuid="ea99a7d1-0ffc-42c9-bbf5-b495e912f1e5"/>
-				<graphicElement>
-					<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
-				</graphicElement>
-			</line>
+			</element>
+			<element kind="line" uuid="ea99a7d1-0ffc-42c9-bbf5-b495e912f1e5" key="line-1" x="0" y="22" width="482" height="1" forecolor="#CCCCCC">
+				<pen lineWidth="1.0" lineStyle="Solid" lineColor="#A3A1A1"/>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band splitType="Stretch"/>
-	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<columnFooter splitType="Stretch"/>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>

--- a/src/org/openbravo/erpReports/SubreportLines.jrxml
+++ b/src/org/openbravo/erpReports/SubreportLines.jrxml
@@ -1,61 +1,59 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="SubreportLines" pageWidth="595" pageHeight="842" columnWidth="595" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="a11d1452-2b4d-4e72-8314-c3c1a4dbceb5">
+<!-- Created with Jaspersoft Studio version 7.0.3.final using JasperReports Library version 7.0.3-41034ca841d452f3305ba55b9042260aaa1ab5dd  -->
+<jasperReport name="SubreportLines" language="java" pageWidth="595" pageHeight="842" columnWidth="595" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="a11d1452-2b4d-4e72-8314-c3c1a4dbceb5">
 	<property name="net.sf.jasperreports.awt.ignore.missing.font" value="true"/>
 	<property name="ireport.scriptlethandling" value="0"/>
 	<property name="ireport.encoding" value="UTF-8"/>
-	<import value="net.sf.jasperreports.engine.*"/>
-	<import value="java.util.*"/>
-	<import value="net.sf.jasperreports.engine.data.*"/>
-	<style name="default" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10"/>
-	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18">
+	<import>net.sf.jasperreports.engine.*</import>
+	<import>java.util.*</import>
+	<import>net.sf.jasperreports.engine.data.*</import>
+	<style name="default" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="10.0"/>
+	<style name="Report_Title" fontName="Bitstream Vera Sans" fontSize="18.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="Report_Subtitle" forecolor="#555555" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vAlign="Middle">
+	<style name="Total_Field" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5"/>
 	</style>
-	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle">
+	<style name="Detail_Header" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle">
 		<box leftPadding="5">
 			<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 			<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
 		</box>
 	</style>
-	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14">
+	<style name="GroupHeader_DarkGray" mode="Opaque" forecolor="#FFFFFF" backcolor="#555555" vTextAlign="Middle" vImageAlign="Middle" fontName="Bitstream Vera Sans" fontSize="14.0">
 		<box leftPadding="5"/>
 	</style>
 	<style name="GroupHeader_Gray" mode="Opaque" backcolor="#999999"/>
 	<style name="Detail_Line">
-		<conditionalStyle>
+		<conditionalStyle mode="Opaque" backcolor="#CCCCCC">
 			<conditionExpression><![CDATA[new Boolean($V{REPORT_COUNT}.intValue()%2==1)]]></conditionExpression>
-			<style mode="Opaque" backcolor="#CCCCCC"/>
 		</conditionalStyle>
 	</style>
 	<style name="Total_Gray" mode="Opaque" forecolor="#000000" backcolor="#CCCCCC"/>
-	<parameter name="ATTACH" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_WEB" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="BASE_DESIGN" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="LANGUAGE" class="java.lang.String" isForPrompting="false">
+	<parameter name="ATTACH" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_WEB" forPrompting="false" class="java.lang.String"/>
+	<parameter name="BASE_DESIGN" forPrompting="false" class="java.lang.String"/>
+	<parameter name="LANGUAGE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["en_US"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_CLIENT" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_CLIENT" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(1000000)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="USER_ORG" class="java.lang.String" isForPrompting="false">
+	<parameter name="USER_ORG" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["(0)"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_TITLE" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_TITLE" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA["REPORT TITLE"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="REPORT_SUBTITLE" class="java.lang.String" isForPrompting="false"/>
-	<parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
+	<parameter name="REPORT_SUBTITLE" forPrompting="false" class="java.lang.String"/>
+	<parameter name="SUBREPORT_DIR" forPrompting="false" class="java.lang.String">
 		<defaultValueExpression><![CDATA[".\\"]]></defaultValueExpression>
 	</parameter>
 	<parameter name="C_PROJECTPROPOSAL_ID" class="java.lang.String"/>
-	<parameter name="NUMBERFORMAT" class="java.text.NumberFormat" isForPrompting="false"/>
-	<queryString>
-		<![CDATA[SELECT table3.C_BPartner_ID, '' as proposal, 
+	<parameter name="NUMBERFORMAT" forPrompting="false" class="java.text.NumberFormat"/>
+	<query language="sql"><![CDATA[SELECT table3.C_BPartner_ID, '' as proposal, 
         C_ProjectProposalLine.Description as line_desc,to_char( table6.Name ) as M_Product_ID_D, table6.description as description, C_ProjectProposalLine.Price as price,
         C_ProjectProposalLine.Qty as quantity, table7.NAME as UOMNAME,'' as address1, '' as localidad, '' as phone, '' as fax, '' as fecha, '' as BPname , '' as namecontacto,
          '' as contacto, '' as city, '' as headernote, '' as footnote, '' as reference, table15.CURSYMBOL as CURSYMBOL, '' AS GREET, '' AS GREETAUX
@@ -71,207 +69,160 @@
         AND table6.C_UOM_ID = table7.C_UOM_ID
         AND table5.C_CURRENCY_ID = table15.C_CURRENCY_ID
         and C_ProjectProposalLine.IsActive = 'Y'
-        ORDER BY C_PROJECTPROPOSALLINE.LINENO ASC]]>
-	</queryString>
+        ORDER BY C_PROJECTPROPOSALLINE.LINENO ASC]]></query>
 	<field name="M_Product_ID_D" class="java.lang.String"/>
 	<field name="DESCRIPTION" class="java.lang.String"/>
 	<field name="QUANTITY" class="java.math.BigDecimal"/>
 	<field name="PRICE" class="java.math.BigDecimal"/>
 	<field name="CURSYMBOL" class="java.lang.String"/>
-	<variable name="summQuan" class="java.lang.String" calculation="Sum"/>
-	<variable name="SUM_QUANTITY_1" class="java.math.BigDecimal" resetType="Column" calculation="Sum">
-		<variableExpression><![CDATA[$F{QUANTITY}]]></variableExpression>
+	<variable name="summQuan" calculation="Sum" class="java.lang.String"/>
+	<variable name="SUM_QUANTITY_1" resetType="Column" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{QUANTITY}]]></expression>
 	</variable>
-	<variable name="SUM_PRICE_1" class="java.math.BigDecimal" resetType="Column" calculation="Sum">
-		<variableExpression><![CDATA[$F{PRICE}]]></variableExpression>
+	<variable name="SUM_PRICE_1" resetType="Column" calculation="Sum" class="java.math.BigDecimal">
+		<expression><![CDATA[$F{PRICE}]]></expression>
 	</variable>
-	<background>
-		<band splitType="Stretch"/>
-	</background>
-	<title>
-		<band splitType="Stretch"/>
-	</title>
-	<pageHeader>
-		<band splitType="Stretch"/>
-	</pageHeader>
-	<columnHeader>
-		<band height="16" splitType="Stretch">
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="0" y="0" width="122" height="16" uuid="b11e1368-fddf-40dd-a931-578fe633aff6"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<text><![CDATA[PRODUCT]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="254" y="0" width="130" height="16" uuid="401e8c4c-2f1f-483f-8b67-e67c75b6ceef"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle"/>
-				<text><![CDATA[QUANTITY]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-90" style="Detail_Header" x="383" y="0" width="122" height="16" uuid="e23e2868-2c41-4963-84b3-4c0a864a456b"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<textElement textAlignment="Left" verticalAlignment="Middle"/>
-				<text><![CDATA[PRICE]]></text>
-			</staticText>
-			<staticText>
-				<reportElement key="element-91" style="Detail_Header" x="122" y="0" width="132" height="16" uuid="acdfd987-ffc1-44ac-b80c-6f4c451d937f"/>
-				<box leftPadding="5">
-					<pen lineWidth="0.0"/>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
-				</box>
-				<text><![CDATA[DESCRIPTION]]></text>
-			</staticText>
-		</band>
+	<background splitType="Stretch"/>
+	<title splitType="Stretch"/>
+	<pageHeader splitType="Stretch"/>
+	<columnHeader height="16" splitType="Stretch">
+		<element kind="staticText" uuid="b11e1368-fddf-40dd-a931-578fe633aff6" key="element-90" x="0" y="0" width="122" height="16" style="Detail_Header">
+			<text><![CDATA[PRODUCT]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="401e8c4c-2f1f-483f-8b67-e67c75b6ceef" key="element-90" x="254" y="0" width="130" height="16" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[QUANTITY]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="e23e2868-2c41-4963-84b3-4c0a864a456b" key="element-90" x="383" y="0" width="122" height="16" hTextAlign="Left" vTextAlign="Middle" style="Detail_Header">
+			<text><![CDATA[PRICE]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
+		<element kind="staticText" uuid="acdfd987-ffc1-44ac-b80c-6f4c451d937f" key="element-91" x="122" y="0" width="132" height="16" style="Detail_Header">
+			<text><![CDATA[DESCRIPTION]]></text>
+			<box leftPadding="5" style="Detail_Header">
+				<pen lineWidth="0.0"/>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#FFFFFF"/>
+			</box>
+		</element>
 	</columnHeader>
 	<detail>
 		<band height="18" splitType="Stretch">
-			<frame>
-				<reportElement key="frame-1" x="0" y="0" width="535" height="16" uuid="18cfcff1-866d-46cc-934c-3b89de66c664"/>
+			<element kind="frame" uuid="18cfcff1-866d-46cc-934c-3b89de66c664" key="frame-1" x="0" y="0" width="535" height="16">
 				<box topPadding="2" leftPadding="5">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-			</frame>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" x="0" y="0" width="122" height="16" uuid="f34f3349-94cd-4c07-96c5-4d4dba23f68f"/>
+			</element>
+			<element kind="textField" uuid="f34f3349-94cd-4c07-96c5-4d4dba23f68f" key="textField" x="0" y="0" width="122" height="16" fontName="Times-Roman" fontSize="12.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" vTextAlign="Middle">
+				<expression><![CDATA[$F{M_Product_ID_D}]]></expression>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="12"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$F{M_Product_ID_D}]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" x="254" y="0" width="130" height="16" uuid="12282673-9ec6-4dae-91db-d214699817ca"/>
+			</element>
+			<element kind="textField" uuid="12282673-9ec6-4dae-91db-d214699817ca" key="textField" x="254" y="0" width="130" height="16" fontName="Times-Roman" fontSize="12.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{QUANTITY}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITY}):new String(" ")]]></expression>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="12"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{QUANTITY}!=null)?$P{NUMBERFORMAT}.format($F{QUANTITY}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isStretchWithOverflow="true" pattern="" isBlankWhenNull="true">
-				<reportElement key="textField" x="383" y="0" width="61" height="16" uuid="75627a82-6ccb-4500-b790-543fbaf62a64"/>
+			</element>
+			<element kind="textField" uuid="75627a82-6ccb-4500-b790-543fbaf62a64" key="textField" x="383" y="0" width="61" height="16" fontName="Times-Roman" fontSize="12.0" textAdjust="StretchHeight" pattern="" blankWhenNull="true" hTextAlign="Right" vTextAlign="Middle">
+				<expression><![CDATA[($F{PRICE}!=null)?$P{NUMBERFORMAT}.format($F{PRICE}):new String(" ")]]></expression>
 				<box leftPadding="2" rightPadding="2">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement textAlignment="Right" verticalAlignment="Middle">
-					<font fontName="Times-Roman" size="12"/>
-				</textElement>
-				<textFieldExpression><![CDATA[($F{PRICE}!=null)?$P{NUMBERFORMAT}.format($F{PRICE}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" x="444" y="1" width="28" height="16" uuid="f947d7a8-8226-4db2-a47b-547aa149a6b8"/>
+			</element>
+			<element kind="textField" uuid="f947d7a8-8226-4db2-a47b-547aa149a6b8" key="textField" x="444" y="1" width="28" height="16" blankWhenNull="false">
+				<expression><![CDATA[$F{CURSYMBOL}]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[$F{CURSYMBOL}]]></textFieldExpression>
-			</textField>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" x="122" y="0" width="132" height="16" uuid="e3f1be27-54d7-4226-a21b-bf9d8d86755d"/>
+			</element>
+			<element kind="textField" uuid="e3f1be27-54d7-4226-a21b-bf9d8d86755d" key="textField" x="122" y="0" width="132" height="16" blankWhenNull="false">
+				<expression><![CDATA[($F{DESCRIPTION} == null ? "" : $F{DESCRIPTION})]]></expression>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textFieldExpression><![CDATA[($F{DESCRIPTION} == null ? "" : $F{DESCRIPTION})]]></textFieldExpression>
-			</textField>
+			</element>
 		</band>
 	</detail>
-	<columnFooter>
-		<band height="28" splitType="Stretch">
-			<textField pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="254" y="8" width="130" height="18" uuid="6b78f689-a5cc-4fea-b836-43557eb51a8c"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA[($V{SUM_QUANTITY_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_QUANTITY_1}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<textField pattern="##0.00" isBlankWhenNull="false">
-				<reportElement key="textField" x="384" y="8" width="59" height="18" uuid="5691fff5-e045-471d-8e9a-cd3ceda1aadb"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement textAlignment="Right"/>
-				<textFieldExpression><![CDATA[($V{SUM_PRICE_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_PRICE_1}):new String(" ")]]></textFieldExpression>
-			</textField>
-			<line>
-				<reportElement key="line-1" x="247" y="3" width="263" height="1" uuid="6bc6076c-590f-4aa7-8b0e-b172de00b9b7"/>
-			</line>
-			<staticText>
-				<reportElement key="staticText-1" x="206" y="7" width="46" height="18" uuid="b2c5c76d-b52e-47ce-b1b2-b8b62d7dd690"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textElement>
-					<font size="12"/>
-				</textElement>
-				<text><![CDATA[TOTAL:]]></text>
-			</staticText>
-			<textField isBlankWhenNull="false">
-				<reportElement key="textField" x="445" y="8" width="26" height="18" uuid="c7e79995-4509-456b-b8bf-6d2b9d698984"/>
-				<box>
-					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-					<bottomPen lineWidth="0.0" lineColor="#000000"/>
-					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
-				</box>
-				<textFieldExpression><![CDATA[$F{CURSYMBOL}]]></textFieldExpression>
-			</textField>
-		</band>
+	<columnFooter height="28" splitType="Stretch">
+		<element kind="textField" uuid="6b78f689-a5cc-4fea-b836-43557eb51a8c" key="textField" x="254" y="8" width="130" height="18" pattern="##0.00" blankWhenNull="false" hTextAlign="Right">
+			<expression><![CDATA[($V{SUM_QUANTITY_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_QUANTITY_1}):new String(" ")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="5691fff5-e045-471d-8e9a-cd3ceda1aadb" key="textField" x="384" y="8" width="59" height="18" pattern="##0.00" blankWhenNull="false" hTextAlign="Right">
+			<expression><![CDATA[($V{SUM_PRICE_1}!=null)?$P{NUMBERFORMAT}.format($V{SUM_PRICE_1}):new String(" ")]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="line" uuid="6bc6076c-590f-4aa7-8b0e-b172de00b9b7" key="line-1" x="247" y="3" width="263" height="1"/>
+		<element kind="staticText" uuid="b2c5c76d-b52e-47ce-b1b2-b8b62d7dd690" key="staticText-1" x="206" y="7" width="46" height="18" fontSize="12.0">
+			<text><![CDATA[TOTAL:]]></text>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
+		<element kind="textField" uuid="c7e79995-4509-456b-b8bf-6d2b9d698984" key="textField" x="445" y="8" width="26" height="18" blankWhenNull="false">
+			<expression><![CDATA[$F{CURSYMBOL}]]></expression>
+			<box>
+				<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+				<bottomPen lineWidth="0.0" lineColor="#000000"/>
+				<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
+			</box>
+		</element>
 	</columnFooter>
-	<pageFooter>
-		<band splitType="Stretch"/>
-	</pageFooter>
-	<summary>
-		<band splitType="Stretch"/>
-	</summary>
+	<pageFooter splitType="Stretch"/>
+	<summary splitType="Stretch"/>
 </jasperReport>


### PR DESCRIPTION
This pull request updates the reporting infrastructure to support JasperReports 7.x, which now uses the Jackson XML parser, and makes related dependency and test adjustments. The most important changes are:

**Dependency updates for JasperReports 7.x compatibility:**

* Added `jackson-dataformat-xml` as a dependency to support XML parsing in JasperReports 7.x.
* Added new JasperReports 7.x libraries (`jasperreports`, `jasperreports-chart-themes`, `jasperreports-jdt`) to the compilation dependencies.

**Test infrastructure modernization:**

* Refactored `AllJrxmlCompilation.java` to work with JasperReports 7.x: replaced legacy report compilation with direct use of `JRXmlLoader` and `JasperCompileManager`, added mocking for `ServletContext`, and improved test setup for compatibility with the new JasperReports version. [[1]](diffhunk://#diff-321b81a3f589b6b0918495a50feabb885b31040830a085e42181466904e8b1b6L1-R12) [[2]](diffhunk://#diff-321b81a3f589b6b0918495a50feabb885b31040830a085e42181466904e8b1b6R26-R43) [[3]](diffhunk://#diff-321b81a3f589b6b0918495a50feabb885b31040830a085e42181466904e8b1b6R52-R116)

**JasperReport template update:**

* Updated `CashflowForecast.jrxml` to be compatible with JasperReports 7.x: regenerated with Jaspersoft Studio 7.0.3, updated style and parameter attributes, and adjusted XML structure for the new library.