### PR TITLE
Issue #891: Add validations to filter for dates

### DIFF
--- a/src-test/src/org/openbravo/advpaymentmngt/hqlinjections/AccountingFactEndYearTransformerTest.java
+++ b/src-test/src/org/openbravo/advpaymentmngt/hqlinjections/AccountingFactEndYearTransformerTest.java
@@ -32,6 +32,10 @@ public class AccountingFactEndYearTransformerTest {
   private static final String HAVING_PARAM = "havingParam_";
   private static final String FIELD_NAME_CREATED_OPERATOR_EQUALS_VALUE_DATE = "{\"fieldName\":\"created\",\"operator\":\"equals\",\"value\":\"2024-01-01\"}";
   private static final String FIELD_NAME_UPDATED_OPERATOR_GREATER_THAN_VALUE_DATE = "{\"fieldName\":\"updated\",\"operator\":\"greaterThan\",\"value\":\"2024-01-01T10:00:00\"}";
+  public static final String WHERE = "WHERE";
+  public static final String DESCRIPTION_FILTER = "upper(Max(fa.description)) like upper(:alias_0) escape '|'";
+  public static final String SHOULD_KEEP_CLIENT_ID_PARAMETER = "Should keep clientId parameter";
+  public static final String SHOULD_HAVE_REMOVED_ALIAS_0 = "Should have removed alias_0";
   private AccountingFactEndYearTransformer transformer;
   private Map<String, String> requestParameters;
   private Map<String, Object> queryNamedParameters;
@@ -171,11 +175,11 @@ public class AccountingFactEndYearTransformerTest {
     String result = transformer.transformHqlQuery(queryWithAggregateFilter, requestParameters, queryNamedParameters);
     
     // Verify the aggregate condition was removed from WHERE
-    assertFalse("Should not contain the aggregate condition", result.contains("upper(Max(fa.description)) like upper(:alias_0) escape '|'"));
+    assertFalse("Should not contain the aggregate condition", result.contains(DESCRIPTION_FILTER));
     assertFalse("Should have removed alias_0 parameter", queryNamedParameters.containsKey(ALIAS_0));
-    assertTrue("Should keep clientId parameter", queryNamedParameters.containsKey(CLIENT_ID));
+    assertTrue(SHOULD_KEEP_CLIENT_ID_PARAMETER, queryNamedParameters.containsKey(CLIENT_ID));
     // The WHERE clause should still exist with clientId condition
-    assertTrue("Should contain WHERE clause", result.contains("WHERE"));
+    assertTrue("Should contain WHERE clause", result.contains(WHERE));
     assertTrue("Should contain clientId condition", result.contains("fa.client.id in (:clientId)"));
   }
 
@@ -201,13 +205,13 @@ public class AccountingFactEndYearTransformerTest {
     String result = transformer.transformHqlQuery(queryWithMultipleAggregates, requestParameters, queryNamedParameters);
     
     // Extract the WHERE clause to verify aggregate removal (not SELECT clause)
-    int whereIndex = result.indexOf("WHERE");
+    int whereIndex = result.indexOf(WHERE);
     int groupByIndex = result.indexOf("GROUP BY");
     String whereClause = result.substring(whereIndex, groupByIndex);
     
     assertFalse("Should not contain upper(Max(fa.description)) in WHERE", whereClause.contains(UPPER_MAX_FA_DESCRIPTION));
     assertFalse("Should not contain Max(fa.creationDate) > in WHERE", whereClause.contains("Max(fa.creationDate) >"));
-    assertFalse("Should have removed alias_0", queryNamedParameters.containsKey(ALIAS_0));
+    assertFalse(SHOULD_HAVE_REMOVED_ALIAS_0, queryNamedParameters.containsKey(ALIAS_0));
     assertFalse("Should have removed alias_1", queryNamedParameters.containsKey(ALIAS_1));
     assertTrue("Should contain 1=1 replacements", whereClause.contains("1=1"));
   }
@@ -302,7 +306,7 @@ public class AccountingFactEndYearTransformerTest {
     
     // Should not add HAVING clause since clientId is not debit/credit
     assertFalse("Should not add havingParam for non-aggregate field", result.contains(HAVING_PARAM));
-    assertTrue("Should keep clientId parameter", queryNamedParameters.containsKey(CLIENT_ID));
+    assertTrue(SHOULD_KEEP_CLIENT_ID_PARAMETER, queryNamedParameters.containsKey(CLIENT_ID));
   }
 
   /**
@@ -372,9 +376,9 @@ public class AccountingFactEndYearTransformerTest {
     
     String result = transformer.transformHqlQuery(complexQuery, requestParameters, queryNamedParameters);
     
-    assertFalse("Should remove the aggregate condition", result.contains("upper(Max(fa.description)) like upper(:alias_0) escape '|'"));
+    assertFalse("Should remove the aggregate condition", result.contains(DESCRIPTION_FILTER));
     assertTrue("Should keep non-aggregate condition", result.contains("fa.type = :alias_1"));
-    assertFalse("Should have removed alias_0", queryNamedParameters.containsKey(ALIAS_0));
+    assertFalse(SHOULD_HAVE_REMOVED_ALIAS_0, queryNamedParameters.containsKey(ALIAS_0));
     assertTrue("Should keep alias_1", queryNamedParameters.containsKey(ALIAS_1));
   }
 
@@ -604,10 +608,10 @@ public class AccountingFactEndYearTransformerTest {
     
     String result = transformer.transformHqlQuery(queryWithNestedParens, requestParameters, queryNamedParameters);
     
-    assertFalse("Should remove nested aggregate condition", result.contains("upper(Max(fa.description)) like upper(:alias_0) escape '|'"));
-    assertFalse("Should have removed alias_0", queryNamedParameters.containsKey(ALIAS_0));
-    assertTrue("Should keep clientId parameter", queryNamedParameters.containsKey(CLIENT_ID));
-    assertTrue("Should contain WHERE clause", result.contains("WHERE"));
+    assertFalse("Should remove nested aggregate condition", result.contains(DESCRIPTION_FILTER));
+    assertFalse(SHOULD_HAVE_REMOVED_ALIAS_0, queryNamedParameters.containsKey(ALIAS_0));
+    assertTrue(SHOULD_KEEP_CLIENT_ID_PARAMETER, queryNamedParameters.containsKey(CLIENT_ID));
+    assertTrue("Should contain WHERE clause", result.contains(WHERE));
     assertTrue("Should contain clientId condition", result.contains("fa.client.id in (:clientId)"));
   }
 }


### PR DESCRIPTION
ETP-3262
---
This pull request enhances the test coverage for the `AccountingFactEndYearTransformer` by adding new test cases for date field filtering and improving assertions for aggregate condition removal. It also introduces additional constants for test input values and clarifies existing assertions for better readability.

**Test coverage improvements:**

* Added tests to verify that date fields with the `equals` operator use date range conditions, ensuring both start and end parameters are set and the correct HAVING clause is present (`testDateFieldEqualsOperatorUsesDateRange`).
* Added a test to verify that date fields with the `greaterThan` operator correctly parse dates and set the appropriate parameter type (`testDateFieldGreaterThanOperatorParsesDate`).
* Added a test to ensure that nested parentheses in aggregate conditions are handled correctly (`testNestedParenthesesInAggregateConditions`).

**Test input and assertion improvements:**

* Introduced new constants for date field test criteria to improve test clarity and maintainability.
* Updated assertions in aggregate condition tests to check for the exact condition string, making the tests more precise and easier to understand. [[1]](diffhunk://#diff-fe1875a3975470166f4e30171c4684248821c4b3fe2d01723684aa513f79a7cbL172-R174) [[2]](diffhunk://#diff-fe1875a3975470166f4e30171c4684248821c4b3fe2d01723684aa513f79a7cbL373-R375)