### PR TITLE
Issue #891: Add validations to filter for dates

### DIFF
--- a/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/hqlinjections/AccountingFactEndYearTransformer.java
+++ b/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/hqlinjections/AccountingFactEndYearTransformer.java
@@ -97,6 +97,7 @@ public class AccountingFactEndYearTransformer extends HqlQueryTransformer {
   public static final String GREATEROREQUAL = "greaterorequal";
   public static final String GREATER_EQUAL_QUERY_SYMBOL = " >= :";
   public static final String LESSOREQUAL = "lessorequal";
+  public static final String CREATION_DATE = "creationDate";
 
   @Override
   public String transformHqlQuery(String _hqlQuery, Map<String, String> requestParameters,
@@ -216,7 +217,7 @@ public class AccountingFactEndYearTransformer extends HqlQueryTransformer {
     return StringUtils.equalsIgnoreCase(DEBIT, fieldName)
         || StringUtils.equalsIgnoreCase(CREDIT, fieldName)
         || StringUtils.equalsIgnoreCase("description", fieldName)
-        || StringUtils.equalsIgnoreCase("created", fieldName)
+        || StringUtils.equalsIgnoreCase(CREATION_DATE, fieldName)
         || StringUtils.equalsIgnoreCase(UPDATED, fieldName);
   }
 
@@ -227,7 +228,7 @@ public class AccountingFactEndYearTransformer extends HqlQueryTransformer {
       return "CASE WHEN Sum(fa.credit - fa.debit) > 0 THEN Sum(fa.credit - fa.debit) ELSE 0 END";
     } else if (StringUtils.equalsIgnoreCase("description", fieldName)) {
       return "Max(fa.description)";
-    } else if (StringUtils.equalsIgnoreCase("created", fieldName)) {
+    } else if (StringUtils.equalsIgnoreCase(CREATION_DATE, fieldName)) {
       return "Max(fa.creationDate)";
     } else if (StringUtils.equalsIgnoreCase(UPDATED, fieldName)) {
       return "Max(fa.updated)";
@@ -242,7 +243,7 @@ public class AccountingFactEndYearTransformer extends HqlQueryTransformer {
       return null;
     }
 
-    boolean isDateField = expr.contains("creationDate") || expr.contains(UPDATED);
+    boolean isDateField = expr.contains(CREATION_DATE) || expr.contains(UPDATED);
     Object paramValue = convertValueToAppropriateType(expr, value, isDateField);
 
     if (paramValue == null) {

--- a/src-test/src/org/openbravo/advpaymentmngt/hqlinjections/AccountingFactEndYearTransformerTest.java
+++ b/src-test/src/org/openbravo/advpaymentmngt/hqlinjections/AccountingFactEndYearTransformerTest.java
@@ -30,7 +30,7 @@ public class AccountingFactEndYearTransformerTest {
   private static final String ALIAS_1 = "alias_1";
   private static final String FIELD_NAME_DESCRIPTION_OPERATOR_I_CONTAINS_VALUE_TEST = "{\"fieldName\":\"description\",\"operator\":\"iContains\",\"value\":\"test\"}";
   private static final String HAVING_PARAM = "havingParam_";
-  private static final String FIELD_NAME_CREATED_OPERATOR_EQUALS_VALUE_DATE = "{\"fieldName\":\"created\",\"operator\":\"equals\",\"value\":\"2024-01-01\"}";
+  private static final String FIELD_NAME_CREATION_DATE_OPERATOR_EQUALS_VALUE_DATE = "{\"fieldName\":\"creationDate\",\"operator\":\"equals\",\"value\":\"2024-01-01\"}";
   private static final String FIELD_NAME_UPDATED_OPERATOR_GREATER_THAN_VALUE_DATE = "{\"fieldName\":\"updated\",\"operator\":\"greaterThan\",\"value\":\"2024-01-01T10:00:00\"}";
   public static final String WHERE = "WHERE";
   public static final String DESCRIPTION_FILTER = "upper(Max(fa.description)) like upper(:alias_0) escape '|'";
@@ -564,7 +564,7 @@ public class AccountingFactEndYearTransformerTest {
    */
   @Test
   public void testDateFieldEqualsOperatorUsesDateRange() {
-    requestParameters.put(CRITERIA, FIELD_NAME_CREATED_OPERATOR_EQUALS_VALUE_DATE);
+    requestParameters.put(CRITERIA, FIELD_NAME_CREATION_DATE_OPERATOR_EQUALS_VALUE_DATE);
     
     String result = transformer.transformHqlQuery(baseHqlQuery, requestParameters, queryNamedParameters);
     


### PR DESCRIPTION
ETP-3262
---
This pull request adds new test cases and improves the clarity of existing assertions in the `AccountingFactEndYearTransformerTest` class. The main focus is on enhancing test coverage for date field handling and aggregate condition removal, as well as improving assertion messages for better maintainability.

**Test coverage improvements:**

* Added test data constants for date field filters to support new test cases involving date parsing and range conditions (`FIELD_NAME_CREATED_OPERATOR_EQUALS_VALUE_DATE`, `FIELD_NAME_UPDATED_OPERATOR_GREATER_THAN_VALUE_DATE`).
* Added tests to verify correct transformation of queries with date field filters:
  * [`testDateFieldEqualsOperatorUsesDateRange`](diffhunk://#diff-fe1875a3975470166f4e30171c4684248821c4b3fe2d01723684aa513f79a7cbR557-R612): Ensures that an equals operator on a date field results in a date range condition with appropriate parameters.
  * [`testDateFieldGreaterThanOperatorParsesDate`](diffhunk://#diff-fe1875a3975470166f4e30171c4684248821c4b3fe2d01723684aa513f79a7cbR557-R612): Ensures that a greaterThan operator on a date field is parsed correctly and the parameter is a `Date` object.

**Aggregate condition handling:**

* Improved assertion messages in tests to more clearly state the intent when checking for removal of aggregate conditions from queries. [[1]](diffhunk://#diff-fe1875a3975470166f4e30171c4684248821c4b3fe2d01723684aa513f79a7cbL172-R174) [[2]](diffhunk://#diff-fe1875a3975470166f4e30171c4684248821c4b3fe2d01723684aa513f79a7cbL373-R375)
* Added a test (`testNestedParenthesesInAggregateConditions`) to verify that nested parentheses in aggregate conditions are handled correctly by the transformer.