### PR TITLE
Issue #891: Fix date filters after refresh grid

### DIFF
--- a/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/hqlinjections/AccountingFactEndYearTransformer.java
+++ b/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/hqlinjections/AccountingFactEndYearTransformer.java
@@ -97,6 +97,7 @@ public class AccountingFactEndYearTransformer extends HqlQueryTransformer {
   public static final String GREATEROREQUAL = "greaterorequal";
   public static final String GREATER_EQUAL_QUERY_SYMBOL = " >= :";
   public static final String LESSOREQUAL = "lessorequal";
+  public static final String CREATION_DATE = "creationDate";
 
   @Override
   public String transformHqlQuery(String _hqlQuery, Map<String, String> requestParameters,
@@ -216,7 +217,7 @@ public class AccountingFactEndYearTransformer extends HqlQueryTransformer {
     return StringUtils.equalsIgnoreCase(DEBIT, fieldName)
         || StringUtils.equalsIgnoreCase(CREDIT, fieldName)
         || StringUtils.equalsIgnoreCase("description", fieldName)
-        || StringUtils.equalsIgnoreCase("created", fieldName)
+        || StringUtils.equalsIgnoreCase(CREATION_DATE, fieldName)
         || StringUtils.equalsIgnoreCase(UPDATED, fieldName);
   }
 
@@ -227,7 +228,7 @@ public class AccountingFactEndYearTransformer extends HqlQueryTransformer {
       return "CASE WHEN Sum(fa.credit - fa.debit) > 0 THEN Sum(fa.credit - fa.debit) ELSE 0 END";
     } else if (StringUtils.equalsIgnoreCase("description", fieldName)) {
       return "Max(fa.description)";
-    } else if (StringUtils.equalsIgnoreCase("created", fieldName)) {
+    } else if (StringUtils.equalsIgnoreCase(CREATION_DATE, fieldName)) {
       return "Max(fa.creationDate)";
     } else if (StringUtils.equalsIgnoreCase(UPDATED, fieldName)) {
       return "Max(fa.updated)";
@@ -242,7 +243,7 @@ public class AccountingFactEndYearTransformer extends HqlQueryTransformer {
       return null;
     }
 
-    boolean isDateField = expr.contains("creationDate") || expr.contains(UPDATED);
+    boolean isDateField = expr.contains(CREATION_DATE) || expr.contains(UPDATED);
     Object paramValue = convertValueToAppropriateType(expr, value, isDateField);
 
     if (paramValue == null) {

--- a/src-test/src/org/openbravo/advpaymentmngt/hqlinjections/AccountingFactEndYearTransformerTest.java
+++ b/src-test/src/org/openbravo/advpaymentmngt/hqlinjections/AccountingFactEndYearTransformerTest.java
@@ -30,7 +30,7 @@ public class AccountingFactEndYearTransformerTest {
   private static final String ALIAS_1 = "alias_1";
   private static final String FIELD_NAME_DESCRIPTION_OPERATOR_I_CONTAINS_VALUE_TEST = "{\"fieldName\":\"description\",\"operator\":\"iContains\",\"value\":\"test\"}";
   private static final String HAVING_PARAM = "havingParam_";
-  private static final String FIELD_NAME_CREATED_OPERATOR_EQUALS_VALUE_DATE = "{\"fieldName\":\"created\",\"operator\":\"equals\",\"value\":\"2024-01-01\"}";
+  private static final String FIELD_NAME_CREATION_DATE_OPERATOR_EQUALS_VALUE_DATE = "{\"fieldName\":\"creationDate\",\"operator\":\"equals\",\"value\":\"2024-01-01\"}";
   private static final String FIELD_NAME_UPDATED_OPERATOR_GREATER_THAN_VALUE_DATE = "{\"fieldName\":\"updated\",\"operator\":\"greaterThan\",\"value\":\"2024-01-01T10:00:00\"}";
   public static final String WHERE = "WHERE";
   public static final String DESCRIPTION_FILTER = "upper(Max(fa.description)) like upper(:alias_0) escape '|'";
@@ -564,7 +564,7 @@ public class AccountingFactEndYearTransformerTest {
    */
   @Test
   public void testDateFieldEqualsOperatorUsesDateRange() {
-    requestParameters.put(CRITERIA, FIELD_NAME_CREATED_OPERATOR_EQUALS_VALUE_DATE);
+    requestParameters.put(CRITERIA, FIELD_NAME_CREATION_DATE_OPERATOR_EQUALS_VALUE_DATE);
     
     String result = transformer.transformHqlQuery(baseHqlQuery, requestParameters, queryNamedParameters);
     


### PR DESCRIPTION
ETP-3262
---
This pull request standardizes the usage of the `creationDate` field name throughout the `AccountingFactEndYearTransformer` class and its associated tests, replacing previous references to `created`. This change improves code consistency and reduces the risk of errors due to mismatched field names.

Field name standardization:

* Added a new constant `CREATION_DATE` in `AccountingFactEndYearTransformer` and replaced all hardcoded references to `"created"` with this constant for better maintainability and consistency. [[1]](diffhunk://#diff-044f256db6adfec9490a15e58e85696f3b401270d543ba70284d19e1d6986fcaR100) [[2]](diffhunk://#diff-044f256db6adfec9490a15e58e85696f3b401270d543ba70284d19e1d6986fcaL219-R220) [[3]](diffhunk://#diff-044f256db6adfec9490a15e58e85696f3b401270d543ba70284d19e1d6986fcaL230-R231) [[4]](diffhunk://#diff-044f256db6adfec9490a15e58e85696f3b401270d543ba70284d19e1d6986fcaL245-R246)

Test updates:

* Updated test constants and usage in `AccountingFactEndYearTransformerTest` to use `creationDate` instead of `created`, ensuring tests align with the new field naming convention. [[1]](diffhunk://#diff-fe1875a3975470166f4e30171c4684248821c4b3fe2d01723684aa513f79a7cbL33-R33) [[2]](diffhunk://#diff-fe1875a3975470166f4e30171c4684248821c4b3fe2d01723684aa513f79a7cbL567-R567)