### PR TITLE
Feature ETP-3325-Y27: clean GCField, GCTab and GCSys to check.

### DIFF
--- a/src-test/src/org/openbravo/test/views/GridConfigurationTest.java
+++ b/src-test/src/org/openbravo/test/views/GridConfigurationTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import org.openbravo.client.application.GCField;
 import org.openbravo.client.application.GCSystem;
 import org.openbravo.client.application.GCTab;
 import org.openbravo.client.application.window.StandardWindowComponent;
@@ -51,7 +52,8 @@ public class GridConfigurationTest extends OBBaseTest {
       OBCriteria<GCSystem> systemGridConfig = OBDal.getInstance().createCriteria(GCSystem.class);
       OBCriteria<GCTab> tabGridConfig = OBDal.getInstance().createCriteria(GCTab.class);
       tabGridConfig.add(Restrictions.not(Restrictions.in(GCTab.PROPERTY_ID, CORE_DEFAULT_GRID_CONFIGS)));
-      return systemGridConfig.count() + tabGridConfig.count();
+      OBCriteria<GCField> fieldGridConfig = OBDal.getInstance().createCriteria(GCField.class);
+      return systemGridConfig.count() + tabGridConfig.count() + fieldGridConfig.count();
     } finally {
       OBContext.restorePreviousMode();
     }

--- a/src-test/src/org/openbravo/test/views/SortingFilteringGridConfiguration.java
+++ b/src-test/src/org/openbravo/test/views/SortingFilteringGridConfiguration.java
@@ -73,13 +73,22 @@ public class SortingFilteringGridConfiguration extends GridConfigurationTest {
       before = getNumberOfGridConfigurations();
       if (before != 0) {
         log.info("[GridConfigTest] Found {} existing grid configuration records. Attempting cleanup...", before);
-        for (org.openbravo.client.application.GCSystem sys : OBDal.getInstance().createCriteria(org.openbravo.client.application.GCSystem.class).list()) {
-          OBDal.getInstance().remove(sys);
+        // First remove GCField records (child records must be removed before parents)
+        for (org.openbravo.client.application.GCField field : OBDal.getInstance().createCriteria(org.openbravo.client.application.GCField.class).list()) {
+          OBDal.getInstance().remove(field);
         }
+        OBDal.getInstance().flush();
+        // Then remove GCTab records
         for (org.openbravo.client.application.GCTab tabCfg : OBDal.getInstance().createCriteria(org.openbravo.client.application.GCTab.class).list()) {
           OBDal.getInstance().remove(tabCfg);
         }
         OBDal.getInstance().flush();
+        // Finally remove GCSystem records
+        for (org.openbravo.client.application.GCSystem sys : OBDal.getInstance().createCriteria(org.openbravo.client.application.GCSystem.class).list()) {
+          OBDal.getInstance().remove(sys);
+        }
+        OBDal.getInstance().flush();
+        OBDal.getInstance().commitAndClose();
         after = getNumberOfGridConfigurations();
         log.info("[GridConfigTest] Cleanup done. Grid configuration count now: {}", after);
       } else {
@@ -111,8 +120,36 @@ public class SortingFilteringGridConfiguration extends GridConfigurationTest {
 
   @AfterAll
   public static void cleanUp() {
-    // Only restore core module flag if we changed it; skip if new configs were created during test (unlikely) or core already was in development.
-    if (getNumberOfGridConfigurations() > 0 || Boolean.TRUE.equals(coreWasInDevelopment)) {
+    // Clean up any grid configurations that might have been created during tests
+    OBContext.setAdminMode(true);
+    try {
+      // Remove all GCField records first (children before parents)
+      for (org.openbravo.client.application.GCField field : OBDal.getInstance()
+          .createCriteria(org.openbravo.client.application.GCField.class).list()) {
+        OBDal.getInstance().remove(field);
+      }
+      OBDal.getInstance().flush();
+      // Remove all GCTab records
+      for (org.openbravo.client.application.GCTab tabCfg : OBDal.getInstance()
+          .createCriteria(org.openbravo.client.application.GCTab.class).list()) {
+        OBDal.getInstance().remove(tabCfg);
+      }
+      OBDal.getInstance().flush();
+      // Remove all GCSystem records
+      for (org.openbravo.client.application.GCSystem sys : OBDal.getInstance()
+          .createCriteria(org.openbravo.client.application.GCSystem.class).list()) {
+        OBDal.getInstance().remove(sys);
+      }
+      OBDal.getInstance().flush();
+      OBDal.getInstance().commitAndClose();
+    } catch (Exception e) {
+      log.error("[GridConfigTest] Exception during final cleanup", e);
+    } finally {
+      OBContext.restorePreviousMode();
+    }
+
+    // Restore core module flag
+    if (Boolean.TRUE.equals(coreWasInDevelopment)) {
       return;
     }
     OBContext.setAdminMode(true);
@@ -123,7 +160,6 @@ public class SortingFilteringGridConfiguration extends GridConfigurationTest {
     } finally {
       OBContext.restorePreviousMode();
     }
-
   }
 
   private enum ColumnLevel {


### PR DESCRIPTION
This pull request improves the handling and cleanup of grid configuration test data by ensuring that all types of grid configuration records—including `GCField`—are counted and properly removed in test setup and teardown. The changes enhance test reliability by ensuring a clean state before and after test execution.

**Enhancements to grid configuration test data management:**

* Updated the import statements in `GridConfigurationTest.java` to include the `GCField` class, enabling its use in test logic.
* Modified the `getNumberOfGridConfigurations` method to count `GCField` records in addition to `GCSystem` and `GCTab`, providing a more accurate total of grid configuration records.

**Improvements to test data cleanup procedures:**

* Updated the cleanup logic in `SortingFilteringGridConfiguration.shouldExecuteOnlyIfThereIsNoGridConfig` to remove `GCField` records first (as child records), followed by `GCTab` and then `GCSystem` records, ensuring referential integrity during deletion.
* Enhanced the `@AfterAll cleanUp` method to always remove all `GCField`, `GCTab`, and `GCSystem` records after tests, regardless of test outcome, and added exception handling to log any errors during cleanup.
* Removed an outdated comment and redundant code in the `cleanUp` method to reflect the new, always-run cleanup approach.