### PR TITLE
Feature ETP-3325: clean GCField, GCTab and GCSys to check.

### DIFF
--- a/src-test/src/org/openbravo/test/views/GridConfigurationTest.java
+++ b/src-test/src/org/openbravo/test/views/GridConfigurationTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import org.openbravo.client.application.GCField;
 import org.openbravo.client.application.GCSystem;
 import org.openbravo.client.application.GCTab;
 import org.openbravo.client.application.window.StandardWindowComponent;
@@ -51,7 +52,8 @@ public class GridConfigurationTest extends OBBaseTest {
       OBCriteria<GCSystem> systemGridConfig = OBDal.getInstance().createCriteria(GCSystem.class);
       OBCriteria<GCTab> tabGridConfig = OBDal.getInstance().createCriteria(GCTab.class);
       tabGridConfig.add(Restrictions.not(Restrictions.in(GCTab.PROPERTY_ID, CORE_DEFAULT_GRID_CONFIGS)));
-      return systemGridConfig.count() + tabGridConfig.count();
+      OBCriteria<GCField> fieldGridConfig = OBDal.getInstance().createCriteria(GCField.class);
+      return systemGridConfig.count() + tabGridConfig.count() + fieldGridConfig.count();
     } finally {
       OBContext.restorePreviousMode();
     }


### PR DESCRIPTION
This pull request enhances the handling and cleanup of grid configuration records in the test suite, particularly by ensuring all related records are properly removed in the correct order to maintain data integrity. The changes primarily affect the test cleanup logic for grid configuration entities (`GCSystem`, `GCTab`, and the newly included `GCField`), improving reliability and preventing issues with leftover test data.

**Grid Configuration Cleanup Improvements:**

* Updated the cleanup logic in `SortingFilteringGridConfiguration` tests to remove `GCField` records before `GCTab` and `GCSystem` records, ensuring child records are deleted before their parents and avoiding referential integrity issues. This sequence is now applied both before and after tests. [[1]](diffhunk://#diff-0c330e46be5301f5016917a0f3ee25f2ad7b98f7573afa28f4b3c2e5b3db9581L76-R90) [[2]](diffhunk://#diff-0c330e46be5301f5016917a0f3ee25f2ad7b98f7573afa28f4b3c2e5b3db9581L114-R148)
* Added a final cleanup step in the `@AfterAll` method to remove any grid configuration records created during tests, with error handling and proper context restoration. [[1]](diffhunk://#diff-0c330e46be5301f5016917a0f3ee25f2ad7b98f7573afa28f4b3c2e5b3db9581L114-R148) [[2]](diffhunk://#diff-0c330e46be5301f5016917a0f3ee25f2ad7b98f7573afa28f4b3c2e5b3db9581L126)

**Test Utility Enhancements:**

* Modified the `getNumberOfGridConfigurations` utility method in `GridConfigurationTest.java` to include `GCField` records in its count, ensuring more accurate detection of existing grid configurations.
* Added the required import for `GCField` in `GridConfigurationTest.java` to support the updated utility method.

**Minor Cleanup:**

* Removed an unused static import in `SortingFilteringGridConfiguration.java` for better code clarity.