### PR TITLE
Feature ETP-3339: Fix org.openbravo.test.referencedinventory tests

### DIFF
--- a/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryBoxFullReservationTest.java
+++ b/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryBoxFullReservationTest.java
@@ -19,12 +19,7 @@
 
 package org.openbravo.test.referencedinventory;
 
-import java.util.Arrays;
-
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.openbravo.base.weld.test.ParameterCdiTest;
-import org.openbravo.base.weld.test.ParameterCdiTestRule;
 import org.openbravo.dal.service.OBDal;
 
 /**
@@ -33,20 +28,16 @@ import org.openbravo.dal.service.OBDal;
  */
 public class ReferencedInventoryBoxFullReservationTest extends ReferencedInventoryBoxTest {
 
-  @Rule
-  public ParameterCdiTestRule<ParamsBoxReservationTest> parameterValuesRule = new ParameterCdiTestRule<ParamsBoxReservationTest>(
-      Arrays.asList(new ParamsBoxReservationTest[] { new ParamsBoxReservationTest(
-          " Full Box (10 units of 10 units) of a storage details with a previous reservation of these 10 units.",
-          "10", "10") }));
-
-  private @ParameterCdiTest ParamsBoxReservationTest params;
+  private static final ParamsBoxReservationTest PARAMS = new ParamsBoxReservationTest(
+      " Full Box (10 units of 10 units) of a storage details with a previous reservation of these 10 units.",
+      "10", "10");
 
   @Test
   public void allTests() throws Exception {
     for (boolean isAllocated : ISALLOCATED) {
       for (String[] product : PRODUCTS) {
         for (String toBinId : BINS) {
-          testBox(toBinId, product[0], product[1], params.qtyToBox, params.reservationQty,
+          testBox(toBinId, product[0], product[1], PARAMS.qtyToBox, PARAMS.reservationQty,
               isAllocated);
           OBDal.getInstance().getSession().clear();
         }

--- a/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryBoxOverReservation1MovementLineTest.java
+++ b/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryBoxOverReservation1MovementLineTest.java
@@ -20,11 +20,8 @@
 package org.openbravo.test.referencedinventory;
 
 import java.util.Arrays;
-
-import org.junit.Rule;
+import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.openbravo.base.weld.test.ParameterCdiTest;
-import org.openbravo.base.weld.test.ParameterCdiTestRule;
 import org.openbravo.dal.service.OBDal;
 
 /**
@@ -34,24 +31,22 @@ import org.openbravo.dal.service.OBDal;
 public class ReferencedInventoryBoxOverReservation1MovementLineTest
     extends ReferencedInventoryBoxTest {
 
-  @Rule
-  public ParameterCdiTestRule<ParamsBoxReservationTest> parameterValuesRule = new ParameterCdiTestRule<ParamsBoxReservationTest>(
-      Arrays.asList(new ParamsBoxReservationTest[] {
-          new ParamsBoxReservationTest("Box 3 units where 5 where reserved (over reservation)", "3",
-              "5"),
-          new ParamsBoxReservationTest("Box 4 units where 10 where reserved (over reservation)",
-              "4", "10") }));
-
-  private @ParameterCdiTest ParamsBoxReservationTest params;
+  private static final List<ParamsBoxReservationTest> PARAMS = Arrays.asList(
+      new ParamsBoxReservationTest("Box 3 units where 5 where reserved (over reservation)", "3",
+          "5"),
+      new ParamsBoxReservationTest("Box 4 units where 10 where reserved (over reservation)", "4",
+          "10"));
 
   @Test
   public void allTests() throws Exception {
     for (boolean isAllocated : ISALLOCATED) {
       for (String[] product : PRODUCTS) {
-        for (String toBinId : BINS) {
-          testBox(toBinId, product[0], product[1], params.qtyToBox, params.reservationQty,
-              isAllocated);
-          OBDal.getInstance().getSession().clear();
+        for (ParamsBoxReservationTest params : PARAMS) {
+          for (String toBinId : BINS) {
+            testBox(toBinId, product[0], product[1], params.qtyToBox, params.reservationQty,
+                isAllocated);
+            OBDal.getInstance().getSession().clear();
+          }
         }
       }
     }

--- a/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryBoxOverReservation2MovementLinesTest.java
+++ b/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryBoxOverReservation2MovementLinesTest.java
@@ -22,12 +22,7 @@ package org.openbravo.test.referencedinventory;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import java.util.Arrays;
-
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.openbravo.base.weld.test.ParameterCdiTest;
-import org.openbravo.base.weld.test.ParameterCdiTestRule;
 import org.openbravo.dal.service.OBDal;
 import org.openbravo.model.materialmgmt.transaction.InternalMovement;
 
@@ -38,19 +33,15 @@ import org.openbravo.model.materialmgmt.transaction.InternalMovement;
 public class ReferencedInventoryBoxOverReservation2MovementLinesTest
     extends ReferencedInventoryBoxTest {
 
-  @Rule
-  public ParameterCdiTestRule<ParamsBoxReservationTest> parameterValuesRule = new ParameterCdiTestRule<ParamsBoxReservationTest>(
-      Arrays.asList(new ParamsBoxReservationTest[] { new ParamsBoxReservationTest(
-          "Box 4 units where 9 where reserved (over reservation)", "4", "9") }));
-
-  private @ParameterCdiTest ParamsBoxReservationTest params;
+  private static final ParamsBoxReservationTest PARAMS = new ParamsBoxReservationTest(
+      "Box 4 units where 9 where reserved (over reservation)", "4", "9");
 
   @Test
   public void allTests() throws Exception {
     for (boolean isAllocated : ISALLOCATED) {
       for (String[] product : PRODUCTS) {
         for (String toBinId : BINS) {
-          testBox(toBinId, product[0], product[1], params.qtyToBox, params.reservationQty,
+          testBox(toBinId, product[0], product[1], PARAMS.qtyToBox, PARAMS.reservationQty,
               isAllocated);
           OBDal.getInstance().getSession().clear();
         }

--- a/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryBoxPartialReservation1MovementLineTest.java
+++ b/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryBoxPartialReservation1MovementLineTest.java
@@ -19,12 +19,7 @@
 
 package org.openbravo.test.referencedinventory;
 
-import java.util.Arrays;
-
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.openbravo.base.weld.test.ParameterCdiTest;
-import org.openbravo.base.weld.test.ParameterCdiTestRule;
 import org.openbravo.dal.service.OBDal;
 
 /**
@@ -34,19 +29,15 @@ import org.openbravo.dal.service.OBDal;
 public class ReferencedInventoryBoxPartialReservation1MovementLineTest
     extends ReferencedInventoryBoxTest {
 
-  @Rule
-  public ParameterCdiTestRule<ParamsBoxReservationTest> parameterValuesRule = new ParameterCdiTestRule<ParamsBoxReservationTest>(
-      Arrays.asList(new ParamsBoxReservationTest[] { new ParamsBoxReservationTest(
-          "Box 4 units where 3 were previously reserved", "4", "3") }));
-
-  private @ParameterCdiTest ParamsBoxReservationTest params;
+  private static final ParamsBoxReservationTest PARAMS = new ParamsBoxReservationTest(
+      "Box 4 units where 3 were previously reserved", "4", "3");
 
   @Test
   public void allTests() throws Exception {
     for (boolean isAllocated : ISALLOCATED) {
       for (String[] product : PRODUCTS) {
         for (String toBinId : BINS) {
-          testBox(toBinId, product[0], product[1], params.qtyToBox, params.reservationQty,
+          testBox(toBinId, product[0], product[1], PARAMS.qtyToBox, PARAMS.reservationQty,
               isAllocated);
           OBDal.getInstance().getSession().clear();
         }

--- a/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryBoxPartialReservation2MovementLinesTest.java
+++ b/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryBoxPartialReservation2MovementLinesTest.java
@@ -22,12 +22,7 @@ package org.openbravo.test.referencedinventory;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import java.util.Arrays;
-
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.openbravo.base.weld.test.ParameterCdiTest;
-import org.openbravo.base.weld.test.ParameterCdiTestRule;
 import org.openbravo.dal.service.OBDal;
 import org.openbravo.model.materialmgmt.transaction.InternalMovement;
 
@@ -38,19 +33,15 @@ import org.openbravo.model.materialmgmt.transaction.InternalMovement;
 public class ReferencedInventoryBoxPartialReservation2MovementLinesTest
     extends ReferencedInventoryBoxTest {
 
-  @Rule
-  public ParameterCdiTestRule<ParamsBoxReservationTest> parameterValuesRule = new ParameterCdiTestRule<ParamsBoxReservationTest>(
-      Arrays.asList(new ParamsBoxReservationTest[] { new ParamsBoxReservationTest(
-          "Box 10 units where 4 were previously reserved", "10", "4") }));
-
-  private @ParameterCdiTest ParamsBoxReservationTest params;
+  private static final ParamsBoxReservationTest PARAMS = new ParamsBoxReservationTest(
+      "Box 10 units where 4 were previously reserved", "10", "4");
 
   @Test
   public void allTests() throws Exception {
     for (boolean isAllocated : ISALLOCATED) {
       for (String[] product : PRODUCTS) {
         for (String toBinId : BINS) {
-          testBox(toBinId, product[0], product[1], params.qtyToBox, params.reservationQty,
+          testBox(toBinId, product[0], product[1], PARAMS.qtyToBox, PARAMS.reservationQty,
               isAllocated);
           OBDal.getInstance().getSession().clear();
         }

--- a/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryBoxTest.java
+++ b/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryBoxTest.java
@@ -232,7 +232,7 @@ public abstract class ReferencedInventoryBoxTest extends ReferencedInventoryTest
     }
   }
 
-  protected class ParamsBoxTest {
+  protected static class ParamsBoxTest {
     String testDesc;
     BigDecimal qtyToBox;
 
@@ -247,7 +247,7 @@ public abstract class ReferencedInventoryBoxTest extends ReferencedInventoryTest
     }
   }
 
-  protected class ParamsBoxReservationTest extends ParamsBoxTest {
+  protected static class ParamsBoxReservationTest extends ParamsBoxTest {
     BigDecimal reservationQty;
 
     ParamsBoxReservationTest(String testDesc, String qtyToBox, String reservationQty) {

--- a/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryFullBoxTest.java
+++ b/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryFullBoxTest.java
@@ -19,12 +19,7 @@
 
 package org.openbravo.test.referencedinventory;
 
-import java.util.Arrays;
-
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.openbravo.base.weld.test.ParameterCdiTest;
-import org.openbravo.base.weld.test.ParameterCdiTestRule;
 import org.openbravo.dal.service.OBDal;
 
 /**
@@ -34,20 +29,16 @@ import org.openbravo.dal.service.OBDal;
 public class ReferencedInventoryFullBoxTest extends ReferencedInventoryBoxTest {
   private static final String QTYTOBOX = "10";
 
-  @Rule
-  public ParameterCdiTestRule<ParamsBoxTest> parameterValuesRule = new ParameterCdiTestRule<ParamsBoxTest>(
-      Arrays.asList(new ParamsBoxTest[] { new ParamsBoxTest(
-          "Box of " + QTYTOBOX
-              + " unit of the 10 units available in the storage detail without reservations",
-          QTYTOBOX) }));
-
-  protected @ParameterCdiTest ParamsBoxTest params;
+  private static final ParamsBoxTest PARAMS = new ParamsBoxTest(
+      "Box of " + QTYTOBOX
+          + " unit of the 10 units available in the storage detail without reservations",
+      QTYTOBOX);
 
   @Test
   public void allTests() throws Exception {
     for (String[] product : PRODUCTS) {
       for (String toBinId : BINS) {
-        testBox(toBinId, product[0], product[1], params.qtyToBox, null, false);
+        testBox(toBinId, product[0], product[1], PARAMS.qtyToBox, null, false);
         OBDal.getInstance().getSession().clear();
       }
     }

--- a/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryFullUnboxFullReservation.java
+++ b/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryFullUnboxFullReservation.java
@@ -19,12 +19,7 @@
 
 package org.openbravo.test.referencedinventory;
 
-import java.util.Arrays;
-
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.openbravo.base.weld.test.ParameterCdiTest;
-import org.openbravo.base.weld.test.ParameterCdiTestRule;
 import org.openbravo.dal.service.OBDal;
 
 /**
@@ -34,13 +29,9 @@ import org.openbravo.dal.service.OBDal;
 public class ReferencedInventoryFullUnboxFullReservation
     extends ReferencedInventoryUnboxReservationTest {
 
-  @Rule
-  public ParameterCdiTestRule<ParamsUnboxReservationTest> parameterValuesRule = new ParameterCdiTestRule<ParamsUnboxReservationTest>(
-      Arrays.asList(new ParamsUnboxReservationTest[] { new ParamsUnboxReservationTest(
-          "Fully unbox a full reservation of a storage detail that was 100% reserved and boxed",
-          "10", "10", "10") }));
-
-  private @ParameterCdiTest ParamsUnboxReservationTest params;
+  private static final ParamsUnboxReservationTest PARAMS = new ParamsUnboxReservationTest(
+      "Fully unbox a full reservation of a storage detail that was 100% reserved and boxed", "10",
+      "10", "10");
 
   @Test
   public void allTests() throws Exception {
@@ -48,7 +39,7 @@ public class ReferencedInventoryFullUnboxFullReservation
       for (String[] product : PRODUCTS) {
         for (String toBinId : BINS) {
           final TestUnboxOutputParams outParams = testUnboxReservation(toBinId, product[0],
-              product[1], params.qtyToBox, params.qtyToUnbox, params.reservationQty, isAllocated);
+              product[1], PARAMS.qtyToBox, PARAMS.qtyToUnbox, PARAMS.reservationQty, isAllocated);
           assertsReferenceInventoryIsEmpty(outParams.refInv);
           OBDal.getInstance().getSession().clear();
         }

--- a/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryFullUnboxPartialReservation.java
+++ b/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryFullUnboxPartialReservation.java
@@ -22,12 +22,7 @@ package org.openbravo.test.referencedinventory;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import java.util.Arrays;
-
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.openbravo.base.weld.test.ParameterCdiTest;
-import org.openbravo.base.weld.test.ParameterCdiTestRule;
 import org.openbravo.dal.service.OBDal;
 import org.openbravo.model.materialmgmt.transaction.InternalMovement;
 
@@ -37,13 +32,9 @@ import org.openbravo.model.materialmgmt.transaction.InternalMovement;
  */
 public class ReferencedInventoryFullUnboxPartialReservation
     extends ReferencedInventoryUnboxReservationTest {
-  @Rule
-  public ParameterCdiTestRule<ParamsUnboxReservationTest> parameterValuesRule2 = new ParameterCdiTestRule<ParamsUnboxReservationTest>(
-      Arrays.asList(new ParamsUnboxReservationTest[] { new ParamsUnboxReservationTest(
-          "Full unbox of a partial reservation. Storage detail should be reserved and out of the box",
-          "10", "10", "4") }));
-
-  protected @ParameterCdiTest ParamsUnboxReservationTest params;
+  private static final ParamsUnboxReservationTest PARAMS = new ParamsUnboxReservationTest(
+      "Full unbox of a partial reservation. Storage detail should be reserved and out of the box",
+      "10", "10", "4");
 
   @Test
   public void allTests() throws Exception {
@@ -51,7 +42,7 @@ public class ReferencedInventoryFullUnboxPartialReservation
       for (String[] product : PRODUCTS) {
         for (String toBinId : BINS) {
           final TestUnboxOutputParams outParams = testUnboxReservation(toBinId, product[0],
-              product[1], params.qtyToBox, params.qtyToUnbox, params.reservationQty, isAllocated);
+              product[1], PARAMS.qtyToBox, PARAMS.qtyToUnbox, PARAMS.reservationQty, isAllocated);
           assertsReferenceInventoryIsEmpty(outParams.refInv);
           OBDal.getInstance().getSession().clear();
         }

--- a/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryPartialBoxTest.java
+++ b/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryPartialBoxTest.java
@@ -19,12 +19,7 @@
 
 package org.openbravo.test.referencedinventory;
 
-import java.util.Arrays;
-
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.openbravo.base.weld.test.ParameterCdiTest;
-import org.openbravo.base.weld.test.ParameterCdiTestRule;
 import org.openbravo.dal.service.OBDal;
 
 /**
@@ -34,20 +29,16 @@ public class ReferencedInventoryPartialBoxTest extends ReferencedInventoryBoxTes
 
   private static final String QTYTOBOX = "1";
 
-  @Rule
-  public ParameterCdiTestRule<ParamsBoxTest> parameterValuesRule = new ParameterCdiTestRule<ParamsBoxTest>(
-      Arrays.asList(new ParamsBoxTest[] { new ParamsBoxTest(
-          "Box of " + QTYTOBOX
-              + " unit of the 10 units available in the storage detail without reservations",
-          QTYTOBOX) }));
-
-  protected @ParameterCdiTest ParamsBoxTest params;
+  private static final ParamsBoxTest PARAMS = new ParamsBoxTest(
+      "Box of " + QTYTOBOX
+          + " unit of the 10 units available in the storage detail without reservations",
+      QTYTOBOX);
 
   @Test
   public void allTests() throws Exception {
     for (String[] product : PRODUCTS) {
       for (String toBinId : BINS) {
-        testBox(toBinId, product[0], product[1], params.qtyToBox, null, false);
+        testBox(toBinId, product[0], product[1], PARAMS.qtyToBox, null, false);
         OBDal.getInstance().getSession().clear();
       }
     }

--- a/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryPartialUnboxFullReservation.java
+++ b/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryPartialUnboxFullReservation.java
@@ -19,12 +19,7 @@
 
 package org.openbravo.test.referencedinventory;
 
-import java.util.Arrays;
-
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.openbravo.base.weld.test.ParameterCdiTest;
-import org.openbravo.base.weld.test.ParameterCdiTestRule;
 import org.openbravo.dal.service.OBDal;
 
 /**
@@ -34,12 +29,8 @@ import org.openbravo.dal.service.OBDal;
 public class ReferencedInventoryPartialUnboxFullReservation
     extends ReferencedInventoryUnboxReservationTest {
 
-  @Rule
-  public ParameterCdiTestRule<ParamsUnboxReservationTest> parameterValuesRule = new ParameterCdiTestRule<ParamsUnboxReservationTest>(
-      Arrays.asList(new ParamsUnboxReservationTest[] { new ParamsUnboxReservationTest(
-          "Partial unbox of a fully reserved storage detail", "10", "7", "10") }));
-
-  private @ParameterCdiTest ParamsUnboxReservationTest params;
+  private static final ParamsUnboxReservationTest PARAMS = new ParamsUnboxReservationTest(
+      "Partial unbox of a fully reserved storage detail", "10", "7", "10");
 
   @Test
   public void allTests() throws Exception {
@@ -47,9 +38,9 @@ public class ReferencedInventoryPartialUnboxFullReservation
       for (String[] product : PRODUCTS) {
         for (String toBinId : BINS) {
           final TestUnboxOutputParams outParams = testUnboxReservation(toBinId, product[0],
-              product[1], params.qtyToBox, params.qtyToUnbox, params.reservationQty, isAllocated);
+              product[1], PARAMS.qtyToBox, PARAMS.qtyToUnbox, PARAMS.reservationQty, isAllocated);
           assertsReferenceInventoryIsNotEmpty(outParams.refInv,
-              params.qtyToBox.subtract(params.qtyToUnbox));
+              PARAMS.qtyToBox.subtract(PARAMS.qtyToUnbox));
           OBDal.getInstance().getSession().clear();
         }
       }

--- a/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryPartialUnboxPartialReservation1MovementLineUnboxTest.java
+++ b/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryPartialUnboxPartialReservation1MovementLineUnboxTest.java
@@ -23,12 +23,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.openbravo.base.weld.test.ParameterCdiTest;
-import org.openbravo.base.weld.test.ParameterCdiTestRule;
 import org.openbravo.dal.service.OBDal;
 import org.openbravo.model.materialmgmt.transaction.InternalMovement;
 
@@ -38,27 +36,24 @@ import org.openbravo.model.materialmgmt.transaction.InternalMovement;
  */
 public class ReferencedInventoryPartialUnboxPartialReservation1MovementLineUnboxTest
     extends ReferencedInventoryUnboxReservationTest {
-  @Rule
-  public ParameterCdiTestRule<ParamsUnboxReservationTest> parameterValuesRule = new ParameterCdiTestRule<ParamsUnboxReservationTest>(
-      Arrays.asList(new ParamsUnboxReservationTest[] {
-          new ParamsUnboxReservationTest(
-              "Unbox less quantity than reserved one. Reservation is fully in box", "10", "1", "9"),
-          new ParamsUnboxReservationTest(
-              "Unbox less quantity than reserved one. Reservation is fully in box", "10", "3",
-              "1") }));
-
-  protected @ParameterCdiTest ParamsUnboxReservationTest params;
+  private static final List<ParamsUnboxReservationTest> PARAMS = Arrays.asList(
+      new ParamsUnboxReservationTest(
+          "Unbox less quantity than reserved one. Reservation is fully in box", "10", "1", "9"),
+      new ParamsUnboxReservationTest(
+          "Unbox less quantity than reserved one. Reservation is fully in box", "10", "3", "1"));
 
   @Test
   public void allTests() throws Exception {
     for (boolean isAllocated : ISALLOCATED) {
       for (String[] product : PRODUCTS) {
-        for (String toBinId : BINS) {
-          final TestUnboxOutputParams outParams = testUnboxReservation(toBinId, product[0],
-              product[1], params.qtyToBox, params.qtyToUnbox, params.reservationQty, isAllocated);
-          assertsReferenceInventoryIsNotEmpty(outParams.refInv,
-              params.qtyToBox.subtract(params.qtyToUnbox));
-          OBDal.getInstance().getSession().clear();
+        for (ParamsUnboxReservationTest params : PARAMS) {
+          for (String toBinId : BINS) {
+            final TestUnboxOutputParams outParams = testUnboxReservation(toBinId, product[0],
+                product[1], params.qtyToBox, params.qtyToUnbox, params.reservationQty, isAllocated);
+            assertsReferenceInventoryIsNotEmpty(outParams.refInv,
+                params.qtyToBox.subtract(params.qtyToUnbox));
+            OBDal.getInstance().getSession().clear();
+          }
         }
       }
     }

--- a/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryPartialUnboxPartialReservation2MovementLinesUnboxTest.java
+++ b/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryPartialUnboxPartialReservation2MovementLinesUnboxTest.java
@@ -23,11 +23,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
+import java.util.List;
 
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.openbravo.base.weld.test.ParameterCdiTest;
-import org.openbravo.base.weld.test.ParameterCdiTestRule;
 import org.openbravo.dal.service.OBDal;
 import org.openbravo.model.materialmgmt.transaction.InternalMovement;
 
@@ -37,28 +35,26 @@ import org.openbravo.model.materialmgmt.transaction.InternalMovement;
  */
 public class ReferencedInventoryPartialUnboxPartialReservation2MovementLinesUnboxTest
     extends ReferencedInventoryUnboxReservationTest {
-  @Rule
-  public ParameterCdiTestRule<ParamsUnboxReservationTest> parameterValuesRule = new ParameterCdiTestRule<ParamsUnboxReservationTest>(
-      Arrays.asList(new ParamsUnboxReservationTest[] {
-          new ParamsUnboxReservationTest(
-              "Unbox more quantity than reserved one. Part of the reservation is still in box",
-              "10", "7", "4"),
-          new ParamsUnboxReservationTest(
-              "Unbox less quantity than reserved one. Part of the reservation is still in box",
-              "10", "3", "8") }));
-
-  protected @ParameterCdiTest ParamsUnboxReservationTest params;
+  private static final List<ParamsUnboxReservationTest> PARAMS = Arrays.asList(
+      new ParamsUnboxReservationTest(
+          "Unbox more quantity than reserved one. Part of the reservation is still in box", "10",
+          "7", "4"),
+      new ParamsUnboxReservationTest(
+          "Unbox less quantity than reserved one. Part of the reservation is still in box", "10",
+          "3", "8"));
 
   @Test
   public void allTests() throws Exception {
     for (boolean isAllocated : ISALLOCATED) {
       for (String[] product : PRODUCTS) {
-        for (String toBinId : BINS) {
-          final TestUnboxOutputParams outParams = testUnboxReservation(toBinId, product[0],
-              product[1], params.qtyToBox, params.qtyToUnbox, params.reservationQty, isAllocated);
-          assertsReferenceInventoryIsNotEmpty(outParams.refInv,
-              params.qtyToBox.subtract(params.qtyToUnbox));
-          OBDal.getInstance().getSession().clear();
+        for (ParamsUnboxReservationTest params : PARAMS) {
+          for (String toBinId : BINS) {
+            final TestUnboxOutputParams outParams = testUnboxReservation(toBinId, product[0],
+                product[1], params.qtyToBox, params.qtyToUnbox, params.reservationQty, isAllocated);
+            assertsReferenceInventoryIsNotEmpty(outParams.refInv,
+                params.qtyToBox.subtract(params.qtyToUnbox));
+            OBDal.getInstance().getSession().clear();
+          }
         }
       }
     }

--- a/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryTest.java
+++ b/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryTest.java
@@ -32,6 +32,9 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.openbravo.base.secureApp.VariablesSecureApp;
 import org.openbravo.base.weld.test.WeldBaseTest;
 import org.openbravo.client.kernel.KernelUtils;
@@ -71,16 +74,9 @@ public abstract class ReferencedInventoryTest extends WeldBaseTest {
   }
 
   @Before
+  @BeforeEach
   public void initialize() {
-    boolean awoIsInstalled = isAwoInstalled();
-    assumeThat("Auto-Disabled test case as incompatible with AWO (found to be installed) ", awoIsInstalled, is(false));
-
-    setUserContext(QA_TEST_ADMIN_USER_ID);
-    VariablesSecureApp vsa = new VariablesSecureApp(OBContext.getOBContext().getUser().getId(),
-        OBContext.getOBContext().getCurrentClient().getId(),
-        OBContext.getOBContext().getCurrentOrganization().getId());
-    RequestContext.get().setVariableSecureApp(vsa);
-    ReferencedInventoryTestUtils.initializeReservationsPreferenceIfDoesnotExist();
+    initReferencedInventoryContext();
   }
 
   void assertsGoodsMovementIsProcessed(final InternalMovement boxMovement) {
@@ -95,8 +91,29 @@ public abstract class ReferencedInventoryTest extends WeldBaseTest {
   }
 
   @After
+  @AfterEach
   public void clearSession() {
     OBDal.getInstance().getSession().clear();
+  }
+
+  @Override
+  protected void beforeTestExecution(ExtensionContext context) {
+    super.beforeTestExecution(context);
+    // Ensure QA context even if @BeforeEach is not executed by the runner
+    initReferencedInventoryContext();
+  }
+
+  private void initReferencedInventoryContext() {
+    boolean awoIsInstalled = isAwoInstalled();
+    assumeThat("Auto-Disabled test case as incompatible with AWO (found to be installed) ",
+        awoIsInstalled, is(false));
+
+    setQAAdminContext();
+    VariablesSecureApp vsa = new VariablesSecureApp(OBContext.getOBContext().getUser().getId(),
+        OBContext.getOBContext().getCurrentClient().getId(),
+        OBContext.getOBContext().getCurrentOrganization().getId());
+    RequestContext.get().setVariableSecureApp(vsa);
+    ReferencedInventoryTestUtils.initializeReservationsPreferenceIfDoesnotExist();
   }
 
 }

--- a/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryTestUtils.java
+++ b/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryTestUtils.java
@@ -43,6 +43,7 @@ import org.openbravo.dal.service.OBDao;
 import org.openbravo.dal.service.Restrictions;
 import org.openbravo.erpCommon.utility.SequenceIdData;
 import org.openbravo.materialmgmt.ReservationUtils;
+import org.openbravo.materialmgmt.refinventory.ReferencedInventoryUtil;
 import org.openbravo.model.ad.domain.Preference;
 import org.openbravo.model.ad.system.Client;
 import org.openbravo.model.common.enterprise.Organization;
@@ -142,9 +143,10 @@ class ReferencedInventoryTestUtils {
     refInv.setClient(OBContext.getOBContext().getCurrentClient());
     refInv.setOrganization(OBDal.getInstance().getProxy(Organization.class, orgId));
     refInv.setReferencedInventoryType(refInvType);
-    refInv.setSearchKey(
-        refInvType.getSequence() == null ? StringUtils.left(UUID.randomUUID().toString(), 30)
-            : "<to be replaced>");
+    final String searchKey = refInvType.getSequence() == null
+        ? StringUtils.left(UUID.randomUUID().toString(), 30)
+        : ReferencedInventoryUtil.getProposedValueFromSequenceOrNull(refInvType.getId(), true);
+    refInv.setSearchKey(searchKey);
     OBDal.getInstance().save(refInv);
     assertThat("Referenced Inventory is successfully created", refInv, notNullValue());
     assertThat("Referenced Inventory is empty", refInv.getMaterialMgmtStorageDetailList(), empty());

--- a/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryUnboxReservationTest.java
+++ b/src-test/src/org/openbravo/test/referencedinventory/ReferencedInventoryUnboxReservationTest.java
@@ -82,7 +82,7 @@ public abstract class ReferencedInventoryUnboxReservationTest extends Referenced
         && (RECEIVEDQTY_10.subtract(reservationQty)).compareTo(qtyToUnbox) < 0;
   }
 
-  protected class ParamsUnboxReservationTest extends ParamsBoxReservationTest {
+  protected static class ParamsUnboxReservationTest extends ParamsBoxReservationTest {
     BigDecimal qtyToUnbox;
 
     ParamsUnboxReservationTest(String testDesc, String qtyToBox, String qtyToUnbox,

--- a/src/org/openbravo/materialmgmt/refinventory/ReferencedInventoryUtil.java
+++ b/src/org/openbravo/materialmgmt/refinventory/ReferencedInventoryUtil.java
@@ -74,12 +74,24 @@ public class ReferencedInventoryUtil {
   public static final AttributeSetInstance cloneAttributeSetInstance(
       final AttributeSetInstance _originalAttributeSetInstance,
       final ReferencedInventory referencedInventory) {
-    final AttributeSetInstance originalAttributeSetInstance = _originalAttributeSetInstance == null
-        ? OBDal.getInstance().get(AttributeSetInstance.class, "0")
-        : _originalAttributeSetInstance;
+    final AttributeSetInstance originalAttributeSetInstance;
+    if (_originalAttributeSetInstance == null) {
+      originalAttributeSetInstance = OBDal.getInstance().get(AttributeSetInstance.class, "0");
+    } else {
+      // Avoid copying Hibernate proxies (unregistered class names) by reloading the real entity
+      originalAttributeSetInstance = OBDal.getInstance().get(AttributeSetInstance.class,
+          _originalAttributeSetInstance.getId());
+    }
 
-    final AttributeSetInstance newAttributeSetInstance = (AttributeSetInstance) DalUtil
-        .copy(originalAttributeSetInstance, false);
+    final AttributeSetInstance newAttributeSetInstance = OBProvider.getInstance()
+        .get(AttributeSetInstance.class);
+    newAttributeSetInstance.setAttributeSet(originalAttributeSetInstance.getAttributeSet());
+    newAttributeSetInstance.setSerialNo(originalAttributeSetInstance.getSerialNo());
+    newAttributeSetInstance.setLotName(originalAttributeSetInstance.getLotName());
+    newAttributeSetInstance.setExpirationDate(originalAttributeSetInstance.getExpirationDate());
+    newAttributeSetInstance.setLot(originalAttributeSetInstance.getLot());
+    newAttributeSetInstance.setLocked(originalAttributeSetInstance.isLocked());
+    newAttributeSetInstance.setLockDescription(originalAttributeSetInstance.getLockDescription());
     newAttributeSetInstance.setActive(true);
     newAttributeSetInstance.setClient(referencedInventory.getClient());
     newAttributeSetInstance.setOrganization(originalAttributeSetInstance.getOrganization());


### PR DESCRIPTION
This pull request refactors the parameterization approach in several referenced inventory test classes. The main change is the removal of the Weld-based parameterized test utilities (`ParameterCdiTestRule` and `@ParameterCdiTest`) in favor of static parameter objects, simplifying the test setup and making the tests easier to read and maintain. Additionally, the parameter classes themselves are updated to be static, further improving clarity and encapsulation.

Refactoring of test parameterization:

* Replaced `ParameterCdiTestRule` and `@ParameterCdiTest` usage with static parameter objects (`PARAMS` or `PARAMS` lists) in all test classes, simplifying test method signatures and setup. [[1]](diffhunk://#diff-517f2b5e14527490809a09256afe385d5efe0b17ac6d638fcee1d79bcdf260b7L36-R40) [[2]](diffhunk://#diff-b3223932ae7f262e792b684de3284b46335c090ee8ef595365e99ddd2ce9fef4L37-R44) [[3]](diffhunk://#diff-dabcabfa22d4bde85cad69d61954eb0990d0ae000bd3827658453bf3e41902f7L41-R44) [[4]](diffhunk://#diff-56ba6457eff81f8ee0fcd929428c3bc9c064ec76639720175d80603e98984d36L37-R40) [[5]](diffhunk://#diff-2f011435c52185cf6d77279905c21936a778464c9f0c89506f069a7a06b0373eL41-R44) [[6]](diffhunk://#diff-d7358df6b5801b26385c97844b7753acda986194fd72a029d2c8869cb89b65d0L37-R41) [[7]](diffhunk://#diff-2fe6e48640f67abe137b3b07fc4e6320b9dfa8d619e3dd807c20e6b0de924046L37-R42) [[8]](diffhunk://#diff-9a70f4d32d75bc8fbb3db0eb09b435c63cdb5de08b7cdbd579acf9baeedd0fb7L40-R45) [[9]](diffhunk://#diff-34e87cf2231211d1c36dc8cef5d04252b2de7016de6319a2fed8db69159b5beeL37-R41) [[10]](diffhunk://#diff-9861e7cc167c804069f3bf3f2bc143e5fee8af20ca5bb3b709c959ba34142da0L37-R43)
* Updated test methods to reference static parameter objects directly instead of injected fields, removing complexity from test execution. [[1]](diffhunk://#diff-517f2b5e14527490809a09256afe385d5efe0b17ac6d638fcee1d79bcdf260b7L36-R40) [[2]](diffhunk://#diff-b3223932ae7f262e792b684de3284b46335c090ee8ef595365e99ddd2ce9fef4L37-R44) [[3]](diffhunk://#diff-dabcabfa22d4bde85cad69d61954eb0990d0ae000bd3827658453bf3e41902f7L41-R44) [[4]](diffhunk://#diff-56ba6457eff81f8ee0fcd929428c3bc9c064ec76639720175d80603e98984d36L37-R40) [[5]](diffhunk://#diff-2f011435c52185cf6d77279905c21936a778464c9f0c89506f069a7a06b0373eL41-R44) [[6]](diffhunk://#diff-d7358df6b5801b26385c97844b7753acda986194fd72a029d2c8869cb89b65d0L37-R41) [[7]](diffhunk://#diff-2fe6e48640f67abe137b3b07fc4e6320b9dfa8d619e3dd807c20e6b0de924046L37-R42) [[8]](diffhunk://#diff-9a70f4d32d75bc8fbb3db0eb09b435c63cdb5de08b7cdbd579acf9baeedd0fb7L40-R45) [[9]](diffhunk://#diff-34e87cf2231211d1c36dc8cef5d04252b2de7016de6319a2fed8db69159b5beeL37-R41) [[10]](diffhunk://#diff-9861e7cc167c804069f3bf3f2bc143e5fee8af20ca5bb3b709c959ba34142da0L37-R43)

Parameter class improvements:

* Changed `ParamsBoxTest` and `ParamsBoxReservationTest` classes in `ReferencedInventoryBoxTest.java` to be static, improving encapsulation and clarity. [[1]](diffhunk://#diff-f2ed2f1fcc389d645d01b2c542075cde014882d5857f2b806296080a9c35c30aL235-R235) [[2]](diffhunk://#diff-f2ed2f1fcc389d645d01b2c542075cde014882d5857f2b806296080a9c35c30aL250-R250)

Cleanup of imports:

* Removed unused imports related to Weld and parameterized testing from all affected test files. [[1]](diffhunk://#diff-517f2b5e14527490809a09256afe385d5efe0b17ac6d638fcee1d79bcdf260b7L22-L27) [[2]](diffhunk://#diff-b3223932ae7f262e792b684de3284b46335c090ee8ef595365e99ddd2ce9fef4L23-L27) [[3]](diffhunk://#diff-dabcabfa22d4bde85cad69d61954eb0990d0ae000bd3827658453bf3e41902f7L25-L30) [[4]](diffhunk://#diff-56ba6457eff81f8ee0fcd929428c3bc9c064ec76639720175d80603e98984d36L22-L27) [[5]](diffhunk://#diff-2f011435c52185cf6d77279905c21936a778464c9f0c89506f069a7a06b0373eL25-L30) [[6]](diffhunk://#diff-d7358df6b5801b26385c97844b7753acda986194fd72a029d2c8869cb89b65d0L22-L27) [[7]](diffhunk://#diff-2fe6e48640f67abe137b3b07fc4e6320b9dfa8d619e3dd807c20e6b0de924046L22-L27) [[8]](diffhunk://#diff-9a70f4d32d75bc8fbb3db0eb09b435c63cdb5de08b7cdbd579acf9baeedd0fb7L25-L30) [[9]](diffhunk://#diff-34e87cf2231211d1c36dc8cef5d04252b2de7016de6319a2fed8db69159b5beeL22-L27) [[10]](diffhunk://#diff-9861e7cc167c804069f3bf3f2bc143e5fee8af20ca5bb3b709c959ba34142da0L22-L27) [[11]](diffhunk://#diff-c85533d4048ca455c33911f047ab1a95c868b542fedd680cd2bacd5120f39587R26-L31)

Test logic adjustment:

* In `ReferencedInventoryBoxOverReservation1MovementLineTest.java`, updated the test loop to iterate over a list of parameter objects, allowing multiple scenarios to be tested in a single run. [[1]](diffhunk://#diff-b3223932ae7f262e792b684de3284b46335c090ee8ef595365e99ddd2ce9fef4L37-R44) [[2]](diffhunk://#diff-b3223932ae7f262e792b684de3284b46335c090ee8ef595365e99ddd2ce9fef4R54)