### PR TITLE
Feature ETP-3362: Fix org.openbravo.test.generalsetup.enterprise.organization tests

### DIFF
--- a/src-test/src/org/openbravo/test/generalsetup/enterprise/organization/ADOrgPersistInfoCornerCaseOrgTest.java
+++ b/src-test/src/org/openbravo/test/generalsetup/enterprise/organization/ADOrgPersistInfoCornerCaseOrgTest.java
@@ -20,7 +20,7 @@ package org.openbravo.test.generalsetup.enterprise.organization;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openbravo.test.base.OBBaseTest;
 
 /**

--- a/src-test/src/org/openbravo/test/generalsetup/enterprise/organization/ADOrgPersistInfoSetReadyTest.java
+++ b/src-test/src/org/openbravo/test/generalsetup/enterprise/organization/ADOrgPersistInfoSetReadyTest.java
@@ -18,7 +18,7 @@
  */
 package org.openbravo.test.generalsetup.enterprise.organization;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openbravo.test.base.OBBaseTest;
 
 public class ADOrgPersistInfoSetReadyTest extends OBBaseTest {

--- a/src-test/src/org/openbravo/test/generalsetup/enterprise/organization/ADOrgPersistOrgInfoComplexOrgTreeTest.java
+++ b/src-test/src/org/openbravo/test/generalsetup/enterprise/organization/ADOrgPersistOrgInfoComplexOrgTreeTest.java
@@ -1,6 +1,6 @@
 package org.openbravo.test.generalsetup.enterprise.organization;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openbravo.test.base.OBBaseTest;
 
 public class ADOrgPersistOrgInfoComplexOrgTreeTest extends OBBaseTest {


### PR DESCRIPTION
This pull request updates the test imports in three organization-related test files to use JUnit 5's `@Test` annotation instead of JUnit 4. This change helps modernize the test suite and ensures consistency with newer testing standards.

JUnit 5 migration:

* Replaced `org.junit.Test` with `org.junit.jupiter.api.Test` in `ADOrgPersistInfoCornerCaseOrgTest.java`
* Replaced `org.junit.Test` with `org.junit.jupiter.api.Test` in `ADOrgPersistInfoSetReadyTest.java`
* Replaced `org.junit.Test` with `org.junit.jupiter.api.Test` in `ADOrgPersistOrgInfoComplexOrgTreeTest.java`