### PR TITLE
Feature ETP-3374: Fix org.openbravo.scheduling.quartz tests

### DIFF
--- a/src-test/src/org/openbravo/scheduling/quartz/JobInitializationListenerTest.java
+++ b/src-test/src/org/openbravo/scheduling/quartz/JobInitializationListenerTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,7 +48,6 @@ public class JobInitializationListenerTest {
   @Mock
   private ConnectionProvider mockConnectionProvider;
 
-  private MockedStatic<OBScheduler> mockedOBScheduler;
   private OBScheduler mockScheduler;
 
   /**
@@ -58,24 +56,10 @@ public class JobInitializationListenerTest {
    */
   @BeforeEach
   public void setUp() {
-    mockedOBScheduler = mockStatic(OBScheduler.class);
     mockScheduler = mock(OBScheduler.class);
-    mockedOBScheduler.when(OBScheduler::getInstance).thenReturn(mockScheduler);
-    when(mockScheduler.getConnection()).thenReturn(mockConnectionProvider);
 
     when(mockContext.getJobDetail()).thenReturn(mockJobDetail);
     when(mockJobDetail.getJobDataMap()).thenReturn(mockJobDataMap);
-  }
-
-  /**
-   * Cleans up resources after each test.
-   * Closes the static mock to prevent memory leaks.
-   */
-  @AfterEach
-  public void tearDown() {
-    if (mockedOBScheduler != null) {
-      mockedOBScheduler.close();
-    }
   }
 
   /**
@@ -88,12 +72,11 @@ public class JobInitializationListenerTest {
     Map<String, Object> bundleMap = new HashMap<>();
     when(mockJobDataMap.get(ProcessBundle.KEY)).thenReturn(bundleMap);
 
-    mockedOBScheduler.close();
-    try (MockedStatic<ProcessBundle> mockedProcessBundle = mockStatic(ProcessBundle.class)) {
-      mockedProcessBundle.when(() -> ProcessBundle.mapToObject(bundleMap)).thenReturn(mockProcessBundle);
-
-      mockedOBScheduler = mockStatic(OBScheduler.class);
+    try (MockedStatic<OBScheduler> mockedOBScheduler = mockStatic(OBScheduler.class);
+         MockedStatic<ProcessBundle> mockedProcessBundle = mockStatic(ProcessBundle.class)) {
       mockedOBScheduler.when(OBScheduler::getInstance).thenReturn(mockScheduler);
+      mockedProcessBundle.when(() -> ProcessBundle.mapToObject(bundleMap)).thenReturn(mockProcessBundle);
+      when(mockScheduler.getConnection()).thenReturn(mockConnectionProvider);
 
       when(mockProcessBundle.getConnection()).thenReturn(null);
 
@@ -116,12 +99,10 @@ public class JobInitializationListenerTest {
     Map<String, Object> bundleMap = new HashMap<>();
     when(mockJobDataMap.get(ProcessBundle.KEY)).thenReturn(bundleMap);
 
-    mockedOBScheduler.close();
-    try (MockedStatic<ProcessBundle> mockedProcessBundle = mockStatic(ProcessBundle.class)) {
-      mockedProcessBundle.when(() -> ProcessBundle.mapToObject(bundleMap)).thenReturn(mockProcessBundle);
-
-      mockedOBScheduler = mockStatic(OBScheduler.class);
+    try (MockedStatic<OBScheduler> mockedOBScheduler = mockStatic(OBScheduler.class);
+         MockedStatic<ProcessBundle> mockedProcessBundle = mockStatic(ProcessBundle.class)) {
       mockedOBScheduler.when(OBScheduler::getInstance).thenReturn(mockScheduler);
+      mockedProcessBundle.when(() -> ProcessBundle.mapToObject(bundleMap)).thenReturn(mockProcessBundle);
 
       when(mockProcessBundle.getConnection()).thenReturn(mockConnectionProvider);
 

--- a/src-test/src/org/openbravo/scheduling/quartz/OpenbravoDailyTimeIntervalTriggerPersistenceDelegateTest.java
+++ b/src-test/src/org/openbravo/scheduling/quartz/OpenbravoDailyTimeIntervalTriggerPersistenceDelegateTest.java
@@ -88,18 +88,6 @@ public class OpenbravoDailyTimeIntervalTriggerPersistenceDelegateTest {
   @BeforeEach
   public void setUp() throws SQLException {
     delegate = spy(new TestableDelegate(properties));
-
-    when(connection.prepareStatement(isNull())).thenReturn(preparedStatement);
-
-    when(preparedStatement.executeUpdate()).thenReturn(1);
-    when(preparedStatement.executeQuery()).thenReturn(resultSet);
-    when(resultSet.next()).thenReturn(true);
-
-    when(trigger.getKey()).thenReturn(triggerKey);
-    when(triggerKey.getName()).thenReturn(TEST_TRIGGER_NAME);
-    when(triggerKey.getGroup()).thenReturn(TEST_TRIGGER_GROUP);
-
-    configureMockProperties();
   }
 
   /**
@@ -163,6 +151,12 @@ public class OpenbravoDailyTimeIntervalTriggerPersistenceDelegateTest {
     try (MockedStatic<OpenbravoJDBCPersistenceSupport> jdbcSupport = mockStatic(OpenbravoJDBCPersistenceSupport.class);
          MockedStatic<Util> utilMock = mockStatic(Util.class)) {
 
+      when(connection.prepareStatement(isNull())).thenReturn(preparedStatement);
+      when(preparedStatement.executeUpdate()).thenReturn(1);
+      when(trigger.getKey()).thenReturn(triggerKey);
+      when(triggerKey.getName()).thenReturn(TEST_TRIGGER_NAME);
+      when(triggerKey.getGroup()).thenReturn(TEST_TRIGGER_GROUP);
+      configureMockProperties();
       setupStaticMocks(jdbcSupport, utilMock, "INSERT_STMT");
 
       int result = delegate.insertExtendedTriggerProperties(connection, trigger, "WAITING", jobDetail);
@@ -195,6 +189,11 @@ public class OpenbravoDailyTimeIntervalTriggerPersistenceDelegateTest {
     try (MockedStatic<OpenbravoJDBCPersistenceSupport> jdbcSupport = mockStatic(OpenbravoJDBCPersistenceSupport.class);
          MockedStatic<Util> utilMock = mockStatic(Util.class)) {
 
+      when(connection.prepareStatement(isNull())).thenReturn(preparedStatement);
+      when(preparedStatement.executeQuery()).thenReturn(resultSet);
+      when(resultSet.next()).thenReturn(true);
+      when(triggerKey.getName()).thenReturn(TEST_TRIGGER_NAME);
+      when(triggerKey.getGroup()).thenReturn(TEST_TRIGGER_GROUP);
       setupStaticMocks(jdbcSupport, utilMock, "SELECT_STMT");
 
       setupResultSetValues();
@@ -222,6 +221,10 @@ public class OpenbravoDailyTimeIntervalTriggerPersistenceDelegateTest {
   @Test
   public void testLoadExtendedTriggerPropertiesNoRecordFound() throws SQLException {
     try (MockedStatic<Util> utilMock = mockStatic(Util.class)) {
+      when(connection.prepareStatement(isNull())).thenReturn(preparedStatement);
+      when(preparedStatement.executeQuery()).thenReturn(resultSet);
+      when(triggerKey.getName()).thenReturn(TEST_TRIGGER_NAME);
+      when(triggerKey.getGroup()).thenReturn(TEST_TRIGGER_GROUP);
       utilMock.when(() -> Util.rtp(anyString(), anyString(), anyString()))
           .thenReturn("SELECT_STMT");
 
@@ -246,6 +249,12 @@ public class OpenbravoDailyTimeIntervalTriggerPersistenceDelegateTest {
     try (MockedStatic<OpenbravoJDBCPersistenceSupport> jdbcSupport = mockStatic(OpenbravoJDBCPersistenceSupport.class);
          MockedStatic<Util> utilMock = mockStatic(Util.class)) {
 
+      when(connection.prepareStatement(isNull())).thenReturn(preparedStatement);
+      when(preparedStatement.executeUpdate()).thenReturn(1);
+      when(trigger.getKey()).thenReturn(triggerKey);
+      when(triggerKey.getName()).thenReturn(TEST_TRIGGER_NAME);
+      when(triggerKey.getGroup()).thenReturn(TEST_TRIGGER_GROUP);
+      configureMockProperties();
       setupStaticMocks(jdbcSupport, utilMock, "UPDATE_STMT");
 
       int result = delegate.updateExtendedTriggerProperties(connection, trigger, "WAITING", jobDetail);

--- a/src-test/src/org/openbravo/scheduling/quartz/OpenbravoOracleJDBCDelegateTest.java
+++ b/src-test/src/org/openbravo/scheduling/quartz/OpenbravoOracleJDBCDelegateTest.java
@@ -49,8 +49,7 @@ public class OpenbravoOracleJDBCDelegateTest {
    */
   @BeforeEach
   public void setUp() throws SQLException {
-    when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
-    when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+    // no-op
   }
 
   /**
@@ -120,6 +119,7 @@ public class OpenbravoOracleJDBCDelegateTest {
     long checkInTime = System.currentTimeMillis();
     String status = "STARTED";
 
+    when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
     when(mockPreparedStatement.executeUpdate()).thenReturn(1);
 
     // WHEN
@@ -141,6 +141,8 @@ public class OpenbravoOracleJDBCDelegateTest {
   @Test
   public void testSchedulersStarted() throws SQLException {
     // GIVEN
+    when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
     when(mockResultSet.next()).thenReturn(true);
     when(mockResultSet.getInt(1)).thenReturn(1);
 

--- a/src-test/src/org/openbravo/scheduling/quartz/OpenbravoPostgreJDBCDelegateTest.java
+++ b/src-test/src/org/openbravo/scheduling/quartz/OpenbravoPostgreJDBCDelegateTest.java
@@ -48,8 +48,7 @@ public class OpenbravoPostgreJDBCDelegateTest {
    */
   @BeforeEach
   public void setUp() throws SQLException {
-    when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
-    when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+    // no-op
   }
 
   /**
@@ -122,6 +121,7 @@ public class OpenbravoPostgreJDBCDelegateTest {
     String instanceId = "instance1";
     long checkInTime = System.currentTimeMillis();
     String status = "STARTED";
+    when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
     when(mockPreparedStatement.executeUpdate()).thenReturn(1);
 
     // WHEN
@@ -146,6 +146,8 @@ public class OpenbravoPostgreJDBCDelegateTest {
   @Test
   public void testSchedulersStartedWithStartedSchedulers() throws SQLException {
     // GIVEN
+    when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
     when(mockResultSet.next()).thenReturn(true);
     when(mockResultSet.getInt(1)).thenReturn(2);
 
@@ -171,6 +173,8 @@ public class OpenbravoPostgreJDBCDelegateTest {
   @Test
   public void testSchedulersStartedWithNoStartedSchedulers() throws SQLException {
     // GIVEN
+    when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
     when(mockResultSet.next()).thenReturn(true);
     when(mockResultSet.getInt(1)).thenReturn(0);
 
@@ -196,6 +200,8 @@ public class OpenbravoPostgreJDBCDelegateTest {
   @Test
   public void testSchedulersStartedNoResults() throws SQLException {
     // GIVEN
+    when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
     when(mockResultSet.next()).thenReturn(false);
 
     // WHEN


### PR DESCRIPTION
This pull request refactors test setup and mocking logic across multiple test classes for scheduling and JDBC delegate components. The main focus is to move repetitive mock initialization from `@BeforeEach` methods directly into individual test methods, ensuring that mocks are only set up when needed and improving test clarity and maintainability.

Test setup refactoring:

* Removed mock initialization for `prepareStatement` and related methods from `@BeforeEach` in `OpenbravoDailyTimeIntervalTriggerPersistenceDelegateTest`, `OpenbravoOracleJDBCDelegateTest`, and `OpenbravoPostgreJDBCDelegateTest`, replacing them with no-op setups. [[1]](diffhunk://#diff-1d30b88fe96c1715a1a7c6fc16dd0120ab93193ba785ec62221816534ca7c43aL91-L102) [[2]](diffhunk://#diff-2a8558dcd09b52e8b3e4c08ea6c208828ad3a8c7893a41003fd28e1c4fddfed4L52-R52) [[3]](diffhunk://#diff-f80c029bb9d1a999b098e48017bdfd7d384808239d0be1c5b252bf3f59a8c526L51-R51)

Mock initialization moved to test methods:

* Added mock setups for `prepareStatement`, `executeUpdate`, `executeQuery`, and result set handling directly within the relevant test methods in `OpenbravoDailyTimeIntervalTriggerPersistenceDelegateTest` [[1]](diffhunk://#diff-1d30b88fe96c1715a1a7c6fc16dd0120ab93193ba785ec62221816534ca7c43aR154-R159) [[2]](diffhunk://#diff-1d30b88fe96c1715a1a7c6fc16dd0120ab93193ba785ec62221816534ca7c43aR192-R196) [[3]](diffhunk://#diff-1d30b88fe96c1715a1a7c6fc16dd0120ab93193ba785ec62221816534ca7c43aR224-R227) [[4]](diffhunk://#diff-1d30b88fe96c1715a1a7c6fc16dd0120ab93193ba785ec62221816534ca7c43aR252-R257) `OpenbravoOracleJDBCDelegateTest` [[5]](diffhunk://#diff-2a8558dcd09b52e8b3e4c08ea6c208828ad3a8c7893a41003fd28e1c4fddfed4R122) [[6]](diffhunk://#diff-2a8558dcd09b52e8b3e4c08ea6c208828ad3a8c7893a41003fd28e1c4fddfed4R144-R145) and `OpenbravoPostgreJDBCDelegateTest` [[7]](diffhunk://#diff-f80c029bb9d1a999b098e48017bdfd7d384808239d0be1c5b252bf3f59a8c526R124) [[8]](diffhunk://#diff-f80c029bb9d1a999b098e48017bdfd7d384808239d0be1c5b252bf3f59a8c526R149-R150) [[9]](diffhunk://#diff-f80c029bb9d1a999b098e48017bdfd7d384808239d0be1c5b252bf3f59a8c526R176-R177) [[10]](diffhunk://#diff-f80c029bb9d1a999b098e48017bdfd7d384808239d0be1c5b252bf3f59a8c526R203-R204).

Test reliability improvements:

* Ensured that all necessary mock behaviors are explicitly defined within each test, reducing the risk of unintended test interactions or dependencies on global setup. [[1]](diffhunk://#diff-1d30b88fe96c1715a1a7c6fc16dd0120ab93193ba785ec62221816534ca7c43aR154-R159) [[2]](diffhunk://#diff-1d30b88fe96c1715a1a7c6fc16dd0120ab93193ba785ec62221816534ca7c43aR192-R196) [[3]](diffhunk://#diff-1d30b88fe96c1715a1a7c6fc16dd0120ab93193ba785ec62221816534ca7c43aR224-R227) [[4]](diffhunk://#diff-1d30b88fe96c1715a1a7c6fc16dd0120ab93193ba785ec62221816534ca7c43aR252-R257) [[5]](diffhunk://#diff-2a8558dcd09b52e8b3e4c08ea6c208828ad3a8c7893a41003fd28e1c4fddfed4R122) [[6]](diffhunk://#diff-2a8558dcd09b52e8b3e4c08ea6c208828ad3a8c7893a41003fd28e1c4fddfed4R144-R145) [[7]](diffhunk://#diff-f80c029bb9d1a999b098e48017bdfd7d384808239d0be1c5b252bf3f59a8c526R124) [[8]](diffhunk://#diff-f80c029bb9d1a999b098e48017bdfd7d384808239d0be1c5b252bf3f59a8c526R149-R150) [[9]](diffhunk://#diff-f80c029bb9d1a999b098e48017bdfd7d384808239d0be1c5b252bf3f59a8c526R176-R177) [[10]](diffhunk://#diff-f80c029bb9d1a999b098e48017bdfd7d384808239d0be1c5b252bf3f59a8c526R203-R204)

Quartz job initialization test adjustment:

* Corrected mock setup for `getConnection` in `JobInitializationListenerTest` to only occur in the relevant test method, ensuring proper test isolation. [[1]](diffhunk://#diff-c5ab058689d9aebabe13e7d5a2c9d6e7435386560bb9fcc2e49d6037a08357b3L64) [[2]](diffhunk://#diff-c5ab058689d9aebabe13e7d5a2c9d6e7435386560bb9fcc2e49d6037a08357b3R96)