### PR TITLE
Feature ETP-3382: Fix org.openbravo.test.materialMgmt.invoiceFromShipment tests

### DIFF
--- a/src-test/src/org/openbravo/test/base/OBBaseTest.java
+++ b/src-test/src/org/openbravo/test/base/OBBaseTest.java
@@ -51,6 +51,7 @@ import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.extension.TestWatcher;
+import org.mockito.Mockito;
 import org.openbravo.base.exception.OBException;
 import org.openbravo.base.model.Entity;
 import org.openbravo.base.model.ModelProvider;
@@ -187,6 +188,9 @@ public class OBBaseTest {
     if (shouldMockServletContext()) {
       cleanMockServletContext();
     }
+
+    // Defensive cleanup: avoid leaking inline static mocks between tests in the same thread.
+    Mockito.framework().clearInlineMocks();
   }
 
   private String getTestName(ExtensionContext context) {

--- a/src-test/src/org/openbravo/test/createlinesfrom/CreateLinesFromTest.java
+++ b/src-test/src/org/openbravo/test/createlinesfrom/CreateLinesFromTest.java
@@ -191,23 +191,27 @@ public class CreateLinesFromTest extends WeldBaseTest {
   }
 
   private Order processOrder(Order testOrder) {
+    OBDal.getInstance().flush();
     final List<Object> params = new ArrayList<Object>();
     params.add(null);
     params.add(testOrder.getId());
     CallStoredProcedure.getInstance()
         .call(ORDER_COMPLETE_PROCEDURE_NAME, params, null, true, false);
-    OBDal.getInstance().refresh(testOrder);
-    return testOrder;
+    OBDal.getInstance().flush();
+    OBDal.getInstance().getSession().clear();
+    return OBDal.getInstance().get(Order.class, testOrder.getId());
   }
 
   private Invoice processInvoice(Invoice invoice) {
+    OBDal.getInstance().flush();
     final List<Object> params = new ArrayList<Object>();
     params.add(null);
     params.add(invoice.getId());
     CallStoredProcedure.getInstance()
         .call(INVOICE_COMPLETE_PROCEDURE_NAME, params, null, true, false);
-    OBDal.getInstance().refresh(invoice);
-    return invoice;
+    OBDal.getInstance().flush();
+    OBDal.getInstance().getSession().clear();
+    return OBDal.getInstance().get(Invoice.class, invoice.getId());
   }
 
   private JSONArray createSelectedLinesFromOrder(Order order) {
@@ -294,12 +298,14 @@ public class CreateLinesFromTest extends WeldBaseTest {
   }
 
   private ShipmentInOut processShipmentInOut(ShipmentInOut shipmentInOut) {
+    OBDal.getInstance().flush();
     final List<Object> params = new ArrayList<Object>();
     params.add(null);
     params.add(shipmentInOut.getId());
     CallStoredProcedure.getInstance()
         .call(SHIPMENT_INOUT_COMPLETE_PROCEDURE_NAME, params, null, true, false);
-    OBDal.getInstance().refresh(shipmentInOut);
-    return shipmentInOut;
+    OBDal.getInstance().flush();
+    OBDal.getInstance().getSession().clear();
+    return OBDal.getInstance().get(ShipmentInOut.class, shipmentInOut.getId());
   }
 }

--- a/src-test/src/org/openbravo/test/createlinesfrom/data/CreateLinesFromTestData.java
+++ b/src-test/src/org/openbravo/test/createlinesfrom/data/CreateLinesFromTestData.java
@@ -64,6 +64,8 @@ public abstract class CreateLinesFromTestData {
         .get(Order.class,
             isSales() ? CLFTestDataConstants.SALESORDER_ID : CLFTestDataConstants.PURCHASEORDER_ID);
     Order clonedOrder = (Order) DalUtil.copy(order, false);
+    // Avoid dangling copied order-level taxes; they are rebuilt when posting the order.
+    clonedOrder.getOrderLineTaxList().clear();
     updateOrderHeader(clonedOrder);
     OBDal.getInstance().save(clonedOrder);
 
@@ -72,6 +74,8 @@ public abstract class CreateLinesFromTestData {
     for (int i = 0; i < orderLineData.size(); i++) {
       OrderLineData lineData = orderLineData.get(i);
       OrderLine clonedOrderLine = (OrderLine) DalUtil.copy(orderLine, false);
+      // Avoid keeping copied OrderLineTax rows: c_orderline trigger regenerates them on insert.
+      clonedOrderLine.getOrderLineTaxList().clear();
 
       clonedOrderLine.setLineNo((long) ((i + 1) * 10));
       updateOrderLine(clonedOrderLine, lineData);

--- a/src-test/src/org/openbravo/test/materialMgmt/invoiceFromShipment/InvoiceFromGoodsShipmentDefaultValueFilterExpressionTest.java
+++ b/src-test/src/org/openbravo/test/materialMgmt/invoiceFromShipment/InvoiceFromGoodsShipmentDefaultValueFilterExpressionTest.java
@@ -30,20 +30,17 @@ public class InvoiceFromGoodsShipmentDefaultValueFilterExpressionTest extends OB
   private static final String TEST_FILTER_EXPRESSION_SAME = "TestFilterExpression_Same";
   private static final String CONTEXT = "context";
 
-  private static final String CLIENT_ID = "4028E6C72959682B01295A070852010D";
-  private static final String ORG_ID = "357947E87C284935AD1D783CF6F099A1";
-  private static final String USER_ID = "100";
-  private static final String ROLE_ID = "4028E6C72959682B01295A071429011E";
-
   private static final String GOODS_SHIPMENT_ID = "8BEAC8CAFFCE444FA15D0170F897B641";
   private static final String SALES_ORDER = "5B29AF263D004CD3830D4F9B23C17DFD";
   private static final String T_SHIRTS_PRODUCT_ID = "0CF7C882B8BD4D249F3BCC8727A736D1";
 
   private InvoiceFromGoodsShipmentDefaultValueFilterExpression filterExpression;
 
+  @Override
   @BeforeEach
-  public void setUp() {
-    OBContext.setOBContext(USER_ID, ROLE_ID, CLIENT_ID, ORG_ID);
+  public void setUp() throws Exception {
+    super.setUp();
+    setQAAdminContext();
     filterExpression = new InvoiceFromGoodsShipmentDefaultValueFilterExpression();
   }
 

--- a/src-test/src/org/openbravo/test/materialMgmt/invoiceFromShipment/InvoiceFromShipmentTest.java
+++ b/src-test/src/org/openbravo/test/materialMgmt/invoiceFromShipment/InvoiceFromShipmentTest.java
@@ -34,6 +34,7 @@ import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import org.hibernate.query.Query;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -61,6 +62,7 @@ import org.openbravo.model.materialmgmt.transaction.ShipmentInOut;
 import org.openbravo.model.materialmgmt.transaction.ShipmentInOutLine;
 import org.openbravo.model.pricing.pricelist.PriceList;
 import org.openbravo.service.db.DalConnectionProvider;
+import org.openbravo.test.base.mock.HttpServletRequestMock;
 
 /**
  * Test class for Automatic Invoice From Goods Shipment test cases
@@ -70,11 +72,6 @@ import org.openbravo.service.db.DalConnectionProvider;
 public class InvoiceFromShipmentTest extends WeldBaseTest {
 
   private static final Logger log = LogManager.getLogger();
-
-  private static final String CLIENT_ID = "4028E6C72959682B01295A070852010D"; // QA Testing
-  private static final String ORG_ID = "357947E87C284935AD1D783CF6F099A1"; // Spain
-  private static final String USER_ID = "100"; // Openbravo
-  private static final String ROLE_ID = "4028E6C72959682B01295A071429011E"; // QA Testing Admin
 
   private static final String GOODS_SHIPMENT_ID = "8BEAC8CAFFCE444FA15D0170F897B641";
   private static final String SALES_ORDER = "5B29AF263D004CD3830D4F9B23C17DFD";
@@ -86,14 +83,26 @@ public class InvoiceFromShipmentTest extends WeldBaseTest {
   private static final String AFTER_ORDER_DELIVERY = "O";
   private static final String PRICE_LIST_SALES_ID = "4028E6C72959682B01295ADC1D55022B";
 
+  @Override
   @BeforeEach
-  public void initialize() {
-    log.info("Initializing Invoice From Shipment Tests ...");
-    OBContext.setOBContext(USER_ID, ROLE_ID, CLIENT_ID, ORG_ID);
+  public void setUp() throws Exception {
+    super.setUp();
+    initializeInvoiceFromShipmentContext();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    // Clean up RequestContext to avoid contaminating other tests
+    RequestContext.clear();
+  }
+
+  private void initializeInvoiceFromShipmentContext() {
+    setQAAdminContext();
     final OBContext obContext = OBContext.getOBContext();
     final VariablesSecureApp vars = new VariablesSecureApp(obContext.getUser().getId(),
         obContext.getCurrentClient().getId(), obContext.getCurrentOrganization().getId(),
         obContext.getRole().getId(), obContext.getLanguage().getLanguage());
+    HttpServletRequestMock.setRequestMockInRequestContext(vars);
     RequestContext.get().setVariableSecureApp(vars);
   }
 
@@ -111,6 +120,7 @@ public class InvoiceFromShipmentTest extends WeldBaseTest {
    */
   @Test
   public void invoiceFromShipment_001() {
+    initializeInvoiceFromShipmentContext();
     OBContext.setAdminMode();
     try {
 
@@ -162,6 +172,7 @@ public class InvoiceFromShipmentTest extends WeldBaseTest {
 
   @Test
   public void invoiceFromShipment_002() {
+    initializeInvoiceFromShipmentContext();
     OBContext.setAdminMode();
     try {
 
@@ -224,6 +235,7 @@ public class InvoiceFromShipmentTest extends WeldBaseTest {
 
   @Test
   public void invoiceFromShipment_003() {
+    initializeInvoiceFromShipmentContext();
     OBContext.setAdminMode();
     try {
 
@@ -280,6 +292,7 @@ public class InvoiceFromShipmentTest extends WeldBaseTest {
 
   @Test
   public void invoiceFromShipment_004() {
+    initializeInvoiceFromShipmentContext();
     OBContext.setAdminMode();
     try {
 
@@ -373,6 +386,7 @@ public class InvoiceFromShipmentTest extends WeldBaseTest {
 
   @Test
   public void invoiceFromShipment_005() {
+    initializeInvoiceFromShipmentContext();
     OBContext.setAdminMode();
     try {
 
@@ -439,6 +453,7 @@ public class InvoiceFromShipmentTest extends WeldBaseTest {
 
   @Test
   public void invoiceFromShipment_006() {
+    initializeInvoiceFromShipmentContext();
     OBContext.setAdminMode();
     try {
 
@@ -513,6 +528,7 @@ public class InvoiceFromShipmentTest extends WeldBaseTest {
    */
   @Test
   public void invoiceFromShipment_007() {
+    initializeInvoiceFromShipmentContext();
     OBContext.setAdminMode();
     try {
 
@@ -580,6 +596,7 @@ public class InvoiceFromShipmentTest extends WeldBaseTest {
 
   @Test
   public void invoiceFromShipment_008() {
+    initializeInvoiceFromShipmentContext();
     OBContext.setAdminMode();
     try {
       final Product product = TestUtils.cloneProduct(T_SHIRTS_PRODUCT_ID,
@@ -633,6 +650,7 @@ public class InvoiceFromShipmentTest extends WeldBaseTest {
    */
   @Test
   public void invoiceFromShipment_009() {
+    initializeInvoiceFromShipmentContext();
     OBContext.setAdminMode();
     try {
 
@@ -686,6 +704,7 @@ public class InvoiceFromShipmentTest extends WeldBaseTest {
    */
   @Test
   public void invoiceFromShipment_010() {
+    initializeInvoiceFromShipmentContext();
     OBContext.setAdminMode();
     try {
 
@@ -741,6 +760,9 @@ public class InvoiceFromShipmentTest extends WeldBaseTest {
   }
 
   private void setProductInOrderLine(final OrderLine orderLine, final Product product) {
+    if (orderLine == null) {
+      throw new OBException("Order line not found");
+    }
     orderLine.setProduct(product);
   }
 
@@ -770,6 +792,7 @@ public class InvoiceFromShipmentTest extends WeldBaseTest {
   }
 
   private void assertInvoiceLineNumber(final Invoice invoice, final int numLines) {
+    assertThat("Invoice should not be null", invoice == null, equalTo(false));
     assertThat("Invoice should have " + numLines + " lines", invoice.getInvoiceLineList().size(),
         equalTo(numLines));
   }
@@ -809,22 +832,49 @@ public class InvoiceFromShipmentTest extends WeldBaseTest {
   }
 
   private OrderLine getOrderLineByLineNo(final Order salesOrder, long lineNo) {
-    final String hql = "as ol where ol.salesOrder.id = :salesOrderId and ol.lineNo = :lineNo";
-    final OBQuery<OrderLine> query = OBDal.getInstance().createQuery(OrderLine.class, hql);
-    query.setNamedParameter("salesOrderId", salesOrder.getId());
-    query.setNamedParameter("lineNo", lineNo);
-    query.setMaxResult(1);
-    return query.uniqueResult();
+    final Query<OrderLine> query = OBDal.getInstance().getSession()
+        .createQuery(
+            "from OrderLine as ol where ol.salesOrder.id = :salesOrderId and ol.lineNo = :lineNo",
+            OrderLine.class);
+    query.setParameter("salesOrderId", salesOrder.getId());
+    query.setParameter("lineNo", lineNo);
+    query.setMaxResults(1);
+    final OrderLine orderLine = query.uniqueResult();
+    if (orderLine == null) {
+      final Query<OrderLine> linesQuery = OBDal.getInstance().getSession()
+          .createQuery("from OrderLine as ol where ol.salesOrder.id = :salesOrderId order by ol.lineNo",
+              OrderLine.class);
+      linesQuery.setParameter("salesOrderId", salesOrder.getId());
+      throw new OBException(
+          "Order line not found for order " + salesOrder.getId() + " and lineNo " + lineNo
+              + ". Current persisted lines: " + linesQuery.list().stream()
+                  .map(l -> String.valueOf(l.getLineNo()))
+                  .reduce((a, b) -> a + "," + b).orElse("<none>"));
+    }
+    return orderLine;
   }
 
   private ShipmentInOutLine getShipmentLineByLineNo(final ShipmentInOut shipment, long lineNo) {
-    final String hql = "as sl where sl.shipmentReceipt.id = :shipmentId and sl.lineNo = :lineNo";
-    final OBQuery<ShipmentInOutLine> query = OBDal.getInstance()
-        .createQuery(ShipmentInOutLine.class, hql);
-    query.setNamedParameter("shipmentId", shipment.getId());
-    query.setNamedParameter("lineNo", lineNo);
-    query.setMaxResult(1);
-    return query.uniqueResult();
+    final Query<ShipmentInOutLine> query = OBDal.getInstance().getSession()
+        .createQuery(
+            "from MaterialMgmtShipmentInOutLine as sl where sl.shipmentReceipt.id = :shipmentId and sl.lineNo = :lineNo",
+            ShipmentInOutLine.class);
+    query.setParameter("shipmentId", shipment.getId());
+    query.setParameter("lineNo", lineNo);
+    query.setMaxResults(1);
+    final ShipmentInOutLine shipmentLine = query.uniqueResult();
+    if (shipmentLine == null) {
+      final Query<ShipmentInOutLine> linesQuery = OBDal.getInstance().getSession().createQuery(
+          "from MaterialMgmtShipmentInOutLine as sl where sl.shipmentReceipt.id = :shipmentId order by sl.lineNo",
+          ShipmentInOutLine.class);
+      linesQuery.setParameter("shipmentId", shipment.getId());
+      throw new OBException(
+          "Shipment line not found for shipment " + shipment.getId() + " and lineNo " + lineNo
+              + ". Current persisted lines: " + linesQuery.list().stream()
+                  .map(l -> String.valueOf(l.getLineNo()))
+                  .reduce((a, b) -> a + "," + b).orElse("<none>"));
+    }
+    return shipmentLine;
   }
 
   private InvoiceLine getInvoiceLineByProductQuantity(final Invoice invoice, final Product product,

--- a/src/org/openbravo/common/actionhandler/createlinesfromprocess/UpdatePricesAndAmounts.java
+++ b/src/org/openbravo/common/actionhandler/createlinesfromprocess/UpdatePricesAndAmounts.java
@@ -211,10 +211,10 @@ class UpdatePricesAndAmounts extends CreateLinesFromProcessHook {
     //@formatter:off
     String hql =
             " select " +
-            "   TO_NUMBER(M_BOM_PriceStd(:productID, plv.id)), " +
-            "   TO_NUMBER(M_BOM_PriceList(:productID, plv.id)), " +
-            "   TO_NUMBER(M_BOM_PriceLimit(:productID, plv.id)), " +
-            "   TO_NUMBER(ROUND(TO_NUMBER(M_BOM_PriceStd(:productID, plv.id)), :pricePrecision)) " +
+            "   cast(M_BOM_PriceStd(:productID, plv.id) as big_decimal), " +
+            "   cast(M_BOM_PriceList(:productID, plv.id) as big_decimal), " +
+            "   cast(M_BOM_PriceLimit(:productID, plv.id) as big_decimal), " +
+            "   cast(ROUND(cast(M_BOM_PriceStd(:productID, plv.id) as big_decimal), :pricePrecision) as big_decimal) " +
             " from PricingProductPrice pp " +
             "   join pp.priceListVersion plv " +
             " where pp.product.id = :productID" +


### PR DESCRIPTION
This pull request refactors and improves the test code for the Invoice From Shipment functionality. The main focus is on enhancing test reliability, improving test setup and context management, and making test data creation more robust and less error-prone. The changes include better context initialization, more reliable cloning of test entities, improved error handling, and code simplification.

**Test Context and Setup Improvements:**

- Replaced manual context setup with calls to `setQAAdminContext()` and improved usage of `super.setUp()` in both `InvoiceFromGoodsShipmentDefaultValueFilterExpressionTest` and `InvoiceFromShipmentTest`, ensuring consistent and correct test context initialization. (`[[1]](diffhunk://#diff-9c3da94041b463db2230b9fc2f4088449b79e994b113175086142d21ed60eea7L33-R43)`, `[[2]](diffhunk://#diff-849062ed53b523bee2cc356660a0afb1a0514f5c20af9b2f3669c8f31f066e9aL74-L78)`, `[[3]](diffhunk://#diff-849062ed53b523bee2cc356660a0afb1a0514f5c20af9b2f3669c8f31f066e9aR85-R98)`)
- Added repeated calls to `initializeInvoiceFromShipmentContext()` at the start of each test method in `InvoiceFromShipmentTest` to guarantee proper context for each test case. (`[[1]](diffhunk://#diff-849062ed53b523bee2cc356660a0afb1a0514f5c20af9b2f3669c8f31f066e9aR116)`, `[[2]](diffhunk://#diff-849062ed53b523bee2cc356660a0afb1a0514f5c20af9b2f3669c8f31f066e9aR168)`, `[[3]](diffhunk://#diff-849062ed53b523bee2cc356660a0afb1a0514f5c20af9b2f3669c8f31f066e9aR231)`, `[[4]](diffhunk://#diff-849062ed53b523bee2cc356660a0afb1a0514f5c20af9b2f3669c8f31f066e9aR288)`, `[[5]](diffhunk://#diff-849062ed53b523bee2cc356660a0afb1a0514f5c20af9b2f3669c8f31f066e9aR382)`, `[[6]](diffhunk://#diff-849062ed53b523bee2cc356660a0afb1a0514f5c20af9b2f3669c8f31f066e9aR449)`, `[[7]](diffhunk://#diff-849062ed53b523bee2cc356660a0afb1a0514f5c20af9b2f3669c8f31f066e9aR524)`, `[[8]](diffhunk://#diff-849062ed53b523bee2cc356660a0afb1a0514f5c20af9b2f3669c8f31f066e9aR592)`, `[[9]](diffhunk://#diff-849062ed53b523bee2cc356660a0afb1a0514f5c20af9b2f3669c8f31f066e9aR646)`, `[[10]](diffhunk://#diff-849062ed53b523bee2cc356660a0afb1a0514f5c20af9b2f3669c8f31f066e9aR700)`)

**Test Data Cloning and Uniqueness:**

- Changed the logic for cloning `Product`, `Order`, and `ShipmentInOut` entities in `TestUtils` to use a unique suffix generator instead of counting existing objects, ensuring unique and non-colliding test data. Also, after cloning, the session is cleared and the entity is reloaded to avoid stale data issues. (`[[1]](diffhunk://#diff-ee2134cafbc97b4a399d2495c3f4481402c6366c8e66697f66ed1afca0df8e25L61-R64)`, `[[2]](diffhunk://#diff-ee2134cafbc97b4a399d2495c3f4481402c6366c8e66697f66ed1afca0df8e25L109-R120)`, `[[3]](diffhunk://#diff-ee2134cafbc97b4a399d2495c3f4481402c6366c8e66697f66ed1afca0df8e25L128-R130)`, `[[4]](diffhunk://#diff-ee2134cafbc97b4a399d2495c3f4481402c6366c8e66697f66ed1afca0df8e25L205-R217)`, `[[5]](diffhunk://#diff-ee2134cafbc97b4a399d2495c3f4481402c6366c8e66697f66ed1afca0df8e25L224-R227)`)
- When cloning `Order` and `ShipmentInOut`, explicitly reset their line lists to empty arrays to avoid carrying over lines from the original entities. (`[[1]](diffhunk://#diff-ee2134cafbc97b4a399d2495c3f4481402c6366c8e66697f66ed1afca0df8e25L109-R120)`, `[[2]](diffhunk://#diff-ee2134cafbc97b4a399d2495c3f4481402c6366c8e66697f66ed1afca0df8e25L205-R217)`)

**Error Handling and Assertions:**

- Added explicit null checks and improved error messages in helper methods like `setProductInOrderLine`, `getOrderLineByLineNo`, and `getShipmentLineByLineNo` to make test failures more informative and debugging easier. (`[[1]](diffhunk://#diff-849062ed53b523bee2cc356660a0afb1a0514f5c20af9b2f3669c8f31f066e9aR756-R758)`, `[[2]](diffhunk://#diff-849062ed53b523bee2cc356660a0afb1a0514f5c20af9b2f3669c8f31f066e9aL812-R870)`)
- Improved assertions in `assertInvoiceLineNumber` to ensure the invoice is not null before checking its lines. (`[src-test/src/org/openbravo/test/materialMgmt/invoiceFromShipment/InvoiceFromShipmentTest.javaR788](diffhunk://#diff-849062ed53b523bee2cc356660a0afb1a0514f5c20af9b2f3669c8f31f066e9aR788)`)
- In `processOrder`, added flushes and a check to throw an exception if the order was not processed successfully. (`[src-test/src/org/openbravo/test/materialMgmt/invoiceFromShipment/TestUtils.javaR180-R190](diffhunk://#diff-ee2134cafbc97b4a399d2495c3f4481402c6366c8e66697f66ed1afca0df8e25R180-R190)`)

**Code Simplification and Clean-up:**

- Removed unnecessary static ID constants and simplified test setup code. (`[[1]](diffhunk://#diff-9c3da94041b463db2230b9fc2f4088449b79e994b113175086142d21ed60eea7L33-R43)`, `[[2]](diffhunk://#diff-849062ed53b523bee2cc356660a0afb1a0514f5c20af9b2f3669c8f31f066e9aL74-L78)`)
- Removed unnecessary manual addition of cloned lines to order and shipment line lists, as this is now handled by resetting the lists and saving entities. (`[[1]](diffhunk://#diff-ee2134cafbc97b4a399d2495c3f4481402c6366c8e66697f66ed1afca0df8e25L172)`, `[[2]](diffhunk://#diff-ee2134cafbc97b4a399d2495c3f4481402c6366c8e66697f66ed1afca0df8e25L261)`)
- Removed code that skipped discount lines during order line cloning, possibly to ensure all lines are cloned for test completeness. (`[src-test/src/org/openbravo/test/materialMgmt/invoiceFromShipment/TestUtils.javaL157-L161](diffhunk://#diff-ee2134cafbc97b4a399d2495c3f4481402c6366c8e66697f66ed1afca0df8e25L157-L161)`)

**Dependency Updates:**

- Added import for `HttpServletRequestMock` to support request context mocking in tests. (`[src-test/src/org/openbravo/test/materialMgmt/invoiceFromShipment/InvoiceFromShipmentTest.javaR64](diffhunk://#diff-849062ed53b523bee2cc356660a0afb1a0514f5c20af9b2f3669c8f31f066e9aR64)`)