### PR TITLE
Feature ETP-2931: Add Analytics Eporter module to artifact file

### DIFF
--- a/artifacts.list.COMPILATION.gradle
+++ b/artifacts.list.COMPILATION.gradle
@@ -139,7 +139,10 @@ List<String> _dependenciesListCOMPILATION = [
 
   // Testing Libraries
   'org.hamcrest:hamcrest-all:1.3',
-  'junit:junit:4.12'
+  'junit:junit:4.12',
+
+  // Analytcs
+  'com.etendoerp:analytics.exporter:3.2.0'
 ]
 
 ext {


### PR DESCRIPTION
This pull request adds a new analytics dependency to the compilation dependencies list. The main change is the inclusion of the `com.etendoerp:analytics.exporter:3.2.0` library, which will allow analytics exporting features to be used in the project.

- Dependency updates:
  * Added `com.etendoerp:analytics.exporter:3.2.0` to the `_dependenciesListCOMPILATION` in `artifacts.list.COMPILATION.gradle` to support analytics exporting.