### PR TITLE
Issue #984: Fix SecureWebServicesUtils selecting inaccessible warehouse

### DIFF
--- a/modules_core/com.smf.securewebservices/src/com/smf/securewebservices/utils/SecureWebServicesUtils.java
+++ b/modules_core/com.smf.securewebservices/src/com/smf/securewebservices/utils/SecureWebServicesUtils.java
@@ -45,6 +45,7 @@ import org.openbravo.model.ad.access.Role;
 import org.openbravo.model.ad.access.RoleOrganization;
 import org.openbravo.model.ad.access.User;
 import org.openbravo.model.ad.access.UserRoles;
+import org.openbravo.model.ad.system.Client;
 import org.openbravo.model.common.enterprise.Organization;
 import org.openbravo.model.common.enterprise.OrganizationTree;
 import org.openbravo.model.common.enterprise.Warehouse;
@@ -585,7 +586,7 @@ public class SecureWebServicesUtils {
 			Warehouse defaultWarehouse, Role selectedRole) {
 		Warehouse selectedWarehouse = null;
 		Client client = selectedRole != null ? selectedRole.getClient() : null;
-		List<Warehouse> warehouseList = SecureWebServicesUtils.getOrganizationWarehouses(selectedOrg, client);
+		List<Warehouse> warehouseList = SecureWebServicesUtils.getOrganizationWarehouses(selectedOrg);
 		// if warehouse is valid, select
 		if (warehouse != null)
 			for (Warehouse wh : warehouseList) {
@@ -598,13 +599,30 @@ public class SecureWebServicesUtils {
 		if (selectedWarehouse == null) {
 			if (defaultWarehouse != null) {
 				selectedWarehouse = defaultWarehouse;
-			} else if (!warehouseList.isEmpty()) {
-				selectedWarehouse = warehouseList.get(0);
 			} else {
-				String errorMessage = String.format("SWS - The selected organization (\"%s\") has no warehouses", selectedOrg.getId());
-				log.error(errorMessage);
-				throw new OBException(Utility.messageBD(new DalConnectionProvider(), "SMFSWS_OrgHasNoRole",
-						OBContext.getOBContext().getLanguage().getLanguage()));
+				// Prefer warehouses belonging to the role's client to prevent cross-client
+				// selection when admin mode returns warehouses from multiple clients.
+				// Fall back to the full list only when no client-specific warehouse exists.
+				List<Warehouse> clientWarehouses = new ArrayList<>();
+				if (client != null) {
+					for (Warehouse wh : warehouseList) {
+						if (client.getId().equals(wh.getClient().getId())) {
+							clientWarehouses.add(wh);
+						}
+					}
+				} else {
+					clientWarehouses = warehouseList;
+				}
+				if (!clientWarehouses.isEmpty()) {
+					selectedWarehouse = clientWarehouses.get(0);
+				} else if (!warehouseList.isEmpty()) {
+					selectedWarehouse = warehouseList.get(0);
+				} else {
+					String errorMessage = String.format("SWS - The selected organization (\"%s\") has no warehouses", selectedOrg.getId());
+					log.error(errorMessage);
+					throw new OBException(Utility.messageBD(new DalConnectionProvider(), "SMFSWS_OrgHasNoRole",
+							OBContext.getOBContext().getLanguage().getLanguage()));
+				}
 			}
 		}
 		return selectedWarehouse;

--- a/modules_core/com.smf.securewebservices/src/com/smf/securewebservices/utils/SecureWebServicesUtils.java
+++ b/modules_core/com.smf.securewebservices/src/com/smf/securewebservices/utils/SecureWebServicesUtils.java
@@ -120,12 +120,28 @@ public class SecureWebServicesUtils {
 	 * @return A list of warehouses associated with the given organization and its child organizations.
 	 */
 	public static List<Warehouse> getOrganizationWarehouses(Organization org) {
+		return getOrganizationWarehouses(org, null);
+	}
+
+	/**
+	 * Retrieves the list of warehouses associated with a given organization and its child organizations,
+	 * optionally filtered by client. When {@code client} is non-null only warehouses belonging to that
+	 * client are returned, preventing cross-client warehouse selection when the root org (*) is active.
+	 *
+	 * @param org    The organization for which to retrieve the associated warehouses.
+	 * @param client The client to filter warehouses by, or {@code null} to return all clients.
+	 * @return A list of warehouses associated with the given organization and its child organizations.
+	 */
+	public static List<Warehouse> getOrganizationWarehouses(Organization org, Client client) {
 		List<Organization> childrenOrg = getChildrenOrganizations(org);
 		List<Warehouse> warehouses = null;
 		OBContext.setAdminMode();
 		try {
 			OBCriteria<Warehouse> crit = OBDal.getInstance().createCriteria(Warehouse.class);
 			crit.add(Restrictions.in(Warehouse.PROPERTY_ORGANIZATION, childrenOrg));
+			if (client != null) {
+				crit.add(Restrictions.eq(Warehouse.PROPERTY_CLIENT, client));
+			}
 			crit.setFilterOnReadableClients(false);
 			crit.setFilterOnReadableOrganization(false);
 			warehouses = crit.list();
@@ -471,7 +487,7 @@ public class SecureWebServicesUtils {
 			Warehouse defaultWarehouse = user.getDefaultWarehouse();
 			Role selectedRole = getRole(role, userRoleList, defaultWsRole, defaultRole);
 			Organization selectedOrg = getOrganization(org, selectedRole, defaultRole, defaultOrg);
-			selectedWarehouse = getWarehouse(warehouse, selectedOrg, defaultWarehouse);
+			selectedWarehouse = getWarehouse(warehouse, selectedOrg, defaultWarehouse, selectedRole);
 
 			String privateKey = config.getPrivateKey();
 			Algorithm algorithm;
@@ -566,9 +582,10 @@ public class SecureWebServicesUtils {
 	 * @throws OBException If the organization has no available warehouses.
 	 */
 	private static Warehouse getWarehouse(Warehouse warehouse, Organization selectedOrg,
-			Warehouse defaultWarehouse) {
+			Warehouse defaultWarehouse, Role selectedRole) {
 		Warehouse selectedWarehouse = null;
-		List<Warehouse> warehouseList = SecureWebServicesUtils.getOrganizationWarehouses(selectedOrg);
+		Client client = selectedRole != null ? selectedRole.getClient() : null;
+		List<Warehouse> warehouseList = SecureWebServicesUtils.getOrganizationWarehouses(selectedOrg, client);
 		// if warehouse is valid, select
 		if (warehouse != null)
 			for (Warehouse wh : warehouseList) {

--- a/modules_core/com.smf.securewebservices/src/com/smf/securewebservices/utils/SecureWebServicesUtils.java
+++ b/modules_core/com.smf.securewebservices/src/com/smf/securewebservices/utils/SecureWebServicesUtils.java
@@ -135,7 +135,7 @@ public class SecureWebServicesUtils {
 	 */
 	public static List<Warehouse> getOrganizationWarehouses(Organization org, Client client) {
 		List<Organization> childrenOrg = getChildrenOrganizations(org);
-		List<Warehouse> warehouses = null;
+		List<Warehouse> warehouses = new ArrayList<>();
 		OBContext.setAdminMode();
 		try {
 			OBCriteria<Warehouse> crit = OBDal.getInstance().createCriteria(Warehouse.class);
@@ -584,48 +584,70 @@ public class SecureWebServicesUtils {
 	 */
 	private static Warehouse getWarehouse(Warehouse warehouse, Organization selectedOrg,
 			Warehouse defaultWarehouse, Role selectedRole) {
-		Warehouse selectedWarehouse = null;
 		Client client = selectedRole != null ? selectedRole.getClient() : null;
 		List<Warehouse> warehouseList = SecureWebServicesUtils.getOrganizationWarehouses(selectedOrg);
-		// if warehouse is valid, select
-		if (warehouse != null)
-			for (Warehouse wh : warehouseList) {
-				if (StringUtils.equals(wh.getId(), warehouse.getId())) {
-					selectedWarehouse = warehouse;
-					break;
-				}
-			}
-		// if not valid select default warehouse for the selected org
+		Warehouse selectedWarehouse = findWarehouseInList(warehouse, warehouseList);
 		if (selectedWarehouse == null) {
-			if (defaultWarehouse != null) {
-				selectedWarehouse = defaultWarehouse;
-			} else {
-				// Prefer warehouses belonging to the role's client to prevent cross-client
-				// selection when admin mode returns warehouses from multiple clients.
-				// Fall back to the full list only when no client-specific warehouse exists.
-				List<Warehouse> clientWarehouses = new ArrayList<>();
-				if (client != null) {
-					for (Warehouse wh : warehouseList) {
-						if (client.getId().equals(wh.getClient().getId())) {
-							clientWarehouses.add(wh);
-						}
-					}
-				} else {
-					clientWarehouses = warehouseList;
-				}
-				if (!clientWarehouses.isEmpty()) {
-					selectedWarehouse = clientWarehouses.get(0);
-				} else if (!warehouseList.isEmpty()) {
-					selectedWarehouse = warehouseList.get(0);
-				} else {
-					String errorMessage = String.format("SWS - The selected organization (\"%s\") has no warehouses", selectedOrg.getId());
-					log.error(errorMessage);
-					throw new OBException(Utility.messageBD(new DalConnectionProvider(), "SMFSWS_OrgHasNoRole",
-							OBContext.getOBContext().getLanguage().getLanguage()));
-				}
-			}
+			selectedWarehouse = defaultWarehouse != null
+					? defaultWarehouse
+					: pickFallbackWarehouse(warehouseList, client, selectedOrg);
 		}
 		return selectedWarehouse;
+	}
+
+	/**
+	 * Returns the given warehouse if it exists in the list, or {@code null} otherwise.
+	 */
+	private static Warehouse findWarehouseInList(Warehouse warehouse, List<Warehouse> warehouseList) {
+		if (warehouse == null) {
+			return null;
+		}
+		for (Warehouse wh : warehouseList) {
+			if (StringUtils.equals(wh.getId(), warehouse.getId())) {
+				return wh;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Selects a fallback warehouse from the list, preferring the role's client to prevent
+	 * cross-client selection when admin mode returns warehouses from multiple clients.
+	 * Falls back to the first warehouse in the list if no client-specific one is found.
+	 *
+	 * @throws OBException if the organization has no warehouses at all.
+	 */
+	private static Warehouse pickFallbackWarehouse(List<Warehouse> warehouseList, Client client,
+			Organization selectedOrg) {
+		List<Warehouse> clientWarehouses = filterWarehousesByClient(warehouseList, client);
+		if (!clientWarehouses.isEmpty()) {
+			return clientWarehouses.get(0);
+		}
+		if (!warehouseList.isEmpty()) {
+			return warehouseList.get(0);
+		}
+		String errorMessage = String.format("SWS - The selected organization (\"%s\") has no warehouses",
+				selectedOrg.getId());
+		log.error(errorMessage);
+		throw new OBException(Utility.messageBD(new DalConnectionProvider(), "SMFSWS_OrgHasNoRole",
+				OBContext.getOBContext().getLanguage().getLanguage()));
+	}
+
+	/**
+	 * Returns warehouses from the list that belong to the given client.
+	 * If {@code client} is {@code null}, returns the full list unchanged.
+	 */
+	private static List<Warehouse> filterWarehousesByClient(List<Warehouse> warehouseList, Client client) {
+		if (client == null) {
+			return warehouseList;
+		}
+		List<Warehouse> filtered = new ArrayList<>();
+		for (Warehouse wh : warehouseList) {
+			if (client.getId().equals(wh.getClient().getId())) {
+				filtered.add(wh);
+			}
+		}
+		return filtered;
 	}
 
 	/**

--- a/pipelines/unittests/Jenkinsfile
+++ b/pipelines/unittests/Jenkinsfile
@@ -70,30 +70,30 @@ pipeline {
             env.FAILED_SUITES = "" // List to collect failed test suites
             sh "printenv"
 
+            def skipConditions = load "${pwd()}/pipelines/unittests/utils/skipConditions.groovy"
+
+            echo "--------------- Checking branch type ---------------"
+            if (skipConditions.skipIfVersionHotfix(env.GIT_BRANCH, REPO_NAME, COMMIT_SUCCESS_STATUS, ACCESS_TOKEN, GIT_COMMIT, BUILD_URL, CONTEXT_BUILD)) {
+              return
+            }
+
             echo "--------------- Checking if pipeline should be skipped ---------------"
             def changedFiles = sh(
               script: "git diff --name-only HEAD~1 HEAD",
               returnStdout: true
-            ).trim()
+            ).trim().split('\n') as List
 
             echo "Files changed in last commit: ${changedFiles}"
 
-            // Check if only JenkinsfileOracle was changed
-            def filesList = changedFiles.split('\n')
-            def onlyOracleJenkinsfile = filesList.size() == 1 && filesList[0] == "pipelines/unittests/JenkinsfileOracle"
-
-            if (onlyOracleJenkinsfile) {
-              echo "⏭️ Only pipelines/unittests/JenkinsfileOracle was changed. Skipping pipeline execution."
-
-              sh "./pipelines/unittests/build-update.sh ${REPO_NAME} ${COMMIT_SUCCESS_STATUS} \"Pipeline skipped\" ${ACCESS_TOKEN} ${GIT_COMMIT} ${BUILD_URL} \"${CONTEXT_BUILD}\""
-
-              echo "✅ Pipeline execution aborted successfully. Commit marked as success."
-              currentBuild.result = ABORTED
+            def allowedFiles = [
+              "pipelines/unittests/JenkinsfileOracle"
+            ]
+            if (skipConditions.skipIfOnlyAllowedFilesChanged(changedFiles, allowedFiles, REPO_NAME, COMMIT_SUCCESS_STATUS, "Pipeline skipped", ACCESS_TOKEN, GIT_COMMIT, BUILD_URL, CONTEXT_BUILD)) {
               return
-            } else {
-              echo "✅ Pipeline will continue - Changes detected in other files or multiple files changed."
-              currentBuild.result = SUCCESS
             }
+
+            echo "✅ Pipeline will continue - Changes detected in other files or multiple files changed."
+            currentBuild.result = SUCCESS
           } catch (Exception e) {
             echo "❌ Error in pipeline skip condition check: ${e.getMessage()}"            
             env.ERROR_MESSAGE = "Pipeline Check Failed"
@@ -243,31 +243,8 @@ pipeline {
                       sh "GIT_SSH_COMMAND=\"ssh -i ${keyfile} -o \"UserKnownHostsFile=/dev/null\" -o \"StrictHostKeyChecking=no\"\" git clone ${PLUGIN_URL} ${PLUGIN_NAME}"
                     }
 
-                    if (!(env.GIT_BRANCH.contains("-Y")) && !(env.GIT_BRANCH.startsWith("release")) && !(env.GIT_BRANCH.startsWith("main" )) && !(env.GIT_BRANCH.startsWith("master")) && !(env.GIT_BRANCH.startsWith("hotfix"))) {
-                        if (isFeatureBranch && epicKey) {
-                            sh """
-                            cd ${PLUGIN_NAME}
-                            git checkout ${env.EPIC_BRANCH} || git checkout ${env.DEVELOP_BRANCH}
-                            """
-                        } else {
-                            sh """
-                            cd ${PLUGIN_NAME}
-                            git checkout ${env.DEVELOP_BRANCH}
-                            """
-                        }
-                    } else if (env.GIT_BRANCH.contains("-Y") || env.GIT_BRANCH.startsWith("release")) {
-                        if (isFeatureBranch && epicKey) {
-                            sh """
-                            cd ${PLUGIN_NAME}
-                            git checkout ${env.EPIC_BRANCH} || git checkout ${env.BACKPORT_BRANCH}
-                            """
-                        } else {
-                            sh """
-                            cd ${PLUGIN_NAME}
-                            git checkout ${env.BACKPORT_BRANCH}
-                            """
-                        }
-                    }
+                    def pluginBranchCheckout = load "${rootDir}/pipelines/unittests/utils/pluginBranchCheckout.groovy"
+                    pluginBranchCheckout.run(isFeatureBranch, epicKey)
 
                     sh """
                     cd ${PLUGIN_NAME}

--- a/pipelines/unittests/JenkinsfileOracle
+++ b/pipelines/unittests/JenkinsfileOracle
@@ -64,45 +64,32 @@ pipeline {
                         env.FAILED_SUITES = "" // List to collect failed test suites
                         sh 'printenv'
 
+                        def skipConditions = load "${pwd()}/pipelines/unittests/utils/skipConditions.groovy"
+
+                        echo "--------------- Checking branch type ---------------"
+                        if (skipConditions.skipIfVersionHotfix(env.GIT_BRANCH, REPO_NAME, COMMIT_SUCCESS_STATUS, ACCESS_TOKEN, GIT_COMMIT, BUILD_URL, CONTEXT_BUILD)) {
+                            return
+                        }
+
                         echo "--------------- Checking if pipeline should be skipped ---------------"
                         def changedFiles = sh(
-                        script: "git diff --name-only HEAD~1 HEAD",
-                        returnStdout: true
-                        ).trim()
+                            script: "git diff --name-only HEAD~1 HEAD",
+                            returnStdout: true
+                        ).trim().split('\n') as List
 
                         echo "Files changed in last commit: ${changedFiles}"
 
-                        // Check if only Jenkinsfile and/or sonarUtils.groovy were changed
-                        def filesList = changedFiles.split('\n')
                         def allowedFiles = [
                             "pipelines/unittests/Jenkinsfile",
                             "pipelines/unittests/utils/sonarUtils.groovy"
                         ]
-
-                        // Check if all changed files are in the allowed list
-                        def onlyAllowedFiles = filesList.every { file -> 
-                            allowedFiles.contains(file)
-                        }
-
-                        // Additionally check that at least one of the allowed files was changed
-                        def hasAllowedFiles = filesList.any { file -> 
-                            allowedFiles.contains(file)
-                        }
-
-                        if (onlyAllowedFiles && hasAllowedFiles) {
-                            echo "⏭️ Only Jenkinsfile and/or sonarUtils.groovy were changed. Skipping pipeline execution."
-                            echo "📋 Changed files: ${changedFiles}"
-
-                            sh "./pipelines/unittests/build-update.sh ${REPO_NAME} ${COMMIT_SUCCESS_STATUS} \"Pipeline skipped - Only pipeline config files changed\" ${ACCESS_TOKEN} ${GIT_COMMIT} ${BUILD_URL} \"${CONTEXT_BUILD}\""
-
-                            echo "✅ Pipeline execution aborted successfully. Commit marked as success."
-                            currentBuild.result = ABORTED
+                        if (skipConditions.skipIfOnlyAllowedFilesChanged(changedFiles, allowedFiles, REPO_NAME, COMMIT_SUCCESS_STATUS, "Pipeline skipped - Only pipeline config files changed", ACCESS_TOKEN, GIT_COMMIT, BUILD_URL, CONTEXT_BUILD)) {
                             return
-                        } else {
-                            echo "✅ Pipeline will continue - Changes detected in other files."
-                            echo "📋 Changed files: ${changedFiles}"
-                            currentBuild.result = SUCCESS
                         }
+
+                        echo "✅ Pipeline will continue - Changes detected in other files."
+                        echo "📋 Changed files: ${changedFiles}"
+                        currentBuild.result = SUCCESS
                     } catch (Exception e) {
                         echo "❌ Error in pipeline skip condition check: ${e.getMessage()}"            
                         env.ERROR_MESSAGE = "Pipeline Check Failed"

--- a/pipelines/unittests/utils/pluginBranchCheckout.groovy
+++ b/pipelines/unittests/utils/pluginBranchCheckout.groovy
@@ -1,0 +1,28 @@
+// pipelines/unittests/utils/pluginBranchCheckout.groovy
+
+/**
+ * Checks out the appropriate branch on the Etendo plugin clone,
+ * based on whether the current branch is a backport/release branch or a regular one.
+ *
+ * @param isFeatureBranch  true if the current branch starts with "feature/"
+ * @param epicKey          epic key resolved from Jira (may be empty)
+ */
+def run(boolean isFeatureBranch, String epicKey) {
+    def branch = env.GIT_BRANCH
+    def isBackportOrRelease = branch.contains("-Y") || branch.startsWith("release")
+    def isRegular = !branch.contains("-Y") && !branch.startsWith("release") &&
+                    !branch.startsWith("main") && !branch.startsWith("master") &&
+                    !branch.startsWith("hotfix")
+
+    if (isRegular) {
+        sh isFeatureBranch && epicKey
+            ? "cd ${env.PLUGIN_NAME} && git checkout ${env.EPIC_BRANCH} || git checkout ${env.DEVELOP_BRANCH}"
+            : "cd ${env.PLUGIN_NAME} && git checkout ${env.DEVELOP_BRANCH}"
+    } else if (isBackportOrRelease) {
+        sh isFeatureBranch && epicKey
+            ? "cd ${env.PLUGIN_NAME} && git checkout ${env.EPIC_BRANCH} || git checkout ${env.BACKPORT_BRANCH}"
+            : "cd ${env.PLUGIN_NAME} && git checkout ${env.BACKPORT_BRANCH}"
+    }
+}
+
+return this

--- a/pipelines/unittests/utils/skipConditions.groovy
+++ b/pipelines/unittests/utils/skipConditions.groovy
@@ -1,0 +1,46 @@
+// pipelines/unittests/utils/skipConditions.groovy
+
+/**
+ * Skips the pipeline if the branch is a version-style hotfix branch (e.g. hotfix/25.4.12).
+ * Only Jira-style hotfix branches run tests: hotfix/#12-ETP-900, hotfix/ETP-212.
+ * Sets currentBuild.result = 'ABORTED' and updates the GitHub commit status.
+ * The caller must execute 'return' if this method returns true.
+ *
+ * @return true if pipeline should be skipped, false otherwise
+ */
+def skipIfVersionHotfix(String branchName, String repoName, String successStatus,
+                        String accessToken, String gitCommit, String buildUrl, String contextBuild) {
+    def versionHotfixPattern = /^hotfix\/\d+\.\d+(\.\d+)*$/
+    if (branchName ==~ versionHotfixPattern) {
+        echo "⏭️ Version hotfix branch detected (${branchName}). Skipping pipeline."
+        sh "./pipelines/unittests/build-update.sh ${repoName} ${successStatus} \"Pipeline skipped - version hotfix branch\" ${accessToken} ${gitCommit} ${buildUrl} \"${contextBuild}\""
+        currentBuild.result = 'ABORTED'
+        return true
+    }
+    return false
+}
+
+/**
+ * Skips the pipeline if all changed files are in the allowed list.
+ * Sets currentBuild.result = 'ABORTED' and updates the GitHub commit status.
+ * The caller must execute 'return' if this method returns true.
+ *
+ * @return true if pipeline should be skipped, false otherwise
+ */
+def skipIfOnlyAllowedFilesChanged(List changedFiles, List allowedFiles,
+                                   String repoName, String successStatus, String skipMessage,
+                                   String accessToken, String gitCommit, String buildUrl, String contextBuild) {
+    def onlyAllowed = changedFiles.every { file -> allowedFiles.contains(file) }
+    def hasAllowed  = changedFiles.any  { file -> allowedFiles.contains(file) }
+    if (onlyAllowed && hasAllowed) {
+        echo "⏭️ Only pipeline config files changed. Skipping pipeline execution."
+        echo "📋 Changed files: ${changedFiles}"
+        sh "./pipelines/unittests/build-update.sh ${repoName} ${successStatus} \"${skipMessage}\" ${accessToken} ${gitCommit} ${buildUrl} \"${contextBuild}\""
+        echo "✅ Pipeline execution aborted successfully. Commit marked as success."
+        currentBuild.result = 'ABORTED'
+        return true
+    }
+    return false
+}
+
+return this

--- a/src-test/src/com/smf/securewebservices/utils/SecureWebServicesUtilsAdditionalTests.java
+++ b/src-test/src/com/smf/securewebservices/utils/SecureWebServicesUtilsAdditionalTests.java
@@ -2,6 +2,7 @@ package com.smf.securewebservices.utils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -24,6 +25,7 @@ import org.openbravo.model.ad.access.Role;
 import org.openbravo.model.ad.access.RoleOrganization;
 import org.openbravo.model.ad.access.User;
 import org.openbravo.model.ad.access.UserRoles;
+import org.openbravo.model.ad.system.Client;
 import org.openbravo.model.common.enterprise.Organization;
 import org.openbravo.model.common.enterprise.Warehouse;
 
@@ -170,5 +172,85 @@ public class SecureWebServicesUtilsAdditionalTests {
 
     String result = SecureWebServicesUtils.getExceptionMessage(mockThrowable);
     assertEquals("SQL Error", result);
+  }
+
+  /**
+   * Tests that getOrganizationWarehouses(org, client) filters out warehouses belonging to a
+   * different client. Regression test for ETP-3676: when the root org (*) is active,
+   * getOrganizationWarehouses() ran in admin mode without client restriction and could return
+   * warehouses from unrelated clients. The fallback warehouseList.get(0) would then encode a
+   * cross-client warehouse in the JWT token.
+   *
+   * <p>Given: two warehouses exist — one for clientA and one for clientB.
+   * When: getOrganizationWarehouses is called with clientA as filter.
+   * Then: only the warehouse belonging to clientA is returned.
+   */
+  @Test
+  public void testGetOrganizationWarehousesFiltersOnClient() {
+    try (MockedStatic<SecureWebServicesUtils> mockedUtils = mockStatic(SecureWebServicesUtils.class)) {
+      // GIVEN
+      Organization mockOrg = mock(Organization.class);
+      Client clientA = mock(Client.class);
+      Client clientB = mock(Client.class);
+      when(clientA.getId()).thenReturn("clientA");
+      when(clientB.getId()).thenReturn("clientB");
+
+      Warehouse whClientA = mock(Warehouse.class);
+      when(whClientA.getId()).thenReturn("wh-clientA");
+      when(whClientA.getClient()).thenReturn(clientA);
+
+      Warehouse whClientB = mock(Warehouse.class);
+      when(whClientB.getId()).thenReturn("wh-clientB");
+      when(whClientB.getClient()).thenReturn(clientB);
+
+      List<Warehouse> allWarehouses = new ArrayList<>();
+      allWarehouses.add(whClientA);
+      allWarehouses.add(whClientB);
+
+      // Simulate: unfiltered call returns both; filtered call returns only clientA's
+      mockedUtils.when(() -> SecureWebServicesUtils.getOrganizationWarehouses(mockOrg))
+          .thenReturn(allWarehouses);
+      List<Warehouse> filteredWarehouses = new ArrayList<>();
+      filteredWarehouses.add(whClientA);
+      mockedUtils.when(() -> SecureWebServicesUtils.getOrganizationWarehouses(mockOrg, clientA))
+          .thenReturn(filteredWarehouses);
+
+      // WHEN
+      List<Warehouse> result = SecureWebServicesUtils.getOrganizationWarehouses(mockOrg, clientA);
+
+      // THEN: only the warehouse belonging to clientA is returned
+      assertNotNull(result);
+      assertEquals(1, result.size());
+      assertEquals("wh-clientA", result.get(0).getId());
+      assertTrue("Returned warehouse must belong to clientA",
+          "clientA".equals(result.get(0).getClient().getId()));
+    }
+  }
+
+  /**
+   * Tests that getOrganizationWarehouses(org) — the no-client overload — retains backward
+   * compatibility and returns warehouses from all clients (null filter).
+   */
+  @Test
+  public void testGetOrganizationWarehousesNoClientFilterRetainsAllWarehouses() {
+    try (MockedStatic<SecureWebServicesUtils> mockedUtils = mockStatic(SecureWebServicesUtils.class)) {
+      // GIVEN
+      Organization mockOrg = mock(Organization.class);
+      Warehouse wh1 = mock(Warehouse.class);
+      Warehouse wh2 = mock(Warehouse.class);
+      List<Warehouse> allWarehouses = new ArrayList<>();
+      allWarehouses.add(wh1);
+      allWarehouses.add(wh2);
+
+      mockedUtils.when(() -> SecureWebServicesUtils.getOrganizationWarehouses(mockOrg))
+          .thenReturn(allWarehouses);
+
+      // WHEN
+      List<Warehouse> result = SecureWebServicesUtils.getOrganizationWarehouses(mockOrg);
+
+      // THEN: all warehouses returned (no client restriction)
+      assertNotNull(result);
+      assertEquals(2, result.size());
+    }
   }
 }

--- a/src-test/src/com/smf/securewebservices/utils/SecureWebServicesUtilsAdditionalTests.java
+++ b/src-test/src/com/smf/securewebservices/utils/SecureWebServicesUtilsAdditionalTests.java
@@ -3,8 +3,10 @@ package com.smf.securewebservices.utils;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.sql.BatchUpdateException;
@@ -20,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.openbravo.dal.core.OBContext;
+import org.openbravo.dal.service.OBCriteria;
 import org.openbravo.dal.service.OBDal;
 import org.openbravo.model.ad.access.Role;
 import org.openbravo.model.ad.access.RoleOrganization;
@@ -186,44 +189,47 @@ public class SecureWebServicesUtilsAdditionalTests {
    * Then: only the warehouse belonging to clientA is returned.
    */
   @Test
+  @SuppressWarnings("unchecked")
   public void testGetOrganizationWarehousesFiltersOnClient() {
     try (MockedStatic<SecureWebServicesUtils> mockedUtils = mockStatic(SecureWebServicesUtils.class)) {
       // GIVEN
       Organization mockOrg = mock(Organization.class);
       Client clientA = mock(Client.class);
-      Client clientB = mock(Client.class);
-      when(clientA.getId()).thenReturn("clientA");
-      when(clientB.getId()).thenReturn("clientB");
+
+      // Mock getChildrenOrganizations (dependency of the real method)
+      Organization childOrg = mock(Organization.class);
+      List<Organization> childOrgs = new ArrayList<>();
+      childOrgs.add(childOrg);
+      mockedUtils.when(() -> SecureWebServicesUtils.getChildrenOrganizations(mockOrg))
+          .thenReturn(childOrgs);
+
+      // Invoke the real two-arg implementation
+      mockedUtils.when(() -> SecureWebServicesUtils.getOrganizationWarehouses(mockOrg, clientA))
+          .thenCallRealMethod();
+
+      // Mock OBDal criteria chain to return clientA's warehouse (simulating DB-level filtering)
+      OBDal mockDal = mock(OBDal.class);
+      mockedOBDal.when(OBDal::getInstance).thenReturn(mockDal);
+
+      OBCriteria<Warehouse> mockCriteria = (OBCriteria<Warehouse>) mock(OBCriteria.class);
+      when(mockDal.createCriteria(Warehouse.class)).thenReturn(mockCriteria);
+      when(mockCriteria.add(any())).thenReturn(mockCriteria);
 
       Warehouse whClientA = mock(Warehouse.class);
       when(whClientA.getId()).thenReturn("wh-clientA");
-      when(whClientA.getClient()).thenReturn(clientA);
-
-      Warehouse whClientB = mock(Warehouse.class);
-      when(whClientB.getId()).thenReturn("wh-clientB");
-      when(whClientB.getClient()).thenReturn(clientB);
-
-      List<Warehouse> allWarehouses = new ArrayList<>();
-      allWarehouses.add(whClientA);
-      allWarehouses.add(whClientB);
-
-      // Simulate: unfiltered call returns both; filtered call returns only clientA's
-      mockedUtils.when(() -> SecureWebServicesUtils.getOrganizationWarehouses(mockOrg))
-          .thenReturn(allWarehouses);
       List<Warehouse> filteredWarehouses = new ArrayList<>();
       filteredWarehouses.add(whClientA);
-      mockedUtils.when(() -> SecureWebServicesUtils.getOrganizationWarehouses(mockOrg, clientA))
-          .thenReturn(filteredWarehouses);
+      when(mockCriteria.list()).thenReturn(filteredWarehouses);
 
       // WHEN
       List<Warehouse> result = SecureWebServicesUtils.getOrganizationWarehouses(mockOrg, clientA);
 
-      // THEN: only the warehouse belonging to clientA is returned
+      // THEN: real method executed; returns what the DB (criteria) returned
       assertNotNull(result);
       assertEquals(1, result.size());
       assertEquals("wh-clientA", result.get(0).getId());
-      assertTrue("Returned warehouse must belong to clientA",
-          "clientA".equals(result.get(0).getClient().getId()));
+      // Verify criteria was invoked with the client restriction
+      verify(mockCriteria, org.mockito.Mockito.atLeast(2)).add(any());
     }
   }
 
@@ -242,15 +248,20 @@ public class SecureWebServicesUtilsAdditionalTests {
       allWarehouses.add(wh1);
       allWarehouses.add(wh2);
 
+      // Invoke the real no-arg overload (delegates to two-arg with null)
       mockedUtils.when(() -> SecureWebServicesUtils.getOrganizationWarehouses(mockOrg))
+          .thenCallRealMethod();
+      // Mock the two-arg dependency it delegates to (null = no client restriction)
+      mockedUtils.when(() -> SecureWebServicesUtils.getOrganizationWarehouses(mockOrg, null))
           .thenReturn(allWarehouses);
 
       // WHEN
       List<Warehouse> result = SecureWebServicesUtils.getOrganizationWarehouses(mockOrg);
 
-      // THEN: all warehouses returned (no client restriction)
+      // THEN: delegates to two-arg with null, returning all warehouses (no client filter)
       assertNotNull(result);
       assertEquals(2, result.size());
+      mockedUtils.verify(() -> SecureWebServicesUtils.getOrganizationWarehouses(mockOrg, null));
     }
   }
 }

--- a/src-test/src/com/smf/securewebservices/utils/SecureWebServicesUtilsTest.java
+++ b/src-test/src/com/smf/securewebservices/utils/SecureWebServicesUtilsTest.java
@@ -59,8 +59,8 @@ public class SecureWebServicesUtilsTest extends WeldBaseTest {
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    OBContext.setOBContext(TestConstants.Users.ADMIN, TestConstants.Roles.FB_GRP_ADMIN,
-        TestConstants.Clients.FB_GRP, TestConstants.Orgs.FB_GROUP);
+    OBContext.setOBContext(TestConstants.Users.SYSTEM, TestConstants.Roles.SYS_ADMIN,
+        TestConstants.Clients.SYSTEM, TestConstants.Orgs.MAIN);
     VariablesSecureApp vars = new VariablesSecureApp(OBContext.getOBContext().getUser().getId(),
         OBContext.getOBContext().getCurrentClient().getId(),
         OBContext.getOBContext().getCurrentOrganization().getId());
@@ -132,8 +132,7 @@ public class SecureWebServicesUtilsTest extends WeldBaseTest {
     OBDal.getInstance().save(pref);
     OBDal.getInstance().flush();
     OBDal.getInstance().commitAndClose();
-    OBContext.setOBContext(TestConstants.Users.ADMIN, TestConstants.Roles.FB_GRP_ADMIN,
-        TestConstants.Clients.FB_GRP, TestConstants.Orgs.FB_GROUP);
+    OBContext.setOBContext(TestConstants.Users.SYSTEM);
   }
 
   /**

--- a/src-test/src/com/smf/securewebservices/utils/SecureWebServicesUtilsTest.java
+++ b/src-test/src/com/smf/securewebservices/utils/SecureWebServicesUtilsTest.java
@@ -59,8 +59,8 @@ public class SecureWebServicesUtilsTest extends WeldBaseTest {
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    OBContext.setOBContext(TestConstants.Users.SYSTEM, TestConstants.Roles.SYS_ADMIN,
-        TestConstants.Clients.SYSTEM, TestConstants.Orgs.MAIN);
+    OBContext.setOBContext(TestConstants.Users.ADMIN, TestConstants.Roles.FB_GRP_ADMIN,
+        TestConstants.Clients.FB_GRP, TestConstants.Orgs.FB_GROUP);
     VariablesSecureApp vars = new VariablesSecureApp(OBContext.getOBContext().getUser().getId(),
         OBContext.getOBContext().getCurrentClient().getId(),
         OBContext.getOBContext().getCurrentOrganization().getId());
@@ -132,7 +132,8 @@ public class SecureWebServicesUtilsTest extends WeldBaseTest {
     OBDal.getInstance().save(pref);
     OBDal.getInstance().flush();
     OBDal.getInstance().commitAndClose();
-    OBContext.setOBContext(TestConstants.Users.SYSTEM);
+    OBContext.setOBContext(TestConstants.Users.ADMIN, TestConstants.Roles.FB_GRP_ADMIN,
+        TestConstants.Clients.FB_GRP, TestConstants.Orgs.FB_GROUP);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Fix cross-client warehouse selection bug in `SecureWebServicesUtils.getWarehouse()`: when the root org (`*`) was active, `getOrganizationWarehouses()` ran in admin mode without client restriction and could return warehouses from unrelated clients, causing the JWT token to encode an inaccessible warehouse.
- Added overload `getOrganizationWarehouses(org, client)` with optional client filter; single-arg overload retains backward compatibility.
- Added regression tests for client-filtering behavior.
- Added condition in `Jenkinsfile` and `JenkinsfileOracle` to skip unit test pipelines for version-style hotfix branches (e.g. `hotfix/25.4.12`), marking them as success.

## Test plan

- [ ] `testGetOrganizationWarehousesFiltersOnClient` — verifies only warehouses from the correct client are returned
- [ ] `testGetOrganizationWarehousesNoClientFilterRetainsAllWarehouses` — verifies backward compatibility of single-arg overload
- [ ] Existing tests in `SecureWebServicesUtilsTest` and `SecureWebServicesUtilsAdditionalTests` pass without changes

---

## Related module fix

This hotfix requires a companion fix in `com.etendoerp.metadata`:

- **PR:** https://github.com/etendosoftware/com.etendoerp.metadata/pull/156
- **Root cause:** `Utils.java` in that module calls `SecureWebServicesUtils.getWarehouse()` via reflection. The method signature changed from 3 to 4 params (`Role` added) in this PR, so the `getDeclaredMethod` lookup was failing with `NoSuchMethodException`.

> ⚠️ When publishing this fix, the metadata module PR must also be published.

---

Fixes #984
ETP-3676