### PR TITLE
Issue #993: Fix Payment Monitor not recalculating daystilldue

### DIFF
--- a/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/process/FIN_PaymentMonitorProcess.java
+++ b/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/process/FIN_PaymentMonitorProcess.java
@@ -108,7 +108,10 @@ public class FIN_PaymentMonitorProcess extends DalBaseProcess {
           "      )" +
           "    ))" +
           "    or (i.outstandingAmount <> 0 and i.lastCalculatedOnDate is null)" +
-          "    or (i.paymentComplete = true and i.finalSettlementDate is null and i.outstandingAmount = 0)";
+          "    or (i.paymentComplete = true and i.finalSettlementDate is null and i.outstandingAmount = 0)" +
+          "    or (i.paymentComplete = false" +
+          "        and i.lastCalculatedOnDate is not null" +
+          "        and cast(i.lastCalculatedOnDate as date) < current_date())";
       //@formatter:on
 
       if (migration != null) {


### PR DESCRIPTION
## Summary

- `FIN_PaymentMonitorProcess` was permanently excluding invoices with pending payment from recalculation after the first run, because the HQL filter (`fps.updated >= lastCalculatedOnDate`) only selected invoices where a payment record had changed since the last execution.
- As a result, `daystilldue` was frozen at the value calculated on the first run and never decremented, even as real calendar days passed.
- Fix: added an additional OR condition to always include pending invoices (`paymentComplete = false`) whose `lastCalculatedOnDate` is from a previous calendar day, ensuring daily recalculation regardless of payment activity.

## Test plan

- [ ] Create a Sales Invoice with a future due date and no payments registered
- [ ] Run the Payment Monitor process — verify `daystilldue` is calculated correctly
- [ ] Set `lastCalculatedOnDate` to yesterday via SQL: `UPDATE c_invoice SET lastcalculatedondate = CURRENT_TIMESTAMP - INTERVAL '1 day' WHERE documentno = '<number>'`
- [ ] Run Payment Monitor again — verify `daystilldue` is recalculated (decrements by 1)
- [ ] Verify invoices with `paymentComplete = true` are unaffected

Backport of #1000 to release/25.4
ETP-3806