### PR TITLE
Feature ETP-3916: Fix PostStartHook in agent YAMLs

### DIFF
--- a/pipelines/unittests/Agent.yaml
+++ b/pipelines/unittests/Agent.yaml
@@ -42,11 +42,12 @@ spec:
           exec:
             command:
               - bash
-              - '-c'
-              - >-
-                chmod a+x /var/run/docker.sock && rm
-                /etc/apt/sources.list.d/pgdg.list || echo 0 && apt update && apt
-                install -y curl
+              - '-lc'
+              - |
+                chmod a+x /var/run/docker.sock || true
+                rm /etc/apt/sources.list.d/pgdg.list || true
+                apt-get update -y || true
+                apt-get install -y curl || echo "Could not install curl"
       terminationMessagePath: /dev/termination-log
       terminationMessagePolicy: File
       imagePullPolicy: IfNotPresent

--- a/pipelines/unittests/AgentOracle.yaml
+++ b/pipelines/unittests/AgentOracle.yaml
@@ -44,11 +44,12 @@ spec:
           exec:
             command:
               - bash
-              - '-c'
-              - >-
-                chmod a+x /var/run/docker.sock && rm
-                /etc/apt/sources.list.d/pgdg.list || echo 0 && apt update && apt
-                install -y curl
+              - '-lc'
+              - |
+                chmod a+x /var/run/docker.sock || true
+                rm /etc/apt/sources.list.d/pgdg.list || true
+                apt-get update -y || true
+                apt-get install -y curl || echo "Could not install curl"
       terminationMessagePath: /dev/termination-log
       terminationMessagePolicy: File
       imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary
- Fix `PostStartHook` in `Agent.yaml` and `AgentOracle.yaml` that caused `compiler` container to crash with `CrashLoopBackOff`
- Root cause: `apt install -y curl` failed with exit code 100 (`dpkg requires superuser privilege`) on `compiler_jenkins:1.0.7-jdk.17.0.13`, causing the strict `&&` chain to fail the hook
- Changed hook to use `|| true` on each step so the container never fails to start

## Test plan
- [x] Verified fix on `feature/ETP-3916`: both `etendo_core_oracle` and `etendo_core_unittest` pods started `3/3 Running` with `0` restarts
- [ ] Merge to `develop` so all branches inherit the fix on next rebase/merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)