### PR TITLE
Issue #1017: Move analytics.exporter from COMPILATION to MODULES_CORE list

### DIFF
--- a/artifacts.list.COMPILATION.gradle
+++ b/artifacts.list.COMPILATION.gradle
@@ -137,12 +137,15 @@ List<String> _dependenciesListCOMPILATION = [
 
   // Testing Libraries
   'org.hamcrest:hamcrest-all:1.3',
-  'junit:junit:4.12',
+  'junit:junit:4.12'
+]
 
-  // Analytcs
+List<String> _dependenciesListMODULESCORE = [
+  // Modules considered part of modules_core, resolved always as JARs
   'com.etendoerp:analytics.exporter:3.3.0'
 ]
 
 ext {
    dependenciesListCOMPILATION = _dependenciesListCOMPILATION
+   dependenciesListMODULESCORE = _dependenciesListMODULESCORE
 }


### PR DESCRIPTION
## Summary

- Moves `com.etendoerp:analytics.exporter:3.3.0` out of `_dependenciesListCOMPILATION` and into the new `_dependenciesListMODULESCORE` list in `artifacts.list.COMPILATION.gradle`
- Adds `dependenciesListMODULESCORE` to the `ext` block so the Gradle plugin can read and process it correctly

## Related

- Jira: ETP-3964
- GitHub: #1017