### PR TITLE
Issue #1025: Fix invoice status causing full table scan on M_MATCHINV/M_MATCHSI

### DIFF
--- a/src-db/database/model/functions/C_GETINVOICESTATUSFROMSHIPMENT.xml
+++ b/src-db/database/model/functions/C_GETINVOICESTATUSFROMSHIPMENT.xml
@@ -46,14 +46,15 @@ BEGIN
       JOIN c_invoice i ON i.c_invoice_id = il.c_invoice_id
       WHERE i.processed = 'Y'
         AND i.docstatus NOT IN ('VO', 'CL', 'DR')
+        AND msi.m_inoutline_id IN (SELECT m_inoutline_id FROM m_inoutline WHERE m_inout_id = p_minoutid)
       GROUP BY msi.m_inoutline_id
     ) inv_si ON inv_si.m_inoutline_id = del.m_inoutline_id
     WHERE del.m_inout_id = p_minoutid;
   ELSE
-    SELECT 
-    CASE 
-      WHEN SUM(ABS(COALESCE(del.movementqty, 0))) = 0 THEN 0 
-      ELSE ROUND(SUM(ABS(COALESCE(inv_pi.qtymatched, 0))) / SUM(ABS(COALESCE(del.movementqty, 0))) * 100, 0) 
+    SELECT
+    CASE
+      WHEN SUM(ABS(COALESCE(del.movementqty, 0))) = 0 THEN 0
+      ELSE ROUND(SUM(ABS(COALESCE(inv_pi.qtymatched, 0))) / SUM(ABS(COALESCE(del.movementqty, 0))) * 100, 0)
     END
     into v_percent
     FROM m_inoutline del
@@ -66,6 +67,7 @@ BEGIN
       JOIN c_invoice i ON i.c_invoice_id = il.c_invoice_id
       WHERE i.processed = 'Y'
         AND i.docstatus NOT IN ('VO', 'CL', 'DR')
+        AND mi.m_inoutline_id IN (SELECT m_inoutline_id FROM m_inoutline WHERE m_inout_id = p_minoutid)
       GROUP BY mi.m_inoutline_id
     ) inv_pi ON inv_pi.m_inoutline_id = del.m_inoutline_id
     WHERE del.m_inout_id = p_minoutid;


### PR DESCRIPTION
## Summary

- `C_GETINVOICESTATUSFROMSHIPMENT` was performing a full sequential scan of `M_MATCHINV` (171k rows) and `M_MATCHSI` on every function call, because the match table subqueries had no filter by `m_inoutline_id`.
- The outer JOIN filtered the results correctly, but PostgreSQL could not push the predicate into the derived table — causing the full scan to materialize on every row in the grid.
- Fix: added `AND *.m_inoutline_id IN (SELECT m_inoutline_id FROM m_inoutline WHERE m_inout_id = p_minoutid)` inside both subqueries so the planner uses the existing `M_MATCHINV_INOUT` / `M_MATCHSI_INOUT` indexes.

## Performance results (high-volume DB)

| Scenario | Before | After |
|---|---|---|
| Unfiltered grid WITH Invoice Status | **1.4 minutes** | **342 ms** |
| Filtered grid WITH Invoice Status | **13.18 s** | **182 ms** |

Subquery execution time: **1,114 ms → 1.2 ms** (900× improvement).

## Test plan

- [ ] Open Goods Receipt (Proveedor) window with Invoice Status column visible — grid must load in under 1 second
- [ ] Open Goods Shipment window with Invoice Status column visible — same
- [ ] Verify Invoice Status values match pre-fix values (0% / 100% / partial %)
- [ ] Complete a purchase invoice and verify Invoice Status updates correctly on the receipt

Fixes #1025 | ETP-4045