### PR TITLE
Issue #1029: Fix DocType reset when Payment Method changes on vendor invoice

### DIFF
--- a/src/org/openbravo/erpCommon/ad_callouts/SE_Invoice_BPartner.java
+++ b/src/org/openbravo/erpCommon/ad_callouts/SE_Invoice_BPartner.java
@@ -62,10 +62,6 @@ public class SE_Invoice_BPartner extends SimpleCallout {
     String strOrgId = info.getStringParameter("inpadOrgId", IsIDFilter.instance);
 
     boolean isSales = StringUtils.equals("Y", strIsSOTrx);
-    String applied = BpDocTypeUtils.applyInvoiceDocType(info, strOrgId, strBPartner, isSales, "inpcDoctypetargetId", "inpcDoctypetargetId_R");
-    if (StringUtils.isNotBlank(applied)) {
-      strDocType = applied;
-    }
 
     // Payment Method changed
     if (StringUtils.equals(strChanged, "inpfinPaymentmethodId")
@@ -78,6 +74,13 @@ public class SE_Invoice_BPartner extends SimpleCallout {
     }
 
     else {
+      // Apply document type only when Business Partner changes, not when Payment Method changes
+      String applied = BpDocTypeUtils.applyInvoiceDocType(info, strOrgId, strBPartner, isSales,
+          "inpcDoctypetargetId", "inpcDoctypetargetId_R");
+      if (StringUtils.isNotBlank(applied)) {
+        strDocType = applied;
+      }
+
       if (StringUtils.isEmpty(strBPartner)) {
         info.vars.removeSessionValue(info.getWindowId() + "|C_BPartner_ID");
       }


### PR DESCRIPTION
## Description

Fixes the incorrect behavior in `SE_Invoice_BPartner` callout where changing the **Payment Method** on a vendor invoice header was unintentionally resetting the **Document Type**, even when the user had already manually selected one.

## Root Cause

The callout is registered on two columns of `C_Invoice`: `C_BPartner_ID` and `FIN_Paymentmethod_ID`. The call to `BpDocTypeUtils.applyInvoiceDocType()` was placed **before** the conditional block that evaluates which field triggered the callout, causing it to execute unconditionally in both cases.

## Fix

Moved `BpDocTypeUtils.applyInvoiceDocType()` inside the `else` block (Business Partner change), so it only executes when `C_BPartner_ID` changes — not when `FIN_Paymentmethod_ID` changes.

## Test Cases

- ✅ **Payment Method changes** → Document Type remains unchanged
- ✅ **Business Partner changes** (has DocType in `C_BPARTNER_DOCTYPE`) → Document Type updates automatically (ETP-2261 preserved)
- ✅ **Business Partner changes** (no DocType configured) → Organization default applied (`AD_GET_DOCTYPE`)

## References

- Jira: [ETP-4105](https://etendoproject.atlassian.net/browse/ETP-4105)
- GitHub: #1029
- Related: ETP-2261, ETP-2540, ESD-1690

[ETP-4105]: https://etendoproject.atlassian.net/browse/ETP-4105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ