### PR TITLE
Issue #1027: Fix MultipleDeleteActionHandler missing setAdminMode

### DIFF
--- a/modules_core/org.openbravo.client.application/src/org/openbravo/client/application/MultipleDeleteActionHandler.java
+++ b/modules_core/org.openbravo.client.application/src/org/openbravo/client/application/MultipleDeleteActionHandler.java
@@ -61,6 +61,7 @@ public class MultipleDeleteActionHandler extends BaseActionHandler {
   protected JSONObject execute(Map<String, Object> parameters, String data) {
 
     try {
+      OBContext.setAdminMode(true);
       final JSONObject dataObject = new JSONObject(data);
       final String entityName = dataObject.getString("entity");
       final JSONArray ids = dataObject.getJSONArray("ids");
@@ -93,6 +94,8 @@ public class MultipleDeleteActionHandler extends BaseActionHandler {
       } catch (JSONException t) {
         throw new OBException(t);
       }
+    } finally {
+      OBContext.restorePreviousMode();
     }
   }
 


### PR DESCRIPTION
## Summary

- `MultipleDeleteActionHandler.execute()` was performing OBDal deletions without calling `OBContext.setAdminMode(true)`, causing `OBSecurityException` for users with manual roles (`isManual = Y`) when deleting multiple records at once.
- Single-record deletion worked correctly because `DefaultDataSourceService.remove()` already wraps the operation with `OBContext.setAdminMode(true)`.
- Fix: added `OBContext.setAdminMode(true)` at the beginning of the `try` block in `execute()` and `OBContext.restorePreviousMode()` in the corresponding `finally` block, making the behavior consistent with single-record deletion.

## Test plan

- [ ] Log in with a manual role (`isManual = Y`) that has write access to Sales Invoice
- [ ] Navigate to Sales Management → Transactions → Sales Invoice
- [ ] Open a Draft invoice with at least 2 lines, go to the Lines tab
- [ ] Select multiple lines using the checkboxes and click Delete
- [ ] Verify the lines are deleted successfully (no "this action is not allowed" error)
- [ ] Verify single-record deletion still works correctly

Fixes #1027 | ETP-4090