### PR TITLE
Feature ETP-4150: Fix GL Items grid pre-loading on Add Payment popup

### DIFF
--- a/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/actionHandler/AddPaymentActionHandler.java
+++ b/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/actionHandler/AddPaymentActionHandler.java
@@ -612,6 +612,9 @@ public class AddPaymentActionHandler extends Action {
     boolean isReceipt = payment.isReceipt();
     for (int i = 0; i < addedGLITemsArray.length(); i++) {
       JSONObject glItem = addedGLITemsArray.getJSONObject(i);
+      if (!isGLItemFromCurrentPayment(payment, glItem)) {
+        continue;
+      }
       BigDecimal glItemOutAmt = BigDecimal.ZERO;
       BigDecimal glItemInAmt = BigDecimal.ZERO;
 
@@ -656,6 +659,22 @@ public class AddPaymentActionHandler extends Action {
           OBDal.getInstance().get(GLItem.class, strGLItemId), businessPartnerGLItem, product,
           project, campaign, activity, null, costCenter, user1, user2);
     }
+  }
+
+  private boolean isGLItemFromCurrentPayment(FIN_Payment payment, JSONObject glItem)
+      throws JSONException, ServletException {
+    final String FIN_PAYMENT_DETAIL = "fin_payment_detail_id";
+    if (!glItem.has(FIN_PAYMENT_DETAIL) || glItem.get(FIN_PAYMENT_DETAIL) == JSONObject.NULL) {
+      return true;
+    }
+
+    final String paymentDetailId = glItem.getString(FIN_PAYMENT_DETAIL);
+    checkID(paymentDetailId);
+
+    FIN_PaymentDetail paymentDetail = OBDal.getInstance()
+        .get(FIN_PaymentDetail.class, paymentDetailId);
+    return paymentDetail != null && paymentDetail.getFinPayment() != null
+        && payment.getId().equals(paymentDetail.getFinPayment().getId());
   }
 
   private BaseOBObject getAccountDimension(final JSONObject glItem, final String dimension,

--- a/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/filterexpression/AddOrderOrInvoiceFilterExpressionHandler.java
+++ b/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/filterexpression/AddOrderOrInvoiceFilterExpressionHandler.java
@@ -94,7 +94,7 @@ abstract class AddOrderOrInvoiceFilterExpressionHandler {
   private boolean hasDetailsWithDifferentPaymentMethods(final String paymentId) {
     //@formatter:off
     final String hql = 
-            "select coalesce(ipspm.id, opspm.id) as pm" +
+            "select distinct coalesce(ipspm.id, opspm.id) as pm" +
             "  from FIN_Payment_ScheduleDetail as psd" +
             "    join psd.paymentDetails as pd" +
             "    left join psd.orderPaymentSchedule as ops" +
@@ -102,8 +102,7 @@ abstract class AddOrderOrInvoiceFilterExpressionHandler {
             "    left join psd.invoicePaymentSchedule as ips" +
             "    left join ips.finPaymentmethod as ipspm" +
             " where pd.finPayment.id = :paymentId" +
-            "   and pd.gLItem is null" +
-            " group by coalesce(ipspm, opspm)";
+            "   and pd.gLItem is null";
   //@formatter:on
 
     final FIN_Payment payment = OBDal.getInstance().get(FIN_Payment.class, paymentId);

--- a/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/hqlinjections/AddPaymentGLItemInjector.java
+++ b/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/hqlinjections/AddPaymentGLItemInjector.java
@@ -12,6 +12,10 @@ public class AddPaymentGLItemInjector extends HqlInserter {
   public String insertHql(Map<String, String> requestParameters,
       Map<String, Object> queryNamedParameters) {
     final String strPaymentId = requestParameters.get("fin_payment_id");
+    if (strPaymentId == null || strPaymentId.isEmpty() || "null".equals(strPaymentId)) {
+      // No valid payment ID: return no results to avoid loading GL items from unrelated payments.
+      return "1=2";
+    }
     queryNamedParameters.put("pid", strPaymentId);
     return "p.id = :pid";
   }

--- a/modules_core/org.openbravo.advpaymentmngt/web/org.openbravo.advpaymentmngt/js/ob-aprm-addPayment.js
+++ b/modules_core/org.openbravo.advpaymentmngt/web/org.openbravo.advpaymentmngt/js/ob-aprm-addPayment.js
@@ -172,6 +172,11 @@ OB.APRM.AddPayment.onLoad = function(view) {
   orderInvoiceGrid.dataProperties.transformData =
     OB.APRM.AddPayment.ordInvTransformData;
   glitemGrid.removeRecordClick = OB.APRM.AddPayment.removeRecordClick;
+  // Prevent new rows from being auto-saved to the DB before the form is submitted.
+  // Without this, adding a row and then cancelling the popup would persist an orphaned
+  // FIN_PaymentDetail in the database. With autoSaveEdits=false, new rows are held in
+  // memory and only sent to the server when the form is actually submitted.
+  glitemGrid.autoSaveEdits = false;
   creditUseGrid.selectionChanged = OB.APRM.AddPayment.selectionChangedCredit;
   creditUseGrid.userSelectAllRecords = OB.APRM.AddPayment.userSelectAllRecords;
   creditUseGrid.deselectAllRecords = OB.APRM.AddPayment.deselectAllRecords;

--- a/modules_core/org.openbravo.advpaymentmngt/web/org.openbravo.advpaymentmngt/js/ob-aprm-addPayment.js
+++ b/modules_core/org.openbravo.advpaymentmngt/web/org.openbravo.advpaymentmngt/js/ob-aprm-addPayment.js
@@ -172,11 +172,19 @@ OB.APRM.AddPayment.onLoad = function(view) {
   orderInvoiceGrid.dataProperties.transformData =
     OB.APRM.AddPayment.ordInvTransformData;
   glitemGrid.removeRecordClick = OB.APRM.AddPayment.removeRecordClick;
-  // Prevent new rows from being auto-saved to the DB before the form is submitted.
-  // Without this, adding a row and then cancelling the popup would persist an orphaned
-  // FIN_PaymentDetail in the database. With autoSaveEdits=false, new rows are held in
-  // memory and only sent to the server when the form is actually submitted.
-  glitemGrid.autoSaveEdits = false;
+  // Intercept the datasource add so new GL item rows are committed locally (keeping them
+  // in allRows so totals update in real time) but never persisted to the DB before the
+  // payment form is actually submitted. Without this, adding a row and then cancelling
+  // the popup would leave an orphaned FIN_PaymentDetail in the database.
+  glitemGrid.dataSource.addData = function(newValues, callback) {
+    if (callback) {
+      var saved = isc.addProperties({}, newValues);
+      if (!saved.id) {
+        saved.id = 'glitem_new_' + new Date().getTime();
+      }
+      callback({status: 0}, saved, {});
+    }
+  };
   creditUseGrid.selectionChanged = OB.APRM.AddPayment.selectionChangedCredit;
   creditUseGrid.userSelectAllRecords = OB.APRM.AddPayment.userSelectAllRecords;
   creditUseGrid.deselectAllRecords = OB.APRM.AddPayment.deselectAllRecords;
@@ -207,7 +215,8 @@ OB.APRM.AddPayment.onLoad = function(view) {
 };
 
 OB.APRM.AddPayment.addNewGLItem = function(grid) {
-  var returnObject = grid.data[0] ? isc.addProperties({}, grid.data[0]) : {};
+  var record = grid.getRecord(0);
+  var returnObject = record ? isc.addProperties({}, record) : {};
   returnObject.paidOut = 0;
   returnObject.receivedIn = 0;
   return returnObject;

--- a/modules_core/org.openbravo.advpaymentmngt/web/org.openbravo.advpaymentmngt/js/ob-aprm-addPayment.js
+++ b/modules_core/org.openbravo.advpaymentmngt/web/org.openbravo.advpaymentmngt/js/ob-aprm-addPayment.js
@@ -202,7 +202,7 @@ OB.APRM.AddPayment.onLoad = function(view) {
 };
 
 OB.APRM.AddPayment.addNewGLItem = function(grid) {
-  var returnObject = isc.addProperties({}, grid.data[0]);
+  var returnObject = grid.data[0] ? isc.addProperties({}, grid.data[0]) : {};
   returnObject.paidOut = 0;
   returnObject.receivedIn = 0;
   return returnObject;
@@ -460,6 +460,14 @@ OB.APRM.AddPayment.refreshEditedSelectedRecordsInGrid = function(grid) {
 };
 
 OB.APRM.AddPayment.glitemsOnLoadGrid = function(grid) {
+  // splice clears rows in-place, preserving the ResultSet so updateGLItemsTotal works after manual adds.
+  if (!grid.isReady && grid.data && grid.data.allRows && grid.data.allRows.length > 0) {
+    grid.selectedIds = [];
+    grid.deselectedIds = [];
+    grid.pneSelectedRecords = [];
+    grid.data.allRows.splice(0, grid.data.allRows.length);
+    grid.markForRedraw();
+  }
   if (!grid.isReady) {
     // If Gl Items Grid contains records when first opened then section is uncollapsed
     if (grid.getSelectedRecords() && grid.getSelectedRecords().size() > 0) {


### PR DESCRIPTION
## Summary

- The G/L Items grid in the Add Payment popup was pre-loading existing GL items from the DB when opened from the Payment In window via "Add Details", while it correctly showed empty when opened from Sales Invoice or Sales Order.
- Root cause: Openbravo framework automatically injects all form parameters (including `fin_payment_id`) into every grid DataSource fetch, so when an existing payment is in context the HQL injector returns its GL items.
- Fix: intercept in `glitemsOnLoadGrid` (the `ONGRIDLOADFUNCTION` callback) and clear the server-returned rows using `Array.splice` instead of `setData([])`. Splice empties the array in-place, preserving the SmartClient ResultSet so `updateGLItemsTotal` can still use `grid.data.allRows` when the user manually adds items.
- Added null-safety in `addNewGLItem` to handle an empty grid gracefully.

## Test plan

- [ ] Open Add Payment from **Payment In** → "Add Details": G/L Items grid must be empty on load.
- [ ] Add a G/L Item manually and verify the outstanding difference updates correctly.
- [ ] Open Add Payment from **Sales Invoice** or **Sales Order**: G/L Items grid must remain empty (regression check).
- [ ] Add a G/L Item manually from Sales Invoice/Order context and verify totals update correctly.