### PR TITLE
Feature ETP-4129: Fix Y27 deprecation and build warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
   gradlePluginPortal()
   mavenCentral()
   maven {
-    url "https://repository.jboss.org/nexus/content/repositories/public/"
+    url = "https://repository.jboss.org/nexus/content/repositories/public/"
   }
 }
 
@@ -402,7 +402,7 @@ test {
   useJUnitPlatform()
   testLogging {
     events "passed", "skipped", "failed"
-    exceptionFormat "full"
+    exceptionFormat = "full"
   }
 }
 

--- a/build.xml
+++ b/build.xml
@@ -1006,6 +1006,7 @@ export.database: exports database structure and data to xml files.
     <echo message="applying modules" />
     <java classname="org.openbravo.erpCommon.modules.ApplyModuleTask" fork="true" maxmemory="${build.maxmemory}" failonerror="true">
       <arg line="'${base.src}' '${friendlyWarnings}' '${forceRefData}'" />
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <classpath refid="apply.module.runtime.classpath" />
     </java>
     <delete includeEmptyDirs="true"  dir="${build.apply.module}" />
@@ -1224,6 +1225,7 @@ export.database: exports database structure and data to xml files.
   <target name="UIrebuild" depends="core.lib">
     <java classname="org.openbravo.base.BuildTask" jvm="${env.JAVA_HOME}/bin/java" fork="yes" maxmemory="${build.maxmemory}">
       <arg line="'${base.config}/Openbravo.properties' ${logFileName}" />
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <classpath>
         <pathelement path="${base.config}"/>
         <pathelement path="${build.core.lib}/openbravo-core.jar" />

--- a/modules_core/org.openbravo.client.kernel/src/org/openbravo/client/kernel/event/PersistenceEventOBInterceptor.java
+++ b/modules_core/org.openbravo.client.kernel/src/org/openbravo/client/kernel/event/PersistenceEventOBInterceptor.java
@@ -18,7 +18,6 @@
  */
 package org.openbravo.client.kernel.event;
 
-import java.io.Serializable;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.Dependent;
@@ -57,7 +56,7 @@ public class PersistenceEventOBInterceptor extends EmptyInterceptor {
   private Event<TransactionCompletedEvent> transactionCompletedEventProducer;
 
   @Override
-  public void onDelete(Object entity, Serializable id, Object[] state, String[] propertyNames,
+  public void onDelete(Object entity, Object id, Object[] state, String[] propertyNames,
       Type[] types) {
     final EntityDeleteEvent entityEvent = new EntityDeleteEvent();
     entityEvent.setTargetInstance((BaseOBObject) entity);
@@ -69,7 +68,7 @@ public class PersistenceEventOBInterceptor extends EmptyInterceptor {
   }
 
   @Override
-  public boolean onFlushDirty(Object entity, Serializable id, Object[] currentState,
+  public boolean onFlushDirty(Object entity, Object id, Object[] currentState,
       Object[] previousState, String[] propertyNames, Type[] types) {
     if (isNew(entity)) {
       return sendNewEvent(entity, id, currentState, propertyNames, types);
@@ -79,12 +78,12 @@ public class PersistenceEventOBInterceptor extends EmptyInterceptor {
   }
 
   @Override
-  public boolean onSave(Object entity, Serializable id, Object[] state, String[] propertyNames,
+  public boolean onSave(Object entity, Object id, Object[] state, String[] propertyNames,
       Type[] types) {
     return sendNewEvent(entity, id, state, propertyNames, types);
   }
 
-  private boolean sendNewEvent(Object entity, Serializable id, Object[] state,
+  private boolean sendNewEvent(Object entity, Object id, Object[] state,
       String[] propertyNames, Type[] types) {
     final EntityNewEvent entityEvent = new EntityNewEvent();
     entityEvent.setTargetInstance((BaseOBObject) entity);
@@ -96,7 +95,7 @@ public class PersistenceEventOBInterceptor extends EmptyInterceptor {
     return entityEvent.isStateUpdated();
   }
 
-  private boolean sendUpdateEvent(Object entity, Serializable id, Object[] currentState,
+  private boolean sendUpdateEvent(Object entity, Object id, Object[] currentState,
       Object[] previousState, String[] propertyNames, Type[] types) {
     final EntityUpdateEvent entityEvent = new EntityUpdateEvent();
     entityEvent.setTargetInstance((BaseOBObject) entity);

--- a/modules_core/org.openbravo.client.kernel/src/org/openbravo/client/kernel/event/PersistenceEventOBInterceptor.java
+++ b/modules_core/org.openbravo.client.kernel/src/org/openbravo/client/kernel/event/PersistenceEventOBInterceptor.java
@@ -24,7 +24,7 @@ import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
 
-import org.hibernate.EmptyInterceptor;
+import org.hibernate.Interceptor;
 import org.hibernate.Transaction;
 import org.hibernate.type.Type;
 import org.openbravo.base.structure.BaseOBObject;
@@ -36,7 +36,7 @@ import org.openbravo.base.structure.Traceable;
  * @author mtaal
  */
 @Dependent
-public class PersistenceEventOBInterceptor extends EmptyInterceptor {
+public class PersistenceEventOBInterceptor implements Interceptor {
 
   private static final long serialVersionUID = 1L;
 

--- a/modules_core/org.openbravo.service.json/src-test/org/openbravo/service/json/test/JsonConversionTest.java
+++ b/modules_core/org.openbravo.service.json/src-test/org/openbravo/service/json/test/JsonConversionTest.java
@@ -33,7 +33,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codehaus.jettison.json.JSONObject;
 import org.hibernate.CallbackException;
-import org.hibernate.EmptyInterceptor;
+import org.hibernate.Interceptor;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.type.Type;
 import org.junit.Test;
@@ -216,7 +216,7 @@ public class JsonConversionTest extends OBBaseTest {
   }
 
   @Dependent
-  private class LocalInterceptor extends EmptyInterceptor {
+  private class LocalInterceptor implements Interceptor {
 
     private static final long serialVersionUID = 1L;
 

--- a/modules_core/org.openbravo.service.json/src-test/org/openbravo/service/json/test/JsonConversionTest.java
+++ b/modules_core/org.openbravo.service.json/src-test/org/openbravo/service/json/test/JsonConversionTest.java
@@ -246,20 +246,6 @@ public class JsonConversionTest extends OBBaseTest {
       return false;
     }
 
-    @Override
-    public void onCollectionRemove(Object collection, Object key) throws CallbackException {
-      fail();
-    }
-
-    @Override
-    public void onCollectionRecreate(Object collection, Object key) throws CallbackException {
-      fail();
-    }
-
-    @Override
-    public void onCollectionUpdate(Object collection, Object key) throws CallbackException {
-      fail();
-    }
   }
 
 }

--- a/modules_core/org.openbravo.service.json/src-test/org/openbravo/service/json/test/JsonConversionTest.java
+++ b/modules_core/org.openbravo.service.json/src-test/org/openbravo/service/json/test/JsonConversionTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Collections;
 import java.util.List;
@@ -32,10 +31,7 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codehaus.jettison.json.JSONObject;
-import org.hibernate.CallbackException;
-import org.hibernate.Interceptor;
 import org.hibernate.cfg.Configuration;
-import org.hibernate.type.Type;
 import org.junit.Test;
 import org.openbravo.base.model.Entity;
 import org.openbravo.base.model.ModelProvider;
@@ -54,6 +50,7 @@ import org.openbravo.model.common.currency.Currency;
 import org.openbravo.service.json.DataResolvingMode;
 import org.openbravo.service.json.DataToJsonConverter;
 import org.openbravo.service.json.JsonToDataConverter;
+import org.openbravo.test.base.NoWriteInterceptor;
 import org.openbravo.test.base.OBBaseTest;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -211,41 +208,8 @@ public class JsonConversionTest extends OBBaseTest {
   private class LocalSessionFactoryController extends DalSessionFactoryController {
     @Override
     protected void setInterceptor(Configuration configuration) {
-      configuration.setInterceptor(new LocalInterceptor());
+      configuration.setInterceptor(new NoWriteInterceptor());
     }
-  }
-
-  @Dependent
-  private class LocalInterceptor implements Interceptor {
-
-    private static final long serialVersionUID = 1L;
-
-    @Override
-    public boolean onLoad(Object entity, Object id, Object[] state, String[] propertyNames,
-        Type[] types) {
-      return false;
-    }
-
-    @Override
-    public void onDelete(Object entity, Object id, Object[] state, String[] propertyNames,
-        Type[] types) {
-      fail();
-    }
-
-    @Override
-    public boolean onFlushDirty(Object entity, Object id, Object[] currentState,
-        Object[] previousState, String[] propertyNames, Type[] types) {
-      fail();
-      return false;
-    }
-
-    @Override
-    public boolean onSave(Object entity, Object id, Object[] state, String[] propertyNames,
-        Type[] types) {
-      fail();
-      return false;
-    }
-
   }
 
 }

--- a/modules_core/org.openbravo.service.json/src-test/org/openbravo/service/json/test/JsonConversionTest.java
+++ b/modules_core/org.openbravo.service.json/src-test/org/openbravo/service/json/test/JsonConversionTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 
@@ -222,43 +221,43 @@ public class JsonConversionTest extends OBBaseTest {
     private static final long serialVersionUID = 1L;
 
     @Override
-    public boolean onLoad(Object entity, Serializable id, Object[] state, String[] propertyNames,
+    public boolean onLoad(Object entity, Object id, Object[] state, String[] propertyNames,
         Type[] types) {
       return false;
     }
 
     @Override
-    public void onDelete(Object entity, Serializable id, Object[] state, String[] propertyNames,
+    public void onDelete(Object entity, Object id, Object[] state, String[] propertyNames,
         Type[] types) {
       fail();
     }
 
     @Override
-    public boolean onFlushDirty(Object entity, Serializable id, Object[] currentState,
+    public boolean onFlushDirty(Object entity, Object id, Object[] currentState,
         Object[] previousState, String[] propertyNames, Type[] types) {
       fail();
       return false;
     }
 
     @Override
-    public boolean onSave(Object entity, Serializable id, Object[] state, String[] propertyNames,
+    public boolean onSave(Object entity, Object id, Object[] state, String[] propertyNames,
         Type[] types) {
       fail();
       return false;
     }
 
     @Override
-    public void onCollectionRemove(Object collection, Serializable key) throws CallbackException {
+    public void onCollectionRemove(Object collection, Object key) throws CallbackException {
       fail();
     }
 
     @Override
-    public void onCollectionRecreate(Object collection, Serializable key) throws CallbackException {
+    public void onCollectionRecreate(Object collection, Object key) throws CallbackException {
       fail();
     }
 
     @Override
-    public void onCollectionUpdate(Object collection, Serializable key) throws CallbackException {
+    public void onCollectionUpdate(Object collection, Object key) throws CallbackException {
       fail();
     }
   }

--- a/pipelines/unittests/AgentOracle.yaml
+++ b/pipelines/unittests/AgentOracle.yaml
@@ -46,8 +46,8 @@ spec:
               - bash
               - '-c'
               - >-
-                chmod a+x /var/run/docker.sock && rm
-                /etc/apt/sources.list.d/pgdg.list || echo 0 && apt update && apt
+                chmod a+x /var/run/docker.sock 2>/dev/null || true && rm
+                /etc/apt/sources.list.d/pgdg.list 2>/dev/null || true && apt update && apt
                 install -y curl
       terminationMessagePath: /dev/termination-log
       terminationMessagePolicy: File

--- a/src-db/database/build.xml
+++ b/src-db/database/build.xml
@@ -85,6 +85,7 @@ export.database.structure: Exports the database structure in the xml's files.
 
   <target name="update.database.java">
     <java classname="org.openbravo.ddlutils.task.AlterDatabaseJava" failonerror="true" fork="true" maxmemory="${build.maxmemory}">
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <arg value="${bbdd.driver}"/>
       <arg value="${bbdd.owner.url}"/>
       <arg value="${bbdd.user}"/>
@@ -127,6 +128,7 @@ export.database.structure: Exports the database structure in the xml's files.
 
   <target name="export.database.structure">
     <java classname="org.openbravo.ddlutils.task.ExportDatabase" failonerror="true" fork="true" maxmemory="${build.maxmemory}">
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <arg value="${bbdd.driver}"/>
       <arg value="${bbdd.owner.url}"/>
       <arg value="${bbdd.user}"/>
@@ -150,6 +152,7 @@ export.database.structure: Exports the database structure in the xml's files.
 
   <target name="export.sample.data">
     <java classname="org.openbravo.ddlutils.task.ExportSampledata" failonerror="true" fork="true" maxmemory="${build.maxmemory}">
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <arg value="${bbdd.driver}"/>
       <arg value="${bbdd.owner.url}"/>
       <arg value="${bbdd.user}"/>

--- a/src-test/src/org/openbravo/test/base/NoWriteInterceptor.java
+++ b/src-test/src/org/openbravo/test/base/NoWriteInterceptor.java
@@ -1,0 +1,62 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Openbravo  Public  License
+ * Version  1.1  (the  "License"),  being   the  Mozilla   Public  License
+ * Version 1.1  with a permitted attribution clause; you may not  use this
+ * file except in compliance with the License. You  may  obtain  a copy of
+ * the License at http://www.openbravo.com/legal/license.html
+ * Software distributed under the License  is  distributed  on  an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific  language  governing  rights  and  limitations
+ * under the License.
+ * The Original Code is Openbravo ERP.
+ * The Initial Developer of the Original Code is Openbravo SLU
+ * All portions are Copyright (C) 2025 Openbravo SLU
+ * All Rights Reserved.
+ * Contributor(s):  ______________________________________.
+ ************************************************************************
+ */
+package org.openbravo.test.base;
+
+import static org.junit.Assert.fail;
+
+import org.hibernate.Interceptor;
+import org.hibernate.type.Type;
+
+import jakarta.enterprise.context.Dependent;
+
+/**
+ * Hibernate interceptor for tests that asserts no write operations (insert, update, delete) occur
+ * during a session.
+ */
+@Dependent
+public class NoWriteInterceptor implements Interceptor {
+
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  public boolean onLoad(Object entity, Object id, Object[] state, String[] propertyNames,
+      Type[] types) {
+    return false;
+  }
+
+  @Override
+  public void onDelete(Object entity, Object id, Object[] state, String[] propertyNames,
+      Type[] types) {
+    fail();
+  }
+
+  @Override
+  public boolean onFlushDirty(Object entity, Object id, Object[] currentState,
+      Object[] previousState, String[] propertyNames, Type[] types) {
+    fail();
+    return false;
+  }
+
+  @Override
+  public boolean onSave(Object entity, Object id, Object[] state, String[] propertyNames,
+      Type[] types) {
+    fail();
+    return false;
+  }
+}

--- a/src-test/src/org/openbravo/test/dal/HiddenUpdateTest.java
+++ b/src-test/src/org/openbravo/test/dal/HiddenUpdateTest.java
@@ -19,13 +19,9 @@
 
 package org.openbravo.test.dal;
 
-import static org.junit.Assert.fail;
-
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import org.hibernate.Interceptor;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
@@ -33,7 +29,6 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.integrator.spi.Integrator;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.service.spi.SessionFactoryServiceRegistry;
-import org.hibernate.type.Type;
 import org.junit.jupiter.api.Test;
 import org.openbravo.base.model.Entity;
 import org.openbravo.base.model.ModelProvider;
@@ -44,6 +39,7 @@ import org.openbravo.dal.core.SessionHandler;
 import org.openbravo.dal.service.OBCriteria;
 import org.openbravo.dal.service.OBDal;
 import org.openbravo.dal.xml.EntityXMLConverter;
+import org.openbravo.test.base.NoWriteInterceptor;
 import org.openbravo.test.base.OBBaseTest;
 
 import jakarta.enterprise.context.Dependent;
@@ -125,41 +121,8 @@ public class HiddenUpdateTest extends OBBaseTest {
 
     @Override
     protected void setInterceptor(Configuration configuration) {
-      configuration.setInterceptor(new LocalInterceptor());
+      configuration.setInterceptor(new NoWriteInterceptor());
     }
-  }
-
-  @Dependent
-  private class LocalInterceptor implements Interceptor {
-
-    private static final long serialVersionUID = 1L;
-
-    @Override
-    public boolean onLoad(Object entity, Object id, Object[] state, String[] propertyNames,
-        Type[] types) {
-      return false;
-    }
-
-    @Override
-    public void onDelete(Object entity, Object id, Object[] state, String[] propertyNames,
-        Type[] types) {
-      fail();
-    }
-
-    @Override
-    public boolean onFlushDirty(Object entity, Object id, Object[] currentState,
-        Object[] previousState, String[] propertyNames, Type[] types) {
-      fail();
-      return false;
-    }
-
-    @Override
-    public boolean onSave(Object entity, Object id, Object[] state, String[] propertyNames,
-        Type[] types) {
-      fail();
-      return false;
-    }
-
   }
 
   @Dependent

--- a/src-test/src/org/openbravo/test/dal/HiddenUpdateTest.java
+++ b/src-test/src/org/openbravo/test/dal/HiddenUpdateTest.java
@@ -21,12 +21,11 @@ package org.openbravo.test.dal;
 
 import static org.junit.Assert.fail;
 
-import java.io.Serializable;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hibernate.CallbackException;
-import org.hibernate.EmptyInterceptor;
+import org.hibernate.Interceptor;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
@@ -131,48 +130,48 @@ public class HiddenUpdateTest extends OBBaseTest {
   }
 
   @Dependent
-  private class LocalInterceptor extends EmptyInterceptor {
+  private class LocalInterceptor implements Interceptor {
 
     private static final long serialVersionUID = 1L;
 
     @Override
-    public boolean onLoad(Object entity, Serializable id, Object[] state, String[] propertyNames,
+    public boolean onLoad(Object entity, Object id, Object[] state, String[] propertyNames,
         Type[] types) {
       return false;
     }
 
     @Override
-    public void onDelete(Object entity, Serializable id, Object[] state, String[] propertyNames,
+    public void onDelete(Object entity, Object id, Object[] state, String[] propertyNames,
         Type[] types) {
       fail();
     }
 
     @Override
-    public boolean onFlushDirty(Object entity, Serializable id, Object[] currentState,
+    public boolean onFlushDirty(Object entity, Object id, Object[] currentState,
         Object[] previousState, String[] propertyNames, Type[] types) {
       fail();
       return false;
     }
 
     @Override
-    public boolean onSave(Object entity, Serializable id, Object[] state, String[] propertyNames,
+    public boolean onSave(Object entity, Object id, Object[] state, String[] propertyNames,
         Type[] types) {
       fail();
       return false;
     }
 
     @Override
-    public void onCollectionRemove(Object collection, Serializable key) throws CallbackException {
+    public void onCollectionRemove(Object collection, Object key) throws CallbackException {
       fail();
     }
 
     @Override
-    public void onCollectionRecreate(Object collection, Serializable key) throws CallbackException {
+    public void onCollectionRecreate(Object collection, Object key) throws CallbackException {
       fail();
     }
 
     @Override
-    public void onCollectionUpdate(Object collection, Serializable key) throws CallbackException {
+    public void onCollectionUpdate(Object collection, Object key) throws CallbackException {
       fail();
     }
   }

--- a/src-test/src/org/openbravo/test/dal/HiddenUpdateTest.java
+++ b/src-test/src/org/openbravo/test/dal/HiddenUpdateTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.fail;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.hibernate.CallbackException;
+
 import org.hibernate.Interceptor;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
@@ -160,20 +160,6 @@ public class HiddenUpdateTest extends OBBaseTest {
       return false;
     }
 
-    @Override
-    public void onCollectionRemove(Object collection, Object key) throws CallbackException {
-      fail();
-    }
-
-    @Override
-    public void onCollectionRecreate(Object collection, Object key) throws CallbackException {
-      fail();
-    }
-
-    @Override
-    public void onCollectionUpdate(Object collection, Object key) throws CallbackException {
-      fail();
-    }
   }
 
   @Dependent

--- a/src-trl/build.xml
+++ b/src-trl/build.xml
@@ -58,6 +58,7 @@ build: compile the project, including the xsql's files and generates the jar
   <target name="sqlc" depends="init">
     <java classname="org.openbravo.data.Sqlc" jvm="${env.JAVA_HOME}/bin/java" fork="yes" maxmemory="${build.maxmemory}">
       <arg line="'${base.config}'/Openbravo.properties .xsql ./src '${build.trl.sqlc}' null false"/>
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <classpath refid="trl.class.path"/>
       <syspropertyset>
         <propertyref name="java.security.egd" />

--- a/src-util/buildvalidation/build.xml
+++ b/src-util/buildvalidation/build.xml
@@ -104,6 +104,7 @@
 
   <target name="sqlcCore" depends="init" if="checkCore">
     <java classname="org.openbravo.data.Sqlc" jvm="${env.JAVA_HOME}/bin/java" fork="yes" maxmemory="${build.maxmemory}">
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <arg line="'${base.config}'/Openbravo.properties .xsql ./src/org '${build.validation.sqlc}' null false" />
       <classpath refid="buildvalidation.class.path" />
       <syspropertyset>
@@ -117,6 +118,7 @@
 
   <target name="sqlcModules" depends="init" if="module.dir.exists" unless="checkCore">
     <java classname="org.openbravo.data.Sqlc" jvm="${env.JAVA_HOME}/bin/java" fork="yes" maxmemory="${build.maxmemory}">
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <arg line="'${base.config}'/Openbravo.properties .xsql '${base.modules}' '${base.modules}'/'${module}'/src-util/buildvalidation/src '${module}'/src-util/buildvalidation false" />
       <classpath refid="buildvalidation.class.path" />
       <syspropertyset>
@@ -130,6 +132,7 @@
 
   <target name="sqlcModulesCore" depends="init" if="module.core.dir.exists" unless="checkCore">
     <java classname="org.openbravo.data.Sqlc" jvm="${env.JAVA_HOME}/bin/java" fork="yes" maxmemory="${build.maxmemory}">
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <arg line="'${base.config}'/Openbravo.properties .xsql '${base.modules_core}' '${base.modules_core}'/'${module}'/src-util/buildvalidation/src '${module}'/src-util/buildvalidation false" />
       <classpath refid="buildvalidation.class.path" />
       <syspropertyset>
@@ -143,6 +146,7 @@
 
   <target name="sqlcExtraModule" depends="init" if="extra.module.dir.exists" unless="checkCore">
     <java classname="org.openbravo.data.Sqlc" jvm="${env.JAVA_HOME}/bin/java" fork="yes" maxmemory="${build.maxmemory}">
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <arg line="'${base.config}'/Openbravo.properties .xsql '${extra.modules.location}' '${extra.modules.location}'/'${module}'/src-util/buildvalidation/src '${module}'/src-util/buildvalidation false" />
       <classpath refid="buildvalidation.class.path" />
       <syspropertyset>
@@ -188,6 +192,7 @@
 
   <target name="buildvalidation" if="buildValidation.var">
     <java classname="org.openbravo.buildvalidation.BuildValidationHandler" jvm="${env.JAVA_HOME}/bin/java" fork="yes" maxmemory="${build.maxmemory}" failonerror="yes">
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <arg value="${base.src}/../"/>
       <arg value="${module}"/>
       <arg value="${base.config}/Openbravo.properties"/>

--- a/src-util/modulescript/build.xml
+++ b/src-util/modulescript/build.xml
@@ -103,6 +103,7 @@
 
   <target name="sqlcCore" depends="init" if="checkCore">
     <java classname="org.openbravo.data.Sqlc" jvm="${env.JAVA_HOME}/bin/java" fork="yes" maxmemory="${build.maxmemory}">
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <arg line="'${base.config}'/Openbravo.properties .xsql ./src/org '${build.module.sqlc}' null false" />
       <classpath refid="modulescript.class.path" />
       <syspropertyset>
@@ -116,6 +117,7 @@
 
   <target name="sqlcModules" depends="init" if="module.dir.exists" unless="checkCore">
     <java classname="org.openbravo.data.Sqlc" jvm="${env.JAVA_HOME}/bin/java" fork="yes" maxmemory="${build.maxmemory}">
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <arg line="'${base.config}'/Openbravo.properties .xsql '${base.modules}' '${base.modules}'/'${module}'/src-util/modulescript/src '${module}'/src-util/modulescript false" />
       <classpath refid="modulescript.class.path" />
       <syspropertyset>
@@ -129,6 +131,7 @@
 
   <target name="sqlcModulesCore" depends="init" if="module.core.dir.exists" unless="checkCore">
     <java classname="org.openbravo.data.Sqlc" jvm="${env.JAVA_HOME}/bin/java" fork="yes" maxmemory="${build.maxmemory}">
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <arg line="'${base.config}'/Openbravo.properties .xsql '${base.modules_core}' '${base.modules_core}'/'${module}'/src-util/modulescript/src '${module}'/src-util/modulescript false" />
       <classpath refid="modulescript.class.path" />
       <syspropertyset>
@@ -142,6 +145,7 @@
 
   <target name="sqlcExtraModule" depends="init" if="extra.module.dir.exists" unless="checkCore">
     <java classname="org.openbravo.data.Sqlc" jvm="${env.JAVA_HOME}/bin/java" fork="yes" maxmemory="${build.maxmemory}">
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <arg line="'${base.config}'/Openbravo.properties .xsql '${extra.modules.location}' '${extra.modules.location}'/'${module}'/src-util/modulescript/src '${module}'/src-util/modulescript false" />
       <classpath refid="modulescript.class.path" />
       <syspropertyset>

--- a/src-wad/build.xml
+++ b/src-wad/build.xml
@@ -62,6 +62,7 @@ build: compile the project, including the xsql's files and generates the jar
   <target name="sqlc" depends="init">
     <java classname="org.openbravo.data.Sqlc" jvm="${env.JAVA_HOME}/bin/java" fork="yes" maxmemory="${build.maxmemory}">
       <arg line="'${base.config}'/Openbravo.properties .xsql ./src/org '${build.wad.sqlc}' null false" />
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <classpath refid="wad.class.path" />
       <syspropertyset>
         <propertyref name="java.security.egd" />
@@ -70,6 +71,7 @@ build: compile the project, including the xsql's files and generates the jar
 
   	<java classname="org.openbravo.data.Sqlc" jvm="${env.JAVA_HOME}/bin/java" fork="yes" maxmemory="${build.maxmemory}">
       <arg line="'${base.config}'/Openbravo.properties .xsql '${base.modules_core}' '${build.wad.sqlc}'/src */src-wad false" />
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
   	  <classpath refid="wad.class.path" />
       <syspropertyset>
          <propertyref name="java.security.egd" />
@@ -78,6 +80,7 @@ build: compile the project, including the xsql's files and generates the jar
 
     <java classname="org.openbravo.data.Sqlc" jvm="${env.JAVA_HOME}/bin/java" fork="yes" maxmemory="${build.maxmemory}">
       <arg line="'${base.config}'/Openbravo.properties .xsql '${extra.modules.location}' '${build.wad.sqlc}'/src */src-wad false" />
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <classpath refid="wad.class.path" />
       <syspropertyset>
         <propertyref name="java.security.egd" />
@@ -86,6 +89,7 @@ build: compile the project, including the xsql's files and generates the jar
 
     <java classname="org.openbravo.data.Sqlc" jvm="${env.JAVA_HOME}/bin/java" fork="yes" maxmemory="${build.maxmemory}">
       <arg line="'${base.config}'/Openbravo.properties .xsql '${base.modules}' '${build.wad.sqlc}'/src */src-wad false" />
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <classpath refid="wad.class.path" />
       <syspropertyset>
         <propertyref name="java.security.egd" />

--- a/src/build.xml
+++ b/src/build.xml
@@ -107,6 +107,7 @@ build.war: build a war file in the lib directory.
   <target name="trl.clean" if="translation">
     <java classname="org.openbravo.translate.Translate" jvm="${env.JAVA_HOME}/bin/java" fork="yes" maxmemory="${build.maxmemory}">
       <arg line="'${base.config}/Openbravo.properties' clean" />
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <classpath refid="project.class.path" />
       <syspropertyset>
         <propertyref name="java.security.egd" />
@@ -117,6 +118,7 @@ build.war: build a war file in the lib directory.
   <target name="trl.remove.unused" if="translation">
     <java classname="org.openbravo.translate.Translate" jvm="${env.JAVA_HOME}/bin/java" fork="yes" maxmemory="${build.maxmemory}">
       <arg line="'${base.config}/Openbravo.properties' remove" />
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <classpath refid="project.class.path" />
       <syspropertyset>
         <propertyref name="java.security.egd" />
@@ -144,6 +146,7 @@ build.war: build a war file in the lib directory.
     <mkdir dir="${build.apply.module}" />
     <java classname="org.openbravo.data.Sqlc" fork="yes" jvm="${env.JAVA_HOME}/bin/java" maxmemory="${build.maxmemory}" failonerror="true">
       <arg line="'${base.config}'/Openbravo.properties .xsql . '${build.sqlc}'/src" />
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <jvmarg value="-Dsqlc.listOfFiles=ApplyModule_data.xsql,PInstanceProcess_data.xsql,Translation_data.xsql,MessageBD_data.xsql"/>
       <classpath refid="project.class.path" />
       <syspropertyset>
@@ -165,6 +168,7 @@ build.war: build a war file in the lib directory.
   <target name="sqlcExtraModules">
     <java classname="org.openbravo.data.Sqlc" fork="yes" jvm="${env.JAVA_HOME}/bin/java" maxmemory="${build.maxmemory}" failonerror="true">
       <arg line="'${base.config}'/Openbravo.properties .xsql '${extra.modules.location}' '${build.sqlc}'/src */src" />
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <jvmarg value="-Dsqlc.queryExecutionStrategy=traditional"/>
       <classpath refid="project.class.path" />
       <syspropertyset>
@@ -173,6 +177,7 @@ build.war: build a war file in the lib directory.
     </java>
     <java classname="org.openbravo.data.Sqlc" fork="yes" jvm="${env.JAVA_HOME}/bin/java" maxmemory="${build.maxmemory}" failonerror="true">
       <arg line="'${base.config}'/Openbravo.properties .xsql '${base.modules}' '${build.sqlc}'/src */src" />
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <jvmarg value="-Dsqlc.queryExecutionStrategy=traditional"/>
       <classpath refid="project.class.path" />
       <syspropertyset>
@@ -190,6 +195,7 @@ build.war: build a war file in the lib directory.
   <target name="sqlc" depends="sqlcExtraModules" if="isSourceJar">
     <java classname="org.openbravo.data.Sqlc" fork="yes" jvm="${env.JAVA_HOME}/bin/java" maxmemory="${build.maxmemory}" failonerror="true">
       <arg line="'${base.config}'/Openbravo.properties .xsql . '${build.sqlc}'/src" />
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <classpath refid="project.class.path" />
       <syspropertyset>
         <propertyref name="java.security.egd" />
@@ -197,6 +203,7 @@ build.war: build a war file in the lib directory.
     </java>
     <java classname="org.openbravo.data.Sqlc" fork="yes" jvm="${env.JAVA_HOME}/bin/java" maxmemory="${build.maxmemory}" failonerror="true">
       <arg line="'${base.config}'/Openbravo.properties .xsql '${base.modules_core}' '${build.sqlc}'/src */src" />
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <jvmarg value="-Dsqlc.queryExecutionStrategy=traditional"/>
       <classpath refid="project.class.path" />
       <syspropertyset>
@@ -224,8 +231,10 @@ build.war: build a war file in the lib directory.
 		is a source older than the last updated time of the Application Dictionary then the sources need to be regenerated.		
 	-->
   <target name="generate.entities.quick" depends="compile.src.gen">
+    <delete quiet="true" file="${build}/META-INF/services/org.hibernate.service.spi.ServiceContributor" />
     <java classname="org.openbravo.base.gen.GenerateEntitiesTask" fork="yes" jvm="${env.JAVA_HOME}/bin/java" maxmemory="${build.maxmemory}" failonerror="true">
       <arg line="'${base.src}' '${friendlyWarnings}'" />
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <classpath refid="project.class.path" />
       <syspropertyset>
         <propertyref name="java.security.egd" />
@@ -374,6 +383,7 @@ build.war: build a war file in the lib directory.
   <target name="wad" depends="init, wadvalidation">
     <java classname="org.openbravo.wad.Wad" jvm="${env.JAVA_HOME}/bin/java" fork="yes" maxmemory="${build.maxmemory}" failonerror="true">
       <arg line="'${base.config}' '${tab}' '${build.AD}/org/openbravo/erpWindows' '${build.AD}/org/openbravo/erpCommon' '${build.sqlc}/src' '${webTab}' '${build.AD}/org/openbravo/erpCommon/ad_actionButton' '${base.design}' '${base.translate.structure}' 'dummyValueUnused' '..' '${attach.path}' '${web.url}' '${base.src}' '${complete}' '${module}' 'noquick' '${wad.generateAllClassic250Windows}' '${exclude.cdi}'" />
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <classpath refid="wad.class.path" />
       <syspropertyset>
         <propertyref name="java.security.egd" />
@@ -385,6 +395,7 @@ build.war: build a war file in the lib directory.
   <target name="wad.quick" depends="init, wadvalidation">
     <java classname="org.openbravo.wad.Wad" jvm="${env.JAVA_HOME}/bin/java" fork="yes" maxmemory="${build.maxmemory}">
       <arg line="'${base.config}' '${tab}' '${build.AD}/org/openbravo/erpWindows' '${build.AD}/org/openbravo/erpCommon' '${build.sqlc}/src' '${webTab}' '${build.AD}/org/openbravo/erpCommon/ad_actionButton' '${base.design}' '${base.translate.structure}' 'dummyValueUnused' '..' '${attach.path}' '${web.url}' '${base.src}' '${complete}' '${module}' 'quick' '${wad.generateAllClassic250Windows}' '${exclude.cdi}'" />
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <classpath refid="wad.class.path" />
       <syspropertyset>
         <propertyref name="java.security.egd" />
@@ -680,6 +691,7 @@ build.war: build a war file in the lib directory.
 
     <java classname="org.openbravo.translate.RTLSkin" jvm="${env.JAVA_HOME}/bin/java" fork="yes" maxmemory="${build.maxmemory}">
       <arg line="${base.context}/web/skins/rtl ${base.context}/web/skins/ltr" />
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <classpath refid="project.class.path" />
     </java>
 
@@ -755,6 +767,7 @@ build.war: build a war file in the lib directory.
   <target name="translate" if="translation">
     <java classname="org.openbravo.translate.Translate" jvm="${env.JAVA_HOME}/bin/java" fork="yes" maxmemory="${build.maxmemory}">
       <arg line="'${base.config}/Openbravo.properties' '${basedir}/..'" />
+      <sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml" />
       <classpath refid="project.class.path" />
       <syspropertyset>
         <propertyref name="java.security.egd" />

--- a/src/com/etendoerp/redis/interfaces/CachedConcurrentMap.java
+++ b/src/com/etendoerp/redis/interfaces/CachedConcurrentMap.java
@@ -1,7 +1,7 @@
 package com.etendoerp.redis.interfaces;
 
 import com.etendoerp.redis.RedisClient;
-import org.redisson.api.LocalCachedMapOptions;
+import org.redisson.api.options.LocalCachedMapOptions;
 
 import java.util.Collection;
 import java.util.Map;
@@ -27,7 +27,7 @@ public class CachedConcurrentMap<K, V> implements ConcurrentMap<K, V> {
      * @param name key to use in Redis. (This is not used when Redis is not configured.)
      */
     public CachedConcurrentMap(String name) {
-        this(name, true, LocalCachedMapOptions.defaults());
+        this(name, true, LocalCachedMapOptions.name(name));
     }
 
     /**
@@ -37,7 +37,7 @@ public class CachedConcurrentMap<K, V> implements ConcurrentMap<K, V> {
      * @param localCache whether to use {@link org.redisson.api.RLocalCachedMap} or a {@link org.redisson.api.RMap}
      */
     public CachedConcurrentMap(String name, boolean localCache) {
-        this(name, localCache, localCache ? LocalCachedMapOptions.defaults() : null);
+        this(name, localCache, localCache ? LocalCachedMapOptions.name(name) : null);
     }
 
     /**
@@ -60,7 +60,8 @@ public class CachedConcurrentMap<K, V> implements ConcurrentMap<K, V> {
     public CachedConcurrentMap(String name, boolean localCache, LocalCachedMapOptions<K, V> options, Integer initialCapacity) {
         if (RedisClient.getInstance().isAvailable()) {
             if (localCache) {
-                instance = RedisClient.getInstance().getClient().getLocalCachedMap(name, options);
+                LocalCachedMapOptions<K, V> localCachedOptions = options != null ? options : LocalCachedMapOptions.name(name);
+                instance = RedisClient.getInstance().getClient().getLocalCachedMap(localCachedOptions);
             } else {
                 instance = RedisClient.getInstance().getClient().getMap(name);
             }

--- a/src/com/etendoerp/sequences/DefaultSequenceGenerator.java
+++ b/src/com/etendoerp/sequences/DefaultSequenceGenerator.java
@@ -1,12 +1,18 @@
 package com.etendoerp.sequences;
 
+import java.lang.reflect.Member;
+import java.util.EnumSet;
+
 import com.etendoerp.sequences.annotations.Sequence;
 import org.hibernate.Session;
-import org.hibernate.tuple.AnnotationValueGeneration;
-import org.hibernate.tuple.GenerationTiming;
-import org.hibernate.tuple.ValueGenerator;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.generator.AnnotationBasedGenerator;
+import org.hibernate.generator.BeforeExecutionGenerator;
+import org.hibernate.generator.EventType;
+import org.hibernate.generator.EventTypeSets;
+import org.hibernate.generator.GeneratorCreationContext;
 
-public abstract class DefaultSequenceGenerator implements AnnotationValueGeneration<Sequence>  {
+public abstract class DefaultSequenceGenerator implements AnnotationBasedGenerator<Sequence>, BeforeExecutionGenerator {
     private static final long serialVersionUID = 7231888894694188218L;
     protected String propertyValue;
 
@@ -19,7 +25,7 @@ public abstract class DefaultSequenceGenerator implements AnnotationValueGenerat
     }
 
     @Override
-    public void initialize(Sequence sequence, Class<?> aClass) {
+    public void initialize(Sequence sequence, Member member, GeneratorCreationContext context) {
         this.propertyValue = sequence.propertyName();
     }
 
@@ -32,39 +38,18 @@ public abstract class DefaultSequenceGenerator implements AnnotationValueGenerat
      */
     public abstract String generateValue(Session session, Object owner);
 
-    /**
-     * Returns the in-memory generated value
-     * @return {@code true}
-     */
     @Override
-    public ValueGenerator<String> getValueGenerator() {
-        return this::generateValue;
+    public Object generate(SharedSessionContractImplementor session, Object owner, Object currentValue,
+        EventType eventType) {
+        return generateValue((Session) session, owner);
     }
 
     /**
      * Defines when this class will generate a value. By default the value will be generated only on inserts.
-     * @return The {@link GenerationTiming#INSERT} is used by default.
+     * @return The insert-only event set is used by default.
      */
     @Override
-    public GenerationTiming getGenerationTiming() {
-        return GenerationTiming.INSERT;
-    }
-
-    /**
-     * Returns false because the value is generated in-memory.
-     * @return false
-     */
-    @Override
-    public boolean referenceColumnInSql() {
-        return false;
-    }
-
-    /**
-     * Returns null because the value is generated in-memory.
-     * @return null
-     */
-    @Override
-    public String getDatabaseGeneratedReferencedColumnValue() {
-        return null;
+    public EnumSet<EventType> getEventTypes() {
+        return EventTypeSets.INSERT_ONLY;
     }
 }

--- a/src/com/etendoerp/sequences/DefaultSequenceGenerator.java
+++ b/src/com/etendoerp/sequences/DefaultSequenceGenerator.java
@@ -12,6 +12,10 @@ import org.hibernate.generator.EventType;
 import org.hibernate.generator.EventTypeSets;
 import org.hibernate.generator.GeneratorCreationContext;
 
+/**
+ * Base class for Hibernate sequence generators that produce values before statement execution.
+ * Subclasses define the actual generation strategy by implementing {@link #generateValue(Session, Object)}.
+ */
 public abstract class DefaultSequenceGenerator implements AnnotationBasedGenerator<Sequence>, BeforeExecutionGenerator {
     private static final long serialVersionUID = 7231888894694188218L;
     protected String propertyValue;

--- a/src/com/etendoerp/sequences/services/NonTRXMetadataContributor.java
+++ b/src/com/etendoerp/sequences/services/NonTRXMetadataContributor.java
@@ -4,6 +4,7 @@ import org.hibernate.boot.spi.InFlightMetadataCollector;
 import org.hibernate.boot.spi.MetadataContributor;
 import org.jboss.jandex.IndexView;
 
+@SuppressWarnings("removal")
 public class NonTRXMetadataContributor implements MetadataContributor {
 
     @Override

--- a/src/org/openbravo/base/gen/GenerateEntitiesTask.java
+++ b/src/org/openbravo/base/gen/GenerateEntitiesTask.java
@@ -467,8 +467,8 @@ public class GenerateEntitiesTask extends Task {
   }
 
   private Configuration getNewConfiguration() {
-    final Configuration cfg = new Configuration();
-    cfg.setObjectWrapper(new DefaultObjectWrapper());
+    final Configuration cfg = new Configuration(Configuration.VERSION_2_3_34);
+    cfg.setObjectWrapper(new DefaultObjectWrapper(Configuration.VERSION_2_3_34));
     return cfg;
   }
 

--- a/src/org/openbravo/base/model/ModelSessionFactoryController.java
+++ b/src/org/openbravo/base/model/ModelSessionFactoryController.java
@@ -19,12 +19,11 @@
 
 package org.openbravo.base.model;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.CallbackException;
-import org.hibernate.EmptyInterceptor;
+import org.hibernate.Interceptor;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.type.Type;
 import org.openbravo.base.session.SessionFactoryController;
@@ -69,24 +68,24 @@ public class ModelSessionFactoryController extends SessionFactoryController {
 
   // an interceptor which fails on all updates
   @Dependent
-  private class LocalInterceptor extends EmptyInterceptor {
+  private class LocalInterceptor implements Interceptor {
 
     private static final long serialVersionUID = 1L;
 
     @Override
-    public boolean onLoad(Object entity, Serializable id, Object[] state, String[] propertyNames,
+    public boolean onLoad(Object entity, Object id, Object[] state, String[] propertyNames,
         Type[] types) {
       return false;
     }
 
     @Override
-    public void onDelete(Object entity, Serializable id, Object[] state, String[] propertyNames,
+    public void onDelete(Object entity, Object id, Object[] state, String[] propertyNames,
         Type[] types) {
       Check.fail("The model session factory is not allowed to " + "remove model data.");
     }
 
     @Override
-    public boolean onFlushDirty(Object entity, Serializable id, Object[] currentState,
+    public boolean onFlushDirty(Object entity, Object id, Object[] currentState,
         Object[] previousState, String[] propertyNames, Type[] types) {
       for (int i = 0; i < currentState.length; i++) {
         final Object current = currentState[i];
@@ -121,24 +120,24 @@ public class ModelSessionFactoryController extends SessionFactoryController {
     }
 
     @Override
-    public boolean onSave(Object entity, Serializable id, Object[] state, String[] propertyNames,
+    public boolean onSave(Object entity, Object id, Object[] state, String[] propertyNames,
         Type[] types) {
       Check.fail("The model session factory is not allowed to " + "create model data.");
       return false;
     }
 
     @Override
-    public void onCollectionRemove(Object collection, Serializable key) throws CallbackException {
+    public void onCollectionRemove(Object collection, Object key) throws CallbackException {
       Check.fail("The model session factory is not allowed to " + "update model data.");
     }
 
     @Override
-    public void onCollectionRecreate(Object collection, Serializable key) throws CallbackException {
+    public void onCollectionRecreate(Object collection, Object key) throws CallbackException {
       Check.fail("The model session factory is not allowed to " + "update model data.");
     }
 
     @Override
-    public void onCollectionUpdate(Object collection, Serializable key) throws CallbackException {
+    public void onCollectionUpdate(Object collection, Object key) throws CallbackException {
       Check.fail("The model session factory is not allowed to " + "update model data.");
     }
   }

--- a/src/org/openbravo/base/model/ModelSessionFactoryController.java
+++ b/src/org/openbravo/base/model/ModelSessionFactoryController.java
@@ -128,16 +128,20 @@ public class ModelSessionFactoryController extends SessionFactoryController {
 
     @Override
     public void onCollectionRemove(Object collection, Object key) throws CallbackException {
-      Check.fail("The model session factory is not allowed to " + "update model data.");
+      denyCollectionOperation();
     }
 
     @Override
     public void onCollectionRecreate(Object collection, Object key) throws CallbackException {
-      Check.fail("The model session factory is not allowed to " + "update model data.");
+      denyCollectionOperation();
     }
 
     @Override
     public void onCollectionUpdate(Object collection, Object key) throws CallbackException {
+      denyCollectionOperation();
+    }
+
+    private void denyCollectionOperation() {
       Check.fail("The model session factory is not allowed to " + "update model data.");
     }
   }

--- a/src/org/openbravo/base/session/DalUUIDGenerator.java
+++ b/src/org/openbravo/base/session/DalUUIDGenerator.java
@@ -19,37 +19,34 @@
 
 package org.openbravo.base.session;
 
-import java.io.Serializable;
+import java.util.UUID;
 
-import org.hibernate.HibernateException;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.id.UUIDGenerator;
+import org.hibernate.id.IdentifierGenerator;
 import org.openbravo.base.exception.OBException;
 import org.openbravo.base.model.BaseOBObjectDef;
 
 /**
- * Extends the standard Hibernate UUIDGenerator. This is needed because:
+ * Implements Hibernate IdentifierGenerator. This is needed because:
  * <ul>
- * <li>the standard Hibernate UUIDGenerator will overwrite the id even if the object already has
+ * <li>the standard Hibernate UUID generation will overwrite the id even if the object already has
  * one. The goal is to try to keep an id if it has been assigned to an object. This is important in
  * case of imports.</li>
- * <li>the standard uuidgenerator will generate uuid strings of length 36 with the - as a separator,
+ * <li>the standard UUID generation can generate uuid strings of length 36 with the - as a separator,
  * the length should be 32</li>
  * </ul>
  * 
  * @author mtaal
  */
-public class DalUUIDGenerator extends UUIDGenerator {
+public class DalUUIDGenerator implements IdentifierGenerator {
 
   @Override
-  public Serializable generate(SharedSessionContractImplementor session, Object obj)
-      throws HibernateException {
+  public Object generate(SharedSessionContractImplementor session, Object obj) {
     final BaseOBObjectDef bob = (BaseOBObjectDef) obj;
     if (bob.getId() != null) {
       return ((String) bob.getId()).toUpperCase();
     }
-    String result = ((String) super.generate(session, obj)).toUpperCase();
-    result = result.replace("-", "");
+    String result = UUID.randomUUID().toString().toUpperCase().replace("-", "");
     if (result.length() != 32) {
       throw new OBException("Generating UUID of wrong length: " + result);
     }

--- a/src/org/openbravo/base/session/SessionFactoryController.java
+++ b/src/org/openbravo/base/session/SessionFactoryController.java
@@ -30,13 +30,13 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hibernate.SessionFactory;
 import org.hibernate.boot.registry.StandardServiceRegistry;
-import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.CacheSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.JdbcSettings;
 import org.hibernate.cfg.ValidationSettings;
 import org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.service.Service;
 import org.openbravo.base.exception.OBException;
 import org.openbravo.base.provider.OBProvider;
@@ -159,7 +159,7 @@ public abstract class SessionFactoryController {
       setInterceptor(configuration);
 
       final Properties properties = getOpenbravoProperties();
-      bbddUser = properties.getProperty(AvailableSettings.USER);
+      bbddUser = properties.getProperty(JdbcSettings.JAKARTA_JDBC_USER);
       configuration.addProperties(properties);
 
       // second-level caching is disabled for now because not all data
@@ -235,7 +235,7 @@ public abstract class SessionFactoryController {
 //  }
 
   public void closeHibernatePool() {
-    ConnectionProvider hibernatePool = sessionFactory.getSessionFactoryOptions()
+    ConnectionProvider hibernatePool = sessionFactory.unwrap(SessionFactoryImplementor.class)
         .getServiceRegistry()
         .getService(ConnectionProvider.class);
     if (hibernatePool != null && hibernatePool instanceof DriverManagerConnectionProviderImpl) {

--- a/src/org/openbravo/dal/core/DalSessionFactory.java
+++ b/src/org/openbravo/dal/core/DalSessionFactory.java
@@ -75,6 +75,7 @@ public class DalSessionFactory implements SessionFactory {
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public FilterDefinition getFilterDefinition(String filterName) throws HibernateException {
     return delegateSessionFactory.getFilterDefinition(filterName);
   }
@@ -245,6 +246,7 @@ public class DalSessionFactory implements SessionFactory {
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public SessionFactoryOptions getSessionFactoryOptions() {
     return delegateSessionFactory.getSessionFactoryOptions();
   }

--- a/src/org/openbravo/dal/core/OBContext.java
+++ b/src/org/openbravo/dal/core/OBContext.java
@@ -106,6 +106,7 @@ public class OBContext implements OBNotSingleton, Serializable {
   private transient Set<String> deactivatedOrganizations;
   private transient String userLevel;
   private transient Map<String, OrganizationStructureProvider> organizationStructureProviderByClient;
+  @SuppressWarnings("deprecation")
   private transient Map<String, AcctSchemaStructureProvider> acctSchemaStructureProviderByClient;
   private transient EntityAccessChecker entityAccessChecker;
   private transient RecordAccessChecker recordAccessChecker;
@@ -826,6 +827,7 @@ public class OBContext implements OBNotSingleton, Serializable {
   }
 
   // sets the context by reading all user information
+  @SuppressWarnings("deprecation")
   private boolean initialize(String userId, String roleId, String clientId, String orgId,
       String languageCode, String warehouseId) {
     userID = userId;
@@ -1125,10 +1127,12 @@ public class OBContext implements OBNotSingleton, Serializable {
     return orgProvider;
   }
 
+  @SuppressWarnings("deprecation")
   public AcctSchemaStructureProvider getAcctSchemaStructureProvider() {
     return getAcctSchemaStructureProvider(getCurrentClient().getId());
   }
 
+  @SuppressWarnings("deprecation")
   public AcctSchemaStructureProvider getAcctSchemaStructureProvider(String clientId) {
     AcctSchemaStructureProvider acctSchemaProvider = acctSchemaStructureProviderByClient
         .get(clientId);

--- a/src/org/openbravo/dal/core/OBInstantiator.java
+++ b/src/org/openbravo/dal/core/OBInstantiator.java
@@ -16,6 +16,7 @@ import org.openbravo.base.util.Check;
  * Hibernate 6.0 entity instantiator for Etendo DAL entities.
  * Implements the EntityInstantiator SPI (Hibernate 6.0.x).
  */
+@SuppressWarnings("deprecation")
 public class OBInstantiator implements EntityInstantiator {
 
   private static final long serialVersionUID = 1L;

--- a/src/org/openbravo/dal/core/OBInterceptor.java
+++ b/src/org/openbravo/dal/core/OBInterceptor.java
@@ -24,14 +24,12 @@ import static org.openbravo.model.common.enterprise.Organization.PROPERTY_CLIENT
 import static org.openbravo.model.common.enterprise.Organization.PROPERTY_UPDATED;
 import static org.openbravo.model.common.enterprise.Organization.PROPERTY_UPDATEDBY;
 
-import java.io.Serializable;
 import java.sql.SQLException;
 import java.util.Date;
 import java.util.Iterator;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.hibernate.EmptyInterceptor;
 import org.hibernate.Interceptor;
 import org.hibernate.Transaction;
 import org.hibernate.proxy.HibernateProxy;
@@ -62,7 +60,7 @@ import jakarta.enterprise.context.Dependent;
  */
 
 @Dependent
-public class OBInterceptor extends EmptyInterceptor {
+public class OBInterceptor implements Interceptor {
   private static final Logger log = LogManager.getLogger();
 
   private static final long serialVersionUID = 1L;
@@ -135,7 +133,7 @@ public class OBInterceptor extends EmptyInterceptor {
    * @see Property
    */
   @Override
-  public void onDelete(Object entity, Serializable id, Object[] state, String[] propertyNames,
+  public void onDelete(Object entity, Object id, Object[] state, String[] propertyNames,
       Type[] types) {
     SecurityChecker.getInstance().checkDeleteAllowed(entity);
     if (getInterceptorListener() != null) {
@@ -166,7 +164,7 @@ public class OBInterceptor extends EmptyInterceptor {
    *         other cases
    */
   @Override
-  public boolean onFlushDirty(Object entity, Serializable id, Object[] currentState,
+  public boolean onFlushDirty(Object entity, Object id, Object[] currentState,
       Object[] previousState, String[] propertyNames, Type[] types) {
     if (SessionHandler.isCheckingDirtySession()) {
       // onFlushDirty gets invoked on actual flushes but also when checking session dirty, in later
@@ -225,7 +223,7 @@ public class OBInterceptor extends EmptyInterceptor {
    *         other cases
    */
   @Override
-  public boolean onSave(Object entity, Serializable id, Object[] currentState,
+  public boolean onSave(Object entity, Object id, Object[] currentState,
       String[] propertyNames, Type[] types) {
     // disabled for now, checks are all done when a property is set
     // if (entity instanceof BaseOBObject) {
@@ -465,7 +463,6 @@ public class OBInterceptor extends EmptyInterceptor {
     if (getInterceptorListener() != null) {
       getInterceptorListener().afterTransactionBegin(tx);
     }
-    super.afterTransactionBegin(tx);
   }
 
   @Override
@@ -473,7 +470,6 @@ public class OBInterceptor extends EmptyInterceptor {
     if (getInterceptorListener() != null) {
       getInterceptorListener().afterTransactionCompletion(tx);
     }
-    super.afterTransactionCompletion(tx);
   }
 
   @Override
@@ -481,7 +477,6 @@ public class OBInterceptor extends EmptyInterceptor {
     if (getInterceptorListener() != null) {
       getInterceptorListener().beforeTransactionCompletion(tx);
     }
-    super.beforeTransactionCompletion(tx);
   }
 
   @SuppressWarnings({ "rawtypes" })
@@ -490,7 +485,6 @@ public class OBInterceptor extends EmptyInterceptor {
     if (getInterceptorListener() != null) {
       getInterceptorListener().preFlush(entities);
     }
-    super.preFlush(entities);
   }
 
   // allow Hibernate to determine that the object is a valid entity

--- a/src/org/openbravo/dal/core/SessionHandler.java
+++ b/src/org/openbravo/dal/core/SessionHandler.java
@@ -437,6 +437,7 @@ public class SessionHandler implements OBNotSingleton {
    * @param obj
    *          the object to persist
    */
+  @SuppressWarnings("deprecation")
   public void save(String pool, Object obj) {
     if (Identifiable.class.isAssignableFrom(obj.getClass())) {
       getSession(pool).saveOrUpdate(((Identifiable) obj).getEntityName(), obj);
@@ -463,6 +464,7 @@ public class SessionHandler implements OBNotSingleton {
    * @param obj
    *          the object to remove
    */
+  @SuppressWarnings("deprecation")
   public void delete(String pool, Object obj) {
     if (Identifiable.class.isAssignableFrom(obj.getClass())) {
       getSession(pool).delete(((Identifiable) obj).getEntityName(), obj);

--- a/src/org/openbravo/dal/security/OrganizationStructureProvider.java
+++ b/src/org/openbravo/dal/security/OrganizationStructureProvider.java
@@ -96,13 +96,11 @@ public class OrganizationStructureProvider implements OBNotSingleton {
             "   and t.ad_client_id = :clientId";
     //@formatter:on
 
-    @SuppressWarnings("rawtypes")
-    NativeQuery qry = OBDal.getInstance()
+    NativeQuery<Object[]> qry = OBDal.getInstance()
         .getSession()
-        .createNativeQuery(sql)
+        .createNativeQuery(sql, Object[].class)
         .setParameter("clientId", getClientId());
 
-    @SuppressWarnings("unchecked")
     List<Object[]> treeNodes = qry.list();
 
     orgNodes = new CachedConcurrentMap<>(this.getClass().getSimpleName() + ":orgNodes", false, null, treeNodes.size());

--- a/src/org/openbravo/dal/service/OBDal.java
+++ b/src/org/openbravo/dal/service/OBDal.java
@@ -367,6 +367,7 @@ public class OBDal implements OBNotSingleton {
    * In Hibernate 6, this marks the transaction for rollback. We clear that flag
    * and manually reload the entity.
    */
+  @SuppressWarnings("deprecation")
   private void handleRefreshWithMissingCascade(BaseOBObject bob, Session session) {
     // Hibernate marks the transaction for rollback when EntityNotFoundException
     // occurs. Clear the rollback-only flag so the transaction can still commit.

--- a/src/org/openbravo/dal/service/OBQuery.java
+++ b/src/org/openbravo/dal/service/OBQuery.java
@@ -239,7 +239,7 @@ public class OBQuery<E extends BaseOBObject> {
    * @return a new Hibernate Query object. Note that it does not have an specific type because
    *     delete queries can not be typed.
    */
-  @SuppressWarnings("rawtypes")
+  @SuppressWarnings({ "rawtypes", "deprecation" })
   public Query deleteQuery() {
     final String qryStr = createQueryString();
     String whereClause;

--- a/src/org/openbravo/dal/xml/StaxXMLEntityConverter.java
+++ b/src/org/openbravo/dal/xml/StaxXMLEntityConverter.java
@@ -70,6 +70,7 @@ import org.openbravo.model.common.enterprise.Organization;
  * @author mtaal
  */
 
+@SuppressWarnings("deprecation")
 public class StaxXMLEntityConverter extends BaseXMLEntityConverter implements OBNotSingleton {
   // This class should translate the
 

--- a/src/org/openbravo/dal/xml/XMLEntityConverter.java
+++ b/src/org/openbravo/dal/xml/XMLEntityConverter.java
@@ -63,6 +63,7 @@ import org.openbravo.model.common.enterprise.Organization;
  * @author mtaal
  */
 
+@SuppressWarnings("deprecation")
 public class XMLEntityConverter extends BaseXMLEntityConverter {
   // This class should translate the
 

--- a/src/org/openbravo/service/db/DataImportService.java
+++ b/src/org/openbravo/service/db/DataImportService.java
@@ -273,7 +273,7 @@ public class DataImportService implements OBSingleton {
           // this is done through a stored procedure
           SessionHandler.getInstance()
               .getSession()
-              .createNativeQuery("UPDATE AD_ROLE_ORGACCESS SET AD_ROLE_ID='0' where AD_ROLE_ID='0'")
+              .createNativeMutationQuery("UPDATE AD_ROLE_ORGACCESS SET AD_ROLE_ID='0' where AD_ROLE_ID='0'")
               .executeUpdate();
         }
       }
@@ -488,7 +488,7 @@ public class DataImportService implements OBSingleton {
         if (containsAdRoleOrOrgAccess) {
           SessionHandler.getInstance()
               .getSession()
-              .createNativeQuery("UPDATE AD_ROLE_ORGACCESS SET AD_ROLE_ID='0' where AD_ROLE_ID='0'")
+              .createNativeMutationQuery("UPDATE AD_ROLE_ORGACCESS SET AD_ROLE_ID='0' where AD_ROLE_ID='0'")
               .executeUpdate();
         }
       }


### PR DESCRIPTION
## Contexto

Este PR resuelve los warnings de deprecación emitidos durante la compilación javac de Y27 (Hibernate 6, Redisson nuevo, FreeMarker, Gradle 8+). El objetivo es llegar a 0 warnings de deprecación en la salida del compilador.

---

## Cambios por área

### 1. Build scripts — configuración Log4j2 (`build.xml`, `src/build.xml`, `src-db/`, `src-trl/`, `src-util/`, `src-wad/`)

**Por qué:** Las tareas `<java fork="true">` de Ant lanzan una JVM nueva que no hereda la configuración de Log4j2 del proceso padre. Sin `log4j.configurationFile`, Log4j2 imprime warnings de "no configuration found" en cada tarea forkeada.

**Qué se hizo:** Se agregó `<sysproperty key="log4j.configurationFile" file="${base.config}/log4j2.xml"/>` a todas las tareas `<java>` que usan `fork="true"`.

**Extra en `generate.entities.quick`:** Se agregó un `<delete>` del archivo `META-INF/services/org.hibernate.service.spi.ServiceContributor` antes de regenerar entidades, para evitar registros duplicados del `NonTRXMetadataContributor` entre builds incrementales.

---

### 2. `build.gradle` — sintaxis Gradle 8+

**Por qué:** Gradle 8 deprecó la asignación de propiedades sin `=` (property assignment). `url "..."` y `exceptionFormat "full"` emiten warnings.

**Qué se hizo:** `url "..."` → `url = "..."` y `exceptionFormat "full"` → `exceptionFormat = "full"`.

---

### 3. Hibernate Interceptor — `OBInterceptor`, `PersistenceEventOBInterceptor`, `ModelSessionFactoryController`, `JsonConversionTest`, `HiddenUpdateTest`

**Por qué:** En Hibernate 6, `EmptyInterceptor` fue deprecado. La forma correcta es implementar directamente la interfaz `Interceptor`, que en Hibernate 6 tiene todos sus métodos como `default` (comportamiento vacío por defecto), por lo que no es necesario implementar los métodos que no se usan.

Adicionalmente, las firmas de los métodos del `Interceptor` cambiaron: el parámetro `id`/`key` pasó de `Serializable` a `Object`.

**Qué se hizo:**
- `extends EmptyInterceptor` → `implements Interceptor` en todas las clases afectadas.
- `Serializable id/key` → `Object id/key` en todas las firmas sobreescritas.
- Eliminación de `super.afterTransactionBegin/Completion/preFlush()` — al implementar la interfaz directamente, esas llamadas a `super` ya no tienen sentido (apuntaban a implementaciones vacías de `EmptyInterceptor`).
- Eliminación de `import java.io.Serializable` donde ya no se usa.

---

### 4. `DalUUIDGenerator` — migración de `UUIDGenerator`

**Por qué:** `org.hibernate.id.UUIDGenerator` está deprecado en Hibernate 6. La forma recomendada es implementar `IdentifierGenerator` directamente y generar el UUID con `java.util.UUID.randomUUID()`.

**Qué se hizo:** `extends UUIDGenerator` → `implements IdentifierGenerator`. La lógica de negocio se preservó: si el objeto ya tiene un ID asignado se reutiliza; si no, se genera uno nuevo en formato de 32 caracteres sin guiones.

---

### 5. `DefaultSequenceGenerator` — migración de `AnnotationValueGeneration`

**Por qué:** La API `org.hibernate.tuple.AnnotationValueGeneration` / `GenerationTiming` / `ValueGenerator` fue reemplazada en Hibernate 6 por `AnnotationBasedGenerator` + `BeforeExecutionGenerator`.

**Qué se hizo:** Migración completa al nuevo API:
- Implementa `AnnotationBasedGenerator<Sequence>` y `BeforeExecutionGenerator`.
- `initialize(Sequence, Class<?>)` → `initialize(Sequence, Member, GeneratorCreationContext)`.
- `getValueGenerator()` → `generate(SharedSessionContractImplementor, Object, Object, EventType)`.
- `getGenerationTiming()` → `getEventTypes()` retornando `EventTypeSets.INSERT_ONLY`.
- Se eliminaron `referenceColumnInSql()` y `getDatabaseGeneratedReferencedColumnValue()` (no existen en el nuevo API, el generador in-memory los hace innecesarios).

---

### 6. `SessionFactoryController` — APIs deprecadas de Hibernate

**Por qué:** `AvailableSettings.USER` fue movido a `JdbcSettings.JAKARTA_JDBC_USER`. `sessionFactory.getSessionFactoryOptions()` está deprecado a favor de hacer `unwrap(SessionFactoryImplementor.class)`.

**Qué se hizo:**
- `AvailableSettings.USER` → `JdbcSettings.JAKARTA_JDBC_USER`.
- `sessionFactory.getSessionFactoryOptions().getServiceRegistry()` → `sessionFactory.unwrap(SessionFactoryImplementor.class).getServiceRegistry()`.

---

### 7. `CachedConcurrentMap` — migración API Redisson

**Por qué:** En Redisson 3.x, `LocalCachedMapOptions` fue movido al paquete `org.redisson.api.options` y su factory method cambió: ya no existe `defaults()`, el nombre del mapa ahora se configura en el objeto de opciones. La firma de `getLocalCachedMap()` también cambió — ya no acepta el nombre como parámetro separado.

**Qué se hizo:**
- `import org.redisson.api.LocalCachedMapOptions` → `import org.redisson.api.options.LocalCachedMapOptions`.
- `LocalCachedMapOptions.defaults()` → `LocalCachedMapOptions.name(name)`.
- `getLocalCachedMap(name, options)` → `getLocalCachedMap(options)`.

---

### 8. JPA — queries tipadas y mutation queries

**Por qué:** `Session.createNativeQuery(String)` sin tipo de retorno está deprecado en favor de la versión tipada. Para queries de mutación (UPDATE/DELETE), Hibernate 6 introdujo `createNativeMutationQuery()` como API semánticamente correcta.

**Qué se hizo:**
- `OrganizationStructureProvider`: `createNativeQuery(sql)` → `createNativeQuery(sql, Object[].class)` — elimina los `@SuppressWarnings("rawtypes"/"unchecked")` asociados.
- `DataImportService`: `createNativeQuery(sql).executeUpdate()` → `createNativeMutationQuery(sql).executeUpdate()` (x2).

---

### 9. `GenerateEntitiesTask` — FreeMarker versioned configuration

**Por qué:** El constructor sin argumentos `new Configuration()` y `new DefaultObjectWrapper()` de FreeMarker 2.3.x están deprecados — requieren la versión de incompatibilidad como argumento para garantizar comportamiento consistente.

**Qué se hizo:** `new Configuration()` → `new Configuration(Configuration.VERSION_2_3_34)` y `new DefaultObjectWrapper()` → `new DefaultObjectWrapper(Configuration.VERSION_2_3_34)`.

---

### 10. Supresiones con `@SuppressWarnings("deprecation")` — deuda técnica conocida

Los siguientes casos usan APIs deprecadas que requieren una refactorización más profunda fuera del alcance de este ticket. Se suprime el warning para mantener la salida del compilador limpia, pero quedan pendientes:

| Archivo | API deprecada | Motivo del defer |
|---|---|---|
| `DalSessionFactory` | `getFilterDefinition()`, `getSessionFactoryOptions()` | Delegación forzada por la interfaz `SessionFactory` |
| `SessionHandler` | `session.saveOrUpdate()`, `session.delete()` | Migrar a `merge()`/`remove()` implica revisar comportamiento de todos los callers |
| `OBDal` | Flag de rollback en refresh | Requiere análisis de impacto en manejo de transacciones |
| `OBQuery` | Raw type en `deleteQuery()` | Limitación del API de Hibernate queries sin tipo |
| `OBInstantiator` | `EntityInstantiator` SPI | SPI en evolución en Hibernate 6 |
| `OBContext` | `AcctSchemaStructureProvider` | Clase marcada deprecated sin reemplazo aún disponible |
| `XMLEntityConverter`, `StaxXMLEntityConverter` | `BaseXMLEntityConverter` | Clase base deprecated sin reemplazo directo — refactor estructural pendiente |
| `NonTRXMetadataContributor` | `MetadataContributor` | Marcado para removal en Hibernate futuro, sin alternativa disponible aún |