### PR TITLE
Feature ETP-4200: Inherit client from document in line tax insert functions

### DIFF
--- a/src-db/database/model/functions/C_INVOICELINETAX_INSERT.xml
+++ b/src-db/database/model/functions/C_INVOICELINETAX_INSERT.xml
@@ -59,10 +59,11 @@
     Cur_Taxes RECORD;
   BEGIN --BODY
     v_TaxBaseAmount:=0;
-    SELECT ISSUMMARY, CASCADE, RATE, BASEAMOUNT, AD_CLIENT_ID, C_TAXBASE_ID
+    SELECT t.ISSUMMARY, t.CASCADE, t.RATE, t.BASEAMOUNT, i.AD_CLIENT_ID, t.C_TAXBASE_ID
     INTO v_IsSummary, v_Cascade, v_Rate, v_BaseAmount, v_Client_ID, v_C_TaxBase_ID
-    FROM C_TAX
-    WHERE C_TAX_ID = p_tax_id;
+    FROM C_TAX t, C_INVOICE i
+    WHERE t.C_TAX_ID = p_tax_id
+    AND i.C_INVOICE_ID = p_invoice_id;
     IF(v_BaseAmount='LNA' OR v_BaseAmount='LNATAX') THEN
       v_TaxBaseAmount:=p_LineNetAmt;
     ELSIF (v_BaseAmount='TBA' OR v_BaseAmount='TBATAX') THEN
@@ -100,32 +101,26 @@
       IF(p_invoice_id IS NULL OR p_invoiceline_id IS NULL) THEN
          RAISE_APPLICATION_ERROR(-20000, '@20200@');
       END IF;
-      INSERT
-      INTO C_INVOICELINETAX (
-      C_InvoiceLineTax_ID, C_InvoiceLine_ID, C_Invoice_ID, C_Tax_ID, AD_Client_ID, AD_Org_ID,
-      IsActive, Created, CreatedBy, Updated, UpdatedBy,
-      TaxBaseAmt, TaxAmt, Line)
+      INSERT INTO C_INVOICELINETAX (
+        C_InvoiceLineTax_ID, C_InvoiceLine_ID, C_Invoice_ID, C_Tax_ID, AD_Client_ID, AD_Org_ID,
+        IsActive, Created, CreatedBy, Updated, UpdatedBy,
+        TaxBaseAmt, TaxAmt, Line)
       VALUES (
-      GET_UUID(), p_invoiceline_id, p_invoice_id, p_tax_id, v_Client_ID, p_org_id,
-      'Y', now(), p_user_id, now(), p_user_id,
-      v_TaxBaseAmount, ROUND(ROUND(v_TaxBaseAmount, p_StdPrecision) * v_Rate/100, p_StdPrecision), v_LineNo);
+        GET_UUID(), p_invoiceline_id, p_invoice_id, p_tax_id, v_Client_ID, p_org_id,
+        'Y', now(), p_user_id, now(), p_user_id,
+        v_TaxBaseAmount, ROUND(ROUND(v_TaxBaseAmount, p_StdPrecision) * v_Rate/100, p_StdPrecision), v_LineNo);
     ELSE
       FOR Cur_Taxes IN
-        (SELECT C_Tax_ID, RATE
-         FROM C_TAX
-        WHERE Parent_Tax_ID=p_tax_id
-        ORDER BY Line)
+        (SELECT C_Tax_ID, RATE FROM C_TAX WHERE Parent_Tax_ID=p_tax_id ORDER BY Line)
       LOOP
         C_INVOICELINETAX_INSERT(p_org_id, p_invoice_id, p_invoiceline_id, p_user_id, p_originaltax_id, Cur_Taxes.C_Tax_ID, p_LineNetAmt, p_AlternateTaxBaseAmt, p_StdPrecision);
       END LOOP;
     END IF;
     RETURN;
-    --<<FINISH_PROCESS>>
 EXCEPTION
 WHEN OTHERS THEN
   v_ResultStr:= '@ERROR=' || SQLERRM;
-  DBMS_OUTPUT.PUT_LINE(v_ResultStr) ;
-  ROLLBACK;
+  DBMS_OUTPUT.PUT_LINE(v_ResultStr);
   RAISE;
 END C_INVOICELINETAX_INSERT
 ]]></body>

--- a/src-db/database/model/functions/C_INVOICELINETAX_INSERT.xml
+++ b/src-db/database/model/functions/C_INVOICELINETAX_INSERT.xml
@@ -59,11 +59,13 @@
     Cur_Taxes RECORD;
   BEGIN --BODY
     v_TaxBaseAmount:=0;
-    SELECT t.ISSUMMARY, t.CASCADE, t.RATE, t.BASEAMOUNT, i.AD_CLIENT_ID, t.C_TAXBASE_ID
-    INTO v_IsSummary, v_Cascade, v_Rate, v_BaseAmount, v_Client_ID, v_C_TaxBase_ID
-    FROM C_TAX t, C_INVOICE i
-    WHERE t.C_TAX_ID = p_tax_id
-    AND i.C_INVOICE_ID = p_invoice_id;
+    SELECT ISSUMMARY, CASCADE, RATE, BASEAMOUNT, C_TAXBASE_ID
+    INTO v_IsSummary, v_Cascade, v_Rate, v_BaseAmount, v_C_TaxBase_ID
+    FROM C_TAX
+    WHERE C_TAX_ID = p_tax_id;
+    IF (p_invoice_id IS NOT NULL) THEN
+      SELECT AD_CLIENT_ID INTO v_Client_ID FROM C_INVOICE WHERE C_INVOICE_ID = p_invoice_id;
+    END IF;
     IF(v_BaseAmount='LNA' OR v_BaseAmount='LNATAX') THEN
       v_TaxBaseAmount:=p_LineNetAmt;
     ELSIF (v_BaseAmount='TBA' OR v_BaseAmount='TBATAX') THEN
@@ -120,7 +122,8 @@
 EXCEPTION
 WHEN OTHERS THEN
   v_ResultStr:= '@ERROR=' || SQLERRM;
-  DBMS_OUTPUT.PUT_LINE(v_ResultStr);
+  DBMS_OUTPUT.PUT_LINE(v_ResultStr) ;
+  ROLLBACK;
   RAISE;
 END C_INVOICELINETAX_INSERT
 ]]></body>

--- a/src-db/database/model/functions/C_ORDERLINETAX_INSERT.xml
+++ b/src-db/database/model/functions/C_ORDERLINETAX_INSERT.xml
@@ -59,11 +59,13 @@
     Cur_Taxes RECORD;
   BEGIN --BODY
     v_TaxBaseAmount:=0;
-    SELECT t.ISSUMMARY, t.CASCADE, t.RATE, t.BASEAMOUNT, o.AD_CLIENT_ID, t.C_TAXBASE_ID
-    INTO v_IsSummary, v_Cascade, v_Rate, v_BaseAmount, v_Client_ID, v_C_TaxBase_ID
-    FROM C_TAX t, C_ORDER o
-    WHERE t.C_TAX_ID = p_tax_id
-    AND o.C_ORDER_ID = p_order_id;
+    SELECT ISSUMMARY, CASCADE, RATE, BASEAMOUNT, C_TAXBASE_ID
+    INTO v_IsSummary, v_Cascade, v_Rate, v_BaseAmount, v_C_TaxBase_ID
+    FROM C_TAX
+    WHERE C_TAX_ID = p_tax_id;
+    IF (p_order_id IS NOT NULL) THEN
+      SELECT AD_CLIENT_ID INTO v_Client_ID FROM C_ORDER WHERE C_ORDER_ID = p_order_id;
+    END IF;
     IF(v_BaseAmount='LNA' OR v_BaseAmount='LNATAX') THEN
       v_TaxBaseAmount:=p_LineNetAmt;
     ELSIF (v_BaseAmount='TBA' OR v_BaseAmount='TBATAX') THEN
@@ -120,7 +122,8 @@
 EXCEPTION
 WHEN OTHERS THEN
   v_ResultStr:= '@ERROR=' || SQLERRM;
-  DBMS_OUTPUT.PUT_LINE(v_ResultStr);
+  DBMS_OUTPUT.PUT_LINE(v_ResultStr) ;
+  --ROLLBACK;
   RAISE;
 END C_ORDERLINETAX_INSERT
 ]]></body>

--- a/src-db/database/model/functions/C_ORDERLINETAX_INSERT.xml
+++ b/src-db/database/model/functions/C_ORDERLINETAX_INSERT.xml
@@ -59,10 +59,11 @@
     Cur_Taxes RECORD;
   BEGIN --BODY
     v_TaxBaseAmount:=0;
-    SELECT ISSUMMARY, CASCADE, RATE, BASEAMOUNT, AD_CLIENT_ID, C_TAXBASE_ID
+    SELECT t.ISSUMMARY, t.CASCADE, t.RATE, t.BASEAMOUNT, o.AD_CLIENT_ID, t.C_TAXBASE_ID
     INTO v_IsSummary, v_Cascade, v_Rate, v_BaseAmount, v_Client_ID, v_C_TaxBase_ID
-    FROM C_TAX
-    WHERE C_TAX_ID = p_tax_id;
+    FROM C_TAX t, C_ORDER o
+    WHERE t.C_TAX_ID = p_tax_id
+    AND o.C_ORDER_ID = p_order_id;
     IF(v_BaseAmount='LNA' OR v_BaseAmount='LNATAX') THEN
       v_TaxBaseAmount:=p_LineNetAmt;
     ELSIF (v_BaseAmount='TBA' OR v_BaseAmount='TBATAX') THEN
@@ -100,32 +101,26 @@
       IF(p_order_id IS NULL OR p_orderline_id IS NULL) THEN
          RAISE_APPLICATION_ERROR(-20000, '@20200@');
       END IF;
-      INSERT
-      INTO C_ORDERLINETAX (
-      C_OrderLineTax_ID, C_OrderLine_ID, C_Order_ID, C_Tax_ID, AD_Client_ID, AD_Org_ID,
-      IsActive, Created, CreatedBy, Updated, UpdatedBy,
-      TaxBaseAmt, TaxAmt, Line)
+      INSERT INTO C_ORDERLINETAX (
+        C_OrderLineTax_ID, C_OrderLine_ID, C_Order_ID, C_Tax_ID, AD_Client_ID, AD_Org_ID,
+        IsActive, Created, CreatedBy, Updated, UpdatedBy,
+        TaxBaseAmt, TaxAmt, Line)
       VALUES (
-      GET_UUID(), p_orderline_id, p_order_id, p_tax_id, v_Client_ID, p_org_id,
-      'Y', now(), p_user_id, now(), p_user_id,
-      v_TaxBaseAmount, ROUND(ROUND(v_TaxBaseAmount, p_StdPrecision) * v_Rate/100, p_StdPrecision), v_LineNo);
+        GET_UUID(), p_orderline_id, p_order_id, p_tax_id, v_Client_ID, p_org_id,
+        'Y', now(), p_user_id, now(), p_user_id,
+        v_TaxBaseAmount, ROUND(ROUND(v_TaxBaseAmount, p_StdPrecision) * v_Rate/100, p_StdPrecision), v_LineNo);
     ELSE
       FOR Cur_Taxes IN
-        (SELECT C_Tax_ID, RATE
-         FROM C_TAX
-        WHERE Parent_Tax_ID=p_tax_id
-        ORDER BY Line)
+        (SELECT C_Tax_ID, RATE FROM C_TAX WHERE Parent_Tax_ID=p_tax_id ORDER BY Line)
       LOOP
         C_ORDERLINETAX_INSERT(p_org_id, p_order_id, p_orderline_id, p_user_id, p_originaltax_id, Cur_Taxes.C_Tax_ID, p_LineNetAmt, p_AlternateTaxBaseAmt, p_StdPrecision);
       END LOOP;
     END IF;
     RETURN;
-    --<<FINISH_PROCESS>>
 EXCEPTION
 WHEN OTHERS THEN
   v_ResultStr:= '@ERROR=' || SQLERRM;
-  DBMS_OUTPUT.PUT_LINE(v_ResultStr) ;
-  --ROLLBACK;
+  DBMS_OUTPUT.PUT_LINE(v_ResultStr);
   RAISE;
 END C_ORDERLINETAX_INSERT
 ]]></body>


### PR DESCRIPTION
## Summary

- `C_INVOICELINETAX_INSERT` and `C_ORDERLINETAX_INSERT` were reading `AD_CLIENT_ID` from `C_TAX` and using it directly as the owner of the inserted line tax row.
- When using system-level taxes (`ad_client_id = '0'`), this produced `c_invoicelinetax` / `c_orderlinetax` rows owned by client `'0'`, causing `OBSecurityException` when the session tried to operate on them.
- Fix: after reading the tax data, do a separate lookup of `AD_CLIENT_ID` from `C_INVOICE` / `C_ORDER` (guarded by a null check), so the inserted row always belongs to the document's client.

## Implementation

```sql
SELECT ISSUMMARY, CASCADE, RATE, BASEAMOUNT, C_TAXBASE_ID
INTO v_IsSummary, v_Cascade, v_Rate, v_BaseAmount, v_C_TaxBase_ID
FROM C_TAX WHERE C_TAX_ID = p_tax_id;
IF (p_invoice_id IS NOT NULL) THEN
  SELECT AD_CLIENT_ID INTO v_Client_ID FROM C_INVOICE WHERE C_INVOICE_ID = p_invoice_id;
END IF;
```

Same pattern applied to `C_ORDERLINETAX_INSERT` using `C_ORDER`.

Both SELECTs are PK lookups — no performance impact regardless of table size.

## Test plan

- [ ] Create an invoice with a system-level tax (`ad_client_id = '0'`) from a non-system client
- [ ] Confirm `c_invoicelinetax` rows are created with the invoice's `ad_client_id`, not `'0'`
- [ ] Complete the invoice — no `OBSecurityException`
- [ ] Create an order with a system-level tax and verify same behavior on `c_orderlinetax`
- [ ] Verify existing per-client taxes still work (result is identical since `tax.client == invoice.client` in that case)

Closes ETP-4200