### PR TITLE
Issue #1049: Fix TypeError when sending emails to multiple customers

### DIFF
--- a/src/org/openbravo/erpCommon/utility/reporting/printing/EmailOptions.html
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/EmailOptions.html
@@ -96,6 +96,22 @@
       }
     }
 
+    function validateOptionalEmail(fieldId) {
+      var el = document.getElementById(fieldId);
+      if (!el) { return false; }
+      if (!el.value.trim()) {
+        setEmailError(fieldId, null);
+        return false;
+      }
+      var invalid = findInvalidAddress(el.value);
+      if (invalid !== null) {
+        setEmailError(fieldId, '"' + invalid + '" is not a valid email address.');
+        return true;
+      }
+      setEmailError(fieldId, null);
+      return false;
+    }
+
     function validateAndSendEmail() {
       var hasError = false;
       var toEmailEl = document.getElementById('toEmail');
@@ -114,30 +130,8 @@
           }
         }
       }
-      var ccEl = document.getElementById('ccEmail');
-      if (ccEl && ccEl.value.trim()) {
-        var invalidCC = findInvalidAddress(ccEl.value);
-        if (invalidCC !== null) {
-          setEmailError('ccEmail', '"' + invalidCC + '" is not a valid email address.');
-          hasError = true;
-        } else {
-          setEmailError('ccEmail', null);
-        }
-      } else if (ccEl) {
-        setEmailError('ccEmail', null);
-      }
-      var bccEl = document.getElementById('bccEmail');
-      if (bccEl && bccEl.value.trim()) {
-        var invalidBCC = findInvalidAddress(bccEl.value);
-        if (invalidBCC !== null) {
-          setEmailError('bccEmail', '"' + invalidBCC + '" is not a valid email address.');
-          hasError = true;
-        } else {
-          setEmailError('bccEmail', null);
-        }
-      } else if (bccEl) {
-        setEmailError('bccEmail', null);
-      }
+      if (validateOptionalEmail('ccEmail')) { hasError = true; }
+      if (validateOptionalEmail('bccEmail')) { hasError = true; }
 
       if (!hasError) {
         submitThisPage('EMAIL');

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/EmailOptions.html
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/EmailOptions.html
@@ -98,17 +98,20 @@
 
     function validateAndSendEmail() {
       var hasError = false;
-      var toVal = document.getElementById('toEmail').value.trim();
-      if (!toVal) {
-        setEmailError('toEmail', 'Recipient email is required.');
-        hasError = true;
-      } else {
-        var invalidTo = findInvalidAddress(toVal);
-        if (invalidTo !== null) {
-          setEmailError('toEmail', '"' + invalidTo + '" is not a valid email address.');
+      var toEmailEl = document.getElementById('toEmail');
+      if (toEmailEl !== null) {
+        var toVal = toEmailEl.value.trim();
+        if (!toVal) {
+          setEmailError('toEmail', 'Recipient email is required.');
           hasError = true;
         } else {
-          setEmailError('toEmail', null);
+          var invalidTo = findInvalidAddress(toVal);
+          if (invalidTo !== null) {
+            setEmailError('toEmail', '"' + invalidTo + '" is not a valid email address.');
+            hasError = true;
+          } else {
+            setEmailError('toEmail', null);
+          }
         }
       }
       var ccEl = document.getElementById('ccEmail');
@@ -217,7 +220,8 @@
         setWindowElementFocus('firstElement');
         resizeWindow();
 
-        if (document.getElementById('toEmail').value === '') {
+        var toEmailEl = document.getElementById('toEmail');
+        if (toEmailEl && toEmailEl.value === '') {
           var warnCallback = function(paramXMLParticular, XMLHttpRequestObj) {
             if (getReadyStateHandler(XMLHttpRequestObj)) {
               try {


### PR DESCRIPTION
## Summary

- Fixes uncaught `TypeError: Cannot read properties of null (reading 'value')` thrown in `EmailOptions.html` when selecting invoices from multiple customers and clicking the Email icon.
- Root cause: `PrintController.getHiddenTags()` removes the `<tr id="to">` row (and its child `<input id="toEmail">`) from the DOM when `moreThanOneCustomer == true`, but `onLoadDo()` and `validateAndSendEmail()` accessed `#toEmail.value` unconditionally.
- Two null-guard fixes applied in `EmailOptions.html`:
  1. `onLoadDo()`: guard the BP-contacts AJAX call that reads `toEmail.value` on page load.
  2. `validateAndSendEmail()`: skip the `To` field validation entirely when the element is absent (server already handles per-customer routing in multi-customer mode).

## Test plan

- [ ] Configure a valid SMTP server at Client level (General Setup > Application > Client > Email Configuration).
- [ ] Navigate to Sales Invoice, clear the transactional filter.
- [ ] Select two or more completed invoices from **different customers**.
- [ ] Click the Email icon — popup should open without console errors, showing "This email will be sent to N customers".
- [ ] Click Send — emails should be dispatched successfully.
- [ ] Repeat with invoices from a **single customer** — verify the To field still appears, validates correctly, and Send works as before.

Closes #1049

🤖 Generated with [Claude Code](https://claude.com/claude-code)