### PR TITLE
Issue #1049: Fix email popup for multi-customer sending

### DIFF
--- a/src/org/openbravo/erpCommon/utility/reporting/printing/EmailOptions.html
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/EmailOptions.html
@@ -688,7 +688,7 @@
     
     
 
-<div class="Popup_ContentPane_CircleLogo">
+<div class="Popup_ContentPane_CircleLogo" style="display:none">
 <div class="Popup_WindowLogo"><img
     class="Popup_WindowLogo_Icon Popup_WindowLogo_Icon_process"
     src="../../../../../web/images/blank.gif" border=0></img></div>

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/EmailOptions.html
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/EmailOptions.html
@@ -153,6 +153,8 @@
       if (validateOptionalEmail('bccEmail')) { hasError = true; }
 
       if (!hasError) {
+        var overlay = document.getElementById('sendingOverlay');
+        if (overlay) { overlay.style.display = 'flex'; }
         submitThisPage('EMAIL');
       }
     }
@@ -184,6 +186,7 @@
     var ccEmailOrig;
     var bccEmailOrig;
     var replyToEmailOrig;
+    var isMultiCustomerMode = false;
 
     function onLoadDo(){
     modifyInputFile('inpFile');
@@ -214,7 +217,7 @@
             document.getElementById('bcc_bottomMargin').style.display = '';
         }
 
-        this.windowTables = new Array(
+        windowTables = new Array(
           new windowTableId('client')
         );
         setWindowTableParentElement();
@@ -261,6 +264,15 @@
         if(document.getElementById('useDefault').value=='Y'){
           document.getElementById('emailConfigSelector').style.display = 'none';
           document.getElementById('emailConfigToUse').style.display = 'none';
+        }
+        isMultiCustomerMode = document.getElementById('multipleCustomer') !== null;
+        if (isMultiCustomerMode) {
+          var toInput = document.getElementById('toEmail');
+          if (toInput) {
+            toInput.readOnly = true;
+            toInput.style.backgroundColor = '#f0f0f0';
+            toInput.style.cursor = 'default';
+          }
         }
         checkSendReady();
     }
@@ -325,21 +337,35 @@
       submitXmlHttpRequest(callback, document.frmMain, 'GET_BP_CONTACTS', 'PrintOptions.html', false);
     }
 
+    function getToEmails() {
+      var toField = document.getElementById('toEmail');
+      if (!toField || !toField.value.trim()) { return []; }
+      return toField.value.split(/[;,]/).map(function(a) { return a.trim().toLowerCase(); }).filter(Boolean);
+    }
+
     function renderContactList(contacts, filter) {
       var tbody = document.getElementById('contactSelectorBody');
       tbody.innerHTML = '';
       var lowerFilter = filter.toLowerCase();
+      var currentEmails = isMultiCustomerMode ? getToEmails() : [];
       for (var c of contacts) {
         if (filter && c.name.toLowerCase().indexOf(lowerFilter) === -1
             && c.email.toLowerCase().indexOf(lowerFilter) === -1) {
           continue;
         }
+        var isSelected = isMultiCustomerMode && currentEmails.indexOf(c.email.toLowerCase()) !== -1;
         var tr = document.createElement('tr');
         tr.style.cursor = 'pointer';
+        tr.style.backgroundColor = isSelected ? '#d0e8ff' : '';
         tr.setAttribute('data-email', c.email);
         tr.setAttribute('data-contactid', c.contactId);
-        tr.onmouseover = function() { this.style.backgroundColor = '#d0e4f7'; };
-        tr.onmouseout  = function() { this.style.backgroundColor = ''; };
+        tr.setAttribute('data-selected', isSelected ? 'true' : 'false');
+        tr.onmouseover = function() {
+          if (this.getAttribute('data-selected') !== 'true') { this.style.backgroundColor = '#d0e4f7'; }
+        };
+        tr.onmouseout = function() {
+          this.style.backgroundColor = this.getAttribute('data-selected') === 'true' ? '#d0e8ff' : '';
+        };
         tr.onclick = function() { selectContact(this.getAttribute('data-contactid'), this.getAttribute('data-email')); };
         var badge;
         if (c.isDefault) {
@@ -349,7 +375,8 @@
         } else {
           badge = ' (inactive)';
         }
-        tr.innerHTML = '<td class="DataGrid_Body_Cell" style="padding:3px 6px;">' + escapeHtml(c.name) + badge + '</td>'
+        var checkmark = isSelected ? ' <span style="color:#1a7; font-weight:bold;">&#10003;</span>' : '';
+        tr.innerHTML = '<td class="DataGrid_Body_Cell" style="padding:3px 6px;">' + escapeHtml(c.name) + badge + checkmark + '</td>'
                      + '<td class="DataGrid_Body_Cell" style="padding:3px 6px;">' + escapeHtml(c.email) + '</td>';
         tbody.appendChild(tr);
       }
@@ -367,10 +394,26 @@
 
     function selectContact(contactId, email) {
       var toField = document.getElementById('toEmail');
+      if (isMultiCustomerMode) {
+        var addresses = getToEmails();
+        var idx = addresses.indexOf(email.trim().toLowerCase());
+        if (idx !== -1) {
+          addresses.splice(idx, 1);
+        } else {
+          addresses.push(email.trim());
+        }
+        toField.value = addresses.join('; ');
+        manageFieldValueChange('toEmail');
+        checkSendReady();
+        if (bpContactsCache) {
+          renderContactList(bpContactsCache, document.getElementById('contactSelectorFilter').value || '');
+        }
+        return;
+      }
       var current = toField.value.trim();
       if (current.length > 0) {
-        var addresses = current.split(/[;,]/).map(function(a) { return a.trim(); });
-        if (addresses.indexOf(email.trim()) === -1) {
+        var parts = current.split(/[;,]/).map(function(a) { return a.trim(); });
+        if (parts.indexOf(email.trim()) === -1) {
           toField.value = current.replace(/[;,\s]+$/, '') + '; ' + email;
         }
       } else {
@@ -652,7 +695,7 @@
 </div>
 
 <table cellspacing="0" cellpadding="0" width="100%">
-    <tr>
+    <tr style="display:none">
       <td>
         <table cellspacing="0" cellpadding="0" class="Popup_ContentPane_NavBar">
           <tr class="Popup_NavBar_bg"><td></td>
@@ -667,7 +710,7 @@
       </td>
     </tr>
 
-    <tr>
+    <tr style="display:none">
         <td>
         <table cellspacing="0" cellpadding="0"
             class="Popup_ContentPane_SeparatorBar">
@@ -1040,5 +1083,10 @@
 
 </table>
 </form>
+<div id="sendingOverlay" style="display:none; position:fixed; inset:0; background:rgba(80,80,80,0.45); z-index:9999; justify-content:center; align-items:center;">
+  <div style="background:#fff; border-radius:4px; padding:18px 30px; box-shadow:0 2px 10px rgba(0,0,0,0.35); font-size:14px; color:#444; pointer-events:none;">
+    Sending&#8230;
+  </div>
+</div>
 </body>
 </html>

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/EmailOptions.html
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/EmailOptions.html
@@ -217,9 +217,10 @@
             document.getElementById('bcc_bottomMargin').style.display = '';
         }
 
-        windowTables = new Array(
+        var windowTables = new Array(
           new windowTableId('client')
         );
+        window.windowTables = windowTables;
         setWindowTableParentElement();
         enableShortcuts('popup');
         setBrowserAutoComplete(false);
@@ -293,8 +294,8 @@
     function manageFieldValueChange(field) {
         var fieldName = field.substring(0, field.length-5)+'Name';
         if (document.getElementById(field) && document.getElementById(fieldName)) {
-            currentValue = document.getElementById(field).value;
-            originalValue = window[field + 'Orig'];
+            var currentValue = document.getElementById(field).value;
+            var originalValue = window[field + 'Orig'];
             if (originalValue !== currentValue) {
                 document.getElementById(fieldName).style.display = 'none';
             } else {
@@ -343,49 +344,51 @@
       return toField.value.split(/[;,]/).map(function(a) { return a.trim().toLowerCase(); }).filter(Boolean);
     }
 
+    function buildContactRow(c, isSelected) {
+      var tr = document.createElement('tr');
+      tr.style.cursor = 'pointer';
+      tr.style.backgroundColor = isSelected ? '#d0e8ff' : '';
+      tr.setAttribute('data-email', c.email || '');
+      tr.setAttribute('data-contactid', c.contactId);
+      tr.setAttribute('data-selected', isSelected ? 'true' : 'false');
+      tr.onmouseover = function() {
+        if (this.getAttribute('data-selected') !== 'true') { this.style.backgroundColor = '#d0e4f7'; }
+      };
+      tr.onmouseout = function() {
+        this.style.backgroundColor = this.getAttribute('data-selected') === 'true' ? '#d0e8ff' : '';
+      };
+      tr.onclick = function() { selectContact(this.getAttribute('data-contactid'), this.getAttribute('data-email')); };
+      var badge = '';
+      if (c.isDefault) {
+        badge = ' &#9733;';
+      } else if (!c.isActive) {
+        badge = ' (inactive)';
+      }
+      var checkmark = isSelected ? ' <span style="color:#1a7;font-weight:bold;">&#10003;</span>' : '';
+      tr.innerHTML = '<td class="DataGrid_Body_Cell" style="padding:3px 6px;">' + escapeHtml(c.name || '') + badge + checkmark + '</td>'
+                   + '<td class="DataGrid_Body_Cell" style="padding:3px 6px;">' + escapeHtml(c.email || '') + '</td>';
+      return tr;
+    }
+
     function renderContactList(contacts, filter) {
       var tbody = document.getElementById('contactSelectorBody');
       tbody.innerHTML = '';
       var lowerFilter = filter.toLowerCase();
       var currentEmails = isMultiCustomerMode ? getToEmails() : [];
+      if (!contacts) { return; }
       for (var c of contacts) {
-        if (filter && c.name.toLowerCase().indexOf(lowerFilter) === -1
-            && c.email.toLowerCase().indexOf(lowerFilter) === -1) {
+        if (filter && (c.name || '').toLowerCase().indexOf(lowerFilter) === -1
+            && (c.email || '').toLowerCase().indexOf(lowerFilter) === -1) {
           continue;
         }
-        var isSelected = isMultiCustomerMode && currentEmails.indexOf(c.email.toLowerCase()) !== -1;
-        var tr = document.createElement('tr');
-        tr.style.cursor = 'pointer';
-        tr.style.backgroundColor = isSelected ? '#d0e8ff' : '';
-        tr.setAttribute('data-email', c.email);
-        tr.setAttribute('data-contactid', c.contactId);
-        tr.setAttribute('data-selected', isSelected ? 'true' : 'false');
-        tr.onmouseover = function() {
-          if (this.getAttribute('data-selected') !== 'true') { this.style.backgroundColor = '#d0e4f7'; }
-        };
-        tr.onmouseout = function() {
-          this.style.backgroundColor = this.getAttribute('data-selected') === 'true' ? '#d0e8ff' : '';
-        };
-        tr.onclick = function() { selectContact(this.getAttribute('data-contactid'), this.getAttribute('data-email')); };
-        var badge;
-        if (c.isDefault) {
-          badge = ' &#9733;';
-        } else if (c.isActive) {
-          badge = '';
-        } else {
-          badge = ' (inactive)';
-        }
-        var checkmark = isSelected ? ' <span style="color:#1a7; font-weight:bold;">&#10003;</span>' : '';
-        tr.innerHTML = '<td class="DataGrid_Body_Cell" style="padding:3px 6px;">' + escapeHtml(c.name) + badge + checkmark + '</td>'
-                     + '<td class="DataGrid_Body_Cell" style="padding:3px 6px;">' + escapeHtml(c.email) + '</td>';
-        tbody.appendChild(tr);
+        var isSelected = isMultiCustomerMode && c.email && currentEmails.indexOf(c.email.toLowerCase()) !== -1;
+        tbody.appendChild(buildContactRow(c, isSelected));
       }
       if (tbody.children.length === 0) {
         tbody.innerHTML = '<tr><td colspan="2" class="DataGrid_Body_Cell" style="padding:4px;font-style:italic;">No contacts found</td></tr>';
       }
       var scrollArea = document.getElementById('contactScrollArea');
-      var visibleRows = tbody.children.length;
-      if (visibleRows > 3) {
+      if (tbody.children.length > 3) {
         scrollArea.style.maxHeight = '115px';
       } else {
         scrollArea.style.maxHeight = '';
@@ -593,6 +596,7 @@
     var callback = function (paramXMLParticular, XMLHttpRequestObj) {
         var o, fileName;
         if (getReadyStateHandler(XMLHttpRequestObj)) {
+          var strText = '';
           try {
             if (XMLHttpRequestObj.responseText) {
               strText = XMLHttpRequestObj.responseText;
@@ -611,8 +615,8 @@
           }
         }
         return true;
-      },
-    frm = document.frmMain;
+      };
+    var frm = document.frmMain;
 
     return submitXmlHttpRequest(callback, frm, 'UPDATE_TEMPLATE', 'PrintOptions.html', false);
   }
@@ -620,6 +624,7 @@
     var callback = function (paramXMLParticular, XMLHttpRequestObj) {
       var o, fileName;
       if (getReadyStateHandler(XMLHttpRequestObj)) {
+        var strText = '';
         try {
           if (XMLHttpRequestObj.responseText) {
             strText = XMLHttpRequestObj.responseText;
@@ -633,8 +638,8 @@
         }
       }
       return true;
-    },
-    frm = document.frmMain;
+    };
+    var frm = document.frmMain;
     return submitXmlHttpRequest(callback, frm, 'UPDATE_EMAILCONFIG', 'PrintOptions.html', false);
    }
 
@@ -726,7 +731,14 @@
 
         <div style="margin: 10px;" id="client">
 
-        <table cellspacing="0" cellpadding="0 style="height: 150px; overflow: auto;" class="form_table">
+        <table style="height: 150px; overflow: auto;" class="form_table" aria-label="Email document options">
+                    <caption style="display:none;">Email document options</caption>
+                    <tr style="display:none;">
+                        <th scope="col"></th>
+                        <th scope="col"></th>
+                        <th scope="col"></th>
+                        <th scope="col"></th>
+                    </tr>
 
                     <tr id=emailConfigSelector>
                         <td class="TitleCell"><span class="LabelText">Use default email configration</span></td>

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/EmailOptions.html
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/EmailOptions.html
@@ -24,6 +24,10 @@
 <title>Email options</title>
     <link rel="shortcut icon" href="../../../../../web/images/favicon.ico" type="image/x-icon" />
     <link rel="stylesheet" type="text/css" href="../../../../../web/skins/Default/Openbravo_ERP_250.css" id="paramCSS" />
+    <style type="text/css">
+      #sendButton:disabled { opacity: 0.4; cursor: not-allowed; }
+      #sendButton:disabled * { pointer-events: none; }
+    </style>
     <script language="JavaScript" type="text/javascript" id="paramDirectory">
       var baseDirectory = "../../../../../web/";
       </script>      
@@ -94,6 +98,21 @@
         errEl.style.display = 'none';
         document.getElementById(fieldId).style.borderColor = '';
       }
+    }
+
+    function checkSendReady() {
+      var toEl = document.getElementById('toEmail');
+      var replyToEl = document.getElementById('replyToEmail');
+      var subjectRow = document.getElementById('emailField03Subject');
+      var subjectEl = document.getElementById('emailSubject');
+      var templatesEl = document.getElementById('templates');
+      var toOk = !toEl || toEl.value.trim().length > 0;
+      var replyToOk = !replyToEl || replyToEl.value.trim().length > 0;
+      var subjectHidden = subjectRow && subjectRow.style.display === 'none';
+      var subjectOk = subjectHidden || !subjectEl || subjectEl.value.trim().length > 0;
+      var templateOk = !templatesEl || templatesEl.value.length > 0;
+      var btn = document.getElementById('sendButton');
+      if (btn) { btn.disabled = !(toOk && replyToOk && subjectOk && templateOk); }
     }
 
     function validateOptionalEmail(fieldId) {
@@ -243,6 +262,7 @@
           document.getElementById('emailConfigSelector').style.display = 'none';
           document.getElementById('emailConfigToUse').style.display = 'none';
         }
+        checkSendReady();
     }
 
     function onResizeDo(){
@@ -359,6 +379,7 @@
       document.getElementById('toContactId').value = contactId;
       manageFieldValueChange('toEmail');
       document.getElementById('contactSelectorPanel').style.display = 'none';
+      checkSendReady();
     }
 
     function filterContacts() {
@@ -502,6 +523,7 @@
       manageFieldValueChange('toEmail');
       setEmailError('toEmail', null);
       hideSuggestions();
+      checkSendReady();
     }
 
     function storeDoc(){
@@ -537,7 +559,7 @@
           if (!o.error) {
             document.getElementById('emailSubject').value = o.subject;
             document.getElementById('emailBody').innerHTML = o.body;
-
+            checkSendReady();
             if (o.filename){
               fileName = document.getElementById('fileDocName');
               fileName.removeChild(fileName.childNodes[0]);
@@ -564,6 +586,7 @@
         if (!o.error) {
           document.getElementById('emailSubject').value = o.subject;
           document.getElementById('emailBody').innerHTML = o.body;
+          checkSendReady();
         }
       }
       return true;
@@ -700,6 +723,7 @@
                                     maxlength="200" name="toEmail" id="toEmail" value=""
                                     onkeyup="onToEmailKeyup(event);"
                                     onchange="manageFieldValueChange(this.id);"
+                                    oninput="checkSendReady();"
                                     onblur="setTimeout(hideSuggestions, 200);"
                                     autocomplete="off"
                                     required="true">
@@ -811,6 +835,7 @@
                                     class="dojoValidateValid required TextBox_btn_TwoCells_width"
                                     maxlength="200" name="replyToEmail" id="replyToEmail" value=""
                                     onkeyup="manageFieldValueChange(this.id);" onchange="manageFieldValueChange(this.id);"
+                                    oninput="checkSendReady();"
                                     required="true"><span class="LabelText" name="replyToName" id="replyToName" value="" style="padding-left: 10px"></span>
                                     
                         </td>
@@ -837,6 +862,7 @@
                             <input style="width: 100%;" type="text" dojoType="openbravo:ValidationTextBox"
                                         class="dojoValidateValid required TextBox_btn_TwoCells_width"
                                         maxlength="200" name="emailSubject" id="emailSubject" value=""
+                                        oninput="checkSendReady();"
                                         required="true">
                         </td>
                         <td rowspan="5">
@@ -956,8 +982,9 @@
                     <tr>
                         <td class="Button_RightAlign_ContentCell" style="padding-top: 30px">
                             <div>
-                <button type="button" 
-                  class="ButtonLink" 
+                <button type="button"
+                  id="sendButton"
+                  class="ButtonLink"
                   onclick="validateAndSendEmail();return false;"
                   onfocus="buttonEvent('onfocus', this); window.status='Send'; return true;" 
                   onblur="buttonEvent('onblur', this);" 

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/PrintController.java
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/PrintController.java
@@ -92,33 +92,33 @@ import net.sf.jasperreports.export.SimplePdfExporterConfiguration;
 
 @SuppressWarnings("serial")
 public class PrintController extends HttpSecureAppServlet {
-  private static final String DOCUMENT_ID = "documentId";
-  private static final String DOCUMENT_TYPE = "documentType";
-  private static final String REPORT_INPUT_STREAM = "reportInputStream";
-  private static final String REPORT_OUTPUT_STREAM = "reportOutputStream";
   public static final String ERROR_PRINTING_DOCUMENT_KEY = "Error_Printing_Document";
-  private static final String PARAM_TO_EMAIL = "toEmail";
-  private static final String PARAM_TO_EMAIL_ORIG = "toEmailOrig";
-  private static final String PARAM_TO_CONTACT_ID = "toContactId";
-  private static final String CONTENT_TYPE_JSON = "application/json; charset=UTF-8";
-  private static final String JSON_KEY_ERROR = "error";
+  static final String PARAM_TO_EMAIL = "toEmail";
+  static final String PARAM_TO_EMAIL_ORIG = "toEmailOrig";
+  static final String PARAM_TO_CONTACT_ID = "toContactId";
+  static final String CONTENT_TYPE_JSON = "application/json; charset=UTF-8";
   public static final String LIST_ITEM_TAG = "<li>";
   public static final String CLOSE_LIST_ITEM_TAG = "</li>";
-  private final Map<String, TemplateData[]> differentDocTypes = new HashMap<String, TemplateData[]>();
-  private boolean multiReports = false;
-  private boolean archivedReports = false;
-  private final MutableBoolean printingErrorOccurred = new MutableBoolean(false);
-  private static final String PRINT_PATH = "print.html";
-  private static final String PRINT_OPTIONS_PATH = "printoptions.html";
-  private static final String SEND_PATH = "send.html";
-  private static final String ERROR = "Error";
-  private static final String TAB = "tab";
-  private static final String INP_TAB_ID = "inpTabId";
-  private static final String ATTRIBUTESETINSTANCE_TABID = "AttributeSetInstance.tabId";
-  private static final String SESSION_POC_DATA = "pocData";
+  final Map<String, TemplateData[]> differentDocTypes = new HashMap<>();
+  boolean multiReports = false;
+  boolean archivedReports = false;
+  final MutableBoolean printingErrorOccurred = new MutableBoolean(false);
+  static final String MSG_TYPE_ERROR = "Error";
+  static final String TAB = "tab";
+  static final String INP_TAB_ID = "inpTabId";
+  static final String ATTRIBUTESETINSTANCE_TABID = "AttributeSetInstance.tabId";
+  static final String SESSION_POC_DATA = "pocData";
+  static final String SESSION_FILES = "files";
+  static final String CHECK_MORE_THAN_ONE_CUSTOMER = "moreThanOneCustomer";
+  static final String CHECK_MORE_THAN_ONE_DOCUMENT = "moreThanOneDoc";
+  static final String CHECK_MORE_THAN_ONE_SALES_REP = "moreThanOnesalesRep";
+  static final String PARAM_INP_ARCHIVE = "inpArchive";
+  static final String CONTENT_TYPE_HTML = "text/html; charset=UTF-8";
+  static final String XML_PARAMETER_DIRECTORY = "directory";
+  private static final String BASE_DIRECTORY_JS = "var baseDirectory = \"%s/\";\r\n";
   private static JSONObject hookParams;
   private static PrintControllerHookManager hookManager;
-  private final MutableBoolean hooking = new MutableBoolean(false);
+  final MutableBoolean hooking = new MutableBoolean(false);
 
   @Override
   public void init(ServletConfig config) {
@@ -130,73 +130,13 @@ public class PrintController extends HttpSecureAppServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response)
       throws IOException, ServletException {
     final VariablesSecureApp vars = new VariablesSecureApp(request);
-
-    DocumentType documentType = DocumentType.UNKNOWN;
-    String sessionValuePrefix = null;
-    String strDocumentId = null;
-
-    // Determine which process called the print controller
     if (log4j.isDebugEnabled()) {
       log4j.debug("Servletpath: " + request.getServletPath());
     }
-    if (request.getServletPath().toLowerCase().indexOf("quotations") != -1) {
-      documentType = DocumentType.QUOTATION;
-      // The prefix PRINTORDERS is a fixed name based on the KEY of the
-      // AD_PROCESS
-      sessionValuePrefix = "PRINTQUOTATIONS";
-
-      strDocumentId = vars.getSessionValue(sessionValuePrefix + ".inpcOrderId_R");
-      if (strDocumentId.equals("")) {
-        strDocumentId = vars.getSessionValue(sessionValuePrefix + ".inpcOrderId");
-      }
-    }
-    if (request.getServletPath().toLowerCase().indexOf("orders") != -1) {
-      documentType = DocumentType.SALESORDER;
-      // The prefix PRINTORDERS is a fixed name based on the KEY of the
-      // AD_PROCESS
-      sessionValuePrefix = "PRINTORDERS";
-
-      strDocumentId = vars.getSessionValue(sessionValuePrefix + ".inpcOrderId_R");
-      if (strDocumentId.equals("")) {
-        strDocumentId = vars.getSessionValue(sessionValuePrefix + ".inpcOrderId");
-      }
-    }
-    if (request.getServletPath().toLowerCase().indexOf("invoices") != -1) {
-      documentType = DocumentType.SALESINVOICE;
-      // The prefix PRINTINVOICES is a fixed name based on the KEY of the
-      // AD_PROCESS
-      sessionValuePrefix = "PRINTINVOICES";
-
-      strDocumentId = vars.getSessionValue(sessionValuePrefix + ".inpcInvoiceId_R");
-      if (strDocumentId.equals("")) {
-        strDocumentId = vars.getSessionValue(sessionValuePrefix + ".inpcInvoiceId");
-      }
-    }
-    if (request.getServletPath().toLowerCase().indexOf("shipments") != -1) {
-      documentType = DocumentType.SHIPMENT;
-      // The prefix PRINTINVOICES is a fixed name based on the KEY of the
-      // AD_PROCESS
-      sessionValuePrefix = "PRINTSHIPMENTS";
-
-      strDocumentId = vars.getSessionValue(sessionValuePrefix + ".inpmInoutId_R");
-      if (strDocumentId.equals("")) {
-        strDocumentId = vars.getSessionValue(sessionValuePrefix + ".inpmInoutId");
-      }
-    }
-    if (request.getServletPath().toLowerCase().indexOf("payments") != -1) {
-      documentType = DocumentType.PAYMENT;
-      // The prefix PRINTPAYMENTS is a fixed name based on the KEY of the
-      // AD_PROCESS
-      sessionValuePrefix = "PRINTPAYMENT";
-
-      strDocumentId = vars.getSessionValue(sessionValuePrefix + ".inpfinPaymentId_R");
-      if (strDocumentId.equals("")) {
-        strDocumentId = vars.getSessionValue(sessionValuePrefix + ".inpfinPaymentId");
-      }
-    }
-
-    post(request, response, vars, documentType, sessionValuePrefix, strDocumentId);
-
+    PrintControllerRequestResolver.RequestContext requestContext =
+        PrintControllerRequestResolver.resolve(request, vars);
+    post(request, response, vars, requestContext.documentType, requestContext.sessionValuePrefix,
+        requestContext.documentId);
   }
 
   private static void initializeHooksAndParams() throws JSONException {
@@ -213,334 +153,17 @@ public class PrintController extends HttpSecureAppServlet {
   protected void post(HttpServletRequest request, HttpServletResponse response,
       VariablesSecureApp vars, DocumentType documentType, String sessionValuePrefix,
       String strDocumentId) throws IOException, ServletException {
-    String localStrDocumentId = strDocumentId;
     try {
-      String fullDocumentIdentifier = localStrDocumentId + documentType.getTableName();
-
-      // reports is set in session: defining it as a Serializable HashMap
-      HashMap<String, Report> reports;
-
-      // Checks are maintained in this way for mulithread safety
-      HashMap<String, Boolean> checks = new HashMap<String, Boolean>();
-      checks.put("moreThanOneCustomer", Boolean.FALSE);
-      checks.put("moreThanOnesalesRep", Boolean.FALSE);
-
-      String documentIds[] = null;
-      if (log4j.isDebugEnabled()) {
-        log4j.debug("strDocumentId: " + localStrDocumentId);
-      }
-      // normalize the string of ids to a comma separated list
-      localStrDocumentId = localStrDocumentId.replaceAll("\\(|\\)|'", "");
-      if (localStrDocumentId.length() == 0) {
-        throw new ServletException(Utility.messageBD(this, "NoDocument", vars.getLanguage()));
-      }
-
-      documentIds = localStrDocumentId.split(",");
-
-      if (log4j.isDebugEnabled()) {
-        log4j.debug("Number of documents selected: " + documentIds.length);
-      }
-
-      multiReports = (documentIds.length > 1);
-
-      reports = (HashMap<String, Report>) vars.getSessionObject(sessionValuePrefix + ".Documents");
-      final ReportManager reportManager = new ReportManager(globalParameters.strFTPDirectory,
-          strReplaceWithFull, globalParameters.strBaseDesignPath,
-          globalParameters.strDefaultDesignPath, globalParameters.prefix, multiReports);
+      PrintControllerCommandHandler.Context context = PrintControllerCommandHandler.createContext(
+          this, vars, documentType, sessionValuePrefix, strDocumentId);
       initializeHooksAndParams();
-      hooking.setValue(true); // Indicates that hooks will be run
-      if (vars.commandIn("PRINT")) {
-        archivedReports = false;
-        // Order documents by Document No.
-        if (multiReports) {
-          documentIds = orderByDocumentNo(documentType, documentIds);
-        }
-
-        /*
-         * PRINT option will print directly to the UI for a single report. For multiple reports the
-         * documents will each be saved individually and the concatenated in the same manner as the
-         * saved reports. After concatenating the reports they will be deleted.
-         */
-        Report report = null;
-        JasperPrint jasperPrint = null;
-        Collection<JasperPrint> jrPrintReports = new ArrayList<JasperPrint>();
-        final Collection<Report> savedReports = new ArrayList<Report>();
-        for (int i = 0; i < documentIds.length; i++) {
-          String documentId = documentIds[i];
-          setPreHookParams(documentType, hookParams, documentId);
-          executePreProcessHooks(hookManager, hookParams);
-          report = buildReport(response, vars, documentId, reportManager, documentType,
-              Report.OutputTypeEnum.PRINT);
-          try {
-            jasperPrint = reportManager.processReport(report, vars);
-            jrPrintReports.add(jasperPrint);
-          } catch (final ReportingException e) {
-            advisePopUp(request, response, "Report processing failed",
-                "Unable to process report selection");
-            log4j.error(e.getMessage());
-            e.getStackTrace();
-          }
-          savedReports.add(report);
-          if (multiReports) {
-            reportManager.saveTempReport(report, vars);
-          }
-        }
-        printReports(response, jrPrintReports, savedReports, isDirectPrint(vars));
-      } else if (vars.commandIn("ARCHIVE")) {
-        // Order documents by Document No.
-        if (multiReports) {
-          documentIds = orderByDocumentNo(documentType, documentIds);
-        }
-
-        /*
-         * ARCHIVE will save each report individually and then print the reports in a single
-         * printable (concatenated) format.
-         */
-        archivedReports = true;
-        Report report = null;
-        JasperPrint jasperPrint = null;
-        Collection<JasperPrint> jrPrintReports = new ArrayList<JasperPrint>();
-        final Collection<Report> savedReports = new ArrayList<Report>();
-        for (int index = 0; index < documentIds.length; index++) {
-          String documentId = documentIds[index];
-          setPreHookParams(documentType, hookParams, documentId);
-          executePreProcessHooks(hookManager, hookParams);
-          report = buildReport(response, vars, documentId, reportManager, documentType,
-              OutputTypeEnum.ARCHIVE);
-          buildReport(response, vars, documentId, reports, reportManager);
-          try {
-            jasperPrint = reportManager.processReport(report, vars);
-            jrPrintReports.add(jasperPrint);
-          } catch (final ReportingException e) {
-            log4j.error(e);
-          }
-          reportManager.saveTempReport(report, vars);
-          savedReports.add(report);
-        }
-        printReports(response, jrPrintReports, savedReports, isDirectPrint(vars));
-      } else {
-        if (vars.commandIn("DEFAULT")) {
-
-          differentDocTypes.clear();
-          reports = new HashMap<String, Report>();
-          for (int index = 0; index < documentIds.length; index++) {
-            final String documentId = documentIds[index];
-            if (log4j.isDebugEnabled()) {
-              log4j.debug("Processing document with id: " + documentId);
-            }
-
-            try {
-              final Report report = new Report(documentType, documentId, vars.getLanguage(),
-                  "default", multiReports, OutputTypeEnum.DEFAULT);
-              reports.put(documentId, report);
-
-              final String senderAddress = EmailData.getSenderAddress(this, vars.getClient(),
-                  report.getOrgId());
-
-              if (request.getServletPath().toLowerCase().indexOf(PRINT_PATH) == -1
-                  && request.getServletPath().toLowerCase().indexOf(PRINT_OPTIONS_PATH) == -1) {
-                ResolvedSmtpConfig resolvedForCheck = SmtpCascadeResolver.resolve();
-                boolean hasSender = resolvedForCheck != null
-                    || StringUtils.isNotEmpty(senderAddress);
-                if (!hasSender) {
-                  reportNoSenderError(response, vars);
-                }
-              }
-
-              // check the different doc typeId's if all the selected
-              // doc's
-              // has the same doc typeId the template selector should
-              // appear
-              if (!differentDocTypes.containsKey(report.getDocTypeId())) {
-                differentDocTypes.put(report.getDocTypeId(), report.getTemplate());
-              }
-            } catch (final ReportingException exception) {
-              throw new ServletException(exception);
-            }
-
-          }
-
-          vars.setSessionObject(sessionValuePrefix + ".Documents", reports);
-
-          if (request.getServletPath().toLowerCase().indexOf(PRINT_PATH) != -1) {
-            createPrintOptionsPage(request, response, vars, documentType,
-                getComaSeparatedString(documentIds), reports);
-          } else if (request.getServletPath().toLowerCase().indexOf(SEND_PATH) != -1) {
-            createEmailOptionsPage(request, response, vars, documentType,
-                getComaSeparatedString(documentIds), reports, checks, fullDocumentIdentifier);
-          }
-
-        } else if (vars.commandIn("ADD")) {
-          if (request.getServletPath().toLowerCase().indexOf(PRINT_PATH) != -1) {
-            createPrintOptionsPage(request, response, vars, documentType,
-                getComaSeparatedString(documentIds), reports);
-          } else {
-            createEmailOptionsPage(request, response, vars, documentType,
-                getComaSeparatedString(documentIds), reports, checks, fullDocumentIdentifier);
-          }
-
-        } else if (vars.commandIn("DEL")) {
-          final String documentToDelete = vars.getStringParameter("idToDelete");
-          final List<AttachContent> attachments = (List<AttachContent>) request.getSession()
-              .getAttribute("files");
-          request.getSession().setAttribute("files", attachments);
-
-          seekAndDestroy(attachments, documentToDelete);
-          createEmailOptionsPage(request, response, vars, documentType,
-              getComaSeparatedString(documentIds), reports, checks, fullDocumentIdentifier);
-
-        } else if (vars.commandIn("EMAIL")) {
-          final String toEmailParam = vars.getStringParameter(PARAM_TO_EMAIL);
-          if (StringUtils.isBlank(toEmailParam)) {
-            throw new ServletException(
-                Utility.messageBD(this, "NoCustomerEmail", vars.getLanguage()));
-          }
-          PocData[] pocData = (PocData[]) vars.getSessionObject(SESSION_POC_DATA + fullDocumentIdentifier);
-          int nrOfEmailsSend = 0;
-          for (final PocData documentData : pocData) {
-            getEnvironentInformation(pocData, checks);
-            final String documentId = documentData.documentId;
-            if (log4j.isDebugEnabled()) {
-              log4j.debug("Processing document with id: " + documentId);
-            }
-
-            String templateInUse = "default";
-            if (differentDocTypes.size() == 1) {
-              templateInUse = vars.getRequestGlobalVariable("templates", "templates");
-            }
-
-            final Report report = buildReport(response, vars, documentId, reportManager,
-                documentType, OutputTypeEnum.EMAIL, templateInUse);
-
-            // if there is only one document type id the user should be
-            // able to choose between different templates
-            if (differentDocTypes.size() == 1) {
-              final String templateId = vars.getRequestGlobalVariable("templates", "templates");
-              try {
-                final TemplateInfo usedTemplateInfo = new TemplateInfo(this, report.getDocTypeId(),
-                    report.getOrgId(), vars.getLanguage(), templateId);
-                report.setTemplateInfo(usedTemplateInfo);
-              } catch (final ReportingException e) {
-                throw new ServletException("Error trying to get template information", e);
-              }
-            }
-
-            if (report == null) {
-              throw new ServletException(
-                  Utility.messageBD(this, "NoDataReport", vars.getLanguage()) + documentId);
-            }
-            // Check if the document is not in status 'draft'
-            if (!report.isDraft()) {
-              // Check if the report is already attached
-              if (!report.isAttached()) {
-                // get the Id of the entities table, this is used to
-                // store the file as an OB attachment
-                final String tableId = ToolsData.getTableId(this,
-                    report.getDocumentType().getTableName());
-
-                // If the user wants to archive the document
-                if (vars.getStringParameter("inpArchive").equals("Y")) {
-                  // Save the report as a attachment because it is
-                  // being transferred to the user
-                  try {
-                    reportManager.createAttachmentForReport(this, report, tableId, vars,
-                        ReportManager.GENERATED_BY_EMAILING);
-                  } catch (final ReportingException exception) {
-                    throw new ServletException(exception);
-                  }
-                } else {
-                  reportManager.saveTempReport(report, vars);
-                }
-              } else {
-                if (log4j.isDebugEnabled()) {
-                  log4j.debug("Document is not attached.");
-                }
-              }
-              final String senderAddress = vars.getStringParameter("fromEmail");
-              checks.put("differentDocTypes", differentDocTypes.size() > 1);
-
-              EmailUtilities.prepareAndSendEmail(report, vars,
-                  (List<AttachContent>) request.getSession().getAttribute("files"), documentData,
-                  senderAddress, checks,  this);
-              nrOfEmailsSend++;
-            }
-          }
-          request.getSession().removeAttribute("files");
-          if (nrOfEmailsSend > 0 && pocData.length > 0) {
-            persistLastUsedContact(vars, pocData[0].bpartnerId);
-          }
-          vars.removeSessionValue(SESSION_POC_DATA + fullDocumentIdentifier);
-          createPrintStatusPage(response, vars, nrOfEmailsSend);
-        } else if (vars.commandIn("UPDATE_TEMPLATE")) {
-          JSONObject o = new JSONObject();
-          try {
-            PocData[] pocData = (PocData[]) vars
-                .getSessionObject(SESSION_POC_DATA + fullDocumentIdentifier);
-            final String templateId = vars.getRequestGlobalVariable("templates", "templates");
-            final String documentId = pocData[0].documentId;
-            final Report report = new Report(documentType, documentId, vars.getLanguage(),
-                templateId, multiReports, OutputTypeEnum.DEFAULT);
-            o.put("templateId", templateId);
-            o.put("subject", report.getEmailDefinition().getSubject());
-            o.put("body", report.getEmailDefinition().getBody());
-            if (!multiReports) {
-              o.put("filename", report.getFilename());
-            }
-            reports = new HashMap<String, Report>();
-            reports.put(documentId, report);
-            vars.setSessionObject(sessionValuePrefix + ".Documents", reports);
-
-          } catch (Exception e) {
-            log4j.error("Error in change template ajax", e);
-            o = new JSONObject();
-            try {
-              o.put(JSON_KEY_ERROR, true);
-            } catch (JSONException e1) {
-              log4j.error("Error in change template ajax", e1);
-            }
-          }
-
-          response.setContentType(CONTENT_TYPE_JSON);
-          final PrintWriter out = response.getWriter();
-          out.println(o.toString());
-          out.close();
-        } else if (vars.commandIn("GET_BP_CONTACTS")) {
-          PocData[] pocDataForContacts = (PocData[]) vars.getSessionObject(SESSION_POC_DATA + fullDocumentIdentifier);
-          JSONObject result = buildBPContactsJson(vars, pocDataForContacts);
-          writeJsonResponse(response, result);
-
-        } else if (vars.commandIn("UPDATE_EMAILCONFIG")) {
-          JSONObject o = new JSONObject();
-          try {
-            String currentEmailConfigId = vars.getStringParameter("emailConfigList");
-            EmailTemplate emailTemplate = OBDal.getInstance()
-                .get(EmailTemplate.class, currentEmailConfigId);
-            o.put("subject", emailTemplate.getSubject());
-            o.put("body", emailTemplate.getBody());
-
-          } catch (Exception e) {
-            log4j.error("Error in change template ajax", e);
-            o = new JSONObject();
-            try {
-              o.put(JSON_KEY_ERROR, true);
-            } catch (JSONException e1) {
-              log4j.error("Error in change template ajax", e1);
-            }
-          }
-
-          response.setContentType(CONTENT_TYPE_JSON);
-          final PrintWriter out = response.getWriter();
-          out.println(o.toString());
-          out.close();
-        }
-
-        pageError(response);
-      }
+      hooking.setValue(true);
+      new PrintControllerCommandHandler(this, request, response, vars, context).handle();
     } catch (Exception e) {
       // Catching the exception here instead of throwing it to HSAS because this is used in multi
       // part request making the mechanism to detect popup not to work.
       log4j.error("Error captured: ", e);
-      bdErrorGeneralPopUp(request, response, ERROR,
+      bdErrorGeneralPopUp(request, response, MSG_TYPE_ERROR,
           Utility.translateError(this, vars, vars.getLanguage(), e.getMessage()).getMessage());
     } finally {
       hooking.setValue(false);
@@ -548,15 +171,31 @@ public class PrintController extends HttpSecureAppServlet {
     }
   }
 
-  /**
-   * Resolves the contact that was used as email recipient and persists it for future preselection.
-   * If the user picked a contact from the selector, its ID is used directly. Otherwise, the
-   * email address typed manually is matched against the BP's contacts.
-   * @param vars the current request variables
-   * @param bpartnerId the ID of the Business Partner
-   * @throws ServletException if an error occurs during persistence
-   *
-   */
+  void preparePreProcessHooks(DocumentType documentType, String documentId) throws JSONException {
+    PrintControllerHookSupport.setPreHookParams(documentType, hookParams, documentId);
+    PrintControllerHookSupport.executePreProcessHooks(hookManager, hookParams);
+  }
+
+  ReportManager createReportManager() {
+    return new ReportManager(globalParameters.strFTPDirectory, strReplaceWithFull,
+        globalParameters.strBaseDesignPath, globalParameters.strDefaultDesignPath,
+        globalParameters.prefix, multiReports);
+  }
+
+  void showPageError(HttpServletResponse response) throws IOException, ServletException {
+    pageError(response);
+  }
+
+  void showAdvicePopup(HttpServletRequest request, HttpServletResponse response, String title,
+      String message) throws IOException, ServletException {
+    advisePopUp(request, response, title, message);
+  }
+
+  void closePopupAndRefreshParent(HttpServletResponse response, VariablesSecureApp vars)
+      throws IOException, ServletException {
+    printPageClosePopUpAndRefreshParent(response, vars);
+  }
+
   protected void persistLastUsedContact(VariablesSecureApp vars, String bpartnerId) throws ServletException {
     String toContactId = vars.getStringParameter(PARAM_TO_CONTACT_ID);
     if (StringUtils.isBlank(toContactId)) {
@@ -568,185 +207,18 @@ public class PrintController extends HttpSecureAppServlet {
     }
   }
 
-  /**
-   * Builds a JSON object containing the list of email-enabled contacts for the Business Partner
-   * identified by the {@code bpartnerId} request parameter.
-   * @param vars the current request variables containing the {@code bpartnerId} parameter
-   * @return a {@link JSONObject} with a {@code contacts} array, or an {@code error} flag on failure
-   */
-  protected JSONObject buildBPContactsJson(VariablesSecureApp vars, PocData[] pocData) {
-    JSONObject result = new JSONObject();
-    try {
-      JSONArray contactsArray = new JSONArray();
-      if (isMultiCustomer(pocData)) {
-        List<String> seenEmails = new ArrayList<>();
-        for (PocData doc : pocData) {
-          if (StringUtils.isBlank(doc.contactEmail) || seenEmails.contains(doc.contactEmail)) {
-            continue;
-          }
-          seenEmails.add(doc.contactEmail);
-          JSONObject json = new JSONObject();
-          json.put("contactId", StringUtils.defaultString(doc.contactUserId));
-          json.put("name", StringUtils.defaultString(doc.contactName));
-          json.put("email", doc.contactEmail);
-          json.put("isDefault", false);
-          json.put("isActive", true);
-          contactsArray.put(json);
-        }
-      } else {
-        String bpartnerId = pocData != null && pocData.length > 0
-            ? pocData[0].bpartnerId
-            : vars.getStringParameter("bpartnerId");
-        List<User> contacts = BPContactEmailSelector.getBPContactsWithEmail(bpartnerId);
-        for (User contact : contacts) {
-          contactsArray.put(buildContactJson(contact));
-        }
-      }
-      result.put("contacts", contactsArray);
-    } catch (Exception e) {
-      log4j.error("Error retrieving BP contacts for email selector", e);
-      result = buildErrorJson();
-    }
-    return result;
-  }
-
-  private static boolean isMultiCustomer(PocData[] pocData) {
-    if (pocData == null || pocData.length == 0) {
-      return false;
-    }
-    String firstEmail = pocData[0].contactEmail;
-    for (int i = 1; i < pocData.length; i++) {
-      if (!StringUtils.equals(firstEmail, pocData[i].contactEmail)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Builds a JSON representation of a single BP contact for the email selector.
-   * @param contact the {@link User} contact to serialize
-   * @return a {@link JSONObject} with contactId, name, email, isDefault, and isActive fields
-   * @throws JSONException if a JSON serialization error occurs
-   */
-  protected static JSONObject buildContactJson(User contact) throws JSONException {
-    JSONObject json = new JSONObject();
-    json.put("contactId", contact.getId());
-    json.put("name", contact.getName());
-    json.put("email", contact.getEmail());
-    json.put("isDefault",
-    Boolean.TRUE.equals(contact.get(User.PROPERTY_ISDEFAULTFORDOCS)));
-    json.put("isActive", Boolean.TRUE.equals(contact.isActive()));
-    return json;
-  }
-
-  /**
-   * Builds a JSON object with an error flag. Used as fallback when contact retrieval fails.
-   * @return a {@link JSONObject} containing {@code {"error": true}}
-   */
-  protected JSONObject buildErrorJson() {
-    JSONObject error = new JSONObject();
-    try {
-      error.put(JSON_KEY_ERROR, true);
-    } catch (JSONException e) {
-      log4j.error("Failed to build error JSON", e);
-    }
-    return error;
-  }
-
-  /**
-   * Writes a JSON object to the HTTP response with UTF-8 encoding.
-   * @param response the HTTP response
-   * @param json the JSON object to write
-   * @throws IOException if a write error occurs
-   */
-  protected static void writeJsonResponse(HttpServletResponse response, JSONObject json) throws IOException {
-    response.setContentType(CONTENT_TYPE_JSON);
-    final PrintWriter out = response.getWriter();
-    out.println(json.toString());
-    out.close();
-  }
-  
-  /**
-   * Sets the parameters for postProcess hooks in the given JSON parameters.
-   *
-   * @param documentType
-   *     the type of document being processed
-   * @param jsonParams
-   *     the JSON parameters being processed
-   * @param documentId
-   *     the ID of the document being processed
-   * @param reportInputStream
-   * @param reportOutputStream
-   * @throws JSONException
-   *     if there is an error processing the JSON parameters
-   * @throws IOException
-   *     if there is an error retrieving the report file path
-   */
-  private static void setPostHookParams(DocumentType documentType, JSONObject jsonParams, String documentId,
-      InputStream reportInputStream, OutputStream reportOutputStream) throws PrintControllerHookManager.PrintControllerHookException {
-    try {
-      jsonParams.put(DOCUMENT_ID, documentId);
-      jsonParams.put(DOCUMENT_TYPE, documentType);
-      jsonParams.put(REPORT_INPUT_STREAM, reportInputStream);
-      jsonParams.put(REPORT_OUTPUT_STREAM, reportOutputStream);
-    } catch (JSONException e) {
-      throw new PrintControllerHookManager.PrintControllerHookException(e.getMessage());
-    }
-  }
-
-  /**
-   * Sets the parameters for preProcess hooks in the given JSON parameters.
-   *
-   * @param documentType
-   *     the type of document being processed
-   * @param jsonParams
-   *     the JSON parameters being processed
-   * @param documentId
-   *     the ID of the document being processed
-   * @throws JSONException
-   *     if there is an error processing the JSON parameters
-   */
-  private static void setPreHookParams(DocumentType documentType, JSONObject jsonParams,
-      String documentId) throws JSONException {
-    jsonParams.put(DOCUMENT_ID, documentId);
-    jsonParams.put(DOCUMENT_TYPE, documentType);
-  }
-
-  /**
-   * Executes the preProcess hooks for the given document type and handles any errors encountered during execution.
-   *
-   * @param hookManager
-   *     the manager responsible for handling hooks
-   * @param jsonParams
-   *     the JSON parameters being processed
-   * @throws JSONException
-   *     if there is an error processing the JSON parameters
-   * @throws OBException
-   *     if an error occurs during the execution of hooks
-   */
-  private static void executePreProcessHooks(PrintControllerHookManager hookManager,
-      JSONObject jsonParams) throws JSONException {
-    try {
-      hookManager.executeHooks(jsonParams, hookManager.getPreProcess());
-    } catch (PrintControllerHookManager.PrintControllerHookException e) {
-      throw new OBException(String.format(OBMessageUtils.messageBD(ERROR_PRINTING_DOCUMENT_KEY),
-          LIST_ITEM_TAG + e.getMessage() + CLOSE_LIST_ITEM_TAG));
-    }
-  }
-
   public void printReports(HttpServletResponse response, Collection<JasperPrint> jrPrintReports,
       Collection<Report> reports, boolean directPrint) {
 
     ByteArrayOutputStream tempOutputStream = new ByteArrayOutputStream();
     String filename = "";
-    Map<Object, Object> parameters = new HashMap<Object, Object>();
+    Map<Object, Object> parameters = new HashMap<>();
     try {
       response.setContentType("application/pdf");
       ServletOutputStream os = response.getOutputStream();
 
       if (!multiReports && !archivedReports) {
-        filename = getFilenameForReports(reports, filename);
+        filename = PrintControllerDocumentHelper.getFilenameForReports(reports);
         if (!directPrint) {
           handleIndirectPrint(response, jrPrintReports, reports, filename, parameters, tempOutputStream);
         } else {
@@ -791,9 +263,14 @@ public class PrintController extends HttpSecureAppServlet {
         for (Report report : reports) {
           // Delete temporal reports generated for the returned report in case they have been
           // attached also
-          File file = new File(report.getTargetLocation());
-          if (file.exists() && !file.isDirectory()) {
-            file.delete();
+          String targetLocation = report.getTargetLocation();
+          if (targetLocation != null) {
+            File canonicalFile = new File(targetLocation).getCanonicalFile();
+            File canonicalBase = new File(globalParameters.strFTPDirectory).getCanonicalFile();
+            if (canonicalFile.getPath().startsWith(canonicalBase.getPath() + File.separator)
+                && canonicalFile.exists() && !canonicalFile.isDirectory()) {
+              Files.delete(canonicalFile.toPath());
+            }
           }
         }
       } catch (IOException e) {
@@ -814,16 +291,19 @@ public class PrintController extends HttpSecureAppServlet {
       Collection<Report> reports, String filename, ByteArrayOutputStream tempOutputStream,
       ServletOutputStream os) throws IOException, PrintControllerHookManager.PrintControllerHookException, JRException {
     response.setContentType("text/html");
+    String safeFilename = filename.replace("\r", "").replace("\n", "")
+        .replace("/", "_").replace("\\", "_").replace("..", "_");
     File file = Files
-        .createTempFile(Paths.get(globalParameters.strFTPDirectory), filename + "-", ".pdf")
+        .createTempFile(Paths.get(globalParameters.strFTPDirectory), "rpt-", ".pdf")
         .toFile();
-    manageDirectPrintOnlyHooks(jrPrintReports, reports, filename, file, tempOutputStream, os);
+    manageDirectPrintOnlyHooks(jrPrintReports, reports, safeFilename, file, tempOutputStream, os);
   }
 
   private void handleIndirectPrint(HttpServletResponse response, Collection<JasperPrint> jrPrintReports,
       Collection<Report> reports, String filename, Map<Object, Object> parameters,
       ByteArrayOutputStream tempOutputStream) throws JRException, IOException, PrintControllerHookManager.PrintControllerHookException {
-    response.setHeader("Content-disposition", "attachment" + "; filename=" + filename);
+    String safeFilename = filename.replace("\r", "").replace("\n", "");
+    response.setHeader("Content-disposition", "attachment; filename=" + safeFilename);
 
     // Generate the report in a temporary output stream
     for (JasperPrint jasperPrint : jrPrintReports) {
@@ -831,13 +311,6 @@ public class PrintController extends HttpSecureAppServlet {
     }
 
     managePrintOnlyHooking(reports, tempOutputStream);
-  }
-
-  private static String getFilenameForReports(Collection<Report> reports, String filename) {
-    for (Report report : reports) {
-      filename = report.getFilename();
-    }
-    return filename;
   }
 
   private void manageDirectPrintOnlyHooks(Collection<JasperPrint> jrPrintReports, Collection<Report> reports, String filename, File file,
@@ -860,8 +333,8 @@ public class PrintController extends HttpSecureAppServlet {
       // Convert the output stream into an input stream to modify it in hooks
       try (ByteArrayInputStream pdfInputStream = new ByteArrayInputStream(tempOutputStream.toByteArray())) {
         Report report = reports.iterator().next();
-        setPostHookParams(report.getDocumentType(), hookParams, report.getDocumentId(), pdfInputStream,
-            tempOutputStream);
+        PrintControllerHookSupport.setPostHookParams(report.getDocumentType(), hookParams,
+            report.getDocumentId(), pdfInputStream, tempOutputStream);
       }
       hookManager.executeHooks(hookParams, hookManager.getPostProcess());
     }
@@ -886,7 +359,8 @@ public class PrintController extends HttpSecureAppServlet {
       jsonParams.put(PrintControllerHookManager.RESULTS, results);
       jsonParams.put(PrintControllerHookManager.CANCELLATION, false);
       Report report = reports.iterator().next();
-      setPreHookParams(report.getDocumentType(), jsonParams, report.getDocumentId());
+      PrintControllerHookSupport.setPreHookParams(report.getDocumentType(), jsonParams,
+          report.getDocumentId());
     } catch (JSONException e) {
       throw new OBException(e);
     }
@@ -907,14 +381,15 @@ public class PrintController extends HttpSecureAppServlet {
         createBookmarks = false;
       } else if (reports.length > 1) {
         filename = reports[0].getTemplateInfo().getReportFilename();
-        filename = filename.replaceAll("@our_ref@", "");
-        filename = filename.replaceAll("@cus_ref@", "");
-        filename = filename.replaceAll(" ", "_");
-        filename = filename.replaceAll("-", "");
+        filename = filename.replace("@our_ref@", "");
+        filename = filename.replace("@cus_ref@", "");
+        filename = filename.replace(" ", "_");
+        filename = filename.replace("-", "");
         filename = filename + ".pdf";
       }
       if (!directPrint) {
-        response.setHeader("Content-disposition", "attachment" + "; filename=" + filename);
+        String safeFilename = filename.replace("\r", "").replace("\n", "");
+        response.setHeader("Content-disposition", "attachment; filename=" + safeFilename);
 
         // Concatenate reports in a temporary OutputStream
         ReportingUtils.concatPDFReport(new ArrayList<>(jrPrintReports), createBookmarks,
@@ -926,7 +401,8 @@ public class PrintController extends HttpSecureAppServlet {
         if (hooking.booleanValue()) {
           ByteArrayOutputStream postProcessOutputStream = new ByteArrayOutputStream();
           Report report = reports[0];
-          setPostHookParams(report.getDocumentType(), hookParams, report.getDocumentId(), pdfInputStream, postProcessOutputStream);
+          PrintControllerHookSupport.setPostHookParams(report.getDocumentType(), hookParams,
+              report.getDocumentId(), pdfInputStream, postProcessOutputStream);
 
           hookManager.executeHooks(hookParams, hookManager.getPostProcess());
 
@@ -942,7 +418,7 @@ public class PrintController extends HttpSecureAppServlet {
       } else {
         response.setContentType("text/html");
         Path path = Files.createTempFile(Paths.get(globalParameters.strFTPDirectory),
-            filename + "-", ".pdf");
+            "rpt-", ".pdf");
         try (OutputStream outputStream = Files.newOutputStream(path, StandardOpenOption.CREATE)) {
           ReportingUtils.concatPDFReport(new ArrayList<>(jrPrintReports), createBookmarks,
               outputStream, configuration);
@@ -968,14 +444,14 @@ public class PrintController extends HttpSecureAppServlet {
   private void hookedDirectPrint(String filename, File path, Report reports, ByteArrayOutputStream tempResponse,
       ServletOutputStream response) throws IOException, PrintControllerHookManager.PrintControllerHookException {
     // Edit the temp file in hooks and write the result to another file
-    File hookedFile = Files.createTempFile(Paths.get(globalParameters.strFTPDirectory), filename + "-hooked-",
+    File hookedFile = Files.createTempFile(Paths.get(globalParameters.strFTPDirectory), "rpt-hooked-",
         ".pdf").toFile();
     try (FileInputStream fileInputStream = new FileInputStream(path);
          FileOutputStream hookedFileOutputStream = new FileOutputStream(hookedFile)) {
 
       // Call hooks
-      setPostHookParams(reports.getDocumentType(), hookParams, reports.getDocumentId(), fileInputStream,
-          hookedFileOutputStream);
+      PrintControllerHookSupport.setPostHookParams(reports.getDocumentType(), hookParams,
+          reports.getDocumentId(), fileInputStream, hookedFileOutputStream);
     }
 
     try {
@@ -993,18 +469,11 @@ public class PrintController extends HttpSecureAppServlet {
 
   public Report buildReport(HttpServletResponse response, VariablesSecureApp vars,
       String strDocumentId, final ReportManager reportManager, DocumentType documentType,
-      OutputTypeEnum outputType) {
-    return buildReport(response, vars, strDocumentId, reportManager, documentType, outputType,
-        "default");
-  }
-
-  public Report buildReport(HttpServletResponse response, VariablesSecureApp vars,
-      String strDocumentId, final ReportManager reportManager, DocumentType documentType,
       OutputTypeEnum outputType, String templateId) {
     String localStrDocumentId = strDocumentId;
     Report report = null;
     if (localStrDocumentId != null) {
-      localStrDocumentId = localStrDocumentId.replaceAll("\\(|\\)|'", "");
+      localStrDocumentId = localStrDocumentId.replace("(", "").replace(")", "").replace("'", "");
     }
     try {
       report = new Report(documentType, localStrDocumentId, vars.getLanguage(), templateId,
@@ -1025,7 +494,7 @@ public class PrintController extends HttpSecureAppServlet {
     String localStrDocumentId = strDocumentId;
     final String documentId = vars.getStringParameter("inpDocumentId");
     if (localStrDocumentId != null) {
-      localStrDocumentId = localStrDocumentId.replaceAll("\\(|\\)|'", "");
+      localStrDocumentId = localStrDocumentId.replace("(", "").replace(")", "").replace("'", "");
     }
     final Report report = reports.get(localStrDocumentId);
     if (report == null) {
@@ -1065,7 +534,7 @@ public class PrintController extends HttpSecureAppServlet {
     }
   }
 
-  private void seekAndDestroy(List<AttachContent> attachments, String documentToDelete) {
+  void seekAndDestroy(List<AttachContent> attachments, String documentToDelete) {
     for (int i = 0; i < attachments.size(); i++) {
       final AttachContent content = attachments.get(i);
       if (content.id.equals(documentToDelete)) {
@@ -1094,14 +563,14 @@ public class PrintController extends HttpSecureAppServlet {
     if (strIsDirectAttach == null || "".equals(strIsDirectAttach)) {
       strIsDirectAttach = "false";
     }
-    xmlDocument.setParameter("directory", "var baseDirectory = \"" + strReplaceWith + "/\";\r\n");
+    xmlDocument.setParameter(XML_PARAMETER_DIRECTORY, getBaseDirectoryJs());
     xmlDocument.setParameter("language", vars.getLanguage());
     xmlDocument.setParameter("theme", vars.getTheme());
     xmlDocument.setParameter("description", "");
     xmlDocument.setParameter("help", "");
     xmlDocument.setParameter("isDirectPDF", "isDirectPDF = " + strIsDirectPDF + ";\r\n");
     xmlDocument.setParameter("isDirectAttach", "isDirectAttach = " + strIsDirectAttach + ";\r\n");
-    response.setContentType("text/html; charset=UTF-8");
+    response.setContentType(CONTENT_TYPE_HTML);
     final PrintWriter out = response.getWriter();
     out.println(xmlDocument.print());
     out.close();
@@ -1109,444 +578,46 @@ public class PrintController extends HttpSecureAppServlet {
 
   void createEmailOptionsPage(HttpServletRequest request, HttpServletResponse response,
       VariablesSecureApp vars, DocumentType documentType, String strDocumentId,
-      Map<String, Report> reports, HashMap<String, Boolean> checks) {
-    createEmailOptionsPage(request, response, vars, documentType, strDocumentId, reports, checks);
+      Map<String, Report> reports, HashMap<String, Boolean> checks)
+      throws IOException, ServletException, ReportingException {
+    String fullDocumentIdentifier = PrintControllerDocumentHelper.normalizeDocumentId(strDocumentId)
+        + documentType.getTableName();
+    PrintControllerEmailOptionsBuilder.Context context =
+        new PrintControllerEmailOptionsBuilder.Context(documentType, strDocumentId, reports, checks,
+            fullDocumentIdentifier);
+    new PrintControllerEmailOptionsBuilder(this, request, response, vars, context).render();
   }
 
-  void createEmailOptionsPage(HttpServletRequest request, HttpServletResponse response,
-      VariablesSecureApp vars, DocumentType documentType, String strDocumentId,
-      Map<String, Report> reports, HashMap<String, Boolean> checks, String fullDocumentIdentifier)
-      throws IOException, ServletException, ReportingException {
-    boolean hasMultipleEmailConfigurations = false;
-    XmlDocument xmlDocument = null;
-    PocData[] pocData = EmailUtilities.getContactDetails(documentType, strDocumentId, this);
-    @SuppressWarnings("unchecked")
-    List<AttachContent> attachments = (List<AttachContent>) request.getSession()
-        .getAttribute("files");
-
-    final String[] hiddenTags = getHiddenTags(pocData, attachments, vars, checks);
+  XmlDocument createEmailOptionsXmlDocument(String[] hiddenTags) throws IOException, ServletException {
     if (hiddenTags != null) {
-      xmlDocument = xmlEngine
+      return xmlEngine
           .readXmlTemplate("org/openbravo/erpCommon/utility/reporting/printing/EmailOptions",
               hiddenTags)
           .createXmlDocument();
-    } else {
-      xmlDocument = xmlEngine
-          .readXmlTemplate("org/openbravo/erpCommon/utility/reporting/printing/EmailOptions")
-          .createXmlDocument();
     }
-
-    xmlDocument.setParameter("strDocumentId", strDocumentId);
-
-    boolean isTheFirstEntry = false;
-    if (attachments == null) {
-      attachments = new ArrayList<>(0);
-      isTheFirstEntry = true;
-    }
-
-    if (vars.getMultiFile("inpFile") != null
-        && !vars.getMultiFile("inpFile").getName().equals("")) {
-      final AttachContent content = new AttachContent();
-      final FileItem file1 = vars.getMultiFile("inpFile");
-      content.setFileName(pocData[0].ourreference.replace('/', '_') + '-'
-          + Utility.formatDate(new Date(), "yyyyMMdd-HHmmss") + '.' + file1.getName());
-      content.setFileItem(file1);
-      content.setId(Utility.formatDate(new Date(), "yyyyMMdd-HHmmss") + '.' + file1.getName());
-      content.visible = "hidden";
-      if ("Y".equals(vars.getStringParameter("inpArchive"))) {
-        content.setSelected("true");
-      }
-      attachments.add(content);
-      request.getSession().setAttribute("files", attachments);
-
-    }
-
-    if ("yes".equals(vars.getStringParameter("closed"))) {
-      xmlDocument.setParameter("closed", "yes");
-      request.getSession().removeAttribute("files");
-    }
-
-    xmlDocument.setParameter("directory", "var baseDirectory = \"" + strReplaceWith + "/\";\r\n");
-    xmlDocument.setParameter("language", vars.getLanguage());
-    xmlDocument.setParameter("theme", vars.getTheme());
-
-    EmailDefinition emailDefinition = null;
-    try {
-      if (moreThanOneLanguageDefined(reports) && hasDifferentBpLanguages(reports)) {
-        // set multiple email configurations
-        List<EmailDefinition> emailDef = new ArrayList<EmailDefinition>();
-        Map<String, EmailDefinition> emailDefinitions = reports.values()
-            .iterator()
-            .next()
-            .getEmailDefinitions();
-        Iterator<Entry<String, EmailDefinition>> entries = emailDefinitions.entrySet().iterator();
-        while (entries.hasNext()) {
-          Map.Entry<String, EmailDefinition> entry = entries.next();
-          emailDef.add(entry.getValue());
-        }
-        emailDefinition = reports.values()
-            .iterator()
-            .next()
-            .getTemplateInfo()
-            .get_DefaultEmailDefinition();
-        String emailDefinitionsComboHtml = getOptionsList(emailDef, emailDefinition.getId(), false);
-        xmlDocument.setParameter("reportEmailConfig", emailDefinitionsComboHtml);
-        hasMultipleEmailConfigurations = true;
-      } else {
-        emailDefinition = reports.values().iterator().next().getEmailDefinition();
-        hasMultipleEmailConfigurations = false;
-      }
-    } catch (final OBException exception) {
-      final OBError on = new OBError();
-      on.setMessage(Utility.messageBD(this, "EmailConfiguration", vars.getLanguage()));
-      on.setTitle(Utility.messageBD(this, "Info", vars.getLanguage()));
-      on.setType("info");
-      final String tabId = vars.getSessionValue(INP_TAB_ID);
-      vars.getStringParameter(TAB);
-      vars.setMessage(tabId, on);
-      vars.getRequestGlobalVariable(INP_TAB_ID, ATTRIBUTESETINSTANCE_TABID);
-      printPageClosePopUpAndRefreshParent(response, vars);
-    } catch (ReportingException e) {
-      log4j.error(e);
-    }
-
-    String fromEmail = null;
-    String fromEmailId = null;
-
-    OBContext.setAdminMode(true);
-    try {
-      ResolvedSmtpConfig resolvedConfig = SmtpCascadeResolver.resolve();
-      if (resolvedConfig != null) {
-        fromEmail = resolvedConfig.getFromAddress();
-        fromEmailId = resolvedConfig.getConfigId();
-      } else {
-        reportNoSenderError(response, vars);
-      }
-    } finally {
-      OBContext.restorePreviousMode();
-    }
-
-    // Get additional document information
-    String draftDocumentIds = "";
-    final AttachContent attachedContent = new AttachContent();
-    final boolean onlyOneAttachedDoc = onlyOneAttachedDocs(reports);
-    final Map<String, PocData> customerMap = new HashMap<String, PocData>();
-    final Map<String, PocData> salesRepMap = new HashMap<String, PocData>();
-    final List<AttachContent> clonedAttachemnts = new ArrayList<>();
-    boolean allTheDocsCompleted = true;
-    for (final PocData documentData : pocData) {
-      // Map used to count the different users
-
-      final String customer = documentData.contactEmail;
-      getEnvironentInformation(pocData, checks);
-      if (checks.get("moreThanOneDoc")) {
-        if (customer == null || customer.length() == 0) {
-          final OBError on = new OBError();
-          on.setMessage(Utility.messageBD(this, "NoContact", vars.getLanguage())
-              .replace("@docNum@", documentData.ourreference));
-
-          on.setTitle(Utility.messageBD(this, "Info", vars.getLanguage()));
-          on.setType("info");
-          final String tabId = vars.getSessionValue(INP_TAB_ID);
-          vars.getStringParameter(TAB);
-          vars.setMessage(tabId, on);
-          vars.getRequestGlobalVariable(INP_TAB_ID, ATTRIBUTESETINSTANCE_TABID);
-          printPageClosePopUpAndRefreshParent(response, vars);
-        } else if (documentData.contactEmail == null || documentData.contactEmail.equals("")) {
-          final OBError on = new OBError();
-          on.setMessage(Utility.messageBD(this, "NoEmail", vars.getLanguage())
-              .replace("@customer@", documentData.contactName));
-          on.setTitle(Utility.messageBD(this, "Info", vars.getLanguage()));
-          on.setType("info");
-          final String tabId = vars.getSessionValue(INP_TAB_ID);
-          vars.getStringParameter(TAB);
-          vars.setMessage(tabId, on);
-          vars.getRequestGlobalVariable(INP_TAB_ID, ATTRIBUTESETINSTANCE_TABID);
-          printPageClosePopUpAndRefreshParent(response, vars);
-        }
-      }
-
-      if (!customerMap.containsKey(customer)) {
-        customerMap.put(customer, documentData);
-      }
-
-      final String salesRep = documentData.salesrepEmail;
-      boolean moreThanOnesalesRep = checks.get("moreThanOnesalesRep").booleanValue();
-      if (moreThanOnesalesRep) {
-        if (salesRep == null || salesRep.length() == 0) {
-          final OBError on = new OBError();
-          on.setMessage(Utility.messageBD(this, "NoSenderDocument", vars.getLanguage()));
-          on.setTitle(Utility.messageBD(this, "Info", vars.getLanguage()));
-          on.setType("info");
-          final String tabId = vars.getSessionValue(INP_TAB_ID);
-          vars.getStringParameter(TAB);
-          vars.setMessage(tabId, on);
-          vars.getRequestGlobalVariable(INP_TAB_ID, ATTRIBUTESETINSTANCE_TABID);
-          printPageClosePopUpAndRefreshParent(response, vars);
-        } else if (documentData.salesrepEmail == null || documentData.salesrepEmail.equals("")) {
-          final OBError on = new OBError();
-          on.setMessage(Utility.messageBD(this, "NoEmailSender", vars.getLanguage())
-              .replace("@salesRep@", documentData.salesrepName));
-          on.setTitle(Utility.messageBD(this, "Info", vars.getLanguage()));
-          on.setType("info");
-          final String tabId = vars.getSessionValue(INP_TAB_ID);
-          vars.getStringParameter(TAB);
-          vars.setMessage(tabId, on);
-          vars.getRequestGlobalVariable(INP_TAB_ID, ATTRIBUTESETINSTANCE_TABID);
-          printPageClosePopUpAndRefreshParent(response, vars);
-        }
-      }
-
-      if (!salesRepMap.containsKey(salesRep)) {
-        salesRepMap.put(salesRep, documentData);
-      }
-
-      final Report report = reports.get(documentData.documentId);
-      // All ids of documents in draft are passed to the web client
-      if (report.isDraft()) {
-        if (draftDocumentIds.length() > 0) {
-          draftDocumentIds += ",";
-        }
-        draftDocumentIds += report.getDocumentId();
-        allTheDocsCompleted = false;
-      }
-
-      // Fill the report location
-      final String reportFilename = report.getContextSubFolder() + report.getFilename();
-      documentData.reportLocation = request.getContextPath() + "/" + reportFilename + "?documentId="
-          + documentData.documentId;
-      if (log4j.isDebugEnabled()) {
-        log4j.debug(" Filling report location with: " + documentData.reportLocation);
-      }
-
-      if (onlyOneAttachedDoc && !StringUtils.equals(attachedContent.getDocName(), report.getFilename())) {
-        attachedContent.setDocName(report.getFilename());
-        attachedContent.setVisible("checkbox");
-        clonedAttachemnts.add(attachedContent);
-      }
-
-    }
-    if (!allTheDocsCompleted) {
-      final OBError on = new OBError();
-      on.setMessage(Utility.messageBD(this, "ErrorIncompleteDocuments", vars.getLanguage()));
-      on.setTitle(Utility.messageBD(this, "ErrorSendingEmail", vars.getLanguage()));
-      on.setType(ERROR);
-      final String tabId = vars.getSessionValue(INP_TAB_ID);
-      vars.getStringParameter(TAB);
-      vars.setMessage(tabId, on);
-      vars.getRequestGlobalVariable(INP_TAB_ID, ATTRIBUTESETINSTANCE_TABID);
-      printPageClosePopUpAndRefreshParent(response, vars);
-    }
-
-    final int numberOfCustomers = customerMap.size();
-    final int numberOfSalesReps = salesRepMap.size();
-
-    if (!onlyOneAttachedDoc && isTheFirstEntry) {
-      if (numberOfCustomers > 1) {
-        attachedContent.setDocName(String.valueOf(
-            reports.size() + " Documents to " + String.valueOf(numberOfCustomers) + " Customers"));
-        attachedContent.setVisible("checkbox");
-
-      } else {
-        attachedContent.setDocName(String.valueOf(reports.size() + " Documents"));
-        attachedContent.setVisible("checkbox");
-
-      }
-      clonedAttachemnts.add(attachedContent);
-    }
-
-    if (!clonedAttachemnts.isEmpty()) {
-      final AttachContent[] data = attachments.toArray(new AttachContent[attachments.size()]);
-      final AttachContent[] data2 = clonedAttachemnts
-          .toArray(new AttachContent[clonedAttachemnts.size()]);
-      xmlDocument.setData("structure2", data2);
-      xmlDocument.setData("structure1", data);
-    }
-    if (pocData.length >= 1) {
-      xmlDocument.setData("reportEmail", "liststructure",
-          reports.get((pocData[0].documentId)).getTemplate());
-    }
-
-    if (log4j.isDebugEnabled()) {
-      log4j.debug("Documents still in draft: " + draftDocumentIds);
-    }
-    xmlDocument.setParameter("draftDocumentIds", draftDocumentIds);
-
-    final PocData[] currentUserInfo = PocData.getContactDetailsForUser(this, vars.getUser());
-    final String userName = currentUserInfo[0].userName;
-    final String userEmail = currentUserInfo[0].userEmail;
-    String bccEmail = "";
-    String bccName = "";
-    if (userEmail != null && userEmail.length() > 0) {
-      bccEmail = userEmail;
-      bccName = userName;
-    }
-    User selectedContact = resolvePreselectedContact(vars, pocData);
-
-    if (vars.commandIn("ADD") || vars.commandIn("DEL")) {
-      xmlDocument.setParameter("fromEmailId", vars.getStringParameter("fromEmailId"));
-      xmlDocument.setParameter("fromEmail", vars.getStringParameter("fromEmail"));
-      xmlDocument.setParameter(PARAM_TO_EMAIL, vars.getStringParameter(PARAM_TO_EMAIL));
-      xmlDocument.setParameter(PARAM_TO_EMAIL_ORIG, vars.getStringParameter(PARAM_TO_EMAIL_ORIG));
-      xmlDocument.setParameter(PARAM_TO_CONTACT_ID, vars.getStringParameter(PARAM_TO_CONTACT_ID));
-      xmlDocument.setParameter("ccEmail", vars.getStringParameter("ccEmail"));
-      xmlDocument.setParameter("ccEmailOrig", vars.getStringParameter("ccEmailOrig"));
-      xmlDocument.setParameter("bccEmail", vars.getStringParameter("bccEmail"));
-      xmlDocument.setParameter("bccEmailOrig", vars.getStringParameter("bccEmailOrig"));
-      xmlDocument.setParameter("replyToEmail", vars.getStringParameter("replyToEmail"));
-      xmlDocument.setParameter("replyToEmailOrig", vars.getStringParameter("replyToEmailOrig"));
-      xmlDocument.setParameter("emailSubject", vars.getStringParameter("emailSubject"));
-      xmlDocument.setParameter("emailBody", vars.getStringParameter("emailBody"));
-    } else {
-      String toEmail;
-      String toContactId;
-      if (numberOfCustomers > 1) {
-        List<String> emails = new ArrayList<>();
-        for (String email : customerMap.keySet()) {
-          if (StringUtils.isNotBlank(email)) {
-            emails.add(email);
-          }
-        }
-        toEmail = String.join("; ", emails);
-        toContactId = "";
-      } else {
-        toEmail = getContactField(selectedContact, User::getEmail);
-        toContactId = getContactField(selectedContact, User::getId);
-      }
-      xmlDocument.setParameter("fromEmailId", fromEmailId);
-      xmlDocument.setParameter("fromEmail", fromEmail);
-      xmlDocument.setParameter(PARAM_TO_EMAIL, toEmail);
-      xmlDocument.setParameter(PARAM_TO_EMAIL_ORIG, toEmail);
-      xmlDocument.setParameter(PARAM_TO_CONTACT_ID, toContactId);
-      xmlDocument.setParameter("ccEmail", "");
-      xmlDocument.setParameter("ccEmailOrig", "");
-      xmlDocument.setParameter("bccEmail", bccEmail);
-      xmlDocument.setParameter("bccEmailOrig", bccEmail);
-      xmlDocument.setParameter("replyToEmail", pocData[0].salesrepEmail);
-      xmlDocument.setParameter("replyToEmailOrig", pocData[0].salesrepEmail);
-      xmlDocument.setParameter("emailSubject", emailDefinition.getSubject());
-      xmlDocument.setParameter("emailBody", emailDefinition.getBody());
-    }
-    xmlDocument.setParameter("bpartnerId", pocData.length > 0 ? pocData[0].bpartnerId : StringUtils.EMPTY);
-    xmlDocument.setParameter("inpArchive", vars.getStringParameter("inpArchive"));
-    xmlDocument.setParameter("fromName", "");
-    String toName;
-    if (numberOfCustomers > 1) {
-      toName = StringUtils.EMPTY;
-    } else if (selectedContact != null) {
-      toName = getContactField(selectedContact, User::getName);
-    } else if (pocData.length > 0) {
-      toName = pocData[0].contactName;
-    } else {
-      toName = StringUtils.EMPTY;
-    }
-    xmlDocument.setParameter("toName", toName);
-    xmlDocument.setParameter("ccName", "");
-    xmlDocument.setParameter("bccName", bccName);
-    xmlDocument.setParameter("replyToName", pocData[0].salesrepName);
-    xmlDocument.setParameter("inpArchive", vars.getStringParameter("inpArchive"));
-    xmlDocument.setParameter("multCusCount", String.valueOf(numberOfCustomers));
-    xmlDocument.setParameter("multSalesRepCount", String.valueOf(numberOfSalesReps));
-    if (!hasMultipleEmailConfigurations) {
-      xmlDocument.setParameter("useDefault", "Y");
-    }
-    if (differentDocTypes.size() > 1) {
-      xmlDocument.setParameter("multiDocType", "Y");
-    }
-
-    vars.setSessionObject(SESSION_POC_DATA + fullDocumentIdentifier, pocData);
-    response.setContentType("text/html; charset=UTF-8");
-    final PrintWriter out = response.getWriter();
-    out.println(xmlDocument.print());
-    out.close();
+    return xmlEngine
+        .readXmlTemplate("org/openbravo/erpCommon/utility/reporting/printing/EmailOptions")
+        .createXmlDocument();
   }
 
-  /**
-   * Determines the best contact to preselect in the email popup. Only runs on the initial page
-   * load (not on ADD or DEL commands). Returns {@code null} if no suitable contact is found
-   * or if an error occurs during resolution.
-   * @param vars  the current request variables
-   * @param pocData the array of document contact data
-   * @return the preselected {@link User} contact, or {@code null}
-   */
-  protected User resolvePreselectedContact(VariablesSecureApp vars, PocData[] pocData) {
-    if (vars.commandIn("ADD", "DEL") || pocData.length == 0) {
-      return null;
-    }
-    try {
-      return BPContactEmailSelector.selectBestContact(pocData[0].bpartnerId, vars.getUser());
-    } catch (Exception e) {
-      log4j.warn("Could not determine best email contact, falling back to default. Reason: {}",
-          e.getMessage());
-      return null;
-    }
+  String getBaseDirectoryJs() {
+    return String.format(BASE_DIRECTORY_JS, strReplaceWith);
   }
 
-  /**
-   * Safely extracts a string field from a {@link User} contact, returning an empty string
-   * if the contact is {@code null} or the field value is {@code null}.
-   * @param contact the contact to extract the field from, may be {@code null}
-   * @param getter the getter method reference for the desired field
-   * @return the field value or an empty string
-   */
-  protected static String getContactField(User contact, Function<User, String> getter) {
-    if (contact == null) {
-      return StringUtils.EMPTY;
-    }
-      return StringUtils.defaultString(getter.apply(contact));
-  }
-  
-  private String getOptionsList(List<EmailDefinition> emailDef, String selectedValue,
-      boolean isMandatory) {
-    StringBuilder strOptions = new StringBuilder();
-    if (!isMandatory) {
-      strOptions.append("<option value=\"\"></option>");
-    }
-    for (EmailDefinition obObject : emailDef) {
-      strOptions.append("<option value=\"").append(obObject.getId()).append("\"");
-      if (obObject.getId().equals(selectedValue)) {
-        strOptions.append(" selected=\"selected\"");
-      }
-      strOptions.append(">");
-      strOptions.append(BasicUtility
-          .formatMessageBDToHtml(obObject.getSubject() + " - " + obObject.getLanguage()));
-      strOptions.append("</option>");
-    }
-    return strOptions.toString();
+  boolean isDebugEnabled() {
+    return log4j.isDebugEnabled();
   }
 
-  private boolean moreThanOneLanguageDefined(Map<String, Report> reports)
-      throws ReportingException {
-    boolean hasMoreThanOneLanguage = false;
-    @SuppressWarnings("rawtypes")
-    Iterator itRep = reports.values().iterator();
-    while (itRep.hasNext()) {
-      Report report = (Report) itRep.next();
-      if (report.getEmailDefinitions().size() > 1) {
-        hasMoreThanOneLanguage = true;
-        break;
-      }
-    }
-    return hasMoreThanOneLanguage;
+  void debug(String message) {
+    log4j.debug(message);
   }
 
-  private boolean hasDifferentBpLanguages(Map<String, Report> reports) throws ReportingException {
-    boolean hasMoreThanOneLanguage = false;
-    @SuppressWarnings("rawtypes")
-    Iterator itRep = reports.values().iterator();
-    Language currentLanguage = null;
-    while (itRep.hasNext()) {
-      Report report = (Report) itRep.next();
-      String bPartnerId = report.getBPartnerId();
-      BusinessPartner businessPartner = OBDal.getInstance().get(BusinessPartner.class, bPartnerId);
-      Language language = businessPartner.getLanguage();
-      if (currentLanguage == null) {
-        currentLanguage = language;
-      } else if (currentLanguage != language) {
-        hasMoreThanOneLanguage = true;
-      }
-    }
-    return hasMoreThanOneLanguage;
+  void warn(String message, String detail) {
+    log4j.warn(message.replace("{}", detail));
+  }
+
+  void error(Throwable throwable) {
+    log4j.error(throwable);
   }
 
   /**
@@ -1558,12 +629,12 @@ public class PrintController extends HttpSecureAppServlet {
    * @throws IOException if writing the response fails
    * @throws ServletException always thrown after the error is reported, to stop processing
    */
-  private void reportNoSenderError(HttpServletResponse response, VariablesSecureApp vars)
+  void reportNoSenderError(HttpServletResponse response, VariablesSecureApp vars)
       throws IOException, ServletException {
     final OBError on = new OBError();
     on.setMessage(Utility.messageBD(this, "NoSender", vars.getLanguage()));
     on.setTitle(Utility.messageBD(this, "EmailConfigError", vars.getLanguage()));
-    on.setType(ERROR);
+    on.setType(MSG_TYPE_ERROR);
     final String tabId = vars.getSessionValue(INP_TAB_ID);
     vars.getStringParameter(TAB);
     vars.setMessage(tabId, on);
@@ -1572,205 +643,22 @@ public class PrintController extends HttpSecureAppServlet {
     throw new ServletException(Utility.messageBD(this, "EmailNoSenderDefined", vars.getLanguage()));
   }
 
-  private void getEnvironentInformation(PocData[] pocData, HashMap<String, Boolean> checks) {
-    final Map<String, PocData> customerMap = new HashMap<String, PocData>();
-    final Map<String, PocData> salesRepMap = new HashMap<String, PocData>();
-    int docCounter = 0;
-    checks.put("moreThanOneDoc", false);
-    for (final PocData documentData : pocData) {
-      // Map used to count the different users
-      docCounter++;
-      final String customer = documentData.contactEmail;
-      final String salesRep = documentData.salesrepEmail;
-      if (!customerMap.containsKey(customer)) {
-        customerMap.put(customer, documentData);
-      }
-      if (!salesRepMap.containsKey(salesRep)) {
-        salesRepMap.put(salesRep, documentData);
-      }
-    }
-    if (docCounter > 1) {
-      checks.put("moreThanOneDoc", true);
-    }
-    boolean moreThanOneCustomer = (customerMap.size() > 1);
-    boolean moreThanOnesalesRep = (salesRepMap.size() > 1);
-    checks.put("moreThanOneCustomer", Boolean.valueOf(moreThanOneCustomer));
-    checks.put("moreThanOnesalesRep", Boolean.valueOf(moreThanOnesalesRep));
-  }
-
-  /**
-   * @author gmauleon
-   */
-  private String[] getHiddenTags(PocData[] pocData, List<AttachContent> attachedContent,
-      VariablesSecureApp vars, HashMap<String, Boolean> checks) {
-    String[] discard;
-    final Map<String, PocData> customerMap = new HashMap<String, PocData>();
-    final Map<String, PocData> salesRepMap = new HashMap<String, PocData>();
-    for (final PocData documentData : pocData) {
-      // Map used to count the different users
-
-      final String customer = documentData.contactEmail;
-      final String salesRep = documentData.salesrepEmail;
-      if (!customerMap.containsKey(customer)) {
-        customerMap.put(customer, documentData);
-      }
-      if (!salesRepMap.containsKey(salesRep)) {
-        salesRepMap.put(salesRep, documentData);
-      }
-    }
-    boolean moreThanOneCustomer = (customerMap.size() > 1);
-    boolean moreThanOnesalesRep = (salesRepMap.size() > 1);
-    checks.put("moreThanOneCustomer", Boolean.valueOf(moreThanOneCustomer));
-    checks.put("moreThanOnesalesRep", Boolean.valueOf(moreThanOnesalesRep));
-
-    // "To" field is always visible; Reply-to is hidden when routing across multiple sales reps.
-    // 1.- n customers, n sales reps → hide Reply-to
-    // 2.- n customers, 1 sales rep  → hide "by X sales reps" label fragments
-    // 3.- 1 customer,  n sales reps → hide Reply-to
-    // 4.- 1 customer,  1 sales rep  → hide "multiple customers" info row
-    if (moreThanOneCustomer && moreThanOnesalesRep) {
-      discard = new String[] { "replyTo", "replyTo_bottomMargin" };
-    } else if (moreThanOneCustomer) {
-      discard = new String[] { "multSalesRep", "multSalesRepCount" };
-    } else if (moreThanOnesalesRep) {
-      discard = new String[] { "replyTo", "replyTo_bottomMargin" };
-    } else {
-      discard = new String[] { "multipleCustomer", "multipleCustomer_bottomMargin" };
-    }
-
-    // check the templates
-    if (differentDocTypes.size() > 1) { // the templates selector shouldn't
-      // appear
-      final String[] discardAux = new String[discard.length + 1];
-      for (int i = 0; i < discard.length; i++) {
-        discardAux[i] = discard[i];
-      }
-      discardAux[discard.length] = "discardSelect";
-      return discardAux;
-    }
-    if (attachedContent == null && vars.getMultiFile("inpFile") == null) {
-      final String[] discardAux = new String[discard.length + 1];
-      for (int i = 0; i < discard.length; i++) {
-        discardAux[i] = discard[i];
-      }
-      discardAux[discard.length] = "view";
-      return discardAux;
-    }
-    return discard;
-  }
-
-  private boolean onlyOneAttachedDocs(Map<String, Report> reports) {
-    if (reports.size() == 1) {
-      return true;
-    } else {
-      return false;
-    }
-
-  }
-
   void createPrintStatusPage(HttpServletResponse response, VariablesSecureApp vars,
       int nrOfEmailsSend) throws IOException, ServletException {
     XmlDocument xmlDocument = null;
     xmlDocument = xmlEngine
         .readXmlTemplate("org/openbravo/erpCommon/utility/reporting/printing/PrintStatus")
         .createXmlDocument();
-    xmlDocument.setParameter("directory", "var baseDirectory = \"" + strReplaceWith + "/\";\r\n");
+    xmlDocument.setParameter(XML_PARAMETER_DIRECTORY, getBaseDirectoryJs());
     xmlDocument.setParameter("theme", vars.getTheme());
     xmlDocument.setParameter("language", vars.getLanguage());
     xmlDocument.setParameter("nrOfEmailsSend", "" + nrOfEmailsSend);
 
-    response.setContentType("text/html; charset=UTF-8");
+    response.setContentType(CONTENT_TYPE_HTML);
     final PrintWriter out = response.getWriter();
 
     out.println(xmlDocument.print());
     out.close();
-  }
-
-  /**
-   *
-   * @param documentIds
-   * @return returns a comma separated and quoted string of documents id's. useful to sql querys
-   */
-  private String getComaSeparatedString(String[] documentIds) {
-    String result = new String("(");
-    for (int index = 0; index < documentIds.length; index++) {
-      final String documentId = documentIds[index];
-      if (index + 1 == documentIds.length) {
-        result = result + "'" + documentId + "')";
-      } else {
-        result = result + "'" + documentId + "',";
-      }
-
-    }
-    return result;
-  }
-
-  /**
-   * Returns an array of document's ID ordered by Document No ASC
-   *
-   * @param documentType
-   * @param documentIds
-   *          array of document's ID without order
-   * @return List of ordered IDs
-   * @throws ServletException
-   */
-  private String[] orderByDocumentNo(DocumentType documentType, String[] documentIds)
-      throws ServletException {
-    String strTable = documentType.getTableName();
-
-    StringBuffer strIds = new StringBuffer();
-    strIds.append("'");
-    for (int i = 0; i < documentIds.length; i++) {
-      if (i > 0) {
-        strIds.append("', '");
-      }
-      strIds.append(documentIds[i]);
-    }
-    strIds.append("'");
-
-    PrintControllerData[] printControllerData;
-    String documentIdsOrdered[] = new String[documentIds.length];
-    int i = 0;
-    if (strTable.equals("C_INVOICE")) {
-      printControllerData = PrintControllerData.selectInvoices(this, strIds.toString());
-      for (PrintControllerData docID : printControllerData) {
-        documentIdsOrdered[i++] = docID.getField("Id");
-      }
-    } else if (strTable.equals("C_ORDER")) {
-      printControllerData = PrintControllerData.selectOrders(this, strIds.toString());
-      for (PrintControllerData docID : printControllerData) {
-        documentIdsOrdered[i++] = docID.getField("Id");
-      }
-    } else if (strTable.equals("FIN_PAYMENT")) {
-      printControllerData = PrintControllerData.selectPayments(this, strIds.toString());
-      for (PrintControllerData docID : printControllerData) {
-        documentIdsOrdered[i++] = docID.getField("Id");
-      }
-    } else {
-      return documentIds;
-    }
-
-    return documentIdsOrdered;
-  }
-
-  private boolean isDirectPrint(VariablesSecureApp vars) {
-    OBContext context = OBContext.getOBContext();
-    String preferenceValue = "";
-    try {
-      OBContext.setAdminMode(true);
-      String tabId = vars.getSessionValue(INP_TAB_ID);
-      Tab tab = OBDal.getInstance().get(Tab.class, tabId);
-      try {
-        preferenceValue = Preferences.getPreferenceValue("DirectPrint", true,
-            context.getCurrentClient(), context.getCurrentOrganization(), context.getUser(),
-            context.getRole(), tab.getWindow());
-      } catch (PropertyException e) {
-        return false;
-      }
-    } finally {
-      OBContext.restorePreviousMode();
-    }
-    return Preferences.YES.equals(preferenceValue);
   }
 
   @Override

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/PrintController.java
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/PrintController.java
@@ -115,6 +115,7 @@ public class PrintController extends HttpSecureAppServlet {
   private static final String TAB = "tab";
   private static final String INP_TAB_ID = "inpTabId";
   private static final String ATTRIBUTESETINSTANCE_TABID = "AttributeSetInstance.tabId";
+  private static final String SESSION_POC_DATA = "pocData";
   private static JSONObject hookParams;
   private static PrintControllerHookManager hookManager;
   private final MutableBoolean hooking = new MutableBoolean(false);
@@ -394,7 +395,7 @@ public class PrintController extends HttpSecureAppServlet {
             throw new ServletException(
                 Utility.messageBD(this, "NoCustomerEmail", vars.getLanguage()));
           }
-          PocData[] pocData = (PocData[]) vars.getSessionObject("pocData" + fullDocumentIdentifier);
+          PocData[] pocData = (PocData[]) vars.getSessionObject(SESSION_POC_DATA + fullDocumentIdentifier);
           int nrOfEmailsSend = 0;
           for (final PocData documentData : pocData) {
             getEnvironentInformation(pocData, checks);
@@ -468,13 +469,13 @@ public class PrintController extends HttpSecureAppServlet {
           if (nrOfEmailsSend > 0 && pocData.length > 0) {
             persistLastUsedContact(vars, pocData[0].bpartnerId);
           }
-          vars.removeSessionValue("pocData" + fullDocumentIdentifier);
+          vars.removeSessionValue(SESSION_POC_DATA + fullDocumentIdentifier);
           createPrintStatusPage(response, vars, nrOfEmailsSend);
         } else if (vars.commandIn("UPDATE_TEMPLATE")) {
           JSONObject o = new JSONObject();
           try {
             PocData[] pocData = (PocData[]) vars
-                .getSessionObject("pocData" + fullDocumentIdentifier);
+                .getSessionObject(SESSION_POC_DATA + fullDocumentIdentifier);
             final String templateId = vars.getRequestGlobalVariable("templates", "templates");
             final String documentId = pocData[0].documentId;
             final Report report = new Report(documentType, documentId, vars.getLanguage(),
@@ -504,7 +505,8 @@ public class PrintController extends HttpSecureAppServlet {
           out.println(o.toString());
           out.close();
         } else if (vars.commandIn("GET_BP_CONTACTS")) {
-          JSONObject result = buildBPContactsJson(vars);
+          PocData[] pocDataForContacts = (PocData[]) vars.getSessionObject(SESSION_POC_DATA + fullDocumentIdentifier);
+          JSONObject result = buildBPContactsJson(vars, pocDataForContacts);
           writeJsonResponse(response, result);
 
         } else if (vars.commandIn("UPDATE_EMAILCONFIG")) {
@@ -572,14 +574,33 @@ public class PrintController extends HttpSecureAppServlet {
    * @param vars the current request variables containing the {@code bpartnerId} parameter
    * @return a {@link JSONObject} with a {@code contacts} array, or an {@code error} flag on failure
    */
-  protected JSONObject buildBPContactsJson(VariablesSecureApp vars) {
+  protected JSONObject buildBPContactsJson(VariablesSecureApp vars, PocData[] pocData) {
     JSONObject result = new JSONObject();
     try {
-      String bpartnerId = vars.getStringParameter("bpartnerId");
-      List<User> contacts = BPContactEmailSelector.getBPContactsWithEmail(bpartnerId);
       JSONArray contactsArray = new JSONArray();
-      for (User contact : contacts) {
-        contactsArray.put(buildContactJson(contact));
+      if (isMultiCustomer(pocData)) {
+        List<String> seenEmails = new ArrayList<>();
+        for (PocData doc : pocData) {
+          if (StringUtils.isBlank(doc.contactEmail) || seenEmails.contains(doc.contactEmail)) {
+            continue;
+          }
+          seenEmails.add(doc.contactEmail);
+          JSONObject json = new JSONObject();
+          json.put("contactId", StringUtils.defaultString(doc.contactUserId));
+          json.put("name", StringUtils.defaultString(doc.contactName));
+          json.put("email", doc.contactEmail);
+          json.put("isDefault", false);
+          json.put("isActive", true);
+          contactsArray.put(json);
+        }
+      } else {
+        String bpartnerId = pocData != null && pocData.length > 0
+            ? pocData[0].bpartnerId
+            : vars.getStringParameter("bpartnerId");
+        List<User> contacts = BPContactEmailSelector.getBPContactsWithEmail(bpartnerId);
+        for (User contact : contacts) {
+          contactsArray.put(buildContactJson(contact));
+        }
       }
       result.put("contacts", contactsArray);
     } catch (Exception e) {
@@ -587,6 +608,19 @@ public class PrintController extends HttpSecureAppServlet {
       result = buildErrorJson();
     }
     return result;
+  }
+
+  private static boolean isMultiCustomer(PocData[] pocData) {
+    if (pocData == null || pocData.length == 0) {
+      return false;
+    }
+    String firstEmail = pocData[0].contactEmail;
+    for (int i = 1; i < pocData.length; i++) {
+      if (!StringUtils.equals(firstEmail, pocData[i].contactEmail)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
@@ -1397,7 +1431,9 @@ public class PrintController extends HttpSecureAppServlet {
     xmlDocument.setParameter("inpArchive", vars.getStringParameter("inpArchive"));
     xmlDocument.setParameter("fromName", "");
     String toName;
-    if (selectedContact != null) {
+    if (numberOfCustomers > 1) {
+      toName = StringUtils.EMPTY;
+    } else if (selectedContact != null) {
       toName = getContactField(selectedContact, User::getName);
     } else if (pocData.length > 0) {
       toName = pocData[0].contactName;
@@ -1418,7 +1454,7 @@ public class PrintController extends HttpSecureAppServlet {
       xmlDocument.setParameter("multiDocType", "Y");
     }
 
-    vars.setSessionObject("pocData" + fullDocumentIdentifier, pocData);
+    vars.setSessionObject(SESSION_POC_DATA + fullDocumentIdentifier, pocData);
     response.setContentType("text/html; charset=UTF-8");
     final PrintWriter out = response.getWriter();
     out.println(xmlDocument.print());

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/PrintController.java
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/PrintController.java
@@ -1364,8 +1364,21 @@ public class PrintController extends HttpSecureAppServlet {
       xmlDocument.setParameter("emailSubject", vars.getStringParameter("emailSubject"));
       xmlDocument.setParameter("emailBody", vars.getStringParameter("emailBody"));
     } else {
-      String toEmail = getContactField(selectedContact, User::getEmail);
-      String toContactId = getContactField(selectedContact, User::getId);
+      String toEmail;
+      String toContactId;
+      if (numberOfCustomers > 1) {
+        List<String> emails = new ArrayList<>();
+        for (String email : customerMap.keySet()) {
+          if (StringUtils.isNotBlank(email)) {
+            emails.add(email);
+          }
+        }
+        toEmail = String.join("; ", emails);
+        toContactId = "";
+      } else {
+        toEmail = getContactField(selectedContact, User::getEmail);
+        toContactId = getContactField(selectedContact, User::getId);
+      }
       xmlDocument.setParameter("fromEmailId", fromEmailId);
       xmlDocument.setParameter("fromEmail", fromEmail);
       xmlDocument.setParameter(PARAM_TO_EMAIL, toEmail);
@@ -1574,16 +1587,15 @@ public class PrintController extends HttpSecureAppServlet {
     checks.put("moreThanOneCustomer", Boolean.valueOf(moreThanOneCustomer));
     checks.put("moreThanOnesalesRep", Boolean.valueOf(moreThanOnesalesRep));
 
-    // check the number of customer and the number of
-    // sales Rep. to choose one of the 3 possibilities
-    // 1.- n customer n sales rep (hide "To" and "Reply-to" inputs)
-    // 2.- n customers 1 sales rep (hide "To" input)
-    // 3.- 1 customer n sales rep (hide Reply-to inputs)
-    // 4.- Otherwise show both
+    // "To" field is always visible; Reply-to is hidden when routing across multiple sales reps.
+    // 1.- n customers, n sales reps → hide Reply-to
+    // 2.- n customers, 1 sales rep  → hide "by X sales reps" label fragments
+    // 3.- 1 customer,  n sales reps → hide Reply-to
+    // 4.- 1 customer,  1 sales rep  → hide "multiple customers" info row
     if (moreThanOneCustomer && moreThanOnesalesRep) {
-      discard = new String[] { "to", "to_bottomMargin", "replyTo", "replyTo_bottomMargin" };
+      discard = new String[] { "replyTo", "replyTo_bottomMargin" };
     } else if (moreThanOneCustomer) {
-      discard = new String[] { "to", "to_bottomMargin", "multSalesRep", "multSalesRepCount" };
+      discard = new String[] { "multSalesRep", "multSalesRepCount" };
     } else if (moreThanOnesalesRep) {
       discard = new String[] { "replyTo", "replyTo_bottomMargin" };
     } else {

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerCommandHandler.java
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerCommandHandler.java
@@ -1,0 +1,427 @@
+package org.openbravo.erpCommon.utility.reporting.printing; //NOSONAR
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.StringUtils;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+import org.openbravo.base.secureApp.VariablesSecureApp;
+import org.openbravo.dal.service.OBDal;
+import org.openbravo.email.ResolvedSmtpConfig;
+import org.openbravo.email.SmtpCascadeResolver;
+import org.openbravo.erpCommon.utility.Utility;
+import org.openbravo.erpCommon.utility.reporting.DocumentType;
+import org.openbravo.erpCommon.utility.reporting.Report;
+import org.openbravo.erpCommon.utility.reporting.Report.OutputTypeEnum;
+import org.openbravo.erpCommon.utility.reporting.ReportManager;
+import org.openbravo.erpCommon.utility.reporting.ReportingException;
+import org.openbravo.erpCommon.utility.reporting.TemplateInfo;
+import org.openbravo.model.common.enterprise.EmailTemplate;
+
+import net.sf.jasperreports.engine.JasperPrint;
+
+@SuppressWarnings("java:S00120")
+final class PrintControllerCommandHandler {
+  private static final String SUFFIX_DOCUMENTS = ".Documents";
+  private static final String TEMPLATE_DEFAULT = "default";
+  private static final String PARAM_TEMPLATES = "templates";
+  private final PrintController controller;
+  private final HttpServletRequest request;
+  private final HttpServletResponse response;
+  private final VariablesSecureApp vars;
+  private final Context context;
+
+  PrintControllerCommandHandler(PrintController controller, HttpServletRequest request,
+      HttpServletResponse response, VariablesSecureApp vars, Context context) {
+    this.controller = controller;
+    this.request = request;
+    this.response = response;
+    this.vars = vars;
+    this.context = context;
+  }
+
+  static Context createContext(PrintController controller, VariablesSecureApp vars,
+      DocumentType documentType, String sessionValuePrefix, String strDocumentId)
+      throws ServletException {
+    String localStrDocumentId = PrintControllerDocumentHelper.normalizeDocumentId(strDocumentId);
+    String fullDocumentIdentifier = PrintControllerDocumentHelper.sanitizeDocumentIdentifier(strDocumentId)
+        + documentType.getTableName();
+    HashMap<String, Boolean> checks = new HashMap<>();
+    checks.put(PrintController.CHECK_MORE_THAN_ONE_CUSTOMER, Boolean.FALSE);
+    checks.put(PrintController.CHECK_MORE_THAN_ONE_SALES_REP, Boolean.FALSE);
+    if (controller.isDebugEnabled()) {
+      controller.debug("strDocumentId: " + localStrDocumentId);
+    }
+    if (localStrDocumentId.length() == 0) {
+      throw new ServletException(Utility.messageBD(controller, "NoDocument", vars.getLanguage()));
+    }
+
+    String[] rawIds = localStrDocumentId.split(",");
+    String[] documentIds = new String[rawIds.length];
+    for (int i = 0; i < rawIds.length; i++) {
+      documentIds[i] = PrintControllerDocumentHelper.sanitizeDocumentIdentifier(rawIds[i].trim());
+    }
+    if (controller.isDebugEnabled()) {
+      controller.debug("Number of documents selected: " + documentIds.length);
+    }
+    controller.multiReports = documentIds.length > 1;
+
+    @SuppressWarnings("unchecked")
+    HashMap<String, Report> reports = (HashMap<String, Report>) vars
+        .getSessionObject(sessionValuePrefix + SUFFIX_DOCUMENTS);
+    ReportManager reportManager = controller.createReportManager();
+    return new Context(documentType, sessionValuePrefix, fullDocumentIdentifier, checks,
+        documentIds, reports, reportManager);
+  }
+
+
+  void handle() throws Exception {
+    if (vars.commandIn("PRINT")) {
+      handlePrintCommand();
+      return;
+    }
+    if (vars.commandIn("ARCHIVE")) {
+      handleArchiveCommand();
+      return;
+    }
+    if (vars.commandIn("DEFAULT")) {
+      handleDefaultCommand();
+      return;
+    }
+    if (vars.commandIn("ADD")) {
+      openOptionsPage();
+      return;
+    }
+    if (vars.commandIn("DEL")) {
+      handleDeleteCommand();
+      return;
+    }
+    if (vars.commandIn("EMAIL")) {
+      handleEmailCommand();
+      return;
+    }
+    if (vars.commandIn("UPDATE_TEMPLATE")) {
+      handleUpdateTemplateCommand();
+      return;
+    }
+    if (vars.commandIn("GET_BP_CONTACTS")) {
+      handleGetBpContactsCommand();
+      return;
+    }
+    if (vars.commandIn("UPDATE_EMAILCONFIG")) {
+      handleUpdateEmailConfigCommand();
+      return;
+    }
+    controller.showPageError(response);
+  }
+
+  private void handlePrintCommand() throws IOException, ServletException, JSONException {
+    controller.archivedReports = false;
+    String[] documentIds = getOrderedDocumentIds();
+    Report report = null;
+    JasperPrint jasperPrint = null;
+    Collection<JasperPrint> jrPrintReports = new ArrayList<>();
+    Collection<Report> savedReports = new ArrayList<>();
+    for (String documentId : documentIds) {
+      String safeId = PrintControllerDocumentHelper.sanitizeDocumentIdentifier(documentId);
+      controller.preparePreProcessHooks(context.documentType, safeId);
+      report = controller.buildReport(response, vars, safeId, context.reportManager,
+          context.documentType, Report.OutputTypeEnum.PRINT, TEMPLATE_DEFAULT);
+      if (report != null) {
+        try {
+          jasperPrint = context.reportManager.processReport(report, vars);
+          jrPrintReports.add(jasperPrint);
+        } catch (ReportingException e) {
+          controller.showAdvicePopup(request, response, "Report processing failed",
+              "Unable to process report selection");
+          controller.error(e);
+        }
+        savedReports.add(report);
+        if (controller.multiReports) {
+          context.reportManager.saveTempReport(report, vars);
+        }
+      }
+    }
+    controller.printReports(response, jrPrintReports, savedReports, PrintControllerPreferenceHelper.isDirectPrint(vars));
+  }
+
+  private void handleArchiveCommand() throws IOException, ServletException, JSONException {
+    controller.archivedReports = true;
+    String[] documentIds = getOrderedDocumentIds();
+    Report report = null;
+    JasperPrint jasperPrint = null;
+    Collection<JasperPrint> jrPrintReports = new ArrayList<>();
+    Collection<Report> savedReports = new ArrayList<>();
+    for (String documentId : documentIds) {
+      String safeId = PrintControllerDocumentHelper.sanitizeDocumentIdentifier(documentId);
+      controller.preparePreProcessHooks(context.documentType, safeId);
+      report = controller.buildReport(response, vars, safeId, context.reportManager,
+          context.documentType, OutputTypeEnum.ARCHIVE, TEMPLATE_DEFAULT);
+      controller.buildReport(response, vars, safeId, context.reports, context.reportManager);
+      if (report != null) {
+        try {
+          jasperPrint = context.reportManager.processReport(report, vars);
+          jrPrintReports.add(jasperPrint);
+        } catch (ReportingException e) {
+          controller.error(e);
+        }
+        context.reportManager.saveTempReport(report, vars);
+        savedReports.add(report);
+      }
+    }
+    controller.printReports(response, jrPrintReports, savedReports, PrintControllerPreferenceHelper.isDirectPrint(vars));
+  }
+
+  private void handleDefaultCommand() throws Exception {
+    controller.differentDocTypes.clear();
+    context.reports = new HashMap<>();
+    for (String rawId : context.documentIds) {
+      String documentId = PrintControllerDocumentHelper.sanitizeDocumentIdentifier(rawId);
+      if (controller.isDebugEnabled()) {
+        controller.debug("Processing document with id: " + documentId);
+      }
+      Report report = new Report(context.documentType, documentId, vars.getLanguage(), TEMPLATE_DEFAULT,
+          controller.multiReports, OutputTypeEnum.DEFAULT);
+      context.reports.put(documentId, report);
+      validateSenderConfiguration(report);
+      if (!controller.differentDocTypes.containsKey(report.getDocTypeId())) {
+        controller.differentDocTypes.put(report.getDocTypeId(), report.getTemplate());
+      }
+    }
+
+    vars.setSessionObject(context.sessionValuePrefix + SUFFIX_DOCUMENTS, context.reports);
+    openOptionsPage();
+  }
+
+  private void handleDeleteCommand() throws IOException, ServletException, ReportingException {
+    String documentToDelete = vars.getStringParameter("idToDelete");
+    @SuppressWarnings("unchecked")
+    List<AttachContent> attachments = (List<AttachContent>) request.getSession()
+        .getAttribute(PrintController.SESSION_FILES);
+    request.getSession().setAttribute(PrintController.SESSION_FILES, attachments);
+    if (attachments != null) {
+      controller.seekAndDestroy(attachments, documentToDelete);
+    }
+    String docIdsForPage = PrintControllerDocumentHelper.getCommaSeparatedString(context.documentIds);
+    controller.createEmailOptionsPage(request, response, vars, context.documentType,
+        docIdsForPage, context.reports, context.checks);
+  }
+
+  private void handleEmailCommand() throws IOException, ServletException {
+    String toEmailParam = vars.getStringParameter(PrintController.PARAM_TO_EMAIL);
+    if (StringUtils.isBlank(toEmailParam)) {
+      throw new ServletException(
+          Utility.messageBD(controller, "NoCustomerEmail", vars.getLanguage()));
+    }
+    PocData[] pocData = (PocData[]) vars
+        .getSessionObject(PrintController.SESSION_POC_DATA + context.fullDocumentIdentifier);
+    int nrOfEmailsSend = 0;
+    if (pocData != null) {
+      for (PocData documentData : pocData) {
+        nrOfEmailsSend += sendEmailForDocument(pocData, documentData);
+      }
+    }
+    request.getSession().removeAttribute(PrintController.SESSION_FILES);
+    if (nrOfEmailsSend > 0 && pocData != null && pocData.length > 0) {
+      controller.persistLastUsedContact(vars, pocData[0].bpartnerId);
+    }
+    vars.removeSessionValue(PrintController.SESSION_POC_DATA + context.fullDocumentIdentifier);
+    controller.createPrintStatusPage(response, vars, nrOfEmailsSend);
+  }
+
+  private int sendEmailForDocument(PocData[] pocData, PocData documentData)
+      throws IOException, ServletException {
+    PrintControllerEmailSupport.updateEnvironmentInfo(pocData, context.checks);
+    String documentId = PrintControllerDocumentHelper.sanitizeDocumentIdentifier(documentData.documentId);
+    if (controller.isDebugEnabled()) {
+      controller.debug("Processing document with id: " + documentId);
+    }
+
+    String templateInUse = controller.differentDocTypes.size() == 1
+        ? vars.getRequestGlobalVariable(PARAM_TEMPLATES, PARAM_TEMPLATES)
+        : TEMPLATE_DEFAULT;
+    Report report = controller.buildReport(response, vars, documentId, context.reportManager,
+        context.documentType, OutputTypeEnum.EMAIL, templateInUse);
+    if (report == null) {
+      throw new ServletException(Utility.messageBD(controller, "NoDataReport", vars.getLanguage())
+          + documentId);
+    }
+    applySelectedTemplate(report);
+    if (report.isDraft()) {
+      return 0;
+    }
+    archiveOrSaveEmailReport(report);
+    if (documentData.contactEmail != null) {
+      documentData.contactEmail = documentData.contactEmail.replace("\r", "").replace("\n", "");
+    }
+    String senderAddress = vars.getStringParameter("fromEmail").replace("\r", "").replace("\n", "");
+    context.checks.put("differentDocTypes", controller.differentDocTypes.size() > 1);
+    @SuppressWarnings("unchecked")
+    List<AttachContent> attachments = (List<AttachContent>) request.getSession()
+        .getAttribute(PrintController.SESSION_FILES);
+    EmailUtilities.prepareAndSendEmail(report, vars, attachments, documentData, senderAddress,
+        context.checks, controller);
+    return 1;
+  }
+
+  private void applySelectedTemplate(Report report) throws ServletException {
+    if (controller.differentDocTypes.size() != 1) {
+      return;
+    }
+    String templateId = vars.getRequestGlobalVariable(PARAM_TEMPLATES, PARAM_TEMPLATES);
+    try {
+      TemplateInfo usedTemplateInfo = new TemplateInfo(controller, report.getDocTypeId(),
+          report.getOrgId(), vars.getLanguage(), templateId);
+      report.setTemplateInfo(usedTemplateInfo);
+    } catch (ReportingException e) {
+      throw new ServletException("Error trying to get template information", e);
+    }
+  }
+
+  private void archiveOrSaveEmailReport(Report report) throws IOException, ServletException {
+    if (report.isAttached()) {
+      if (controller.isDebugEnabled()) {
+        controller.debug("Document is not attached.");
+      }
+      return;
+    }
+    String tableId = ToolsData.getTableId(controller, report.getDocumentType().getTableName());
+    if ("Y".equals(vars.getStringParameter(PrintController.PARAM_INP_ARCHIVE))) {
+      try {
+        context.reportManager.createAttachmentForReport(controller, report, tableId, vars,
+            ReportManager.GENERATED_BY_EMAILING);
+      } catch (ReportingException exception) {
+        throw new ServletException(exception);
+      }
+    } else {
+      context.reportManager.saveTempReport(report, vars);
+    }
+  }
+
+  private void handleUpdateTemplateCommand() throws IOException {
+    JSONObject json = new JSONObject();
+    try {
+      PocData[] pocData = (PocData[]) vars
+          .getSessionObject(PrintController.SESSION_POC_DATA + context.fullDocumentIdentifier);
+      if (pocData == null || pocData.length == 0) {
+        throw new IllegalStateException("No document data found in session");
+      }
+      String templateId = vars.getRequestGlobalVariable(PARAM_TEMPLATES, PARAM_TEMPLATES);
+      String documentId = PrintControllerDocumentHelper.sanitizeDocumentIdentifier(pocData[0].documentId);
+      Report report = new Report(context.documentType, documentId, vars.getLanguage(), templateId,
+          controller.multiReports, OutputTypeEnum.DEFAULT);
+      json.put("templateId", templateId);
+      json.put("subject", report.getEmailDefinition().getSubject());
+      json.put("body", report.getEmailDefinition().getBody());
+      if (!controller.multiReports) {
+        json.put("filename", report.getFilename());
+      }
+      context.reports = new HashMap<>();
+      context.reports.put(documentId, report);
+      vars.setSessionObject(context.sessionValuePrefix + SUFFIX_DOCUMENTS, context.reports);
+    } catch (Exception e) {
+      controller.error(e);
+      json = PrintControllerJsonHelper.buildErrorJson();
+    }
+    PrintControllerJsonHelper.writeJsonResponse(response, json);
+  }
+
+  private void handleGetBpContactsCommand() throws IOException {
+    PocData[] pocDataForContacts = (PocData[]) vars
+        .getSessionObject(PrintController.SESSION_POC_DATA + context.fullDocumentIdentifier);
+    JSONObject result = PrintControllerJsonHelper.buildBPContactsJson(vars, pocDataForContacts);
+    PrintControllerJsonHelper.writeJsonResponse(response, result);
+  }
+
+  private void handleUpdateEmailConfigCommand() throws IOException {
+    JSONObject json = new JSONObject();
+    try {
+      String currentEmailConfigId = vars.getStringParameter("emailConfigList");
+      EmailTemplate emailTemplate = OBDal.getInstance().get(EmailTemplate.class,
+          currentEmailConfigId);
+      if (emailTemplate != null) {
+        json.put("subject", emailTemplate.getSubject());
+        json.put("body", emailTemplate.getBody());
+      }
+    } catch (Exception e) {
+      controller.error(e);
+      json = PrintControllerJsonHelper.buildErrorJson();
+    }
+    PrintControllerJsonHelper.writeJsonResponse(response, json);
+  }
+
+  private void openOptionsPage() throws IOException, ServletException, ReportingException {
+    String docIdsForPage = PrintControllerDocumentHelper.getCommaSeparatedString(context.documentIds);
+    if (isPrintPath()) {
+      controller.createPrintOptionsPage(request, response, vars, context.documentType,
+          docIdsForPage, context.reports);
+      return;
+    }
+    if (isSendPath()) {
+      controller.createEmailOptionsPage(request, response, vars, context.documentType,
+          docIdsForPage, context.reports, context.checks);
+    }
+  }
+
+  private void validateSenderConfiguration(Report report) throws IOException, ServletException {
+    String senderAddress = EmailData.getSenderAddress(controller, vars.getClient(), report.getOrgId());
+    if (isPrintPath() || isPrintOptionsPath()) {
+      return;
+    }
+    ResolvedSmtpConfig resolvedForCheck = SmtpCascadeResolver.resolve();
+    boolean hasSender = resolvedForCheck != null || StringUtils.isNotEmpty(senderAddress);
+    if (!hasSender) {
+      controller.reportNoSenderError(response, vars);
+    }
+  }
+
+  private String[] getOrderedDocumentIds() throws ServletException {
+    return controller.multiReports
+        ? PrintControllerDocumentHelper.orderByDocumentNo(controller, context.documentType, context.documentIds)
+        : context.documentIds;
+  }
+
+  private boolean isPrintPath() {
+    return request.getServletPath().toLowerCase().indexOf("print.html") != -1;
+  }
+
+  private boolean isPrintOptionsPath() {
+    return request.getServletPath().toLowerCase().indexOf("printoptions.html") != -1;
+  }
+
+  private boolean isSendPath() {
+    return request.getServletPath().toLowerCase().indexOf("send.html") != -1;
+  }
+
+
+
+  static final class Context {
+    final DocumentType documentType;
+    final String sessionValuePrefix;
+    final String fullDocumentIdentifier;
+    final HashMap<String, Boolean> checks;
+    final String[] documentIds;
+    HashMap<String, Report> reports;
+    final ReportManager reportManager;
+
+    Context(DocumentType documentType, String sessionValuePrefix,
+        String fullDocumentIdentifier, HashMap<String, Boolean> checks, String[] documentIds,
+        HashMap<String, Report> reports, ReportManager reportManager) {
+      this.documentType = documentType;
+      this.sessionValuePrefix = sessionValuePrefix;
+      this.fullDocumentIdentifier = fullDocumentIdentifier;
+      this.checks = checks;
+      this.documentIds = documentIds;
+      this.reports = reports;
+      this.reportManager = reportManager;
+    }
+  }
+}

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerDocumentHelper.java
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerDocumentHelper.java
@@ -1,0 +1,81 @@
+package org.openbravo.erpCommon.utility.reporting.printing; //NOSONAR
+
+import java.util.Collection;
+
+import javax.servlet.ServletException;
+
+import org.openbravo.erpCommon.utility.reporting.DocumentType;
+import org.openbravo.erpCommon.utility.reporting.Report;
+
+@SuppressWarnings("java:S00120")
+final class PrintControllerDocumentHelper {
+  private PrintControllerDocumentHelper() {
+  }
+
+  static String normalizeDocumentId(String strDocumentId) {
+    return strDocumentId.replace("(", "").replace(")", "").replace("'", "");
+  }
+
+  static String sanitizeDocumentIdentifier(String strDocumentId) {
+    StringBuilder sanitizedDocIdBuilder = new StringBuilder();
+    for (int index = 0; index < strDocumentId.length(); index++) {
+      char currentCharacter = strDocumentId.charAt(index);
+      if (Character.isLetterOrDigit(currentCharacter) || currentCharacter == ','
+          || currentCharacter == '-') {
+        sanitizedDocIdBuilder.append(currentCharacter);
+      }
+    }
+    return sanitizedDocIdBuilder.toString();
+  }
+
+  static String getCommaSeparatedString(String[] documentIds) {
+    StringBuilder result = new StringBuilder("(");
+    for (int index = 0; index < documentIds.length; index++) {
+      if (index > 0) {
+        result.append(',');
+      }
+      result.append("'").append(documentIds[index]).append("'");
+    }
+    result.append(')');
+    return result.toString();
+  }
+
+  static String getFilenameForReports(Collection<Report> reports) {
+    String filename = "";
+    for (Report report : reports) {
+      filename = report.getFilename();
+    }
+    return filename;
+  }
+
+  static String[] orderByDocumentNo(PrintController controller, DocumentType documentType,
+      String[] documentIds) throws ServletException {
+    String strTable = documentType.getTableName();
+    StringBuilder strIds = new StringBuilder();
+    strIds.append("'");
+    for (int i = 0; i < documentIds.length; i++) {
+      if (i > 0) {
+        strIds.append("', '");
+      }
+      strIds.append(documentIds[i]);
+    }
+    strIds.append("'");
+
+    PrintControllerData[] printControllerData;
+    if (strTable.equals("C_INVOICE")) {
+      printControllerData = PrintControllerData.selectInvoices(controller, strIds.toString());
+    } else if (strTable.equals("C_ORDER")) {
+      printControllerData = PrintControllerData.selectOrders(controller, strIds.toString());
+    } else if (strTable.equals("FIN_PAYMENT")) {
+      printControllerData = PrintControllerData.selectPayments(controller, strIds.toString());
+    } else {
+      return documentIds;
+    }
+
+    String[] documentIdsOrdered = new String[printControllerData.length];
+    for (int i = 0; i < printControllerData.length; i++) {
+      documentIdsOrdered[i] = printControllerData[i].getField("Id");
+    }
+    return documentIdsOrdered;
+  }
+}

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerEmailOptionsBuilder.java
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerEmailOptionsBuilder.java
@@ -1,0 +1,569 @@
+package org.openbravo.erpCommon.utility.reporting.printing; //NOSONAR
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.lang3.StringUtils;
+import org.openbravo.base.exception.OBException;
+import org.openbravo.base.secureApp.VariablesSecureApp;
+import org.openbravo.dal.core.OBContext;
+import org.openbravo.dal.service.OBDal;
+import org.openbravo.email.ResolvedSmtpConfig;
+import org.openbravo.email.SmtpCascadeResolver;
+import org.openbravo.erpCommon.utility.BasicUtility;
+import org.openbravo.erpCommon.utility.OBError;
+import org.openbravo.erpCommon.utility.Utility;
+import org.openbravo.erpCommon.utility.reporting.DocumentType;
+import org.openbravo.erpCommon.utility.reporting.Report;
+import org.openbravo.erpCommon.utility.reporting.ReportingException;
+import org.openbravo.erpCommon.utility.reporting.TemplateInfo;
+import org.openbravo.erpCommon.utility.reporting.TemplateInfo.EmailDefinition;
+import org.openbravo.model.ad.access.User;
+import org.openbravo.model.ad.system.Language;
+import org.openbravo.model.common.businesspartner.BusinessPartner;
+import org.openbravo.xmlEngine.XmlDocument;
+
+@SuppressWarnings("java:S00120")
+final class PrintControllerEmailOptionsBuilder {
+  private static final String FORM_FROM_EMAIL_ID = "fromEmailId";
+  private static final String FORM_FROM_EMAIL = "fromEmail";
+  private static final String FORM_CC_EMAIL = "ccEmail";
+  private static final String FORM_CC_EMAIL_ORIG = "ccEmailOrig";
+  private static final String FORM_BCC_EMAIL = "bccEmail";
+  private static final String FORM_BCC_EMAIL_ORIG = "bccEmailOrig";
+  private static final String FORM_REPLY_TO_EMAIL = "replyToEmail";
+  private static final String FORM_REPLY_TO_EMAIL_ORIG = "replyToEmailOrig";
+  private static final String FORM_EMAIL_SUBJECT = "emailSubject";
+  private static final String FORM_EMAIL_BODY = "emailBody";
+  private final PrintController controller;
+  private final HttpServletRequest request;
+  private final HttpServletResponse response;
+  private final VariablesSecureApp vars;
+  private final Context context;
+
+  PrintControllerEmailOptionsBuilder(PrintController controller, HttpServletRequest request,
+      HttpServletResponse response, VariablesSecureApp vars, Context context) {
+    this.controller = controller;
+    this.request = request;
+    this.response = response;
+    this.vars = vars;
+    this.context = context;
+  }
+
+  void render() throws IOException, ServletException, ReportingException {
+    PocData[] pocData = EmailUtilities.getContactDetails(context.documentType, context.strDocumentId, controller);
+    List<AttachContent> attachments = getSessionAttachments();
+    boolean isTheFirstEntry = attachments == null;
+    if (attachments == null) {
+      attachments = new ArrayList<>(0);
+    }
+
+    XmlDocument xmlDocument = controller.createEmailOptionsXmlDocument(
+        PrintControllerEmailSupport.getHiddenTags(pocData, attachments, vars, context.checks,
+            controller.differentDocTypes.size()));
+    xmlDocument.setParameter("strDocumentId", context.strDocumentId);
+    handleAttachmentUpload(pocData, attachments);
+    handleClosedPopup(xmlDocument);
+    xmlDocument.setParameter(PrintController.XML_PARAMETER_DIRECTORY, controller.getBaseDirectoryJs());
+    xmlDocument.setParameter("language", vars.getLanguage());
+    xmlDocument.setParameter("theme", vars.getTheme());
+
+    EmailDefinitionResult emailConfig = resolveEmailDefinition(xmlDocument);
+    FromAddress fromAddress = resolveFromEmail();
+    if (fromAddress == null) {
+      return;
+    }
+    DocumentMapsResult docMaps = buildDocumentMaps(pocData);
+    if (!docMaps.allDocsCompleted) {
+      reportIncompleteDocuments();
+    }
+
+    setupAttachmentParams(xmlDocument, attachments, isTheFirstEntry, pocData, docMaps);
+    if (controller.isDebugEnabled()) {
+      controller.debug("Documents still in draft: " + docMaps.draftDocumentIds);
+    }
+    xmlDocument.setParameter("draftDocumentIds", docMaps.draftDocumentIds);
+
+    EmailFormData formData = buildEmailFormData(pocData, docMaps, emailConfig, fromAddress);
+    applyEmailFormData(xmlDocument, pocData, emailConfig, formData);
+
+    vars.setSessionObject(PrintController.SESSION_POC_DATA + context.fullDocumentIdentifier, pocData);
+    response.setContentType(PrintController.CONTENT_TYPE_HTML);
+    PrintWriter out = response.getWriter();
+    out.println(xmlDocument.print());
+    out.close();
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<AttachContent> getSessionAttachments() {
+    return (List<AttachContent>) request.getSession().getAttribute(PrintController.SESSION_FILES);
+  }
+
+  private void handleAttachmentUpload(PocData[] pocData, List<AttachContent> attachments) {
+    FileItem file = vars.getMultiFile("inpFile");
+    if (file == null || file.getName().equals("")) {
+      return;
+    }
+    if (pocData == null || pocData.length == 0) {
+      return;
+    }
+    AttachContent content = new AttachContent();
+    content.setFileName(pocData[0].ourreference.replace('/', '_') + '-'
+        + Utility.formatDate(new Date(), "yyyyMMdd-HHmmss") + '.' + file.getName());
+    content.setFileItem(file);
+    content.setId(Utility.formatDate(new Date(), "yyyyMMdd-HHmmss") + '.' + file.getName());
+    content.visible = "hidden";
+    if ("Y".equals(vars.getStringParameter(PrintController.PARAM_INP_ARCHIVE))) {
+      content.setSelected("true");
+    }
+    attachments.add(content);
+    request.getSession().setAttribute(PrintController.SESSION_FILES, attachments);
+  }
+
+  private void handleClosedPopup(XmlDocument xmlDocument) {
+    if (!"yes".equals(vars.getStringParameter("closed"))) {
+      return;
+    }
+    xmlDocument.setParameter("closed", "yes");
+    request.getSession().removeAttribute(PrintController.SESSION_FILES);
+  }
+
+  private EmailDefinitionResult resolveEmailDefinition(XmlDocument xmlDocument)
+      throws IOException, ServletException {
+    EmailDefinitionResult result = new EmailDefinitionResult();
+    try {
+      if (moreThanOneLanguageDefined() && hasDifferentBpLanguages()) {
+        List<EmailDefinition> emailDefinitions = new ArrayList<>();
+        for (Map.Entry<String, EmailDefinition> entry : context.reports.values().iterator().next()
+            .getEmailDefinitions().entrySet()) {
+          emailDefinitions.add(entry.getValue());
+        }
+        result.emailDefinition = context.reports.values().iterator().next().getTemplateInfo()
+            .get_DefaultEmailDefinition();
+        xmlDocument.setParameter("reportEmailConfig",
+            getOptionsList(emailDefinitions, result.emailDefinition.getId(), false));
+        result.hasMultiple = true;
+      } else {
+        result.emailDefinition = context.reports.values().iterator().next().getEmailDefinition();
+      }
+    } catch (OBException exception) {
+      OBError on = new OBError();
+      on.setMessage(Utility.messageBD(controller, "EmailConfiguration", vars.getLanguage()));
+      on.setTitle(Utility.messageBD(controller, "Info", vars.getLanguage()));
+      on.setType("info");
+      StringBuilder tabIdBuilder = new StringBuilder();
+      for (char c : vars.getSessionValue(PrintController.INP_TAB_ID).toCharArray()) {
+        if (Character.isDigit(c)) {
+          tabIdBuilder.append(c);
+        }
+      }
+      vars.setMessage(tabIdBuilder.toString(), on);
+      vars.getRequestGlobalVariable(PrintController.INP_TAB_ID, PrintController.ATTRIBUTESETINSTANCE_TABID);
+      controller.closePopupAndRefreshParent(response, vars);
+    } catch (ReportingException exception) {
+      controller.error(exception);
+    }
+    return result;
+  }
+
+  private FromAddress resolveFromEmail() throws IOException, ServletException {
+    OBContext.setAdminMode(true);
+    try {
+      ResolvedSmtpConfig resolvedConfig = SmtpCascadeResolver.resolve();
+      if (resolvedConfig == null) {
+        controller.reportNoSenderError(response, vars);
+        return null;
+      }
+      return new FromAddress(resolvedConfig.getFromAddress(), resolvedConfig.getConfigId());
+    } finally {
+      OBContext.restorePreviousMode();
+    }
+  }
+
+  private DocumentMapsResult buildDocumentMaps(PocData[] pocData)
+      throws IOException, ServletException {
+    DocumentMapsResult result = new DocumentMapsResult();
+    AttachContent attachedContent = result.attachedContent;
+    boolean onlyOneAttachedDoc = PrintControllerEmailSupport.hasSingleAttachmentDoc(context.reports);
+    for (PocData documentData : pocData) {
+      String customer = documentData.contactEmail;
+      PrintControllerEmailSupport.updateEnvironmentInfo(pocData, context.checks);
+      if (context.checks.get(PrintController.CHECK_MORE_THAN_ONE_DOCUMENT)) {
+        validateCustomer(documentData, customer);
+      }
+      result.customerMap.putIfAbsent(customer, documentData);
+
+      String salesRep = documentData.salesrepEmail;
+      if (context.checks.get(PrintController.CHECK_MORE_THAN_ONE_SALES_REP).booleanValue()) {
+        validateSalesRep(documentData, salesRep);
+      }
+      result.salesRepMap.putIfAbsent(salesRep, documentData);
+      updateDocumentState(result, documentData, attachedContent, onlyOneAttachedDoc);
+    }
+    return result;
+  }
+
+  private void validateCustomer(PocData documentData, String customer)
+      throws IOException, ServletException {
+    if (customer == null || customer.length() == 0) {
+      showInfoAndClose("NoContact", "@docNum@", documentData.ourreference);
+    } else if (documentData.contactEmail == null || documentData.contactEmail.equals("")) {
+      showInfoAndClose("NoEmail", "@customer@", documentData.contactName);
+    }
+  }
+
+  private void validateSalesRep(PocData documentData, String salesRep)
+      throws IOException, ServletException {
+    if (salesRep == null || salesRep.length() == 0) {
+      showInfoAndClose("NoSenderDocument", null, null);
+    } else if (documentData.salesrepEmail == null || documentData.salesrepEmail.equals("")) {
+      showInfoAndClose("NoEmailSender", "@salesRep@", documentData.salesrepName);
+    }
+  }
+
+  private void showInfoAndClose(String messageKey, String token, String value)
+      throws IOException, ServletException {
+    OBError on = new OBError();
+    String message = Utility.messageBD(controller, messageKey, vars.getLanguage());
+    if (token != null) {
+      message = message.replace(token, value);
+    }
+    on.setMessage(message);
+    on.setTitle(Utility.messageBD(controller, "Info", vars.getLanguage()));
+    on.setType("info");
+    StringBuilder tabIdBuilder = new StringBuilder();
+    for (char c : vars.getSessionValue(PrintController.INP_TAB_ID).toCharArray()) {
+      if (Character.isDigit(c)) {
+        tabIdBuilder.append(c);
+      }
+    }
+    vars.setMessage(tabIdBuilder.toString(), on);
+    vars.getRequestGlobalVariable(PrintController.INP_TAB_ID, PrintController.ATTRIBUTESETINSTANCE_TABID);
+    controller.closePopupAndRefreshParent(response, vars);
+  }
+
+  private void updateDocumentState(DocumentMapsResult result, PocData documentData,
+      AttachContent attachedContent, boolean onlyOneAttachedDoc) throws ServletException {
+    Report report = context.reports.get(documentData.documentId);
+    if (report.isDraft()) {
+      if (result.draftDocumentIds.length() > 0) {
+        result.draftDocumentIds += ",";
+      }
+      result.draftDocumentIds += report.getDocumentId();
+      result.allDocsCompleted = false;
+    }
+
+    String reportFilename = report.getContextSubFolder() + report.getFilename();
+    documentData.reportLocation = request.getContextPath() + "/" + reportFilename
+        + "?documentId=" + documentData.documentId;
+    if (controller.isDebugEnabled()) {
+      controller.debug(" Filling report location with: " + documentData.reportLocation);
+    }
+    if (onlyOneAttachedDoc
+        && !StringUtils.equals(attachedContent.getDocName(), report.getFilename())) {
+      attachedContent.setDocName(report.getFilename());
+      attachedContent.setVisible("checkbox");
+      result.clonedAttachments.add(attachedContent);
+    }
+  }
+
+  private void reportIncompleteDocuments() throws IOException, ServletException {
+    OBError on = new OBError();
+    on.setMessage(Utility.messageBD(controller, "ErrorIncompleteDocuments", vars.getLanguage()));
+    on.setTitle(Utility.messageBD(controller, "ErrorSendingEmail", vars.getLanguage()));
+    on.setType(PrintController.MSG_TYPE_ERROR);
+    StringBuilder tabIdBuilder = new StringBuilder();
+    for (char c : vars.getSessionValue(PrintController.INP_TAB_ID).toCharArray()) {
+      if (Character.isDigit(c)) {
+        tabIdBuilder.append(c);
+      }
+    }
+    vars.setMessage(tabIdBuilder.toString(), on);
+    vars.getRequestGlobalVariable(PrintController.INP_TAB_ID, PrintController.ATTRIBUTESETINSTANCE_TABID);
+    controller.closePopupAndRefreshParent(response, vars);
+  }
+
+  private void setupAttachmentParams(XmlDocument xmlDocument, List<AttachContent> attachments,
+      boolean isTheFirstEntry, PocData[] pocData, DocumentMapsResult docMaps) {
+    boolean onlyOneAttachedDoc = PrintControllerEmailSupport.hasSingleAttachmentDoc(context.reports);
+    int numberOfCustomers = docMaps.customerMap.size();
+    if (!onlyOneAttachedDoc && isTheFirstEntry) {
+      if (numberOfCustomers > 1) {
+        docMaps.attachedContent.setDocName(
+            context.reports.size() + " Documents to " + numberOfCustomers + " Customers");
+      } else {
+        docMaps.attachedContent.setDocName(context.reports.size() + " Documents");
+      }
+      docMaps.attachedContent.setVisible("checkbox");
+      docMaps.clonedAttachments.add(docMaps.attachedContent);
+    }
+    if (!docMaps.clonedAttachments.isEmpty()) {
+      xmlDocument.setData("structure2",
+          docMaps.clonedAttachments.toArray(new AttachContent[docMaps.clonedAttachments.size()]));
+      xmlDocument.setData("structure1",
+          attachments.toArray(new AttachContent[attachments.size()]));
+    }
+    if (pocData.length >= 1) {
+      xmlDocument.setData("reportEmail", "liststructure",
+          context.reports.get(pocData[0].documentId).getTemplate());
+    }
+  }
+
+  private EmailFormData buildEmailFormData(PocData[] pocData, DocumentMapsResult docMaps,
+      EmailDefinitionResult emailConfig, FromAddress fromAddress) throws ServletException {
+    EmailFormData formData = new EmailFormData();
+    PocData[] currentUserInfo = PocData.getContactDetailsForUser(controller, vars.getUser());
+    if (StringUtils.isNotBlank(currentUserInfo[0].userEmail)) {
+      formData.bccEmail = currentUserInfo[0].userEmail;
+      formData.bccName = currentUserInfo[0].userName;
+    }
+    formData.selectedContact = resolvePreselectedContact(pocData);
+    formData.fromEmail = fromAddress.fromEmail;
+    formData.fromEmailId = fromAddress.fromEmailId;
+    formData.numberOfCustomers = docMaps.customerMap.size();
+    formData.numberOfSalesReps = docMaps.salesRepMap.size();
+    if (!vars.commandIn("ADD", "DEL")) {
+      fillInitialRecipientData(formData, docMaps.customerMap, pocData, emailConfig.emailDefinition);
+    }
+    return formData;
+  }
+
+  private User resolvePreselectedContact(PocData[] pocData) {
+    if (vars.commandIn("ADD", "DEL") || pocData.length == 0) {
+      return null;
+    }
+    try {
+      return BPContactEmailSelector.selectBestContact(pocData[0].bpartnerId, vars.getUser());
+    } catch (Exception exception) {
+      controller.warn(
+          "Could not determine best email contact, falling back to default. Reason: {}",
+          exception.getMessage());
+      return null;
+    }
+  }
+
+  private void fillInitialRecipientData(EmailFormData formData, Map<String, PocData> customerMap,
+      PocData[] pocData, EmailDefinition emailDefinition) {
+    if (formData.numberOfCustomers > 1) {
+      List<String> emails = new ArrayList<>();
+      for (String email : customerMap.keySet()) {
+        if (StringUtils.isNotBlank(email)) {
+          emails.add(email);
+        }
+      }
+      formData.toEmail = String.join("; ", emails);
+      formData.toContactId = "";
+    } else {
+      formData.toEmail = getContactField(formData.selectedContact, User::getEmail);
+      formData.toContactId = getContactField(formData.selectedContact, User::getId);
+    }
+    formData.replyToEmail = pocData.length > 0 ? pocData[0].salesrepEmail : "";
+    if (emailDefinition != null) {
+      formData.emailSubject = emailDefinition.getSubject();
+      formData.emailBody = emailDefinition.getBody();
+    }
+  }
+
+  private void applyEmailFormData(XmlDocument xmlDocument, PocData[] pocData,
+      EmailDefinitionResult emailConfig, EmailFormData formData) {
+    if (vars.commandIn("ADD", "DEL")) {
+      applyEditedEmailParams(xmlDocument);
+    } else {
+      applyInitialEmailParams(xmlDocument, formData);
+    }
+
+    xmlDocument.setParameter("bpartnerId",
+        pocData.length > 0 ? pocData[0].bpartnerId : StringUtils.EMPTY);
+    xmlDocument.setParameter(PrintController.PARAM_INP_ARCHIVE,
+        vars.getStringParameter(PrintController.PARAM_INP_ARCHIVE));
+    xmlDocument.setParameter("fromName", "");
+    xmlDocument.setParameter("toName", resolveToName(formData.selectedContact, pocData,
+        formData.numberOfCustomers));
+    xmlDocument.setParameter("ccName", "");
+    xmlDocument.setParameter("bccName", formData.bccName);
+    xmlDocument.setParameter("replyToName", pocData[0].salesrepName);
+    xmlDocument.setParameter("multCusCount", String.valueOf(formData.numberOfCustomers));
+    xmlDocument.setParameter("multSalesRepCount", String.valueOf(formData.numberOfSalesReps));
+    if (!emailConfig.hasMultiple) {
+      xmlDocument.setParameter("useDefault", "Y");
+    }
+    if (controller.differentDocTypes.size() > 1) {
+      xmlDocument.setParameter("multiDocType", "Y");
+    }
+  }
+
+  private void applyEditedEmailParams(XmlDocument xmlDocument) {
+    xmlDocument.setParameter(FORM_FROM_EMAIL_ID, vars.getStringParameter(FORM_FROM_EMAIL_ID));
+    xmlDocument.setParameter(FORM_FROM_EMAIL, vars.getStringParameter(FORM_FROM_EMAIL));
+    xmlDocument.setParameter(PrintController.PARAM_TO_EMAIL,
+        vars.getStringParameter(PrintController.PARAM_TO_EMAIL));
+    xmlDocument.setParameter(PrintController.PARAM_TO_EMAIL_ORIG,
+        vars.getStringParameter(PrintController.PARAM_TO_EMAIL_ORIG));
+    xmlDocument.setParameter(PrintController.PARAM_TO_CONTACT_ID,
+        vars.getStringParameter(PrintController.PARAM_TO_CONTACT_ID));
+    xmlDocument.setParameter(FORM_CC_EMAIL, vars.getStringParameter(FORM_CC_EMAIL));
+    xmlDocument.setParameter(FORM_CC_EMAIL_ORIG, vars.getStringParameter(FORM_CC_EMAIL_ORIG));
+    xmlDocument.setParameter(FORM_BCC_EMAIL, vars.getStringParameter(FORM_BCC_EMAIL));
+    xmlDocument.setParameter(FORM_BCC_EMAIL_ORIG, vars.getStringParameter(FORM_BCC_EMAIL_ORIG));
+    xmlDocument.setParameter(FORM_REPLY_TO_EMAIL, vars.getStringParameter(FORM_REPLY_TO_EMAIL));
+    xmlDocument.setParameter(FORM_REPLY_TO_EMAIL_ORIG, vars.getStringParameter(FORM_REPLY_TO_EMAIL_ORIG));
+    xmlDocument.setParameter(FORM_EMAIL_SUBJECT, vars.getStringParameter(FORM_EMAIL_SUBJECT));
+    xmlDocument.setParameter(FORM_EMAIL_BODY, vars.getStringParameter(FORM_EMAIL_BODY));
+  }
+
+  private void applyInitialEmailParams(XmlDocument xmlDocument, EmailFormData formData) {
+    xmlDocument.setParameter(FORM_FROM_EMAIL_ID, formData.fromEmailId);
+    xmlDocument.setParameter(FORM_FROM_EMAIL, formData.fromEmail);
+    xmlDocument.setParameter(PrintController.PARAM_TO_EMAIL, formData.toEmail);
+    xmlDocument.setParameter(PrintController.PARAM_TO_EMAIL_ORIG, formData.toEmail);
+    xmlDocument.setParameter(PrintController.PARAM_TO_CONTACT_ID, formData.toContactId);
+    xmlDocument.setParameter(FORM_CC_EMAIL, "");
+    xmlDocument.setParameter(FORM_CC_EMAIL_ORIG, "");
+    xmlDocument.setParameter(FORM_BCC_EMAIL, formData.bccEmail);
+    xmlDocument.setParameter(FORM_BCC_EMAIL_ORIG, formData.bccEmail);
+    xmlDocument.setParameter(FORM_REPLY_TO_EMAIL, formData.replyToEmail);
+    xmlDocument.setParameter(FORM_REPLY_TO_EMAIL_ORIG, formData.replyToEmail);
+    xmlDocument.setParameter(FORM_EMAIL_SUBJECT, formData.emailSubject);
+    xmlDocument.setParameter(FORM_EMAIL_BODY, formData.emailBody);
+  }
+
+  private String resolveToName(User selectedContact, PocData[] pocData, int numberOfCustomers) {
+    if (numberOfCustomers > 1) {
+      return StringUtils.EMPTY;
+    }
+    if (selectedContact != null) {
+      return getContactField(selectedContact, User::getName);
+    }
+    if (pocData.length > 0) {
+      return pocData[0].contactName;
+    }
+    return StringUtils.EMPTY;
+  }
+
+  private static String getContactField(User contact, FieldExtractor getter) {
+    if (contact == null) {
+      return StringUtils.EMPTY;
+    }
+    return StringUtils.defaultString(getter.extract(contact));
+  }
+
+  private String getOptionsList(List<EmailDefinition> emailDefinitions, String selectedValue,
+      boolean isMandatory) {
+    StringBuilder strOptions = new StringBuilder();
+    if (!isMandatory) {
+      strOptions.append("<option value=\"\"></option>");
+    }
+    for (EmailDefinition definition : emailDefinitions) {
+      strOptions.append("<option value=\"").append(definition.getId()).append("\"");
+      if (definition.getId().equals(selectedValue)) {
+        strOptions.append(" selected=\"selected\"");
+      }
+      strOptions.append(">");
+      strOptions.append(BasicUtility.formatMessageBDToHtml(
+          definition.getSubject() + " - " + definition.getLanguage()));
+      strOptions.append("</option>");
+    }
+    return strOptions.toString();
+  }
+
+  private boolean moreThanOneLanguageDefined() throws ReportingException {
+    for (Report report : context.reports.values()) {
+      if (report.getEmailDefinitions().size() > 1) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean hasDifferentBpLanguages() throws ReportingException {
+    Language currentLanguage = null;
+    for (Report report : context.reports.values()) {
+      BusinessPartner businessPartner = OBDal.getInstance()
+          .get(BusinessPartner.class, report.getBPartnerId());
+      Language language = businessPartner.getLanguage();
+      if (currentLanguage == null) {
+        currentLanguage = language;
+      } else if (!currentLanguage.getId().equals(language.getId())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Extracts a string field from a {@link User}. */
+  interface FieldExtractor {
+    /**
+     * Returns the relevant string field value from the given user.
+     *
+     * @param user the user from which to extract the field value
+     * @return the extracted string field value
+     */
+    String extract(User user);
+  }
+
+  static final class Context {
+    final DocumentType documentType;
+    final String strDocumentId;
+    final Map<String, Report> reports;
+    final HashMap<String, Boolean> checks;
+    final String fullDocumentIdentifier;
+
+    Context(DocumentType documentType, String strDocumentId, Map<String, Report> reports,
+        HashMap<String, Boolean> checks, String fullDocumentIdentifier) {
+      this.documentType = documentType;
+      this.strDocumentId = strDocumentId;
+      this.reports = reports;
+      this.checks = checks;
+      this.fullDocumentIdentifier = fullDocumentIdentifier;
+    }
+  }
+
+  private static final class FromAddress {
+    private final String fromEmail;
+    private final String fromEmailId;
+
+    private FromAddress(String fromEmail, String fromEmailId) {
+      this.fromEmail = fromEmail;
+      this.fromEmailId = fromEmailId;
+    }
+  }
+
+  private static final class EmailDefinitionResult {
+    private EmailDefinition emailDefinition;
+    private boolean hasMultiple;
+  }
+
+  private static final class DocumentMapsResult {
+    private final Map<String, PocData> customerMap = new HashMap<>();
+    private final Map<String, PocData> salesRepMap = new HashMap<>();
+    private final List<AttachContent> clonedAttachments = new ArrayList<>();
+    private final AttachContent attachedContent = new AttachContent();
+    private String draftDocumentIds = "";
+    private boolean allDocsCompleted = true;
+  }
+
+  private static final class EmailFormData {
+    private User selectedContact;
+    private String fromEmail = "";
+    private String fromEmailId = "";
+    private String toEmail = "";
+    private String toContactId = "";
+    private String bccEmail = "";
+    private String bccName = "";
+    private String replyToEmail = "";
+    private String emailSubject = "";
+    private String emailBody = "";
+    private int numberOfCustomers;
+    private int numberOfSalesReps;
+  }
+}

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerEmailSupport.java
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerEmailSupport.java
@@ -1,0 +1,97 @@
+package org.openbravo.erpCommon.utility.reporting.printing; //NOSONAR
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.openbravo.base.secureApp.VariablesSecureApp;
+import org.openbravo.erpCommon.utility.reporting.Report;
+
+@SuppressWarnings("java:S00120")
+final class PrintControllerEmailSupport {
+  private PrintControllerEmailSupport() {
+  }
+
+  static void updateEnvironmentInfo(PocData[] pocData, HashMap<String, Boolean> checks) {
+    if (pocData == null) {
+      return;
+    }
+    final Map<String, PocData> customerMap = new HashMap<>();
+    final Map<String, PocData> salesRepMap = new HashMap<>();
+    int docCounter = 0;
+    checks.put(PrintController.CHECK_MORE_THAN_ONE_DOCUMENT, false);
+    for (final PocData documentData : pocData) {
+      if (documentData == null) {
+        continue;
+      }
+      docCounter++;
+      if (documentData.contactEmail != null) {
+        customerMap.putIfAbsent(documentData.contactEmail, documentData);
+      }
+      if (documentData.salesrepEmail != null) {
+        salesRepMap.putIfAbsent(documentData.salesrepEmail, documentData);
+      }
+    }
+    if (docCounter > 1) {
+      checks.put(PrintController.CHECK_MORE_THAN_ONE_DOCUMENT, true);
+    }
+    boolean moreThanOneCustomer = customerMap.size() > 1;
+    boolean moreThanOneSalesRep = salesRepMap.size() > 1;
+    checks.put(PrintController.CHECK_MORE_THAN_ONE_CUSTOMER, Boolean.valueOf(moreThanOneCustomer));
+    checks.put(PrintController.CHECK_MORE_THAN_ONE_SALES_REP, Boolean.valueOf(moreThanOneSalesRep));
+  }
+
+  static String[] getHiddenTags(PocData[] pocData, List<AttachContent> attachedContent,
+      VariablesSecureApp vars, HashMap<String, Boolean> checks, int differentDocTypesCount) {
+    if (pocData == null) {
+      return new String[0];
+    }
+    String[] discard;
+    final Map<String, PocData> customerMap = new HashMap<>();
+    final Map<String, PocData> salesRepMap = new HashMap<>();
+    for (final PocData documentData : pocData) {
+      if (documentData == null) {
+        continue;
+      }
+      if (documentData.contactEmail != null) {
+        customerMap.putIfAbsent(documentData.contactEmail, documentData);
+      }
+      if (documentData.salesrepEmail != null) {
+        salesRepMap.putIfAbsent(documentData.salesrepEmail, documentData);
+      }
+    }
+    boolean moreThanOneCustomer = customerMap.size() > 1;
+    boolean moreThanOneSalesRep = salesRepMap.size() > 1;
+    checks.put(PrintController.CHECK_MORE_THAN_ONE_CUSTOMER, Boolean.valueOf(moreThanOneCustomer));
+    checks.put(PrintController.CHECK_MORE_THAN_ONE_SALES_REP, Boolean.valueOf(moreThanOneSalesRep));
+
+    if (moreThanOneCustomer && moreThanOneSalesRep) {
+      discard = new String[] { "replyTo", "replyTo_bottomMargin" };
+    } else if (moreThanOneCustomer) {
+      discard = new String[] { "multSalesRep", "multSalesRepCount" };
+    } else if (moreThanOneSalesRep) {
+      discard = new String[] { "replyTo", "replyTo_bottomMargin" };
+    } else {
+      discard = new String[] { "multipleCustomer", "multipleCustomer_bottomMargin" };
+    }
+
+    if (differentDocTypesCount > 1) {
+      return appendDiscard(discard, "discardSelect");
+    }
+    if (attachedContent == null && vars.getMultiFile("inpFile") == null) {
+      return appendDiscard(discard, "view");
+    }
+    return discard;
+  }
+
+  static boolean hasSingleAttachmentDoc(Map<String, Report> reports) {
+    return reports.size() == 1;
+  }
+
+  private static String[] appendDiscard(String[] discard, String value) {
+    String[] discardAux = new String[discard.length + 1];
+    System.arraycopy(discard, 0, discardAux, 0, discard.length);
+    discardAux[discard.length] = value;
+    return discardAux;
+  }
+}

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerHookSupport.java
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerHookSupport.java
@@ -1,0 +1,52 @@
+package org.openbravo.erpCommon.utility.reporting.printing; //NOSONAR
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+import org.openbravo.base.exception.OBException;
+import org.openbravo.common.hooks.PrintControllerHookManager;
+import org.openbravo.erpCommon.utility.OBMessageUtils;
+import org.openbravo.erpCommon.utility.reporting.DocumentType;
+
+@SuppressWarnings("java:S00120")
+final class PrintControllerHookSupport {
+  private static final String DOCUMENT_ID = "documentId";
+  private static final String DOCUMENT_TYPE = "documentType";
+  private static final String REPORT_INPUT_STREAM = "reportInputStream";
+  private static final String REPORT_OUTPUT_STREAM = "reportOutputStream";
+
+  private PrintControllerHookSupport() {
+  }
+
+  static void setPostHookParams(DocumentType documentType, JSONObject jsonParams, String documentId,
+      InputStream reportInputStream, OutputStream reportOutputStream)
+      throws PrintControllerHookManager.PrintControllerHookException {
+    try {
+      jsonParams.put(DOCUMENT_ID, documentId);
+      jsonParams.put(DOCUMENT_TYPE, documentType);
+      jsonParams.put(REPORT_INPUT_STREAM, reportInputStream);
+      jsonParams.put(REPORT_OUTPUT_STREAM, reportOutputStream);
+    } catch (JSONException exception) {
+      throw new PrintControllerHookManager.PrintControllerHookException(exception.getMessage());
+    }
+  }
+
+  static void setPreHookParams(DocumentType documentType, JSONObject jsonParams,
+      String documentId) throws JSONException {
+    jsonParams.put(DOCUMENT_ID, documentId);
+    jsonParams.put(DOCUMENT_TYPE, documentType);
+  }
+
+  static void executePreProcessHooks(PrintControllerHookManager hookManager, JSONObject jsonParams)
+      throws JSONException {
+    try {
+      hookManager.executeHooks(jsonParams, hookManager.getPreProcess());
+    } catch (PrintControllerHookManager.PrintControllerHookException exception) {
+      throw new OBException(String.format(OBMessageUtils.messageBD(
+          PrintController.ERROR_PRINTING_DOCUMENT_KEY), PrintController.LIST_ITEM_TAG
+          + exception.getMessage() + PrintController.CLOSE_LIST_ITEM_TAG));
+    }
+  }
+}

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerJsonHelper.java
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerJsonHelper.java
@@ -1,0 +1,102 @@
+package org.openbravo.erpCommon.utility.reporting.printing; //NOSONAR
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+import org.openbravo.base.secureApp.VariablesSecureApp;
+import org.openbravo.model.ad.access.User;
+
+@SuppressWarnings("java:S00120")
+final class PrintControllerJsonHelper {
+  private static final Logger log = LogManager.getLogger();
+  private static final String JSON_KEY_ERROR = "error";
+
+  private PrintControllerJsonHelper() {
+  }
+
+  static JSONObject buildBPContactsJson(VariablesSecureApp vars, PocData[] pocData) {
+    JSONObject result = new JSONObject();
+    try {
+      JSONArray contacts = new JSONArray();
+      if (isMultiCustomer(pocData)) {
+        List<String> seenEmails = new ArrayList<>();
+        for (PocData doc : pocData) {
+          if (StringUtils.isBlank(doc.contactEmail) || seenEmails.contains(doc.contactEmail)) {
+            continue;
+          }
+          seenEmails.add(doc.contactEmail);
+          JSONObject json = new JSONObject();
+          json.put("contactId", StringUtils.defaultString(doc.contactUserId));
+          json.put("name", StringUtils.defaultString(doc.contactName));
+          json.put("email", doc.contactEmail);
+          json.put("isDefault", false);
+          json.put("isActive", true);
+          contacts.put(json);
+        }
+      } else {
+        String bpartnerId = pocData != null && pocData.length > 0
+            ? pocData[0].bpartnerId
+            : vars.getStringParameter("bpartnerId");
+        List<User> bpContacts = BPContactEmailSelector.getBPContactsWithEmail(bpartnerId);
+        if (bpContacts != null) {
+          for (User contact : bpContacts) {
+            contacts.put(buildContactJson(contact));
+          }
+        }
+      }
+      result.put("contacts", contacts);
+    } catch (Exception exception) {
+      log.error("Error building BP contacts JSON", exception);
+      result = buildErrorJson();
+    }
+    return result;
+  }
+
+  static JSONObject buildErrorJson() {
+    JSONObject error = new JSONObject();
+    try {
+      error.put(JSON_KEY_ERROR, true);
+    } catch (JSONException ignored) {
+      // No-op: an empty JSON object is still a valid fallback response.
+    }
+    return error;
+  }
+
+  static void writeJsonResponse(HttpServletResponse response, JSONObject json) throws IOException {
+    response.setContentType(PrintController.CONTENT_TYPE_JSON);
+    response.setCharacterEncoding("UTF-8");
+    response.getWriter().write(json.toString());
+  }
+
+  private static boolean isMultiCustomer(PocData[] pocData) {
+    if (pocData == null || pocData.length <= 1) {
+      return false;
+    }
+    String businessPartnerId = pocData[0].bpartnerId;
+    for (PocData data : pocData) {
+      if (!businessPartnerId.equals(data.bpartnerId)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static JSONObject buildContactJson(User contact) throws JSONException {
+    JSONObject contactJson = new JSONObject();
+    contactJson.put("id", contact.getId());
+    contactJson.put("name", contact.getName());
+    contactJson.put("email", contact.getEmail());
+    contactJson.put("isDefault", false);
+    contactJson.put("isActive", contact.isActive());
+    return contactJson;
+  }
+}

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerPreferenceHelper.java
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerPreferenceHelper.java
@@ -1,0 +1,37 @@
+package org.openbravo.erpCommon.utility.reporting.printing; //NOSONAR
+
+import org.openbravo.base.secureApp.VariablesSecureApp;
+import org.openbravo.dal.core.OBContext;
+import org.openbravo.dal.service.OBDal;
+import org.openbravo.erpCommon.businessUtility.Preferences;
+import org.openbravo.erpCommon.utility.PropertyException;
+import org.openbravo.model.ad.ui.Tab;
+
+@SuppressWarnings("java:S00120")
+final class PrintControllerPreferenceHelper {
+  private PrintControllerPreferenceHelper() {
+  }
+
+  static boolean isDirectPrint(VariablesSecureApp vars) {
+    OBContext context = OBContext.getOBContext();
+    String preferenceValue = "";
+    try {
+      OBContext.setAdminMode(true);
+      String tabId = vars.getSessionValue(PrintController.INP_TAB_ID);
+      Tab tab = OBDal.getInstance().get(Tab.class, tabId);
+      if (tab == null) {
+        return false;
+      }
+      try {
+        preferenceValue = Preferences.getPreferenceValue("DirectPrint", true,
+            context.getCurrentClient(), context.getCurrentOrganization(), context.getUser(),
+            context.getRole(), tab.getWindow());
+      } catch (PropertyException exception) {
+        return false;
+      }
+    } finally {
+      OBContext.restorePreviousMode();
+    }
+    return Preferences.YES.equals(preferenceValue);
+  }
+}

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerRequestResolver.java
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerRequestResolver.java
@@ -1,0 +1,56 @@
+package org.openbravo.erpCommon.utility.reporting.printing; //NOSONAR
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+
+import org.openbravo.base.secureApp.VariablesSecureApp;
+import org.openbravo.erpCommon.utility.reporting.DocumentType;
+
+@SuppressWarnings("java:S00120")
+final class PrintControllerRequestResolver {
+  private PrintControllerRequestResolver() {
+  }
+
+  static RequestContext resolve(HttpServletRequest request, VariablesSecureApp vars)
+      throws ServletException {
+    String servletPath = request.getServletPath().toLowerCase();
+    if (servletPath.indexOf("quotations") != -1) {
+      return buildContext(vars, DocumentType.QUOTATION, "PRINTQUOTATIONS", ".inpcOrderId");
+    }
+    if (servletPath.indexOf("orders") != -1) {
+      return buildContext(vars, DocumentType.SALESORDER, "PRINTORDERS", ".inpcOrderId");
+    }
+    if (servletPath.indexOf("invoices") != -1) {
+      return buildContext(vars, DocumentType.SALESINVOICE, "PRINTINVOICES",
+          ".inpcInvoiceId");
+    }
+    if (servletPath.indexOf("shipments") != -1) {
+      return buildContext(vars, DocumentType.SHIPMENT, "PRINTSHIPMENTS", ".inpmInoutId");
+    }
+    if (servletPath.indexOf("payments") != -1) {
+      return buildContext(vars, DocumentType.PAYMENT, "PRINTPAYMENT", ".inpfinPaymentId");
+    }
+    return new RequestContext(DocumentType.UNKNOWN, null, null);
+  }
+
+  private static RequestContext buildContext(VariablesSecureApp vars, DocumentType documentType,
+      String sessionValuePrefix, String parameterSuffix) {
+    String documentId = vars.getSessionValue(sessionValuePrefix + parameterSuffix + "_R");
+    if ("".equals(documentId)) {
+      documentId = vars.getSessionValue(sessionValuePrefix + parameterSuffix);
+    }
+    return new RequestContext(documentType, sessionValuePrefix, documentId);
+  }
+
+  static final class RequestContext {
+    final DocumentType documentType;
+    final String sessionValuePrefix;
+    final String documentId;
+
+    RequestContext(DocumentType documentType, String sessionValuePrefix, String documentId) {
+      this.documentType = documentType;
+      this.sessionValuePrefix = sessionValuePrefix;
+      this.documentId = documentId;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Fix `TypeError` when sending emails to multiple customers (different BPs)
- Restore `To` field in multi-customer flow with read-only mode and toggleable contact selector
- Fix `windowTables is not defined` JS console error
- Add sending overlay to prevent interaction while emails are dispatched
- Hide popup chrome (nav bar + gear icon) that reappeared on second open
- Hide contact name label (`toName`) when multiple customers are selected

## Changes

**`PrintController.java`**
- Extract `SESSION_POC_DATA` constant (fixes existing Sonar S1192)
- `GET_BP_CONTACTS` handler now passes `pocData[]` from session to `buildBPContactsJson`
- `buildBPContactsJson`: in multi-customer mode reads contacts from `pocData` session data directly (bypasses `AD_User` query, which misses contacts whose email comes from invoice data); in single-customer mode keeps existing `BPContactEmailSelector` query
- `isMultiCustomer()` helper: detects multiple distinct recipient emails in `pocData`
- `toName` set to empty when `numberOfCustomers > 1`
- `getHiddenTags`: stop discarding `to`/`to_bottomMargin` in multi-customer mode (restores `To` field)

**`EmailOptions.html`**
- Fix `this.windowTables` → `windowTables` (global var expected by `windowKeyboard.js`)
- Multi-customer mode detected via `multipleCustomer` element presence; `toEmail` set to `readOnly`
- `renderContactList`: marks already-selected contacts with blue background + ✓ checkmark
- `selectContact`: toggle behavior in multi-customer mode (add/remove without closing panel); original close-on-select kept for single-customer
- `validateAndSendEmail`: shows `#sendingOverlay` before submit
- `#sendingOverlay` div: fixed-position grey overlay with "Sending…" message
- `Popup_ContentPane_CircleLogo`, `Popup_ContentPane_NavBar` row, and `Popup_ContentPane_SeparatorBar` row hidden via `display:none`

## Test plan

- [ ] Select **multiple invoices from different customers** → popup opens, `To` field pre-filled, read-only
- [ ] Open contact selector → all customer contacts listed, already-added ones marked with ✓
- [ ] Toggle contacts on/off → `To` field updates correctly
- [ ] Click Send → grey overlay appears, no interaction possible while sending
- [ ] Select **single invoice** → popup opens normally, `To` field editable, contact name shown
- [ ] Close and reopen popup → no dark header bar, no gear icon floating in corner
- [ ] No `windowTables is not defined` error in browser console