### PR TITLE
Feature ETP-4216: Allow alternative email senders without SMTP configuration

### DIFF
--- a/src-test/src/com/etendoerp/email/spi/DefaultSmtpEmailSenderTest.java
+++ b/src-test/src/com/etendoerp/email/spi/DefaultSmtpEmailSenderTest.java
@@ -19,34 +19,24 @@ package com.etendoerp.email.spi;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
-
-import java.util.concurrent.TimeUnit;
 
 import javax.servlet.ServletException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.openbravo.email.ResolvedSmtpConfig;
 import org.openbravo.erpCommon.utility.poc.EmailInfo;
-import org.openbravo.erpCommon.utility.poc.EmailManager;
-import org.openbravo.model.common.enterprise.EmailServerConfiguration;
-import org.openbravo.utils.FormatUtilities;
 
 /**
  * Unit tests for {@link DefaultSmtpEmailSender}: baseline contract (always configured,
- * floor priority), SMTP configuration validation and delegation to the low-level SMTP
- * transport in {@link EmailManager}.
+ * floor priority) and SMTP configuration validation. The delegation to the low-level SMTP
+ * transport is covered in {@code EmailManagerTest}, which lives in the same package as the
+ * protected legacy transport.
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -55,16 +45,8 @@ public class DefaultSmtpEmailSenderTest {
   private static final String SMTP_HOST = "smtp.example.com";
   private static final int SMTP_PORT = 587;
   private static final String FROM_ADDRESS = "noreply@example.com";
-  private static final String FROM_NAME = "Sender Name";
   private static final String RECIPIENT_TO = "recipient@example.com";
-  private static final String ENCRYPTED_PASSWORD = "encryptedPwd";
-  private static final String DECRYPTED_PASSWORD = "decryptedPwd";
-  private static final String SMTP_ACCOUNT = "account";
-  private static final String SECURITY = "STARTTLS";
   private static final String CONFIG_ID = "CONFIG-001";
-  private static final Long TIMEOUT_SECONDS = 600L;
-  private static final String SUBJECT = "Subject";
-  private static final String CONTENT = "Content";
 
   private final DefaultSmtpEmailSender sender = new DefaultSmtpEmailSender();
 
@@ -121,119 +103,11 @@ public class DefaultSmtpEmailSenderTest {
     assertTrue(thrown.getMessage().contains("SMTP From Address"));
   }
 
-  /**
-   * Verifies that sending with a complete resolved configuration decrypts the password and
-   * delegates to the low-level SMTP transport with the configured values and the timeout
-   * converted from seconds to milliseconds.
-   * @throws Exception never expected in this test
-   */
-  @Test
-  void testSendWithResolvedConfigDelegatesToSmtpTransport() throws Exception {
-    ResolvedSmtpConfig conf = mockResolvedConfig(SMTP_HOST, FROM_ADDRESS);
-    EmailSendContext context = contextWithResolvedConfig(conf);
-
-    try (MockedStatic<EmailManager> mockedManager = mockStatic(EmailManager.class)) {
-      mockedManager.when(() -> EmailManager.safeDecrypt(ENCRYPTED_PASSWORD))
-          .thenReturn(DECRYPTED_PASSWORD);
-
-      sender.send(context);
-
-      int expectedTimeoutMillis = (int) TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS);
-      mockedManager.verify(() -> EmailManager.sendEmail(
-          eq(SMTP_HOST), eq(true), eq(SMTP_ACCOUNT), eq(DECRYPTED_PASSWORD),
-          eq(SECURITY), eq(SMTP_PORT), eq(FROM_ADDRESS), eq(FROM_NAME),
-          eq(RECIPIENT_TO), isNull(), isNull(), isNull(),
-          eq(SUBJECT), eq(CONTENT), isNull(),
-          anyList(), isNull(), anyList(),
-          eq(expectedTimeoutMillis)));
-    }
-  }
-
-  /**
-   * Verifies that sending with an {@link EmailServerConfiguration} record decrypts the
-   * stored password and delegates to the low-level SMTP transport.
-   * @throws Exception never expected in this test
-   */
-  @Test
-  void testSendWithServerConfigDelegatesToSmtpTransport() throws Exception {
-    EmailServerConfiguration conf = mock(EmailServerConfiguration.class);
-    when(conf.getSmtpServer()).thenReturn(SMTP_HOST);
-    when(conf.isSMTPAuthentification()).thenReturn(true);
-    when(conf.getSmtpServerAccount()).thenReturn(SMTP_ACCOUNT);
-    when(conf.getSmtpServerPassword()).thenReturn(ENCRYPTED_PASSWORD);
-    when(conf.getSmtpConnectionSecurity()).thenReturn(SECURITY);
-    when(conf.getSmtpPort()).thenReturn((long) SMTP_PORT);
-    when(conf.getSmtpServerSenderAddress()).thenReturn(FROM_ADDRESS);
-    when(conf.getFromName()).thenReturn(FROM_NAME);
-    when(conf.getSmtpConnectionTimeout()).thenReturn(TIMEOUT_SECONDS);
-
-    EmailSendContext context = new EmailSendContext.Builder()
-        .setSmtpConfig(conf)
-        .setEmail(buildEmail())
-        .build();
-
-    try (MockedStatic<FormatUtilities> mockedFormat = mockStatic(FormatUtilities.class);
-         MockedStatic<EmailManager> mockedManager = mockStatic(EmailManager.class)) {
-      mockedFormat.when(() -> FormatUtilities.encryptDecrypt(ENCRYPTED_PASSWORD, false))
-          .thenReturn(DECRYPTED_PASSWORD);
-      mockedManager.when(() -> EmailManager.getSmtpConnectionTimeout(conf))
-          .thenReturn(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
-
-      sender.send(context);
-
-      int expectedTimeoutMillis = (int) TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS);
-      mockedManager.verify(() -> EmailManager.sendEmail(
-          eq(SMTP_HOST), eq(true), eq(SMTP_ACCOUNT), eq(DECRYPTED_PASSWORD),
-          eq(SECURITY), eq(SMTP_PORT), eq(FROM_ADDRESS), eq(FROM_NAME),
-          eq(RECIPIENT_TO), isNull(), isNull(), isNull(),
-          eq(SUBJECT), eq(CONTENT), isNull(),
-          anyList(), isNull(), anyList(),
-          eq(expectedTimeoutMillis)));
-    }
-  }
-
-  /**
-   * Verifies that the resolved configuration path is preferred when the context carries
-   * both configuration flavors.
-   * @throws Exception never expected in this test
-   */
-  @Test
-  void testSendPrefersResolvedConfigWhenBothPresent() throws Exception {
-    ResolvedSmtpConfig resolved = mockResolvedConfig(SMTP_HOST, FROM_ADDRESS);
-    EmailServerConfiguration record = mock(EmailServerConfiguration.class);
-    EmailSendContext context = new EmailSendContext.Builder()
-        .setSmtpConfig(record)
-        .setResolvedSmtpConfig(resolved)
-        .setEmail(buildEmail())
-        .build();
-
-    try (MockedStatic<EmailManager> mockedManager = mockStatic(EmailManager.class)) {
-      mockedManager.when(() -> EmailManager.safeDecrypt(any())).thenReturn(DECRYPTED_PASSWORD);
-
-      sender.send(context);
-
-      mockedManager.verify(() -> EmailManager.sendEmail(
-          eq(SMTP_HOST), eq(true), eq(SMTP_ACCOUNT), eq(DECRYPTED_PASSWORD),
-          eq(SECURITY), eq(SMTP_PORT), eq(FROM_ADDRESS), eq(FROM_NAME),
-          eq(RECIPIENT_TO), isNull(), isNull(), isNull(),
-          eq(SUBJECT), eq(CONTENT), isNull(),
-          anyList(), isNull(), anyList(),
-          eq((int) TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS))));
-    }
-  }
-
   private ResolvedSmtpConfig mockResolvedConfig(String host, String fromAddress) {
     ResolvedSmtpConfig conf = mock(ResolvedSmtpConfig.class);
     when(conf.getHost()).thenReturn(host);
     when(conf.getPort()).thenReturn(SMTP_PORT);
-    when(conf.getConnectionSecurity()).thenReturn(SECURITY);
-    when(conf.isAuth()).thenReturn(true);
-    when(conf.getAccount()).thenReturn(SMTP_ACCOUNT);
-    when(conf.getPassword()).thenReturn(ENCRYPTED_PASSWORD);
     when(conf.getFromAddress()).thenReturn(fromAddress);
-    when(conf.getFromName()).thenReturn(FROM_NAME);
-    when(conf.getReplyTo()).thenReturn(null);
-    when(conf.getTimeoutSeconds()).thenReturn(TIMEOUT_SECONDS);
     when(conf.getLevel()).thenReturn(ResolvedSmtpConfig.Level.CLIENT);
     when(conf.getConfigId()).thenReturn(CONFIG_ID);
     return conf;
@@ -242,15 +116,7 @@ public class DefaultSmtpEmailSenderTest {
   private EmailSendContext contextWithResolvedConfig(ResolvedSmtpConfig conf) {
     return new EmailSendContext.Builder()
         .setResolvedSmtpConfig(conf)
-        .setEmail(buildEmail())
-        .build();
-  }
-
-  private EmailInfo buildEmail() {
-    return new EmailInfo.Builder()
-        .setRecipientTO(RECIPIENT_TO)
-        .setSubject(SUBJECT)
-        .setContent(CONTENT)
+        .setEmail(new EmailInfo.Builder().setRecipientTO(RECIPIENT_TO).build())
         .build();
   }
 }

--- a/src-test/src/com/etendoerp/email/spi/DefaultSmtpEmailSenderTest.java
+++ b/src-test/src/com/etendoerp/email/spi/DefaultSmtpEmailSenderTest.java
@@ -1,0 +1,256 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+package com.etendoerp.email.spi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.servlet.ServletException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openbravo.email.ResolvedSmtpConfig;
+import org.openbravo.erpCommon.utility.poc.EmailInfo;
+import org.openbravo.erpCommon.utility.poc.EmailManager;
+import org.openbravo.model.common.enterprise.EmailServerConfiguration;
+import org.openbravo.utils.FormatUtilities;
+
+/**
+ * Unit tests for {@link DefaultSmtpEmailSender}: baseline contract (always configured,
+ * floor priority), SMTP configuration validation and delegation to the low-level SMTP
+ * transport in {@link EmailManager}.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class DefaultSmtpEmailSenderTest {
+
+  private static final String SMTP_HOST = "smtp.example.com";
+  private static final int SMTP_PORT = 587;
+  private static final String FROM_ADDRESS = "noreply@example.com";
+  private static final String FROM_NAME = "Sender Name";
+  private static final String RECIPIENT_TO = "recipient@example.com";
+  private static final String ENCRYPTED_PASSWORD = "encryptedPwd";
+  private static final String DECRYPTED_PASSWORD = "decryptedPwd";
+  private static final String SMTP_ACCOUNT = "account";
+  private static final String SECURITY = "STARTTLS";
+  private static final String CONFIG_ID = "CONFIG-001";
+  private static final Long TIMEOUT_SECONDS = 600L;
+  private static final String SUBJECT = "Subject";
+  private static final String CONTENT = "Content";
+
+  private final DefaultSmtpEmailSender sender = new DefaultSmtpEmailSender();
+
+  /**
+   * Verifies the baseline contract: the default sender is always configured and sits at
+   * the lowest possible priority.
+   */
+  @Test
+  void testBaselineContract() {
+    assertTrue(sender.isConfigured(new EmailSendContext.Builder().build()));
+    assertEquals(Integer.MIN_VALUE, sender.getPriority());
+  }
+
+  /**
+   * Verifies that sending with a context carrying no SMTP configuration at all fails with
+   * a configuration error instead of attempting any transport.
+   */
+  @Test
+  void testSendWithoutAnyConfigThrowsServletException() {
+    EmailSendContext context = new EmailSendContext.Builder()
+        .setEmail(new EmailInfo.Builder().setRecipientTO(RECIPIENT_TO).build())
+        .build();
+
+    ServletException thrown = assertThrows(ServletException.class, () -> sender.send(context));
+
+    assertTrue(thrown.getMessage().contains("No email configuration available"));
+  }
+
+  /**
+   * Verifies that a resolved configuration missing the SMTP host is rejected with the same
+   * error message previously raised by {@code EmailManager}.
+   */
+  @Test
+  void testSendWithResolvedConfigMissingHostThrowsServletException() {
+    ResolvedSmtpConfig conf = mockResolvedConfig("  ", FROM_ADDRESS);
+    EmailSendContext context = contextWithResolvedConfig(conf);
+
+    ServletException thrown = assertThrows(ServletException.class, () -> sender.send(context));
+
+    assertTrue(thrown.getMessage().contains("SMTP Host is not configured"));
+  }
+
+  /**
+   * Verifies that a resolved configuration missing the From Address is rejected with the
+   * same error message previously raised by {@code EmailManager}.
+   */
+  @Test
+  void testSendWithResolvedConfigMissingFromAddressThrowsServletException() {
+    ResolvedSmtpConfig conf = mockResolvedConfig(SMTP_HOST, null);
+    EmailSendContext context = contextWithResolvedConfig(conf);
+
+    ServletException thrown = assertThrows(ServletException.class, () -> sender.send(context));
+
+    assertTrue(thrown.getMessage().contains("SMTP From Address"));
+  }
+
+  /**
+   * Verifies that sending with a complete resolved configuration decrypts the password and
+   * delegates to the low-level SMTP transport with the configured values and the timeout
+   * converted from seconds to milliseconds.
+   * @throws Exception never expected in this test
+   */
+  @Test
+  void testSendWithResolvedConfigDelegatesToSmtpTransport() throws Exception {
+    ResolvedSmtpConfig conf = mockResolvedConfig(SMTP_HOST, FROM_ADDRESS);
+    EmailSendContext context = contextWithResolvedConfig(conf);
+
+    try (MockedStatic<EmailManager> mockedManager = mockStatic(EmailManager.class)) {
+      mockedManager.when(() -> EmailManager.safeDecrypt(ENCRYPTED_PASSWORD))
+          .thenReturn(DECRYPTED_PASSWORD);
+
+      sender.send(context);
+
+      int expectedTimeoutMillis = (int) TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS);
+      mockedManager.verify(() -> EmailManager.sendEmail(
+          eq(SMTP_HOST), eq(true), eq(SMTP_ACCOUNT), eq(DECRYPTED_PASSWORD),
+          eq(SECURITY), eq(SMTP_PORT), eq(FROM_ADDRESS), eq(FROM_NAME),
+          eq(RECIPIENT_TO), isNull(), isNull(), isNull(),
+          eq(SUBJECT), eq(CONTENT), isNull(),
+          anyList(), isNull(), anyList(),
+          eq(expectedTimeoutMillis)));
+    }
+  }
+
+  /**
+   * Verifies that sending with an {@link EmailServerConfiguration} record decrypts the
+   * stored password and delegates to the low-level SMTP transport.
+   * @throws Exception never expected in this test
+   */
+  @Test
+  void testSendWithServerConfigDelegatesToSmtpTransport() throws Exception {
+    EmailServerConfiguration conf = mock(EmailServerConfiguration.class);
+    when(conf.getSmtpServer()).thenReturn(SMTP_HOST);
+    when(conf.isSMTPAuthentification()).thenReturn(true);
+    when(conf.getSmtpServerAccount()).thenReturn(SMTP_ACCOUNT);
+    when(conf.getSmtpServerPassword()).thenReturn(ENCRYPTED_PASSWORD);
+    when(conf.getSmtpConnectionSecurity()).thenReturn(SECURITY);
+    when(conf.getSmtpPort()).thenReturn((long) SMTP_PORT);
+    when(conf.getSmtpServerSenderAddress()).thenReturn(FROM_ADDRESS);
+    when(conf.getFromName()).thenReturn(FROM_NAME);
+    when(conf.getSmtpConnectionTimeout()).thenReturn(TIMEOUT_SECONDS);
+
+    EmailSendContext context = new EmailSendContext.Builder()
+        .setSmtpConfig(conf)
+        .setEmail(buildEmail())
+        .build();
+
+    try (MockedStatic<FormatUtilities> mockedFormat = mockStatic(FormatUtilities.class);
+         MockedStatic<EmailManager> mockedManager = mockStatic(EmailManager.class)) {
+      mockedFormat.when(() -> FormatUtilities.encryptDecrypt(ENCRYPTED_PASSWORD, false))
+          .thenReturn(DECRYPTED_PASSWORD);
+      mockedManager.when(() -> EmailManager.getSmtpConnectionTimeout(conf))
+          .thenReturn(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+
+      sender.send(context);
+
+      int expectedTimeoutMillis = (int) TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS);
+      mockedManager.verify(() -> EmailManager.sendEmail(
+          eq(SMTP_HOST), eq(true), eq(SMTP_ACCOUNT), eq(DECRYPTED_PASSWORD),
+          eq(SECURITY), eq(SMTP_PORT), eq(FROM_ADDRESS), eq(FROM_NAME),
+          eq(RECIPIENT_TO), isNull(), isNull(), isNull(),
+          eq(SUBJECT), eq(CONTENT), isNull(),
+          anyList(), isNull(), anyList(),
+          eq(expectedTimeoutMillis)));
+    }
+  }
+
+  /**
+   * Verifies that the resolved configuration path is preferred when the context carries
+   * both configuration flavors.
+   * @throws Exception never expected in this test
+   */
+  @Test
+  void testSendPrefersResolvedConfigWhenBothPresent() throws Exception {
+    ResolvedSmtpConfig resolved = mockResolvedConfig(SMTP_HOST, FROM_ADDRESS);
+    EmailServerConfiguration record = mock(EmailServerConfiguration.class);
+    EmailSendContext context = new EmailSendContext.Builder()
+        .setSmtpConfig(record)
+        .setResolvedSmtpConfig(resolved)
+        .setEmail(buildEmail())
+        .build();
+
+    try (MockedStatic<EmailManager> mockedManager = mockStatic(EmailManager.class)) {
+      mockedManager.when(() -> EmailManager.safeDecrypt(any())).thenReturn(DECRYPTED_PASSWORD);
+
+      sender.send(context);
+
+      mockedManager.verify(() -> EmailManager.sendEmail(
+          eq(SMTP_HOST), eq(true), eq(SMTP_ACCOUNT), eq(DECRYPTED_PASSWORD),
+          eq(SECURITY), eq(SMTP_PORT), eq(FROM_ADDRESS), eq(FROM_NAME),
+          eq(RECIPIENT_TO), isNull(), isNull(), isNull(),
+          eq(SUBJECT), eq(CONTENT), isNull(),
+          anyList(), isNull(), anyList(),
+          eq((int) TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS))));
+    }
+  }
+
+  private ResolvedSmtpConfig mockResolvedConfig(String host, String fromAddress) {
+    ResolvedSmtpConfig conf = mock(ResolvedSmtpConfig.class);
+    when(conf.getHost()).thenReturn(host);
+    when(conf.getPort()).thenReturn(SMTP_PORT);
+    when(conf.getConnectionSecurity()).thenReturn(SECURITY);
+    when(conf.isAuth()).thenReturn(true);
+    when(conf.getAccount()).thenReturn(SMTP_ACCOUNT);
+    when(conf.getPassword()).thenReturn(ENCRYPTED_PASSWORD);
+    when(conf.getFromAddress()).thenReturn(fromAddress);
+    when(conf.getFromName()).thenReturn(FROM_NAME);
+    when(conf.getReplyTo()).thenReturn(null);
+    when(conf.getTimeoutSeconds()).thenReturn(TIMEOUT_SECONDS);
+    when(conf.getLevel()).thenReturn(ResolvedSmtpConfig.Level.CLIENT);
+    when(conf.getConfigId()).thenReturn(CONFIG_ID);
+    return conf;
+  }
+
+  private EmailSendContext contextWithResolvedConfig(ResolvedSmtpConfig conf) {
+    return new EmailSendContext.Builder()
+        .setResolvedSmtpConfig(conf)
+        .setEmail(buildEmail())
+        .build();
+  }
+
+  private EmailInfo buildEmail() {
+    return new EmailInfo.Builder()
+        .setRecipientTO(RECIPIENT_TO)
+        .setSubject(SUBJECT)
+        .setContent(CONTENT)
+        .build();
+  }
+}

--- a/src-test/src/com/etendoerp/email/spi/EmailSendContextTest.java
+++ b/src-test/src/com/etendoerp/email/spi/EmailSendContextTest.java
@@ -1,0 +1,133 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+package com.etendoerp.email.spi;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openbravo.dal.core.OBContext;
+import org.openbravo.email.ResolvedSmtpConfig;
+import org.openbravo.erpCommon.utility.poc.EmailInfo;
+import org.openbravo.model.ad.system.Client;
+import org.openbravo.model.common.enterprise.EmailServerConfiguration;
+import org.openbravo.model.common.enterprise.Organization;
+
+/**
+ * Unit tests for {@link EmailSendContext}: builder population and the
+ * {@link EmailSendContext#create} factory, which must populate client/organization from the
+ * current {@link OBContext} and tolerate its absence or failure.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class EmailSendContextTest {
+
+  /**
+   * Verifies that the builder carries every field as provided.
+   */
+  @Test
+  void testBuilderPopulatesAllFields() {
+    Client client = mock(Client.class);
+    Organization organization = mock(Organization.class);
+    EmailServerConfiguration smtpConfig = mock(EmailServerConfiguration.class);
+    ResolvedSmtpConfig resolvedConfig = mock(ResolvedSmtpConfig.class);
+    EmailInfo email = new EmailInfo.Builder().build();
+
+    EmailSendContext context = new EmailSendContext.Builder()
+        .setClient(client)
+        .setOrganization(organization)
+        .setSmtpConfig(smtpConfig)
+        .setResolvedSmtpConfig(resolvedConfig)
+        .setEmail(email)
+        .build();
+
+    assertSame(client, context.getClient());
+    assertSame(organization, context.getOrganization());
+    assertSame(smtpConfig, context.getSmtpConfig());
+    assertSame(resolvedConfig, context.getResolvedSmtpConfig());
+    assertSame(email, context.getEmail());
+  }
+
+  /**
+   * Verifies that {@link EmailSendContext#create} populates client and organization from
+   * the current {@link OBContext} together with the provided configuration and email.
+   */
+  @Test
+  void testCreatePopulatesClientAndOrganizationFromOBContext() {
+    Client client = mock(Client.class);
+    Organization organization = mock(Organization.class);
+    OBContext obContext = mock(OBContext.class);
+    when(obContext.getCurrentClient()).thenReturn(client);
+    when(obContext.getCurrentOrganization()).thenReturn(organization);
+    ResolvedSmtpConfig resolvedConfig = mock(ResolvedSmtpConfig.class);
+    EmailInfo email = new EmailInfo.Builder().build();
+
+    try (MockedStatic<OBContext> mockedOBContext = mockStatic(OBContext.class)) {
+      mockedOBContext.when(OBContext::getOBContext).thenReturn(obContext);
+
+      EmailSendContext context = EmailSendContext.create(null, resolvedConfig, email);
+
+      assertSame(client, context.getClient());
+      assertSame(organization, context.getOrganization());
+      assertNull(context.getSmtpConfig());
+      assertSame(resolvedConfig, context.getResolvedSmtpConfig());
+      assertSame(email, context.getEmail());
+    }
+  }
+
+  /**
+   * Verifies that {@link EmailSendContext#create} leaves client and organization empty when
+   * no {@link OBContext} is available (e.g. background threads), instead of failing.
+   */
+  @Test
+  void testCreateToleratesMissingOBContext() {
+    try (MockedStatic<OBContext> mockedOBContext = mockStatic(OBContext.class)) {
+      mockedOBContext.when(OBContext::getOBContext).thenReturn(null);
+
+      EmailSendContext context = EmailSendContext.create(null, null, null);
+
+      assertNull(context.getClient());
+      assertNull(context.getOrganization());
+    }
+  }
+
+  /**
+   * Verifies that {@link EmailSendContext#create} treats a failure reading the
+   * {@link OBContext} as missing context information instead of propagating the error,
+   * so context building can never break a send.
+   */
+  @Test
+  void testCreateToleratesOBContextFailure() {
+    try (MockedStatic<OBContext> mockedOBContext = mockStatic(OBContext.class)) {
+      mockedOBContext.when(OBContext::getOBContext)
+          .thenThrow(new IllegalStateException("context unavailable"));
+
+      EmailSendContext context = EmailSendContext.create(null, null, null);
+
+      assertNull(context.getClient());
+      assertNull(context.getOrganization());
+    }
+  }
+}

--- a/src-test/src/com/etendoerp/email/spi/EmailSenderDispatcherTest.java
+++ b/src-test/src/com/etendoerp/email/spi/EmailSenderDispatcherTest.java
@@ -1,0 +1,286 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+package com.etendoerp.email.spi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import javax.servlet.ServletException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openbravo.base.weld.WeldUtils;
+
+/**
+ * Unit tests for {@link EmailSenderDispatcher}: candidate ordering by priority,
+ * configuration-based filtering, guaranteed fallback to the default SMTP sender and
+ * propagation of send failures.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class EmailSenderDispatcherTest {
+
+  /**
+   * Configurable fake sender used to drive the selection logic in tests.
+   */
+  private static class FakeSender implements EmailSender {
+    private final int priority;
+    private final boolean configured;
+    private boolean sendInvoked = false;
+
+    FakeSender(int priority, boolean configured) {
+      this.priority = priority;
+      this.configured = configured;
+    }
+
+    @Override
+    public boolean isConfigured(EmailSendContext context) {
+      return configured;
+    }
+
+    @Override
+    public void send(EmailSendContext context) {
+      sendInvoked = true;
+    }
+
+    @Override
+    public int getPriority() {
+      return priority;
+    }
+  }
+
+  private static EmailSendContext emptyContext() {
+    return new EmailSendContext.Builder().build();
+  }
+
+  /**
+   * Verifies the {@link EmailSender} interface contract: implementations that do not
+   * override {@code getPriority} sit at the neutral priority {@code 0}, above the default
+   * SMTP sender's floor.
+   */
+  @Test
+  void testEmailSenderDefaultPriorityIsZero() {
+    EmailSender minimal = new EmailSender() {
+      @Override
+      public boolean isConfigured(EmailSendContext context) {
+        return true;
+      }
+
+      @Override
+      public void send(EmailSendContext context) {
+      }
+    };
+
+    assertEquals(0, minimal.getPriority());
+  }
+
+  /**
+   * Verifies that the highest-priority configured sender is selected among multiple
+   * candidates, including the default SMTP sender at the floor.
+   */
+  @Test
+  void testSelectSenderPicksHighestPriorityConfigured() {
+    FakeSender low = new FakeSender(10, true);
+    FakeSender high = new FakeSender(100, true);
+    List<EmailSender> candidates = Arrays.asList(low, new DefaultSmtpEmailSender(), high);
+
+    EmailSender selected = EmailSenderDispatcher.selectSender(candidates, emptyContext());
+
+    assertSame(high, selected);
+  }
+
+  /**
+   * Verifies that a higher-priority sender that is not configured is skipped in favor of
+   * the next configured candidate.
+   */
+  @Test
+  void testSelectSenderSkipsUnconfiguredSender() {
+    FakeSender notConfigured = new FakeSender(100, false);
+    FakeSender configured = new FakeSender(10, true);
+    List<EmailSender> candidates = Arrays.asList(notConfigured, configured);
+
+    EmailSender selected = EmailSenderDispatcher.selectSender(candidates, emptyContext());
+
+    assertSame(configured, selected);
+  }
+
+  /**
+   * Verifies that the default SMTP sender is selected when no alternative sender is
+   * configured, since it always reports itself as configured at the priority floor.
+   */
+  @Test
+  void testSelectSenderFallsBackToDefaultWhenNoAlternativeConfigured() {
+    FakeSender notConfigured = new FakeSender(100, false);
+    DefaultSmtpEmailSender defaultSender = new DefaultSmtpEmailSender();
+    List<EmailSender> candidates = Arrays.asList(notConfigured, defaultSender);
+
+    EmailSender selected = EmailSenderDispatcher.selectSender(candidates, emptyContext());
+
+    assertSame(defaultSender, selected);
+  }
+
+  /**
+   * Verifies that selection never returns {@code null}: with an empty candidate list (e.g.
+   * CDI unavailable) a default SMTP sender instance is created as fallback.
+   */
+  @Test
+  void testSelectSenderReturnsDefaultOnEmptyCandidates() {
+    EmailSender selected = EmailSenderDispatcher.selectSender(Collections.emptyList(),
+        emptyContext());
+
+    assertInstanceOf(DefaultSmtpEmailSender.class, selected);
+  }
+
+  /**
+   * Verifies that a candidate whose {@code isConfigured} throws is treated as not
+   * configured instead of breaking the selection.
+   */
+  @Test
+  void testSelectSenderTreatsIsConfiguredFailureAsNotConfigured() {
+    EmailSender broken = new EmailSender() {
+      @Override
+      public boolean isConfigured(EmailSendContext context) {
+        throw new IllegalStateException("broken capability check");
+      }
+
+      @Override
+      public void send(EmailSendContext context) {
+      }
+
+      @Override
+      public int getPriority() {
+        return 100;
+      }
+    };
+    FakeSender configured = new FakeSender(10, true);
+
+    EmailSender selected = EmailSenderDispatcher.selectSender(Arrays.asList(broken, configured),
+        emptyContext());
+
+    assertSame(configured, selected);
+  }
+
+  /**
+   * Verifies that {@link EmailSenderDispatcher#dispatch(EmailSendContext)} sends through
+   * the highest-priority configured sender discovered via CDI.
+   * @throws Exception never expected in this test
+   */
+  @Test
+  void testDispatchSendsThroughSelectedSender() throws Exception {
+    FakeSender alternative = new FakeSender(100, true);
+    try (MockedStatic<WeldUtils> mockedWeld = mockStatic(WeldUtils.class)) {
+      mockedWeld.when(() -> WeldUtils.getInstances(EmailSender.class))
+          .thenReturn(Arrays.asList(new DefaultSmtpEmailSender(), alternative));
+
+      EmailSenderDispatcher.dispatch(emptyContext());
+
+      assertTrue(alternative.sendInvoked);
+    }
+  }
+
+  /**
+   * Verifies that an exception thrown by the selected sender's {@code send} propagates
+   * unchanged through {@link EmailSenderDispatcher#dispatch(EmailSendContext)}, with no
+   * retry through another sender.
+   */
+  @Test
+  void testDispatchPropagatesSendFailureWithoutRetry() {
+    FakeSender fallbackCandidate = new FakeSender(10, true);
+    EmailSender failing = new EmailSender() {
+      @Override
+      public boolean isConfigured(EmailSendContext context) {
+        return true;
+      }
+
+      @Override
+      public void send(EmailSendContext context) throws Exception {
+        throw new ServletException("transport failure");
+      }
+
+      @Override
+      public int getPriority() {
+        return 100;
+      }
+    };
+    try (MockedStatic<WeldUtils> mockedWeld = mockStatic(WeldUtils.class)) {
+      mockedWeld.when(() -> WeldUtils.getInstances(EmailSender.class))
+          .thenReturn(Arrays.asList(failing, fallbackCandidate));
+
+      ServletException thrown = assertThrows(ServletException.class,
+          () -> EmailSenderDispatcher.dispatch(emptyContext()));
+
+      assertEquals("transport failure", thrown.getMessage());
+      assertFalse(fallbackCandidate.sendInvoked);
+    }
+  }
+
+  /**
+   * Verifies that {@link EmailSenderDispatcher#dispatch(EmailSendContext)} falls back to
+   * the default SMTP behavior when CDI discovery is unavailable: with no SMTP configuration
+   * in the context, the default sender raises a configuration error.
+   */
+  @Test
+  void testDispatchFallsBackToDefaultWhenDiscoveryUnavailable() {
+    try (MockedStatic<WeldUtils> mockedWeld = mockStatic(WeldUtils.class)) {
+      mockedWeld.when(() -> WeldUtils.getInstances(EmailSender.class))
+          .thenThrow(new IllegalStateException("no container"));
+
+      assertThrows(ServletException.class,
+          () -> EmailSenderDispatcher.dispatch(emptyContext()));
+    }
+  }
+
+  /**
+   * Verifies that {@link EmailSenderDispatcher#hasAlternativeSenderConfigured()} returns
+   * {@code true} only when a configured sender other than the default SMTP one exists.
+   */
+  @Test
+  void testHasAlternativeSenderConfigured() {
+    try (MockedStatic<WeldUtils> mockedWeld = mockStatic(WeldUtils.class)) {
+      mockedWeld.when(() -> WeldUtils.getInstances(EmailSender.class))
+          .thenReturn(Arrays.asList(new DefaultSmtpEmailSender(), new FakeSender(100, true)));
+      assertTrue(EmailSenderDispatcher.hasAlternativeSenderConfigured());
+    }
+  }
+
+  /**
+   * Verifies that {@link EmailSenderDispatcher#hasAlternativeSenderConfigured()} returns
+   * {@code false} when the only candidates are the default SMTP sender or unconfigured
+   * alternatives.
+   */
+  @Test
+  void testHasAlternativeSenderConfiguredFalseWhenOnlyDefaultOrUnconfigured() {
+    try (MockedStatic<WeldUtils> mockedWeld = mockStatic(WeldUtils.class)) {
+      mockedWeld.when(() -> WeldUtils.getInstances(EmailSender.class))
+          .thenReturn(Arrays.asList(new DefaultSmtpEmailSender(), new FakeSender(100, false)));
+      assertFalse(EmailSenderDispatcher.hasAlternativeSenderConfigured());
+    }
+  }
+}

--- a/src-test/src/com/etendoerp/email/spi/EmailSenderDispatcherTest.java
+++ b/src-test/src/com/etendoerp/email/spi/EmailSenderDispatcherTest.java
@@ -95,6 +95,7 @@ public class EmailSenderDispatcherTest {
 
       @Override
       public void send(EmailSendContext context) {
+        // intentionally empty: this fake only exercises the selection logic, never the send
       }
     };
 
@@ -172,6 +173,7 @@ public class EmailSenderDispatcherTest {
 
       @Override
       public void send(EmailSendContext context) {
+        // intentionally empty: this fake only exercises the selection logic, never the send
       }
 
       @Override

--- a/src-test/src/org/openbravo/email/EmailEventManagerTest.java
+++ b/src-test/src/org/openbravo/email/EmailEventManagerTest.java
@@ -1,0 +1,125 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+package org.openbravo.email;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+
+import javax.enterprise.inject.Instance;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openbravo.erpCommon.utility.OBMessageUtils;
+
+import com.etendoerp.email.spi.EmailSenderDispatcher;
+
+/**
+ * Unit tests for {@link EmailEventManager}, focused on the SMTP configuration pre-check:
+ * with no SMTP configuration at any level, the send is rejected only when no alternative
+ * {@link com.etendoerp.email.spi.EmailSender} is configured either.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class EmailEventManagerTest {
+
+  private static final String EVENT = "testEvent";
+  private static final String RECIPIENT = "recipient@example.com";
+  private static final String NOT_FOUND_MESSAGE = "Email configuration not found";
+
+  private MockedStatic<SmtpCascadeResolver> mockedResolver;
+  private MockedStatic<EmailSenderDispatcher> mockedDispatcher;
+  private MockedStatic<OBMessageUtils> mockedMessageUtils;
+
+  private EmailEventManager manager;
+
+  /**
+   * Sets up the manager with an empty generator set and the static mocks for the resolver,
+   * the dispatcher and the message utilities.
+   * @throws Exception if reflection-based injection fails
+   */
+  @BeforeEach
+  void setUp() throws Exception {
+    mockedResolver = mockStatic(SmtpCascadeResolver.class);
+    mockedDispatcher = mockStatic(EmailSenderDispatcher.class);
+    mockedMessageUtils = mockStatic(OBMessageUtils.class);
+    mockedMessageUtils.when(() -> OBMessageUtils.getI18NMessage(any(), any()))
+        .thenReturn(NOT_FOUND_MESSAGE);
+
+    manager = new EmailEventManager();
+    @SuppressWarnings("unchecked")
+    Instance<EmailEventContentGenerator> emptyGenerators = mock(Instance.class);
+    when(emptyGenerators.iterator()).thenReturn(Collections.emptyIterator());
+    Field generatorsField = EmailEventManager.class.getDeclaredField("emailGenerators");
+    generatorsField.setAccessible(true);
+    generatorsField.set(manager, emptyGenerators);
+  }
+
+  /**
+   * Closes the static mocks after each test to prevent leaks.
+   */
+  @AfterEach
+  void tearDown() {
+    mockedResolver.close();
+    mockedDispatcher.close();
+    mockedMessageUtils.close();
+  }
+
+  /**
+   * Verifies that with no SMTP configuration and no alternative sender configured, the
+   * send is rejected upfront with an {@link EmailEventException}, preserving the historical
+   * behavior when no email transport exists at all.
+   */
+  @Test
+  void testSendEmailThrowsWhenNoConfigAndNoAlternativeSender() {
+    mockedResolver.when(SmtpCascadeResolver::resolve).thenReturn(null);
+    mockedDispatcher.when(EmailSenderDispatcher::hasAlternativeSenderConfigured)
+        .thenReturn(false);
+
+    assertThrows(EmailEventException.class,
+        () -> manager.sendEmail(EVENT, RECIPIENT, new Object()));
+  }
+
+  /**
+   * Verifies that with no SMTP configuration but an alternative sender configured, the
+   * send proceeds past the configuration pre-check (returning {@code false} here only
+   * because no content generator listens to the event).
+   * @throws EmailEventException never expected in this test
+   */
+  @Test
+  void testSendEmailProceedsWhenAlternativeSenderConfigured() throws EmailEventException {
+    mockedResolver.when(SmtpCascadeResolver::resolve).thenReturn(null);
+    mockedDispatcher.when(EmailSenderDispatcher::hasAlternativeSenderConfigured)
+        .thenReturn(true);
+
+    boolean sent = manager.sendEmail(EVENT, RECIPIENT, new Object());
+
+    assertFalse(sent);
+  }
+}

--- a/src-test/src/org/openbravo/erpCommon/utility/poc/EmailManagerTest.java
+++ b/src-test/src/org/openbravo/erpCommon/utility/poc/EmailManagerTest.java
@@ -19,6 +19,7 @@ package org.openbravo.erpCommon.utility.poc;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -48,6 +49,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -58,6 +60,9 @@ import org.openbravo.email.ResolvedSmtpConfig;
 import org.openbravo.model.common.enterprise.EmailServerConfiguration;
 import org.openbravo.model.common.enterprise.Organization;
 import org.openbravo.utils.FormatUtilities;
+
+import com.etendoerp.email.spi.EmailSendContext;
+import com.etendoerp.email.spi.EmailSenderDispatcher;
 
 /**
  * Unit tests for {@link EmailManager}.
@@ -589,6 +594,52 @@ public class EmailManagerTest {
     assertThrows(PocException.class, () ->
         manager.sendSimpleEmail(session, INVALID_ADDRESS, SIMPLE_TO,
             null, TEST_SUBJECT, TEST_BODY, null));
+  }
+
+  /**
+   * Verifies that {@link EmailManager#sendEmail(EmailServerConfiguration, EmailInfo)} builds
+   * an {@link EmailSendContext} carrying the configuration record and the email, and routes
+   * it through the {@link EmailSenderDispatcher}.
+   * @throws Exception if an unexpected error occurs during mock setup or verification
+   */
+  @Test
+  void testSendEmailWithServerConfigDispatchesContext() throws Exception {
+    EmailServerConfiguration conf = mock(EmailServerConfiguration.class);
+    EmailInfo email = new EmailInfo.Builder().setRecipientTO(RECIPIENT_TO).build();
+    try (MockedStatic<EmailSenderDispatcher> mockedDispatcher =
+        mockStatic(EmailSenderDispatcher.class)) {
+      EmailManager.sendEmail(conf, email);
+      ArgumentCaptor<EmailSendContext> contextCaptor =
+          ArgumentCaptor.forClass(EmailSendContext.class);
+      mockedDispatcher.verify(() -> EmailSenderDispatcher.dispatch(contextCaptor.capture()));
+      EmailSendContext context = contextCaptor.getValue();
+      assertSame(conf, context.getSmtpConfig());
+      assertSame(email, context.getEmail());
+      assertNull(context.getResolvedSmtpConfig());
+    }
+  }
+
+  /**
+   * Verifies that {@link EmailManager#sendEmail(ResolvedSmtpConfig, EmailInfo)} builds an
+   * {@link EmailSendContext} carrying the resolved configuration and the email, and routes
+   * it through the {@link EmailSenderDispatcher}.
+   * @throws Exception if an unexpected error occurs during mock setup or verification
+   */
+  @Test
+  void testSendEmailWithResolvedConfigDispatchesContext() throws Exception {
+    ResolvedSmtpConfig conf = mock(ResolvedSmtpConfig.class);
+    EmailInfo email = new EmailInfo.Builder().setRecipientTO(RECIPIENT_TO).build();
+    try (MockedStatic<EmailSenderDispatcher> mockedDispatcher =
+        mockStatic(EmailSenderDispatcher.class)) {
+      EmailManager.sendEmail(conf, email);
+      ArgumentCaptor<EmailSendContext> contextCaptor =
+          ArgumentCaptor.forClass(EmailSendContext.class);
+      mockedDispatcher.verify(() -> EmailSenderDispatcher.dispatch(contextCaptor.capture()));
+      EmailSendContext context = contextCaptor.getValue();
+      assertSame(conf, context.getResolvedSmtpConfig());
+      assertSame(email, context.getEmail());
+      assertNull(context.getSmtpConfig());
+    }
   }
 
   /**

--- a/src-test/src/org/openbravo/erpCommon/utility/poc/EmailManagerTest.java
+++ b/src-test/src/org/openbravo/erpCommon/utility/poc/EmailManagerTest.java
@@ -61,6 +61,7 @@ import org.openbravo.model.common.enterprise.EmailServerConfiguration;
 import org.openbravo.model.common.enterprise.Organization;
 import org.openbravo.utils.FormatUtilities;
 
+import com.etendoerp.email.spi.DefaultSmtpEmailSender;
 import com.etendoerp.email.spi.EmailSendContext;
 import com.etendoerp.email.spi.EmailSenderDispatcher;
 
@@ -639,6 +640,76 @@ public class EmailManagerTest {
       assertSame(conf, context.getResolvedSmtpConfig());
       assertSame(email, context.getEmail());
       assertNull(context.getSmtpConfig());
+    }
+  }
+
+  /**
+   * Verifies that {@link DefaultSmtpEmailSender} prefers the cascade-resolved configuration
+   * when the context carries both configuration flavors, delegating to the low-level SMTP
+   * transport with the resolved values.
+   * @throws Exception if an unexpected error occurs during mock setup or verification
+   */
+  @Test
+  void testDefaultSenderPrefersResolvedConfigOverServerConfig() throws Exception {
+    ResolvedSmtpConfig resolved = buildResolvedConfig(
+        SMTP_HOST, SMTP_PORT, CONNECTION_SECURITY, true, SMTP_ACCOUNT, ENCRYPTED_PASSWORD,
+        FROM_ADDRESS, FROM_NAME, CONFIG_REPLY_TO, TIMEOUT_SECONDS);
+    EmailServerConfiguration serverConf = mock(EmailServerConfiguration.class);
+    EmailInfo email = new EmailInfo.Builder().setRecipientTO(RECIPIENT_TO).build();
+    EmailSendContext context = new EmailSendContext.Builder()
+        .setSmtpConfig(serverConf)
+        .setResolvedSmtpConfig(resolved)
+        .setEmail(email)
+        .build();
+    mockedFormatUtils.when(() -> FormatUtilities.encryptDecrypt(ENCRYPTED_PASSWORD, false))
+        .thenReturn(DECRYPTED_PASSWORD);
+    try (MockedStatic<EmailManager> mockedManager = mockStatic(EmailManager.class)) {
+      mockedManager.when(() -> EmailManager.safeDecrypt(any())).thenCallRealMethod();
+      new DefaultSmtpEmailSender().send(context);
+      int expectedTimeoutMillis = (int) TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS);
+      mockedManager.verify(() -> EmailManager.sendEmail(
+          eq(SMTP_HOST), eq(true), eq(SMTP_ACCOUNT), eq(DECRYPTED_PASSWORD),
+          eq(CONNECTION_SECURITY), eq(SMTP_PORT), eq(FROM_ADDRESS), eq(FROM_NAME),
+          eq(RECIPIENT_TO), isNull(), isNull(), eq(CONFIG_REPLY_TO),
+          isNull(), isNull(), isNull(), anyList(), isNull(), anyList(),
+          eq(expectedTimeoutMillis)));
+    }
+  }
+
+  /**
+   * Verifies that {@link DefaultSmtpEmailSender} sends through the low-level SMTP transport
+   * with the values of an {@link EmailServerConfiguration} record, decrypting the stored
+   * password and converting the configured timeout from seconds to milliseconds.
+   * @throws Exception if an unexpected error occurs during mock setup or verification
+   */
+  @Test
+  void testDefaultSenderSendsServerConfigThroughSmtpTransport() throws Exception {
+    EmailServerConfiguration conf = mock(EmailServerConfiguration.class);
+    when(conf.getSmtpServer()).thenReturn(SMTP_HOST);
+    when(conf.isSMTPAuthentification()).thenReturn(true);
+    when(conf.getSmtpServerAccount()).thenReturn(SMTP_ACCOUNT);
+    when(conf.getSmtpServerPassword()).thenReturn(ENCRYPTED_PASSWORD);
+    when(conf.getSmtpConnectionSecurity()).thenReturn(CONNECTION_SECURITY);
+    when(conf.getSmtpPort()).thenReturn((long) SMTP_PORT);
+    when(conf.getSmtpServerSenderAddress()).thenReturn(FROM_ADDRESS);
+    when(conf.getFromName()).thenReturn(FROM_NAME);
+    when(conf.getSmtpConnectionTimeout()).thenReturn(TIMEOUT_SECONDS);
+    mockedFormatUtils.when(() -> FormatUtilities.encryptDecrypt(ENCRYPTED_PASSWORD, false))
+        .thenReturn(DECRYPTED_PASSWORD);
+    EmailInfo email = new EmailInfo.Builder().setRecipientTO(RECIPIENT_TO).build();
+    EmailSendContext context = new EmailSendContext.Builder()
+        .setSmtpConfig(conf)
+        .setEmail(email)
+        .build();
+    try (MockedStatic<EmailManager> mockedManager = mockStatic(EmailManager.class)) {
+      new DefaultSmtpEmailSender().send(context);
+      int expectedTimeoutMillis = (int) TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS);
+      mockedManager.verify(() -> EmailManager.sendEmail(
+          eq(SMTP_HOST), eq(true), eq(SMTP_ACCOUNT), eq(DECRYPTED_PASSWORD),
+          eq(CONNECTION_SECURITY), eq(SMTP_PORT), eq(FROM_ADDRESS), eq(FROM_NAME),
+          eq(RECIPIENT_TO), isNull(), isNull(), isNull(),
+          isNull(), isNull(), isNull(), anyList(), isNull(), anyList(),
+          eq(expectedTimeoutMillis)));
     }
   }
 

--- a/src/com/etendoerp/email/spi/DefaultSmtpEmailSender.java
+++ b/src/com/etendoerp/email/spi/DefaultSmtpEmailSender.java
@@ -36,14 +36,13 @@ import org.openbravo.utils.FormatUtilities;
  * <p>
  * The configuration validation, password decryption and timeout resolution previously
  * performed by {@code EmailManager} before sending live here now; the low-level SMTP
- * transport itself remains in
- * {@link EmailManager#sendEmail(String, boolean, String, String, String, int, String,
- * String, String, String, String, String, String, String, String, java.util.List,
- * java.util.Date, java.util.List, int)}.
+ * transport itself remains in {@code EmailManager}. This class extends
+ * {@link EmailManager} solely to reach that protected legacy transport without widening
+ * the {@code EmailManager} API.
  * </p>
  */
 @ApplicationScoped
-public class DefaultSmtpEmailSender implements EmailSender {
+public class DefaultSmtpEmailSender extends EmailManager implements EmailSender {
 
   private static final long DEFAULT_SMTP_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(10);
 
@@ -127,13 +126,15 @@ public class DefaultSmtpEmailSender implements EmailSender {
   private void sendWithServerConfig(EmailServerConfiguration conf, EmailInfo email)
       throws Exception {
     String decryptedPassword = FormatUtilities.encryptDecrypt(conf.getSmtpServerPassword(), false);
-    Long timeoutMillis = EmailManager.getSmtpConnectionTimeout(conf);
+    long timeoutMillis = conf.getSmtpConnectionTimeout() != null
+        ? TimeUnit.SECONDS.toMillis(conf.getSmtpConnectionTimeout())
+        : DEFAULT_SMTP_TIMEOUT_MILLIS;
     EmailManager.sendEmail(conf.getSmtpServer(), conf.isSMTPAuthentification(),
         conf.getSmtpServerAccount(), decryptedPassword, conf.getSmtpConnectionSecurity(),
         conf.getSmtpPort().intValue(), conf.getSmtpServerSenderAddress(), conf.getFromName(),
         email.getRecipientTO(), email.getRecipientCC(), email.getRecipientBCC(),
         email.getReplyTo(), email.getSubject(), email.getContent(), email.getContentType(),
         email.getAttachments(), email.getSentDate(), email.getHeaderExtras(),
-        timeoutMillis.intValue());
+        (int) timeoutMillis);
   }
 }

--- a/src/com/etendoerp/email/spi/DefaultSmtpEmailSender.java
+++ b/src/com/etendoerp/email/spi/DefaultSmtpEmailSender.java
@@ -1,0 +1,139 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+package com.etendoerp.email.spi;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.servlet.ServletException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.openbravo.email.ResolvedSmtpConfig;
+import org.openbravo.erpCommon.utility.poc.EmailInfo;
+import org.openbravo.erpCommon.utility.poc.EmailManager;
+import org.openbravo.model.common.enterprise.EmailServerConfiguration;
+import org.openbravo.utils.FormatUtilities;
+
+/**
+ * Default {@link EmailSender}: delivers the message over SMTP exactly as core has always
+ * done. It is the guaranteed fallback of the {@link EmailSenderDispatcher}: it reports
+ * itself as always configured and sits at the lowest possible priority, so it is only
+ * chosen when no alternative sender applies.
+ * <p>
+ * The configuration validation, password decryption and timeout resolution previously
+ * performed by {@code EmailManager} before sending live here now; the low-level SMTP
+ * transport itself remains in
+ * {@link EmailManager#sendEmail(String, boolean, String, String, String, int, String,
+ * String, String, String, String, String, String, String, String, java.util.List,
+ * java.util.Date, java.util.List, int)}.
+ * </p>
+ */
+@ApplicationScoped
+public class DefaultSmtpEmailSender implements EmailSender {
+
+  private static final long DEFAULT_SMTP_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(10);
+
+  /**
+   * Always available as the baseline transport. Whether the SMTP configuration is actually
+   * complete is validated at {@link #send(EmailSendContext)} time, so that a configuration
+   * error is reported to the caller instead of silently skipping this sender.
+   * @param context the send context
+   * @return always {@code true}
+   */
+  @Override
+  public boolean isConfigured(EmailSendContext context) {
+    return true;
+  }
+
+  /**
+   * Floor priority: any module-provided sender with a higher priority wins when configured.
+   * @return {@link Integer#MIN_VALUE}
+   */
+  @Override
+  public int getPriority() {
+    return Integer.MIN_VALUE;
+  }
+
+  /**
+   * Sends the message over SMTP using the configuration carried by the context, preferring
+   * the cascade-resolved configuration when present.
+   * @param context the send context
+   * @throws Exception if the SMTP configuration is missing or incomplete, or the send fails
+   */
+  @Override
+  public void send(EmailSendContext context) throws Exception {
+    if (context.getResolvedSmtpConfig() != null) {
+      sendWithResolvedConfig(context.getResolvedSmtpConfig(), context.getEmail());
+    } else if (context.getSmtpConfig() != null) {
+      sendWithServerConfig(context.getSmtpConfig(), context.getEmail());
+    } else {
+      throw new ServletException("No email configuration available: configure SMTP at User,"
+          + " Organization or Client level, or install and configure an alternative email"
+          + " sender module.");
+    }
+  }
+
+  /**
+   * Sends using a cascade-resolved SMTP configuration, validating that the minimum SMTP
+   * fields are present before attempting the connection.
+   * @param conf the resolved SMTP configuration
+   * @param email the message to send
+   * @throws Exception if validation or the send fails
+   */
+  private void sendWithResolvedConfig(ResolvedSmtpConfig conf, EmailInfo email)
+      throws Exception {
+    if (StringUtils.isBlank(conf.getHost())) {
+      throw new ServletException("SMTP Host is not configured in the "
+          + conf.getLevel() + " email configuration (id=" + conf.getConfigId()
+          + "). Please complete the SMTP setup.");
+    }
+    if (StringUtils.isBlank(conf.getFromAddress())) {
+      throw new ServletException("SMTP From Address (sender) is not configured in the "
+          + conf.getLevel() + " email configuration (id=" + conf.getConfigId()
+          + "). Please complete the SMTP setup.");
+    }
+    String decryptedPassword = EmailManager.safeDecrypt(conf.getPassword());
+    long timeoutMillis = conf.getTimeoutSeconds() != null
+        ? TimeUnit.SECONDS.toMillis(conf.getTimeoutSeconds())
+        : DEFAULT_SMTP_TIMEOUT_MILLIS;
+    EmailManager.sendEmail(conf.getHost(), conf.isAuth(), conf.getAccount(), decryptedPassword,
+        conf.getConnectionSecurity(), conf.getPort(), conf.getFromAddress(), conf.getFromName(),
+        email.getRecipientTO(), email.getRecipientCC(), email.getRecipientBCC(),
+        email.getReplyTo() != null ? email.getReplyTo() : conf.getReplyTo(),
+        email.getSubject(), email.getContent(), email.getContentType(), email.getAttachments(),
+        email.getSentDate(), email.getHeaderExtras(), (int) timeoutMillis);
+  }
+
+  /**
+   * Sends using an {@link EmailServerConfiguration} record, decrypting the stored password.
+   * @param conf the SMTP server configuration record
+   * @param email the message to send
+   * @throws Exception if decryption or the send fails
+   */
+  private void sendWithServerConfig(EmailServerConfiguration conf, EmailInfo email)
+      throws Exception {
+    String decryptedPassword = FormatUtilities.encryptDecrypt(conf.getSmtpServerPassword(), false);
+    Long timeoutMillis = EmailManager.getSmtpConnectionTimeout(conf);
+    EmailManager.sendEmail(conf.getSmtpServer(), conf.isSMTPAuthentification(),
+        conf.getSmtpServerAccount(), decryptedPassword, conf.getSmtpConnectionSecurity(),
+        conf.getSmtpPort().intValue(), conf.getSmtpServerSenderAddress(), conf.getFromName(),
+        email.getRecipientTO(), email.getRecipientCC(), email.getRecipientBCC(),
+        email.getReplyTo(), email.getSubject(), email.getContent(), email.getContentType(),
+        email.getAttachments(), email.getSentDate(), email.getHeaderExtras(),
+        timeoutMillis.intValue());
+  }
+}

--- a/src/com/etendoerp/email/spi/EmailSendContext.java
+++ b/src/com/etendoerp/email/spi/EmailSendContext.java
@@ -1,0 +1,166 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+package com.etendoerp.email.spi;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.openbravo.dal.core.OBContext;
+import org.openbravo.email.ResolvedSmtpConfig;
+import org.openbravo.erpCommon.utility.poc.EmailInfo;
+import org.openbravo.model.ad.system.Client;
+import org.openbravo.model.common.enterprise.EmailServerConfiguration;
+import org.openbravo.model.common.enterprise.Organization;
+
+/**
+ * Immutable value object carrying everything an {@link EmailSender} could need to deliver a
+ * message, decoupled from any specific transport.
+ * <p>
+ * All fields are nullable: SMTP configuration objects are only meaningful to SMTP senders
+ * (an alternative sender resolves its own configuration from {@link #getClient() client} /
+ * {@link #getOrganization() organization} and ignores them), client/organization may be
+ * unavailable when sending outside a request context (e.g. background threads), and the
+ * email itself is {@code null} when the context is used as a pure capability probe.
+ * </p>
+ */
+public class EmailSendContext {
+
+  private static final Logger log = LogManager.getLogger();
+
+  private final Client client;
+  private final Organization organization;
+  private final EmailServerConfiguration smtpConfig;
+  private final ResolvedSmtpConfig resolvedSmtpConfig;
+  private final EmailInfo email;
+
+  private EmailSendContext(Client client, Organization organization,
+      EmailServerConfiguration smtpConfig, ResolvedSmtpConfig resolvedSmtpConfig,
+      EmailInfo email) {
+    this.client = client;
+    this.organization = organization;
+    this.smtpConfig = smtpConfig;
+    this.resolvedSmtpConfig = resolvedSmtpConfig;
+    this.email = email;
+  }
+
+  /**
+   * Builds a context taking client and organization from the current {@link OBContext},
+   * when available. This is the factory used by the core entry points.
+   * @param smtpConfig the SMTP server configuration record, or {@code null} when not resolved
+   * @param resolvedSmtpConfig the cascade-resolved SMTP configuration, or {@code null}
+   * @param email the resolved message to send, or {@code null} for capability probes
+   * @return a new context populated from the current execution context
+   */
+  public static EmailSendContext create(EmailServerConfiguration smtpConfig,
+      ResolvedSmtpConfig resolvedSmtpConfig, EmailInfo email) {
+    Client client = null;
+    Organization organization = null;
+    try {
+      OBContext obContext = OBContext.getOBContext();
+      if (obContext != null) {
+        client = obContext.getCurrentClient();
+        organization = obContext.getCurrentOrganization();
+      }
+    } catch (Exception e) {
+      log.debug("Could not read client/organization from OBContext", e);
+    }
+    return new EmailSendContext(client, organization, smtpConfig, resolvedSmtpConfig, email);
+  }
+
+  /**
+   * Returns the client in whose context the email is sent, or {@code null} if unavailable.
+   * @return the client, may be {@code null}
+   */
+  public Client getClient() {
+    return client;
+  }
+
+  /**
+   * Returns the organization in whose context the email is sent, or {@code null} if
+   * unavailable.
+   * @return the organization, may be {@code null}
+   */
+  public Organization getOrganization() {
+    return organization;
+  }
+
+  /**
+   * Returns the SMTP server configuration record, only meaningful to SMTP senders.
+   * @return the SMTP configuration, may be {@code null}
+   */
+  public EmailServerConfiguration getSmtpConfig() {
+    return smtpConfig;
+  }
+
+  /**
+   * Returns the cascade-resolved SMTP configuration, only meaningful to SMTP senders.
+   * @return the resolved SMTP configuration, may be {@code null}
+   */
+  public ResolvedSmtpConfig getResolvedSmtpConfig() {
+    return resolvedSmtpConfig;
+  }
+
+  /**
+   * Returns the resolved message to send (recipients, subject, rendered body, attachments).
+   * @return the email data, or {@code null} when the context is a capability probe
+   */
+  public EmailInfo getEmail() {
+    return email;
+  }
+
+  /**
+   * Builder used to create an {@link EmailSendContext} with explicit values, mainly for
+   * tests and non-standard entry points. Prefer
+   * {@link EmailSendContext#create(EmailServerConfiguration, ResolvedSmtpConfig, EmailInfo)}
+   * in production code.
+   */
+  public static class Builder {
+    private Client client;
+    private Organization organization;
+    private EmailServerConfiguration smtpConfig;
+    private ResolvedSmtpConfig resolvedSmtpConfig;
+    private EmailInfo email;
+
+    public Builder setClient(Client client) {
+      this.client = client;
+      return this;
+    }
+
+    public Builder setOrganization(Organization organization) {
+      this.organization = organization;
+      return this;
+    }
+
+    public Builder setSmtpConfig(EmailServerConfiguration smtpConfig) {
+      this.smtpConfig = smtpConfig;
+      return this;
+    }
+
+    public Builder setResolvedSmtpConfig(ResolvedSmtpConfig resolvedSmtpConfig) {
+      this.resolvedSmtpConfig = resolvedSmtpConfig;
+      return this;
+    }
+
+    public Builder setEmail(EmailInfo email) {
+      this.email = email;
+      return this;
+    }
+
+    public EmailSendContext build() {
+      return new EmailSendContext(client, organization, smtpConfig, resolvedSmtpConfig, email);
+    }
+  }
+}

--- a/src/com/etendoerp/email/spi/EmailSendContext.java
+++ b/src/com/etendoerp/email/spi/EmailSendContext.java
@@ -159,6 +159,10 @@ public class EmailSendContext {
       return this;
     }
 
+    /**
+     * Creates the immutable {@link EmailSendContext} with the values set on this builder.
+     * @return a new context instance
+     */
     public EmailSendContext build() {
       return new EmailSendContext(client, organization, smtpConfig, resolvedSmtpConfig, email);
     }

--- a/src/com/etendoerp/email/spi/EmailSender.java
+++ b/src/com/etendoerp/email/spi/EmailSender.java
@@ -1,0 +1,65 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+package com.etendoerp.email.spi;
+
+/**
+ * Transport-level extension point for email sending. Implementations receive an
+ * already-resolved message (recipients, subject, rendered body, attachments) together with
+ * the client/organization context, and are responsible for delivering it.
+ * <p>
+ * Implementations are discovered through CDI ({@code WeldUtils.getInstances}), so a module
+ * can take over email sending by providing a bean implementing this interface with a
+ * priority above the default. When no alternative sender applies, the
+ * {@link DefaultSmtpEmailSender} guarantees the current SMTP behavior.
+ * </p>
+ *
+ * @see EmailSenderDispatcher
+ */
+public interface EmailSender {
+
+  /**
+   * Determines whether this sender is able to handle the message for the given context.
+   * <p>
+   * Implementations must be cheap and side-effect free: this method is invoked on every
+   * send, and may also be invoked with a context that has no {@link EmailSendContext#getEmail()
+   * email} as a pure capability probe (e.g. UI checks asking "can this client send email?").
+   * Returning {@code false} causes a silent fallback to the next candidate, so an incomplete
+   * configuration must never break a send.
+   * </p>
+   * @param context the send context (the email may be {@code null} for capability probes)
+   * @return {@code true} if this sender can handle the message for this client/organization
+   */
+  boolean isConfigured(EmailSendContext context);
+
+  /**
+   * Sends the resolved message. Transport failures must be propagated as exceptions; the
+   * dispatcher never retries with another sender, to avoid double sends.
+   * @param context the send context carrying the message and client/organization information
+   * @throws Exception if the message cannot be delivered
+   */
+  void send(EmailSendContext context) throws Exception;
+
+  /**
+   * Ordering hint used by the dispatcher to pick a sender; higher wins. The default SMTP
+   * sender sits at {@link Integer#MIN_VALUE} so any module-provided sender with a higher
+   * priority is preferred when configured.
+   * @return the priority of this sender
+   */
+  default int getPriority() {
+    return 0;
+  }
+}

--- a/src/com/etendoerp/email/spi/EmailSender.java
+++ b/src/com/etendoerp/email/spi/EmailSender.java
@@ -48,9 +48,15 @@ public interface EmailSender {
   /**
    * Sends the resolved message. Transport failures must be propagated as exceptions; the
    * dispatcher never retries with another sender, to avoid double sends.
+   * <p>
+   * The generic {@code throws Exception} is deliberate: it mirrors the legacy
+   * {@code EmailManager.sendEmail} contract so each transport propagates its own exception
+   * types unchanged and existing callers observe exactly the same failures as before.
+   * </p>
    * @param context the send context carrying the message and client/organization information
    * @throws Exception if the message cannot be delivered
    */
+  @SuppressWarnings("java:S112")
   void send(EmailSendContext context) throws Exception;
 
   /**

--- a/src/com/etendoerp/email/spi/EmailSenderDispatcher.java
+++ b/src/com/etendoerp/email/spi/EmailSenderDispatcher.java
@@ -1,0 +1,124 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+package com.etendoerp.email.spi;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.openbravo.base.weld.WeldUtils;
+
+/**
+ * Selects the {@link EmailSender} that handles a given send and delegates to it.
+ * <p>
+ * Candidates are discovered through CDI, ordered by {@link EmailSender#getPriority()}
+ * descending, and the first one reporting {@link EmailSender#isConfigured(EmailSendContext)}
+ * wins. The {@link DefaultSmtpEmailSender} sits at the priority floor and is always
+ * configured, so SMTP remains the guaranteed fallback: behavior is unchanged when no
+ * alternative sender module is installed, and an installed-but-unconfigured module falls
+ * through to SMTP silently.
+ * </p>
+ * <p>
+ * The dispatcher only decides <i>which</i> sender runs: a failure thrown by the selected
+ * sender's {@code send()} propagates unchanged, with no automatic retry through another
+ * transport (avoiding double sends).
+ * </p>
+ */
+public class EmailSenderDispatcher {
+
+  private static final Logger log = LogManager.getLogger();
+
+  private EmailSenderDispatcher() {
+  }
+
+  /**
+   * Dispatches the send to the highest-priority configured sender.
+   * @param context the send context
+   * @throws Exception if the selected sender fails to deliver the message
+   */
+  public static void dispatch(EmailSendContext context) throws Exception {
+    EmailSender sender = selectSender(discoverSenders(), context);
+    log.debug("Dispatching email send to {}", sender.getClass().getName());
+    sender.send(context);
+  }
+
+  /**
+   * Determines whether any sender other than the default SMTP one reports itself as
+   * configured for the current execution context. Used by callers that today pre-check the
+   * SMTP configuration before composing an email, so a client relying exclusively on an
+   * alternative sender (no SMTP configured) is not blocked.
+   * @return {@code true} if an alternative configured sender is available
+   */
+  public static boolean hasAlternativeSenderConfigured() {
+    EmailSendContext probe = EmailSendContext.create(null, null, null);
+    return discoverSenders().stream()
+        .filter(sender -> !(sender instanceof DefaultSmtpEmailSender))
+        .anyMatch(sender -> isConfiguredSafe(sender, probe));
+  }
+
+  /**
+   * Discovers the {@link EmailSender} candidates through CDI. When the container is not
+   * available (e.g. plain unit tests), returns an empty list so selection falls back to the
+   * default SMTP sender.
+   * @return the discovered senders, may be empty
+   */
+  private static List<EmailSender> discoverSenders() {
+    try {
+      return WeldUtils.getInstances(EmailSender.class);
+    } catch (Exception e) {
+      log.debug("CDI discovery of EmailSender implementations unavailable,"
+          + " using default SMTP sender", e);
+      return Collections.emptyList();
+    }
+  }
+
+  /**
+   * Selects the sender to use: candidates ordered by priority descending, first one whose
+   * {@code isConfigured} returns {@code true}. Falls back to a {@link DefaultSmtpEmailSender}
+   * when no candidate applies, so a sender is always returned.
+   * @param candidates the discovered sender candidates
+   * @param context the send context
+   * @return the sender that must handle the send, never {@code null}
+   */
+  static EmailSender selectSender(List<EmailSender> candidates, EmailSendContext context) {
+    return candidates.stream()
+        .sorted(Comparator.comparingInt(EmailSender::getPriority).reversed())
+        .filter(sender -> isConfiguredSafe(sender, context))
+        .findFirst()
+        .orElseGet(DefaultSmtpEmailSender::new);
+  }
+
+  /**
+   * Evaluates {@link EmailSender#isConfigured(EmailSendContext)} treating any thrown
+   * exception as "not configured", so a broken capability check in one module can never
+   * break email sending.
+   * @param sender the candidate sender
+   * @param context the send context
+   * @return {@code true} only if the sender reports itself as configured without errors
+   */
+  private static boolean isConfiguredSafe(EmailSender sender, EmailSendContext context) {
+    try {
+      return sender.isConfigured(context);
+    } catch (Exception e) {
+      log.warn("EmailSender {} failed evaluating isConfigured; skipping it",
+          sender.getClass().getName(), e);
+      return false;
+    }
+  }
+}

--- a/src/com/etendoerp/email/spi/EmailSenderDispatcher.java
+++ b/src/com/etendoerp/email/spi/EmailSenderDispatcher.java
@@ -20,6 +20,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.openbravo.base.weld.WeldUtils;
@@ -40,6 +42,7 @@ import org.openbravo.base.weld.WeldUtils;
  * transport (avoiding double sends).
  * </p>
  */
+@ApplicationScoped
 public class EmailSenderDispatcher {
 
   private static final Logger log = LogManager.getLogger();

--- a/src/org/openbravo/email/EmailEventManager.java
+++ b/src/org/openbravo/email/EmailEventManager.java
@@ -75,24 +75,13 @@ public class EmailEventManager {
   public boolean sendEmail(String event, final String recipient, Object data)
       throws EmailEventException {
     final ResolvedSmtpConfig mailConfig = SmtpCascadeResolver.resolve();
-
-    if (mailConfig == null && !EmailSenderDispatcher.hasAlternativeSenderConfigured()) {
-      log.warn("Couldn't find email configuration at any level (User/Organization/Client)");
-      throw new EmailEventException(
-          OBMessageUtils.getI18NMessage("EmailConfigurationNotFound", null));
-    }
+    checkEmailTransportAvailable(mailConfig);
 
     try {
       boolean sent = false;
       for (EmailEventContentGenerator gen : getValidEmailGenerators(event, data)) {
         sent = true;
-        if (mailConfig != null) {
-          log.debug("sending email for event {} with generator {} using {} SMTP config (id={})",
-              event, gen, mailConfig.getLevel(), mailConfig.getConfigId());
-        } else {
-          log.debug("sending email for event {} with generator {} through an alternative"
-              + " email sender (no SMTP configuration found)", event, gen);
-        }
+        logSendingEmail(event, gen, mailConfig);
 
         final EmailInfo email = new EmailInfo.Builder() //
             .setSubject(gen.getSubject(data, event)) //
@@ -126,6 +115,40 @@ public class EmailEventManager {
     } catch (Exception e) {
       log.error("Failed to send email for event {}.", event, e);
       throw new EmailEventException(e);
+    }
+  }
+
+  /**
+   * Ensures that some email transport is available: either an SMTP configuration resolved
+   * by the cascade or an alternative {@link com.etendoerp.email.spi.EmailSender} configured
+   * by a module. Preserves the historical failure when no transport exists at all.
+   * @param mailConfig the cascade-resolved SMTP configuration, may be {@code null}
+   * @throws EmailEventException if no SMTP configuration and no alternative sender exist
+   */
+  private void checkEmailTransportAvailable(ResolvedSmtpConfig mailConfig)
+      throws EmailEventException {
+    if (mailConfig == null && !EmailSenderDispatcher.hasAlternativeSenderConfigured()) {
+      log.warn("Couldn't find email configuration at any level (User/Organization/Client)");
+      throw new EmailEventException(
+          OBMessageUtils.getI18NMessage("EmailConfigurationNotFound", null));
+    }
+  }
+
+  /**
+   * Logs which generator is about to send an email for the given event, including the SMTP
+   * configuration used or noting that an alternative sender will handle the message.
+   * @param event the email event being processed
+   * @param gen the content generator producing the email
+   * @param mailConfig the cascade-resolved SMTP configuration, may be {@code null}
+   */
+  private void logSendingEmail(String event, EmailEventContentGenerator gen,
+      ResolvedSmtpConfig mailConfig) {
+    if (mailConfig != null) {
+      log.debug("sending email for event {} with generator {} using {} SMTP config (id={})",
+          event, gen, mailConfig.getLevel(), mailConfig.getConfigId());
+    } else {
+      log.debug("sending email for event {} with generator {} through an alternative"
+          + " email sender (no SMTP configuration found)", event, gen);
     }
   }
 

--- a/src/org/openbravo/email/EmailEventManager.java
+++ b/src/org/openbravo/email/EmailEventManager.java
@@ -36,6 +36,8 @@ import org.openbravo.erpCommon.utility.OBMessageUtils;
 import org.openbravo.erpCommon.utility.poc.EmailInfo;
 import org.openbravo.erpCommon.utility.poc.EmailManager;
 
+import com.etendoerp.email.spi.EmailSenderDispatcher;
+
 /**
  * This singleton class, is in charge of generating events to send emails.
  * 
@@ -74,7 +76,7 @@ public class EmailEventManager {
       throws EmailEventException {
     final ResolvedSmtpConfig mailConfig = SmtpCascadeResolver.resolve();
 
-    if (mailConfig == null) {
+    if (mailConfig == null && !EmailSenderDispatcher.hasAlternativeSenderConfigured()) {
       log.warn("Couldn't find email configuration at any level (User/Organization/Client)");
       throw new EmailEventException(
           OBMessageUtils.getI18NMessage("EmailConfigurationNotFound", null));
@@ -84,8 +86,13 @@ public class EmailEventManager {
       boolean sent = false;
       for (EmailEventContentGenerator gen : getValidEmailGenerators(event, data)) {
         sent = true;
-        log.debug("sending email for event {} with generator {} using {} SMTP config (id={})",
-            event, gen, mailConfig.getLevel(), mailConfig.getConfigId());
+        if (mailConfig != null) {
+          log.debug("sending email for event {} with generator {} using {} SMTP config (id={})",
+              event, gen, mailConfig.getLevel(), mailConfig.getConfigId());
+        } else {
+          log.debug("sending email for event {} with generator {} through an alternative"
+              + " email sender (no SMTP configuration found)", event, gen);
+        }
 
         final EmailInfo email = new EmailInfo.Builder() //
             .setSubject(gen.getSubject(data, event)) //

--- a/src/org/openbravo/erpCommon/utility/poc/EmailManager.java
+++ b/src/org/openbravo/erpCommon/utility/poc/EmailManager.java
@@ -114,7 +114,7 @@ public class EmailManager {
    * @return the decrypted password, or the original value if decryption is not applicable or fails
    * @throws ServletException if an unexpected servlet-level error occurs
    */
-  protected static String safeDecrypt(String password) throws ServletException {
+  public static String safeDecrypt(String password) throws ServletException {
     if (StringUtils.isBlank(password)) {
       return password;
     }
@@ -144,13 +144,13 @@ public class EmailManager {
         headerExtras, timeoutMillis.intValue());
   }
 
-  protected static Long getSmtpConnectionTimeout(EmailServerConfiguration configuration) {
+  public static Long getSmtpConnectionTimeout(EmailServerConfiguration configuration) {
     return (configuration != null && configuration.getSmtpConnectionTimeout() != null)
         ? TimeUnit.SECONDS.toMillis(configuration.getSmtpConnectionTimeout())
         : DEFAULT_SMTP_TIMEOUT;
   }
 
-  protected static void sendEmail(String host, boolean auth, String username, String password,
+  public static void sendEmail(String host, boolean auth, String username, String password,
       String connSecurity, int port, String senderAddress, String senderName, String recipientTO,
       String recipientCC, String recipientBCC, String replyTo, String subject, String content,
       String contentType, List<File> attachments, Date sentDate, List<String> headerExtras,

--- a/src/org/openbravo/erpCommon/utility/poc/EmailManager.java
+++ b/src/org/openbravo/erpCommon/utility/poc/EmailManager.java
@@ -50,6 +50,9 @@ import org.openbravo.email.ResolvedSmtpConfig;
 import org.openbravo.model.common.enterprise.EmailServerConfiguration;
 import org.openbravo.utils.FormatUtilities;
 
+import com.etendoerp.email.spi.EmailSendContext;
+import com.etendoerp.email.spi.EmailSenderDispatcher;
+
 public class EmailManager {
   private static Logger log4j = LogManager.getLogger();
   private static final Long DEFAULT_SMTP_TIMEOUT = TimeUnit.MINUTES.toMillis(10);
@@ -57,7 +60,12 @@ public class EmailManager {
   /**
    * Sends an email using the given SMTP Server configuration and the email definition contained in
    * the email parameter.
-   * 
+   * <p>
+   * The send is routed through the {@link EmailSenderDispatcher}, so a module providing a
+   * configured {@link com.etendoerp.email.spi.EmailSender} with a higher priority can take
+   * over the transport. With no alternative sender installed and configured, the message is
+   * delivered over SMTP exactly as before.
+   * </p>
    * @param conf
    *          The SMTP Server configuration
    * @param email
@@ -65,47 +73,26 @@ public class EmailManager {
    * @throws Exception
    */
   public static void sendEmail(EmailServerConfiguration conf, EmailInfo email) throws Exception {
-
-    String decryptedPassword = FormatUtilities.encryptDecrypt(conf.getSmtpServerPassword(), false);
-    Long timeoutMillis = getSmtpConnectionTimeout(conf);
-
-    sendEmail(conf.getSmtpServer(), conf.isSMTPAuthentification(), conf.getSmtpServerAccount(),
-        decryptedPassword, conf.getSmtpConnectionSecurity(), conf.getSmtpPort().intValue(),
-        conf.getSmtpServerSenderAddress(), conf.getFromName(), email.getRecipientTO(),
-        email.getRecipientCC(), email.getRecipientBCC(), email.getReplyTo(), email.getSubject(),
-        email.getContent(), email.getContentType(), email.getAttachments(), email.getSentDate(),
-        email.getHeaderExtras(), timeoutMillis.intValue());
+    EmailSenderDispatcher.dispatch(EmailSendContext.create(conf, null, email));
   }
 
   /**
    * Sends an email using a {@link ResolvedSmtpConfig} obtained from the cascade resolver.
    * This is the preferred method when the cascade resolution (User → Organization → Client)
    * has already been performed by {@link org.openbravo.email.SmtpCascadeResolver}.
-   * @param conf The resolved SMTP configuration
+   * <p>
+   * The send is routed through the {@link EmailSenderDispatcher}; see
+   * {@link #sendEmail(EmailServerConfiguration, EmailInfo)}. The configuration may be
+   * {@code null} when no SMTP configuration exists at any level: in that case an alternative
+   * sender handles the message, or a configuration error is raised by the default SMTP
+   * sender.
+   * </p>
+   * @param conf The resolved SMTP configuration, may be {@code null}
    * @param email The data of the email being sent
    * @throws Exception if password decryption or email sending fails
    */
   public static void sendEmail(ResolvedSmtpConfig conf, EmailInfo email) throws Exception {
-    if (StringUtils.isBlank(conf.getHost())) {
-      throw new ServletException("SMTP Host is not configured in the "
-          + conf.getLevel() + " email configuration (id=" + conf.getConfigId()
-          + "). Please complete the SMTP setup.");
-    }
-    if (StringUtils.isBlank(conf.getFromAddress())) {
-      throw new ServletException("SMTP From Address (sender) is not configured in the "
-          + conf.getLevel() + " email configuration (id=" + conf.getConfigId()
-          + "). Please complete the SMTP setup.");
-    }
-    String decryptedPassword = safeDecrypt(conf.getPassword());
-    long timeoutMillis = conf.getTimeoutSeconds() != null
-        ? TimeUnit.SECONDS.toMillis(conf.getTimeoutSeconds())
-        : DEFAULT_SMTP_TIMEOUT;
-    sendEmail(conf.getHost(), conf.isAuth(), conf.getAccount(), decryptedPassword,
-        conf.getConnectionSecurity(), conf.getPort(), conf.getFromAddress(), conf.getFromName(),
-        email.getRecipientTO(), email.getRecipientCC(), email.getRecipientBCC(),
-        email.getReplyTo() != null ? email.getReplyTo() : conf.getReplyTo(),
-        email.getSubject(), email.getContent(), email.getContentType(), email.getAttachments(),
-        email.getSentDate(), email.getHeaderExtras(), (int) timeoutMillis);
+    EmailSenderDispatcher.dispatch(EmailSendContext.create(null, conf, email));
   }
 
   /**
@@ -127,7 +114,9 @@ public class EmailManager {
   }
 
   /**
-   * @deprecated Use {@link #sendEmail(EmailServerConfiguration, EmailInfo)} instead.
+   * @deprecated Use {@link #sendEmail(EmailServerConfiguration, EmailInfo)} instead. This
+   *             overload sends directly over SMTP and does not participate in the
+   *             {@link EmailSenderDispatcher} selection.
    */
   @Deprecated
   public static void sendEmail(String host, boolean auth, String username, String password,
@@ -144,12 +133,25 @@ public class EmailManager {
         headerExtras, timeoutMillis.intValue());
   }
 
+  /**
+   * Resolves the SMTP connection timeout in milliseconds for the given configuration,
+   * falling back to the default (10 minutes) when the configuration or its timeout is
+   * {@code null}.
+   * @param configuration the SMTP server configuration, may be {@code null}
+   * @return the timeout in milliseconds
+   */
   public static Long getSmtpConnectionTimeout(EmailServerConfiguration configuration) {
     return (configuration != null && configuration.getSmtpConnectionTimeout() != null)
         ? TimeUnit.SECONDS.toMillis(configuration.getSmtpConnectionTimeout())
         : DEFAULT_SMTP_TIMEOUT;
   }
 
+  /**
+   * Low-level SMTP transport: builds the MIME message and delivers it through the given
+   * server. Used by {@link com.etendoerp.email.spi.DefaultSmtpEmailSender} and by the
+   * deprecated direct-parameter entry points; it performs no configuration resolution and
+   * does not participate in the {@link EmailSenderDispatcher} selection.
+   */
   public static void sendEmail(String host, boolean auth, String username, String password,
       String connSecurity, int port, String senderAddress, String senderName, String recipientTO,
       String recipientCC, String recipientBCC, String replyTo, String subject, String content,

--- a/src/org/openbravo/erpCommon/utility/poc/EmailManager.java
+++ b/src/org/openbravo/erpCommon/utility/poc/EmailManager.java
@@ -101,7 +101,7 @@ public class EmailManager {
    * @return the decrypted password, or the original value if decryption is not applicable or fails
    * @throws ServletException if an unexpected servlet-level error occurs
    */
-  public static String safeDecrypt(String password) throws ServletException {
+  protected static String safeDecrypt(String password) throws ServletException {
     if (StringUtils.isBlank(password)) {
       return password;
     }
@@ -133,26 +133,13 @@ public class EmailManager {
         headerExtras, timeoutMillis.intValue());
   }
 
-  /**
-   * Resolves the SMTP connection timeout in milliseconds for the given configuration,
-   * falling back to the default (10 minutes) when the configuration or its timeout is
-   * {@code null}.
-   * @param configuration the SMTP server configuration, may be {@code null}
-   * @return the timeout in milliseconds
-   */
-  public static Long getSmtpConnectionTimeout(EmailServerConfiguration configuration) {
+  protected static Long getSmtpConnectionTimeout(EmailServerConfiguration configuration) {
     return (configuration != null && configuration.getSmtpConnectionTimeout() != null)
         ? TimeUnit.SECONDS.toMillis(configuration.getSmtpConnectionTimeout())
         : DEFAULT_SMTP_TIMEOUT;
   }
 
-  /**
-   * Low-level SMTP transport: builds the MIME message and delivers it through the given
-   * server. Used by {@link com.etendoerp.email.spi.DefaultSmtpEmailSender} and by the
-   * deprecated direct-parameter entry points; it performs no configuration resolution and
-   * does not participate in the {@link EmailSenderDispatcher} selection.
-   */
-  public static void sendEmail(String host, boolean auth, String username, String password,
+  protected static void sendEmail(String host, boolean auth, String username, String password,
       String connSecurity, int port, String senderAddress, String senderName, String recipientTO,
       String recipientCC, String recipientBCC, String replyTo, String subject, String content,
       String contentType, List<File> attachments, Date sentDate, List<String> headerExtras,

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/EmailUtilities.java
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/EmailUtilities.java
@@ -146,18 +146,36 @@ public class EmailUtilities {
                 .setSentDate(new Date())
                 .build();
 
-        log4j.debug("From: {}", resolvedConfig.getFromAddress());
-        log4j.debug("Recipient TO (contact email): {}", email.getRecipientTO());
-        log4j.debug("Recipient CC: {}", email.getRecipientCC());
-        log4j.debug("Recipient BCC (user email): {}", email.getRecipientBCC());
-        log4j.debug("Reply-to (sales rep email): {}", email.getReplyTo());
-
-        log4j.info("Sending email using {} SMTP config (id={})", resolvedConfig.getLevel(), resolvedConfig.getConfigId());
+        logEmailDispatch(resolvedConfig, email);
         sendEmail(resolvedConfig, email, attachments);
 
         // Store the email in the database
         saveEmail(connectionProvider, vars.getClient(), vars.getUser(),  email,report, documentData.documentId);
 
+    }
+
+    /**
+     * Logs the email about to be dispatched. The resolved SMTP configuration may be
+     * {@code null} when an alternative email sender handles the message; in that case the
+     * sender address is resolved by that sender at send time and is not logged here.
+     * @param resolvedConfig the cascade-resolved SMTP configuration, may be {@code null}
+     * @param email the email about to be sent
+     */
+    private static void logEmailDispatch(ResolvedSmtpConfig resolvedConfig, EmailInfo email) {
+        if (resolvedConfig != null) {
+            log4j.debug("From: {}", resolvedConfig.getFromAddress());
+        }
+        log4j.debug("Recipient TO (contact email): {}", email.getRecipientTO());
+        log4j.debug("Recipient CC: {}", email.getRecipientCC());
+        log4j.debug("Recipient BCC (user email): {}", email.getRecipientBCC());
+        log4j.debug("Reply-to (sales rep email): {}", email.getReplyTo());
+        if (resolvedConfig != null) {
+            log4j.info("Sending email using {} SMTP config (id={})", resolvedConfig.getLevel(),
+                resolvedConfig.getConfigId());
+        } else {
+            log4j.info("Sending email through an alternative email sender"
+                + " (no SMTP configuration found)");
+        }
     }
 
     private static Collection<? extends File> getDocumentAttachments(String documentId) throws IOException {

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/EmailUtilities.java
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/EmailUtilities.java
@@ -41,6 +41,8 @@ import java.sql.SQLException;
 import java.util.*;
 import java.util.regex.Matcher;
 
+import com.etendoerp.email.spi.EmailSenderDispatcher;
+
 public class EmailUtilities {
     private static final Logger log4j = LogManager.getLogger();
 
@@ -115,7 +117,7 @@ public class EmailUtilities {
 
         // Cascade resolution: User → Organization → Client
         ResolvedSmtpConfig resolvedConfig = SmtpCascadeResolver.resolve();
-        if (resolvedConfig == null) {
+        if (resolvedConfig == null && !EmailSenderDispatcher.hasAlternativeSenderConfigured()) {
             throw new ServletException(
                 "No sender defined: Please configure SMTP at User, Organization or Client level to complete the email configuration.");
         }
@@ -236,7 +238,8 @@ public class EmailUtilities {
             EmailManager.sendEmail(mailConfig, email);
         } catch (Exception exception) {
             log4j.error("Error sending mail via {} SMTP config (id={})",
-                mailConfig.getLevel(), mailConfig.getConfigId(), exception);
+                mailConfig != null ? mailConfig.getLevel() : "<none>",
+                mailConfig != null ? mailConfig.getConfigId() : "<none>", exception);
             throw new ServletException("Problems while sending the email: "
                 + exception.getMessage(), exception);
         } finally {

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/PrintController.java
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/PrintController.java
@@ -342,7 +342,7 @@ public class PrintController extends HttpSecureAppServlet {
                   && request.getServletPath().toLowerCase().indexOf(PRINT_OPTIONS_PATH) == -1) {
                 ResolvedSmtpConfig resolvedForCheck = SmtpCascadeResolver.resolve();
                 boolean hasSender = resolvedForCheck != null
-                    || hasFallbackEmailSender(senderAddress);
+                    || StringUtils.isNotEmpty(senderAddress);
                 if (!hasSender) {
                   reportNoSenderError(response, vars);
                 }
@@ -1188,7 +1188,7 @@ public class PrintController extends HttpSecureAppServlet {
         fromEmail = resolvedConfig.getFromAddress();
         fromEmailId = resolvedConfig.getConfigId();
       } else {
-        reportNoSenderErrorIfNoAlternative(response, vars);
+        reportNoSenderError(response, vars);
       }
     } finally {
       OBContext.restorePreviousMode();
@@ -1503,44 +1503,24 @@ public class PrintController extends HttpSecureAppServlet {
   }
 
   /**
-   * Returns whether an email sender is available besides the cascade-resolved SMTP
-   * configuration: either a legacy per-document sender address or an alternative
-   * {@link com.etendoerp.email.spi.EmailSender} configured by a module.
-   * @param senderAddress the legacy sender address resolved for the document, may be empty
-   * @return {@code true} if a fallback email sender exists
-   */
-  private static boolean hasFallbackEmailSender(String senderAddress) {
-    return StringUtils.isNotEmpty(senderAddress)
-        || EmailSenderDispatcher.hasAlternativeSenderConfigured();
-  }
-
-  /**
-   * Reports the missing-sender error unless an alternative email sender module is
-   * configured. With an alternative sender available, the from field is simply left empty:
-   * the actual sender address is resolved by that sender at send time.
+   * Reports a "no sender configured" error by setting an {@link OBError} message on the current
+   * tab and closing the popup while refreshing the parent record. This ensures the error is
+   * displayed inline on the record (in red) rather than as a generic popup dialog.
+   * <p>
+   * When an alternative {@link com.etendoerp.email.spi.EmailSender} is configured by a
+   * module, no error is reported and processing continues: the actual sender address is
+   * resolved by that sender at send time, so a missing SMTP configuration is not an error.
+   * </p>
    * @param response the HTTP response used to render the close-popup page
    * @param vars the session variables, used to resolve the active tab and language
    * @throws IOException if writing the response fails
    * @throws ServletException thrown after the error is reported, to stop processing
    */
-  private void reportNoSenderErrorIfNoAlternative(HttpServletResponse response,
-      VariablesSecureApp vars) throws IOException, ServletException {
-    if (!EmailSenderDispatcher.hasAlternativeSenderConfigured()) {
-      reportNoSenderError(response, vars);
-    }
-  }
-
-  /**
-   * Reports a "no sender configured" error by setting an {@link OBError} message on the current
-   * tab and closing the popup while refreshing the parent record. This ensures the error is
-   * displayed inline on the record (in red) rather than as a generic popup dialog.
-   * @param response the HTTP response used to render the close-popup page
-   * @param vars the session variables, used to resolve the active tab and language
-   * @throws IOException if writing the response fails
-   * @throws ServletException always thrown after the error is reported, to stop processing
-   */
   private void reportNoSenderError(HttpServletResponse response, VariablesSecureApp vars)
       throws IOException, ServletException {
+    if (EmailSenderDispatcher.hasAlternativeSenderConfigured()) {
+      return;
+    }
     final OBError on = new OBError();
     on.setMessage(Utility.messageBD(this, "NoSender", vars.getLanguage()));
     on.setTitle(Utility.messageBD(this, "EmailConfigError", vars.getLanguage()));

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/PrintController.java
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/PrintController.java
@@ -90,6 +90,8 @@ import net.sf.jasperreports.engine.JRException;
 import net.sf.jasperreports.engine.JasperPrint;
 import net.sf.jasperreports.export.SimplePdfExporterConfiguration;
 
+import com.etendoerp.email.spi.EmailSenderDispatcher;
+
 @SuppressWarnings("serial")
 public class PrintController extends HttpSecureAppServlet {
   private static final String DOCUMENT_ID = "documentId";
@@ -340,7 +342,8 @@ public class PrintController extends HttpSecureAppServlet {
                   && request.getServletPath().toLowerCase().indexOf(PRINT_OPTIONS_PATH) == -1) {
                 ResolvedSmtpConfig resolvedForCheck = SmtpCascadeResolver.resolve();
                 boolean hasSender = resolvedForCheck != null
-                    || StringUtils.isNotEmpty(senderAddress);
+                    || StringUtils.isNotEmpty(senderAddress)
+                    || EmailSenderDispatcher.hasAlternativeSenderConfigured();
                 if (!hasSender) {
                   reportNoSenderError(response, vars);
                 }
@@ -1185,7 +1188,9 @@ public class PrintController extends HttpSecureAppServlet {
       if (resolvedConfig != null) {
         fromEmail = resolvedConfig.getFromAddress();
         fromEmailId = resolvedConfig.getConfigId();
-      } else {
+      } else if (!EmailSenderDispatcher.hasAlternativeSenderConfigured()) {
+        // With an alternative email sender configured, the actual sender address is
+        // resolved by that sender at send time, so the from field is left empty here
         reportNoSenderError(response, vars);
       }
     } finally {

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/PrintController.java
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/PrintController.java
@@ -342,8 +342,7 @@ public class PrintController extends HttpSecureAppServlet {
                   && request.getServletPath().toLowerCase().indexOf(PRINT_OPTIONS_PATH) == -1) {
                 ResolvedSmtpConfig resolvedForCheck = SmtpCascadeResolver.resolve();
                 boolean hasSender = resolvedForCheck != null
-                    || StringUtils.isNotEmpty(senderAddress)
-                    || EmailSenderDispatcher.hasAlternativeSenderConfigured();
+                    || hasFallbackEmailSender(senderAddress);
                 if (!hasSender) {
                   reportNoSenderError(response, vars);
                 }
@@ -1188,10 +1187,8 @@ public class PrintController extends HttpSecureAppServlet {
       if (resolvedConfig != null) {
         fromEmail = resolvedConfig.getFromAddress();
         fromEmailId = resolvedConfig.getConfigId();
-      } else if (!EmailSenderDispatcher.hasAlternativeSenderConfigured()) {
-        // With an alternative email sender configured, the actual sender address is
-        // resolved by that sender at send time, so the from field is left empty here
-        reportNoSenderError(response, vars);
+      } else {
+        reportNoSenderErrorIfNoAlternative(response, vars);
       }
     } finally {
       OBContext.restorePreviousMode();
@@ -1503,6 +1500,34 @@ public class PrintController extends HttpSecureAppServlet {
       }
     }
     return hasMoreThanOneLanguage;
+  }
+
+  /**
+   * Returns whether an email sender is available besides the cascade-resolved SMTP
+   * configuration: either a legacy per-document sender address or an alternative
+   * {@link com.etendoerp.email.spi.EmailSender} configured by a module.
+   * @param senderAddress the legacy sender address resolved for the document, may be empty
+   * @return {@code true} if a fallback email sender exists
+   */
+  private static boolean hasFallbackEmailSender(String senderAddress) {
+    return StringUtils.isNotEmpty(senderAddress)
+        || EmailSenderDispatcher.hasAlternativeSenderConfigured();
+  }
+
+  /**
+   * Reports the missing-sender error unless an alternative email sender module is
+   * configured. With an alternative sender available, the from field is simply left empty:
+   * the actual sender address is resolved by that sender at send time.
+   * @param response the HTTP response used to render the close-popup page
+   * @param vars the session variables, used to resolve the active tab and language
+   * @throws IOException if writing the response fails
+   * @throws ServletException thrown after the error is reported, to stop processing
+   */
+  private void reportNoSenderErrorIfNoAlternative(HttpServletResponse response,
+      VariablesSecureApp vars) throws IOException, ServletException {
+    if (!EmailSenderDispatcher.hasAlternativeSenderConfigured()) {
+      reportNoSenderError(response, vars);
+    }
   }
 
   /**


### PR DESCRIPTION
This pull request introduces comprehensive unit tests for the new email sending SPI, focusing on the core classes involved in email dispatching, context management, and SMTP sending. The tests cover builder population, context creation, sender selection logic, fallback mechanisms, configuration validation, and correct delegation to low-level SMTP transport. These additions ensure robust behavior and correctness of the email sending subsystem, especially regarding extensibility and error handling.

**Unit tests for Email Sending SPI:**

*EmailSendContext and context creation:*
- Added `EmailSendContextTest` to verify builder population, correct extraction of client/organization from `OBContext`, and graceful handling of missing or failing `OBContext` during context creation.

*EmailSenderDispatcher selection and dispatch logic:*
- Added `EmailSenderDispatcherTest` to test sender selection by priority, configuration-based filtering, fallback to the default SMTP sender, non-null guarantees, error propagation, and detection of alternative senders.

*Default SMTP sender contract and delegation:*
- Added `DefaultSmtpEmailSenderTest` to verify baseline contract (always configured, lowest priority), configuration validation (missing host/from address), password decryption, correct delegation to `EmailManager`, and preference for resolved configs over server config records.

---

Doc: https://etendoproject.atlassian.net/wiki/spaces/PYPI/pages/5048074241/Email+Sender+SPI+Developer+Guide