### PR TITLE
Feature ETP-4027: Currency and price List restriction for orders

### DIFF
--- a/src-db/database/model/triggers/C_ORDER_CHK_RESTRINCTIONS_TRG.xml
+++ b/src-db/database/model/triggers/C_ORDER_CHK_RESTRINCTIONS_TRG.xml
@@ -52,16 +52,6 @@ BEGIN
       OR(COALESCE(:OLD.A_ASSET_ID, '0') <> COALESCE(:NEW.A_ASSET_ID, '0')))) THEN
       RAISE_APPLICATION_ERROR(-20000, '@20501@') ;
     END IF;
-    IF (COALESCE(:OLD.C_BPartner_ID, '0')!=COALESCE(:NEW.C_BPartner_ID, '0')) OR (COALESCE(:OLD.M_PriceList_ID,'0') != COALESCE(:NEW.M_PriceList_ID,'0')) OR (COALESCE(:old.C_Currency_ID, '0') != COALESCE(:NEW.C_Currency_ID, '0')) THEN
-      SELECT COUNT(*)
-        INTO v_n
-        FROM C_ORDERLINE
-       WHERE C_Order_ID = :NEW.C_Order_ID;
-
-       IF v_n>0 THEN
-         RAISE_APPLICATION_ERROR(-20000, '@20502@') ;
-       END IF;
-     END IF;
   END IF;
 
   IF(DELETING) THEN


### PR DESCRIPTION
This pull request removes a validation check from the `C_ORDER_CHK_RESTRINCTIONS_TRG` database trigger. Previously, the trigger prevented changes to certain fields in an order if the order already had associated order lines. With this change, updates to `C_BPartner_ID`, `M_PriceList_ID`, or `C_Currency_ID` will no longer be blocked when order lines exist.

Validation logic removal:

* Removed the check that raised an error when attempting to change `C_BPartner_ID`, `M_PriceList_ID`, or `C_Currency_ID` on an order that already has order lines in the `C_ORDER_CHK_RESTRINCTIONS_TRG` trigger (`src-db/database/model/triggers/C_ORDER_CHK_RESTRINCTIONS_TRG.xml`).