### PR TITLE
Issue #1030: Flush pending PSD changes before outstanding query

### DIFF
--- a/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/process/FIN_AddPayment.java
+++ b/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/process/FIN_AddPayment.java
@@ -396,6 +396,12 @@ public class FIN_AddPayment {
         // update Amounts as they have changed
         assignedAmount = assignedAmount
             .subtract(paymentScheduleDetail.getPaymentDetails().getAmount());
+        // Flush pending changes before the criteria query below. A previous iteration may have
+        // removed an outstanding PSD (OBDal.remove); without flushing, getOutstandingPSDs re-reads
+        // stale DB state and re-materializes that row, so the later OBDal.save fails with
+        // "could not re-associate uninitialized transient collection" when a payment groups two
+        // PSDs (invoice + order schedule, e.g. invoice price differs from the order price).
+        OBDal.getInstance().flush();
         // update detail with the new value
         List<FIN_PaymentScheduleDetail> outStandingPSDs = getOutstandingPSDs(paymentScheduleDetail);
         BigDecimal difference = paymentScheduleDetail.getAmount()


### PR DESCRIPTION
## Issue
Closes #1030 — Jira **ETP-4128**

Hibernate error `could not re-associate uninitialized transient collection` when processing **Add Details → Done** after the second reactivation of a payment linked to an order with a modified price.

## Root cause
In `FIN_AddPayment.updatePaymentDetail()` (amount-change branch), a previous loop iteration may remove an outstanding `FIN_PaymentScheduleDetail` via `OBDal.remove()`. The session does not auto-flush before queries, so the subsequent `getOutstandingPSDs()` **criteria query** re-reads stale DB state and re-materializes that row. The following `OBDal.save()` then fails reattaching the entity's uninitialized lazy collection — throwing the Hibernate exception. It only manifests when a payment groups two PSDs (invoice + order schedule), i.e. when the invoice price differs from the order price.

## Fix
Add an explicit `OBDal.getInstance().flush()` right before `getOutstandingPSDs()` so the pending DELETE reaches the DB and the criteria query returns correct state. This matches the validated analysis in ETP-4128 and is consistent with the existing unconditional flushes already present in this class.

## Scope / risk
- Single-line change (+ comment) in one branch of `updatePaymentDetail`.
- `doFlush` is already `true` in every real Add Payment caller; a flush stays within the transaction (not a commit), so rollback semantics are unchanged.

## Affected versions
25.4.16 | 26.1.7 — module `org.openbravo.advpaymentmngt`.

## Backport
Needs backporting to the **25.4** line (`-Y25`).

## Testing
A faithful regression test requires a DB integration scenario (live Hibernate session, two PSDs, double reactivation); validated manually against the reproduction steps in ETP-4128.