### PR TITLE
Issue #1030: Flush pending PSD changes before outstanding query

### DIFF
--- a/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/process/FIN_AddPayment.java
+++ b/modules_core/org.openbravo.advpaymentmngt/src/org/openbravo/advpaymentmngt/process/FIN_AddPayment.java
@@ -396,6 +396,12 @@ public class FIN_AddPayment {
         // update Amounts as they have changed
         assignedAmount = assignedAmount
             .subtract(paymentScheduleDetail.getPaymentDetails().getAmount());
+        // Flush pending changes before the criteria query below. A previous iteration may have
+        // removed an outstanding PSD (OBDal.remove); without flushing, getOutstandingPSDs re-reads
+        // stale DB state and re-materializes that row, so the later OBDal.save fails with
+        // "could not re-associate uninitialized transient collection" when a payment groups two
+        // PSDs (invoice + order schedule, e.g. invoice price differs from the order price).
+        OBDal.getInstance().flush();
         // update detail with the new value
         List<FIN_PaymentScheduleDetail> outStandingPSDs = getOutstandingPSDs(paymentScheduleDetail);
         BigDecimal difference = paymentScheduleDetail.getAmount()


### PR DESCRIPTION
**Backport to 25.4** of #1070 (main).

## Issue
Closes #1030 — Jira **ETP-4128**

Hibernate error `could not re-associate uninitialized transient collection` when processing **Add Details → Done** after the second reactivation of a payment linked to an order with a modified price.

## Root cause
In `FIN_AddPayment.updatePaymentDetail()` (amount-change branch), a previous loop iteration may remove an outstanding `FIN_PaymentScheduleDetail` via `OBDal.remove()`. The session does not auto-flush before queries, so the subsequent `getOutstandingPSDs()` criteria query re-reads stale DB state and re-materializes that row; the following `OBDal.save()` then fails reattaching the entity's uninitialized lazy collection. Only manifests when a payment groups two PSDs (invoice + order schedule).

## Fix
Explicit `OBDal.getInstance().flush()` before `getOutstandingPSDs()`. Cherry-picked clean from the main fix; same placement in 25.4.

## Affected versions
25.4.16 | 26.1.7 — module `org.openbravo.advpaymentmngt`.