### PR TITLE
Feature ETP-4029: Allow currency/price-list edits on orders and invoices

### DIFF
--- a/src-db/database/model/triggers/C_INVOICE_TRG.xml
+++ b/src-db/database/model/triggers/C_INVOICE_TRG.xml
@@ -70,7 +70,7 @@ BEGIN
            END IF;
         END IF;
     END IF;
-      IF (COALESCE(:OLD.C_BPartner_ID, '0')!=COALESCE(:NEW.C_BPartner_ID, '0')) OR (COALESCE(:OLD.M_PriceList_ID,'0') != COALESCE(:NEW.M_PriceList_ID,'0'))  THEN
+      IF (COALESCE(:OLD.C_BPartner_ID, '0')!=COALESCE(:NEW.C_BPartner_ID, '0')) THEN
       SELECT COUNT(*)
         INTO v_n
         FROM C_INVOICELINE

--- a/src-db/database/model/triggers/C_ORDER_CHK_RESTRINCTIONS_TRG.xml
+++ b/src-db/database/model/triggers/C_ORDER_CHK_RESTRINCTIONS_TRG.xml
@@ -52,6 +52,16 @@ BEGIN
       OR(COALESCE(:OLD.A_ASSET_ID, '0') <> COALESCE(:NEW.A_ASSET_ID, '0')))) THEN
       RAISE_APPLICATION_ERROR(-20000, '@20501@') ;
     END IF;
+    IF (COALESCE(:OLD.C_BPartner_ID, '0')!=COALESCE(:NEW.C_BPartner_ID, '0')) THEN
+      SELECT COUNT(*)
+        INTO v_n
+        FROM C_ORDERLINE
+       WHERE C_Order_ID = :NEW.C_Order_ID;
+
+       IF v_n>0 THEN
+         RAISE_APPLICATION_ERROR(-20000, '@20502@') ;
+       END IF;
+     END IF;
   END IF;
 
   IF(DELETING) THEN


### PR DESCRIPTION
## Summary
- Removes the `M_PriceList_ID` (and, for orders, `C_Currency_ID`) restriction from `C_ORDER_CHK_RESTRINCTIONS_TRG` and `C_INVOICE_TRG`, so non-processed documents with existing lines can have their currency/rate edited — required by the new invoice/order currency editing feature (ETP-4029).
- Restores the `C_BPartner_ID` restriction on orders, which was dropped alongside the currency/price-list checks in ETP-4027 (#1069). Changing the business partner on an order with existing lines must stay blocked; only currency/price-list should now be editable.

## Test plan
- [ ] Create a Sales/Purchase Order with lines, change `M_PriceList_ID`/`C_Currency_ID` on the header, confirm it succeeds
- [ ] Attempt to change `C_BPartner_ID` on an order with existing lines, confirm it's still blocked
- [ ] Create a Sales/Purchase Invoice with lines, change `M_PriceList_ID` on the header, confirm it succeeds
- [ ] Attempt to change `C_BPartner_ID` on an invoice with existing lines, confirm it's still blocked