### PR TITLE
Issue #1078: Upgrade gradle plugin version and adjust stress test limits

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'idea'
     id 'groovy'
     id 'jacoco'
-    id 'com.etendoerp.gradleplugin' version '2.3.0'
+    id 'com.etendoerp.gradleplugin' version '2.3.2'
     id 'com.etendoerp.testing.gradleplugin' version '2.1.0'
 }
 compileJava.options.encoding = "UTF-8"

--- a/src-test/src/org/openbravo/test/stress/PurchaseOrderStressTest.java
+++ b/src-test/src/org/openbravo/test/stress/PurchaseOrderStressTest.java
@@ -21,7 +21,7 @@ public class PurchaseOrderStressTest extends StressTestBase {
 
   private static final long MAX_MS_PER_ORDER_CREATION = 15;
   private static final long MAX_MS_PER_ORDER_COMPLETE = 100;
-  private static final long MAX_MS_PER_LINE_CREATION = 15;
+  private static final long MAX_MS_PER_LINE_CREATION = 30;
   private static final long MAX_MEMORY_MB_PER_100_ORDERS = 50;
 
   @Override


### PR DESCRIPTION
ETP-4457: This pull request makes a minor adjustment to the `PurchaseOrderStressTest` performance thresholds. The maximum allowed milliseconds per line creation has been increased to accommodate longer processing times.

- Increased the `MAX_MS_PER_LINE_CREATION` threshold from 15ms to 30ms in `PurchaseOrderStressTest.java` to allow more time for each order line creation.