### PR TITLE
Issue #1078: Adjust stress test limits

### DIFF
--- a/src-test/src/org/openbravo/test/stress/PurchaseOrderStressTest.java
+++ b/src-test/src/org/openbravo/test/stress/PurchaseOrderStressTest.java
@@ -20,7 +20,7 @@ public class PurchaseOrderStressTest extends StressTestBase {
 
   private static final long MAX_MS_PER_ORDER_CREATION = 15;
   private static final long MAX_MS_PER_ORDER_COMPLETE = 100;
-  private static final long MAX_MS_PER_LINE_CREATION = 15;
+  private static final long MAX_MS_PER_LINE_CREATION = 30;
   private static final long MAX_MEMORY_MB_PER_100_ORDERS = 50;
 
   @Override


### PR DESCRIPTION
ETP-4457: This pull request makes a minor adjustment to the performance thresholds in the `PurchaseOrderStressTest` class. Specifically, it increases the maximum allowed time for line creation during stress tests.

- Performance threshold update:
  * Increased the `MAX_MS_PER_LINE_CREATION` constant from 15ms to 30ms in `PurchaseOrderStressTest.java`, allowing more time for each line creation in the stress test.