### PR TITLE
Hotfix ETP-4506: Fix wget install failing on non-root apt-get upgrade (Y25 backport)

### DIFF
--- a/pipelines/unittests/Jenkinsfile
+++ b/pipelines/unittests/Jenkinsfile
@@ -630,7 +630,7 @@ spec:
               echo "--------------- Installing SonarQube ---------------"
               env.JAVA_HOME = "/usr/lib/jvm/jdk-17.0.13"
               sh """
-                apt-get update && apt-get install -y wget unzip
+                apt-get update && apt-get install -y --no-upgrade wget unzip
                 wget https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_VERSION}-linux.zip
                 unzip sonar-scanner-cli-${SONAR_VERSION}-linux.zip
                 export PATH=\$PATH:\${WORKSPACE}/sonar-scanner-${SONAR_VERSION}-linux/bin


### PR DESCRIPTION
## Summary
- Backport of #1088 to `release/25.4`.
- The `SonarQube Analysis` stage in `pipelines/unittests/Jenkinsfile` failed because `apt-get install -y wget unzip` tried to upgrade an already-installed `wget` (a newer version had landed upstream in Ubuntu's `jammy-updates` repo), and the `dpkg` upgrade step requires root privileges the `compiler` container doesn't have.
- Fix: add `--no-upgrade` to the `apt-get install` call so it never attempts to upgrade already-installed packages, avoiding the privileged `dpkg` path entirely.

## Test plan
- [ ] Confirm the `SonarQube Analysis` stage runs successfully on this PR's Jenkins build

Jira: ETP-4506