### PR TITLE
Issue #1098: Fix DepreciatedPlan toggling to 0 on recalculation

### DIFF
--- a/src-test/src/org/openbravo/erpCommon/ad_process/assets/AssetLinearDepreciationMethodProcessTest.java
+++ b/src-test/src/org/openbravo/erpCommon/ad_process/assets/AssetLinearDepreciationMethodProcessTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -19,6 +20,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.hibernate.Session;
+import org.hibernate.query.Query;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -67,6 +70,12 @@ public class AssetLinearDepreciationMethodProcessTest {
   private Organization mockOrg;
   @Mock
   private ProcessBundle mockBundle;
+  @Mock
+  private Session mockSession;
+  @Mock
+  private Query mockQuery;
+  @Mock
+  private OBCriteria<AmortizationLine> mockAmortizationLineCriteria;
 
   private MockedStatic<OBDal> obDalStatic;
   private MockedStatic<OBContext> obContextStatic;
@@ -301,6 +310,57 @@ public class AssetLinearDepreciationMethodProcessTest {
     assertNotNull(result);
     // 1 year of 365 days
     assertEquals(0, result.compareTo(new BigDecimal("365")));
+  }
+
+  /**
+   * Regression test for ETP-4654: DepreciatedPlan must be persisted through a direct bulk UPDATE,
+   * never through the entity setter, since Hibernate's dirty-check silently drops the setter when
+   * the A_AMORTIZATIONLINE_TRG trigger already wrote the same value out-of-band, causing the
+   * field to toggle between 0 and the correct total on every recalculation.
+   * @throws Exception if an error occurs
+   */
+
+  @Test
+  public void testUpdateDepreciatedPlanFromLinesPersistsViaBulkUpdate() throws Exception {
+    final BigDecimal expectedTotal = new BigDecimal("1500.00");
+    when(mockAsset.getId()).thenReturn("ASSET_001");
+    when(mockOBDal.createCriteria(AmortizationLine.class)).thenReturn(mockAmortizationLineCriteria);
+    when(mockAmortizationLineCriteria.add(any())).thenReturn(mockAmortizationLineCriteria);
+    when(mockAmortizationLineCriteria.uniqueResult()).thenReturn(expectedTotal);
+    when(mockOBDal.getSession()).thenReturn(mockSession);
+    when(mockSession.createQuery(anyString())).thenReturn(mockQuery);
+    when(mockQuery.setParameter(anyString(), any())).thenReturn(mockQuery);
+
+    final Method method = AssetLinearDepreciationMethodProcess.class
+        .getDeclaredMethod("updateDepreciatedPlanFromLines", Asset.class);
+    method.setAccessible(true);
+    method.invoke(instance, mockAsset);
+
+    verify(mockAmortizationLineCriteria).setFilterOnReadableOrganization(false);
+    verify(mockQuery).setParameter("plannedAmount", expectedTotal);
+    verify(mockQuery).setParameter("assetId", "ASSET_001");
+    verify(mockQuery).executeUpdate();
+    verify(mockSession).refresh(mockAsset);
+    verify(mockAsset, never()).setDepreciatedPlan(any());
+  }
+
+  /**
+   * Get active amortization lines total zero when no active lines remain.
+   * @throws Exception if an error occurs
+   */
+
+  @Test
+  public void testGetActiveAmortizationLinesTotalReturnsZeroWhenNoLines() throws Exception {
+    when(mockOBDal.createCriteria(AmortizationLine.class)).thenReturn(mockAmortizationLineCriteria);
+    when(mockAmortizationLineCriteria.add(any())).thenReturn(mockAmortizationLineCriteria);
+    when(mockAmortizationLineCriteria.uniqueResult()).thenReturn(null);
+
+    final Method method = AssetLinearDepreciationMethodProcess.class
+        .getDeclaredMethod("getActiveAmortizationLinesTotal", Asset.class);
+    method.setAccessible(true);
+    final BigDecimal result = (BigDecimal) method.invoke(instance, mockAsset);
+
+    assertEquals(0, result.compareTo(BigDecimal.ZERO));
   }
 
   // --- Helper methods ---

--- a/src/org/openbravo/erpCommon/ad_process/assets/AssetLinearDepreciationMethodProcess.java
+++ b/src/org/openbravo/erpCommon/ad_process/assets/AssetLinearDepreciationMethodProcess.java
@@ -30,6 +30,7 @@ import java.util.List;
 import org.apache.commons.codec.binary.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.openbravo.advpaymentmngt.utility.FIN_Utility;
 import org.openbravo.base.exception.OBException;
@@ -67,6 +68,7 @@ public class AssetLinearDepreciationMethodProcess extends DalBaseProcess {
   private static final BigDecimal THIRTY = new BigDecimal("30");
   private static final BigDecimal YEARDAYS = new BigDecimal("365");
   private static final MathContext mc = new MathContext(32, RoundingMode.HALF_UP);
+  private static final String ASSET_ID = "assetId";
 
   @Override
   public void doExecute(final ProcessBundle bundle) throws Exception {
@@ -519,11 +521,74 @@ public class AssetLinearDepreciationMethodProcess extends DalBaseProcess {
 
     asset.setProcessed("Y");
     asset.setProcessAsset("Y");
-    asset.setDepreciatedPlan(amount);
     OBDal.getInstance().save(asset);
 
     OBDal.getInstance().flush();
+
+    // Recompute DepreciatedPlan from the real sum of the asset's active amortization lines and
+    // persist it with an explicit bulk UPDATE. Recalculating deletes and recreates the plan lines,
+    // which fires A_AMORTIZATIONLINE_TRG: the trigger maintains DepreciatedPlan out-of-band (direct
+    // SQL, outside the Hibernate session). A plain asset.setDepreciatedPlan(...) is then silently
+    // dropped by Hibernate's dirty-check against a stale snapshot whenever the value happens to
+    // match the loaded one, leaving the trigger's decremented value in place (the 0/correct toggle,
+    // ETP-4654). A direct UPDATE bypasses the snapshot and always writes the current line total.
+    updateDepreciatedPlanFromLines(asset);
+
     return msg;
+  }
+
+  /**
+   * Recompute the asset's {@code DepreciatedPlan} from the real total of its active amortization
+   * lines and persist it with an explicit bulk UPDATE.
+   * <p>
+   * Recalculating the plan deletes and recreates the amortization lines, which fires the
+   * {@code A_AMORTIZATIONLINE_TRG} trigger. That trigger maintains {@code DepreciatedPlan}
+   * out-of-band (direct SQL, outside the Hibernate session), so a plain
+   * {@link Asset#setDepreciatedPlan(BigDecimal)} is silently dropped by Hibernate's dirty-check
+   * against a snapshot the trigger left stale, leaving the trigger's decremented value in place
+   * (the 0/correct toggle, ETP-4654). A bulk UPDATE bypasses that snapshot and always writes the
+   * current line total; the managed asset is refreshed afterwards so its in-memory value stays
+   * consistent.
+   *
+   * @param asset
+   *          the asset whose {@code DepreciatedPlan} is recomputed and persisted
+   */
+  private void updateDepreciatedPlanFromLines(final Asset asset) {
+    final BigDecimal plannedAmount = getActiveAmortizationLinesTotal(asset);
+    //@formatter:off
+    final String hql = "update " + Asset.ENTITY_NAME
+        + " set depreciatedPlan = :plannedAmount where id = :assetId";
+    //@formatter:on
+    OBDal.getInstance()
+        .getSession()
+        .createQuery(hql)
+        .setParameter("plannedAmount", plannedAmount)
+        .setParameter(ASSET_ID, asset.getId())
+        .executeUpdate();
+    OBDal.getInstance().getSession().refresh(asset);
+  }
+
+  /**
+   * Get the total {@code amortizationAmount} across the asset's active amortization lines. Cancelled
+   * lines are inactive ({@code isActive = 'N'}) and are therefore excluded; the remaining active
+   * lines are exactly the Processed + Pending plan lines that make up the depreciated plan.
+   *
+   * @param asset
+   *          the asset whose amortization lines are summed
+   * @return the total amortization amount of the active lines, {@link BigDecimal#ZERO} if none
+   */
+  private BigDecimal getActiveAmortizationLinesTotal(final Asset asset) {
+    // OBCriteria filters on active = 'Y' by default, so cancelled (inactive) lines are excluded and
+    // the remaining active lines are exactly the Processed + Pending plan lines. Organization
+    // readability is disabled to match the rest of this process: the asset's lines may live in
+    // organizations outside the current context, and leaving them out would produce a partial sum.
+    final OBCriteria<AmortizationLine> obc = OBDal.getInstance()
+        .createCriteria(AmortizationLine.class)
+        .add(Restrictions.eq(AmortizationLine.PROPERTY_ASSET, asset));
+    obc.setProjection(Projections.sum(AmortizationLine.PROPERTY_AMORTIZATIONAMOUNT));
+    obc.setFilterOnReadableOrganization(false);
+    final BigDecimal total = (BigDecimal) obc.uniqueResult();
+    return total == null ? BigDecimal.ZERO : total;
   }
 
   /**
@@ -598,7 +663,7 @@ public class AssetLinearDepreciationMethodProcess extends DalBaseProcess {
     final OBQuery<AmortizationLine> obq = OBDal.getInstance()
         .createQuery(AmortizationLine.class, hql)
         .setFilterOnReadableOrganization(false)
-        .setNamedParameter("assetId", asset.getId());
+        .setNamedParameter(ASSET_ID, asset.getId());
     obq.setNamedParameter("endDate", endDate);
     if (startDate != null) {
       obq.setNamedParameter("startDate", startDate);
@@ -752,7 +817,7 @@ public class AssetLinearDepreciationMethodProcess extends DalBaseProcess {
     final Long maxSeqNoAsset = OBDal.getInstance()
         .getSession()
         .createQuery(hql, Long.class)
-        .setParameter("assetId", asset.getId())
+        .setParameter(ASSET_ID, asset.getId())
         .uniqueResult();
     if (maxSeqNoAsset != null) {
       return maxSeqNoAsset;


### PR DESCRIPTION
## Summary
Fixes ETP-4654: "Depreciated Plan" toggles between 0 and the correct total every time "Recalculate Amortization" is run on an Asset.

Root cause: recalculating deletes and recreates the amortization lines, which fires the `A_AMORTIZATIONLINE_TRG` trigger. That trigger maintains `DepreciatedPlan` out-of-band (direct SQL, outside the Hibernate session). The subsequent `asset.setDepreciatedPlan(amount)` is then silently dropped by Hibernate's dirty-check against a stale snapshot whenever the value happens to match the loaded one, leaving the trigger's decremented value in place.

Fix: replace the entity setter with a direct HQL bulk `UPDATE` that recomputes the total from the asset's active amortization lines (`OBCriteria` + `Projections.sum`) and persists it, bypassing the dirty-check snapshot. The managed asset is refreshed afterwards to stay consistent in memory.

Same fix applied in the `com.etendoerp.accounting.dimensions.assets` module (already merged/in review there) — kept as a separate PR since it lives in a different repo.

Closes #1098

## Test plan
- [x] Added regression tests in `AssetLinearDepreciationMethodProcessTest` verifying the bulk UPDATE path is used and the entity setter is never called
- [x] Verified the new tests fail to compile without the fix, confirming they are tied to the regression
- [x] Full `AssetLinearDepreciationMethodProcessTest` suite passes (14/14)
- [x] Manually verified by the reporter with Core alone installed