### PR TITLE
Issue #1098: Fix DepreciatedPlan toggling to 0 on recalculation

### DIFF
--- a/src-test/src/org/openbravo/erpCommon/ad_process/assets/AssetLinearDepreciationMethodProcessTest.java
+++ b/src-test/src/org/openbravo/erpCommon/ad_process/assets/AssetLinearDepreciationMethodProcessTest.java
@@ -1,0 +1,114 @@
+package org.openbravo.erpCommon.ad_process.assets;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+
+import org.hibernate.Session;
+import org.hibernate.query.Query;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.objenesis.ObjenesisStd;
+import org.openbravo.dal.service.OBCriteria;
+import org.openbravo.dal.service.OBDal;
+import org.openbravo.model.financialmgmt.assetmgmt.AmortizationLine;
+import org.openbravo.model.financialmgmt.assetmgmt.Asset;
+
+/**
+ * Regression tests for ETP-4654 on {@link AssetLinearDepreciationMethodProcess}.
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class AssetLinearDepreciationMethodProcessTest {
+
+  private AssetLinearDepreciationMethodProcess instance;
+
+  @Mock
+  private OBDal mockOBDal;
+  @Mock
+  private Asset mockAsset;
+  @Mock
+  private Session mockSession;
+  @Mock
+  private Query mockQuery;
+  @Mock
+  private OBCriteria<AmortizationLine> mockAmortizationLineCriteria;
+
+  private MockedStatic<OBDal> obDalStatic;
+
+  @Before
+  public void setUp() {
+    ObjenesisStd objenesis = new ObjenesisStd();
+    instance = objenesis.newInstance(AssetLinearDepreciationMethodProcess.class);
+
+    obDalStatic = mockStatic(OBDal.class);
+    obDalStatic.when(OBDal::getInstance).thenReturn(mockOBDal);
+  }
+
+  @After
+  public void tearDown() {
+    if (obDalStatic != null) obDalStatic.close();
+  }
+
+  /**
+   * Regression test for ETP-4654: DepreciatedPlan must be persisted through a direct bulk UPDATE,
+   * never through the entity setter, since Hibernate's dirty-check silently drops the setter when
+   * the A_AMORTIZATIONLINE_TRG trigger already wrote the same value out-of-band, causing the
+   * field to toggle between 0 and the correct total on every recalculation.
+   * @throws Exception if an error occurs
+   */
+
+  @Test
+  public void testUpdateDepreciatedPlanFromLinesPersistsViaBulkUpdate() throws Exception {
+    final BigDecimal expectedTotal = new BigDecimal("1500.00");
+    when(mockAsset.getId()).thenReturn("ASSET_001");
+    when(mockOBDal.createCriteria(AmortizationLine.class)).thenReturn(mockAmortizationLineCriteria);
+    when(mockAmortizationLineCriteria.add(any())).thenReturn(mockAmortizationLineCriteria);
+    when(mockAmortizationLineCriteria.uniqueResult()).thenReturn(expectedTotal);
+    when(mockOBDal.getSession()).thenReturn(mockSession);
+    when(mockSession.createQuery(anyString())).thenReturn(mockQuery);
+    when(mockQuery.setParameter(anyString(), any())).thenReturn(mockQuery);
+
+    final Method method = AssetLinearDepreciationMethodProcess.class
+        .getDeclaredMethod("updateDepreciatedPlanFromLines", Asset.class);
+    method.setAccessible(true);
+    method.invoke(instance, mockAsset);
+
+    verify(mockAmortizationLineCriteria).setFilterOnReadableOrganization(false);
+    verify(mockQuery).setParameter("plannedAmount", expectedTotal);
+    verify(mockQuery).setParameter("assetId", "ASSET_001");
+    verify(mockQuery).executeUpdate();
+    verify(mockSession).refresh(mockAsset);
+    verify(mockAsset, never()).setDepreciatedPlan(any());
+  }
+
+  /**
+   * Get active amortization lines total zero when no active lines remain.
+   * @throws Exception if an error occurs
+   */
+
+  @Test
+  public void testGetActiveAmortizationLinesTotalReturnsZeroWhenNoLines() throws Exception {
+    when(mockOBDal.createCriteria(AmortizationLine.class)).thenReturn(mockAmortizationLineCriteria);
+    when(mockAmortizationLineCriteria.add(any())).thenReturn(mockAmortizationLineCriteria);
+    when(mockAmortizationLineCriteria.uniqueResult()).thenReturn(null);
+
+    final Method method = AssetLinearDepreciationMethodProcess.class
+        .getDeclaredMethod("getActiveAmortizationLinesTotal", Asset.class);
+    method.setAccessible(true);
+    final BigDecimal result = (BigDecimal) method.invoke(instance, mockAsset);
+
+    assertEquals(0, result.compareTo(BigDecimal.ZERO));
+  }
+}

--- a/src-test/src/org/openbravo/erpCommon/ad_process/assets/AssetLinearDepreciationMethodProcessTest.java
+++ b/src-test/src/org/openbravo/erpCommon/ad_process/assets/AssetLinearDepreciationMethodProcessTest.java
@@ -29,6 +29,7 @@ import org.openbravo.model.financialmgmt.assetmgmt.Asset;
 /**
  * Regression tests for ETP-4654 on {@link AssetLinearDepreciationMethodProcess}.
  */
+@SuppressWarnings({"java:S120"})
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class AssetLinearDepreciationMethodProcessTest {
 
@@ -47,6 +48,7 @@ public class AssetLinearDepreciationMethodProcessTest {
 
   private MockedStatic<OBDal> obDalStatic;
 
+  /** Sets up test fixtures. */
   @Before
   public void setUp() {
     ObjenesisStd objenesis = new ObjenesisStd();
@@ -56,6 +58,7 @@ public class AssetLinearDepreciationMethodProcessTest {
     obDalStatic.when(OBDal::getInstance).thenReturn(mockOBDal);
   }
 
+  /** Tears down test fixtures. */
   @After
   public void tearDown() {
     if (obDalStatic != null) obDalStatic.close();

--- a/src-test/src/org/openbravo/erpCommon/ad_process/assets/AssetLinearDepreciationMethodProcessTest.java
+++ b/src-test/src/org/openbravo/erpCommon/ad_process/assets/AssetLinearDepreciationMethodProcessTest.java
@@ -1,4 +1,4 @@
-package org.openbravo.erpCommon.ad_process.assets;
+package org.openbravo.erpCommon.ad_process.assets; // NOSONAR - existing Etendo package naming convention
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;

--- a/src/org/openbravo/erpCommon/ad_process/assets/AssetLinearDepreciationMethodProcess.java
+++ b/src/org/openbravo/erpCommon/ad_process/assets/AssetLinearDepreciationMethodProcess.java
@@ -59,6 +59,7 @@ import org.openbravo.service.db.DbUtility;
 
 public class AssetLinearDepreciationMethodProcess extends DalBaseProcess {
   private static final Logger log4j = LogManager.getLogger();
+  private static final String ASSET_ID = "assetId";
   private static final String LINEAR = "LI";
   private static final String TIME = "TI";
   private static final String PERCENTAGE = "PE";
@@ -562,7 +563,7 @@ public class AssetLinearDepreciationMethodProcess extends DalBaseProcess {
         .getSession()
         .createQuery(hql)
         .setParameter("plannedAmount", plannedAmount)
-        .setParameter("assetId", asset.getId())
+        .setParameter(ASSET_ID, asset.getId())
         .executeUpdate();
     OBDal.getInstance().getSession().refresh(asset);
   }
@@ -662,7 +663,7 @@ public class AssetLinearDepreciationMethodProcess extends DalBaseProcess {
     final OBQuery<AmortizationLine> obq = OBDal.getInstance()
         .createQuery(AmortizationLine.class, hql)
         .setFilterOnReadableOrganization(false)
-        .setNamedParameter("assetId", asset.getId());
+        .setNamedParameter(ASSET_ID, asset.getId());
     obq.setNamedParameter("endDate", endDate);
     if (startDate != null) {
       obq.setNamedParameter("startDate", startDate);
@@ -816,7 +817,7 @@ public class AssetLinearDepreciationMethodProcess extends DalBaseProcess {
     final Long maxSeqNoAsset = OBDal.getInstance()
         .getSession()
         .createQuery(hql, Long.class)
-        .setParameter("assetId", asset.getId())
+        .setParameter(ASSET_ID, asset.getId())
         .uniqueResult();
     if (maxSeqNoAsset != null) {
       return maxSeqNoAsset;

--- a/src/org/openbravo/erpCommon/ad_process/assets/AssetLinearDepreciationMethodProcess.java
+++ b/src/org/openbravo/erpCommon/ad_process/assets/AssetLinearDepreciationMethodProcess.java
@@ -30,6 +30,7 @@ import java.util.List;
 import org.apache.commons.codec.binary.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.openbravo.advpaymentmngt.utility.FIN_Utility;
 import org.openbravo.base.exception.OBException;
@@ -519,11 +520,74 @@ public class AssetLinearDepreciationMethodProcess extends DalBaseProcess {
 
     asset.setProcessed("Y");
     asset.setProcessAsset("Y");
-    asset.setDepreciatedPlan(amount);
     OBDal.getInstance().save(asset);
 
     OBDal.getInstance().flush();
+
+    // Recompute DepreciatedPlan from the real sum of the asset's active amortization lines and
+    // persist it with an explicit bulk UPDATE. Recalculating deletes and recreates the plan lines,
+    // which fires A_AMORTIZATIONLINE_TRG: the trigger maintains DepreciatedPlan out-of-band (direct
+    // SQL, outside the Hibernate session). A plain asset.setDepreciatedPlan(...) is then silently
+    // dropped by Hibernate's dirty-check against a stale snapshot whenever the value happens to
+    // match the loaded one, leaving the trigger's decremented value in place (the 0/correct toggle,
+    // ETP-4654). A direct UPDATE bypasses the snapshot and always writes the current line total.
+    updateDepreciatedPlanFromLines(asset);
+
     return msg;
+  }
+
+  /**
+   * Recompute the asset's {@code DepreciatedPlan} from the real total of its active amortization
+   * lines and persist it with an explicit bulk UPDATE.
+   * <p>
+   * Recalculating the plan deletes and recreates the amortization lines, which fires the
+   * {@code A_AMORTIZATIONLINE_TRG} trigger. That trigger maintains {@code DepreciatedPlan}
+   * out-of-band (direct SQL, outside the Hibernate session), so a plain
+   * {@link Asset#setDepreciatedPlan(BigDecimal)} is silently dropped by Hibernate's dirty-check
+   * against a snapshot the trigger left stale, leaving the trigger's decremented value in place
+   * (the 0/correct toggle, ETP-4654). A bulk UPDATE bypasses that snapshot and always writes the
+   * current line total; the managed asset is refreshed afterwards so its in-memory value stays
+   * consistent.
+   *
+   * @param asset
+   *          the asset whose {@code DepreciatedPlan} is recomputed and persisted
+   */
+  private void updateDepreciatedPlanFromLines(final Asset asset) {
+    final BigDecimal plannedAmount = getActiveAmortizationLinesTotal(asset);
+    //@formatter:off
+    final String hql = "update " + Asset.ENTITY_NAME
+        + " set depreciatedPlan = :plannedAmount where id = :assetId";
+    //@formatter:on
+    OBDal.getInstance()
+        .getSession()
+        .createQuery(hql)
+        .setParameter("plannedAmount", plannedAmount)
+        .setParameter("assetId", asset.getId())
+        .executeUpdate();
+    OBDal.getInstance().getSession().refresh(asset);
+  }
+
+  /**
+   * Get the total {@code amortizationAmount} across the asset's active amortization lines. Cancelled
+   * lines are inactive ({@code isActive = 'N'}) and are therefore excluded; the remaining active
+   * lines are exactly the Processed + Pending plan lines that make up the depreciated plan.
+   *
+   * @param asset
+   *          the asset whose amortization lines are summed
+   * @return the total amortization amount of the active lines, {@link BigDecimal#ZERO} if none
+   */
+  private BigDecimal getActiveAmortizationLinesTotal(final Asset asset) {
+    // OBCriteria filters on active = 'Y' by default, so cancelled (inactive) lines are excluded and
+    // the remaining active lines are exactly the Processed + Pending plan lines. Organization
+    // readability is disabled to match the rest of this process: the asset's lines may live in
+    // organizations outside the current context, and leaving them out would produce a partial sum.
+    final OBCriteria<AmortizationLine> obc = OBDal.getInstance()
+        .createCriteria(AmortizationLine.class)
+        .add(Restrictions.eq(AmortizationLine.PROPERTY_ASSET, asset));
+    obc.setProjection(Projections.sum(AmortizationLine.PROPERTY_AMORTIZATIONAMOUNT));
+    obc.setFilterOnReadableOrganization(false);
+    final BigDecimal total = (BigDecimal) obc.uniqueResult();
+    return total == null ? BigDecimal.ZERO : total;
   }
 
   /**


### PR DESCRIPTION
## Summary
Backport to 25.4 of #1099 (main). Fixes ETP-4654: "Depreciated Plan" toggles between 0 and the correct total every time "Recalculate Amortization" is run on an Asset.

Root cause: recalculating deletes and recreates the amortization lines, which fires the `A_AMORTIZATIONLINE_TRG` trigger. That trigger maintains `DepreciatedPlan` out-of-band (direct SQL, outside the Hibernate session). The subsequent `asset.setDepreciatedPlan(amount)` is then silently dropped by Hibernate's dirty-check against a stale snapshot whenever the value happens to match the loaded one, leaving the trigger's decremented value in place.

Fix: replace the entity setter with a direct HQL bulk `UPDATE` that recomputes the total from the asset's active amortization lines (`OBCriteria` + `Projections.sum`) and persists it, bypassing the dirty-check snapshot. The managed asset is refreshed afterwards to stay consistent in memory.

Production fix is byte-identical to the one merged via #1099 on main (verified with `git diff main release/25.4 -- <file>` before cherry-picking — no drift).

The regression test file did not exist yet on `release/25.4` (added later on `main`), so a lean version with just the two ETP-4654-specific regression tests was added here, instead of importing the full unrelated test suite that only exists on `main`.

Closes #1098

## Test plan
- [x] Cherry-picked production fix applies cleanly (file identical to main pre-fix)
- [x] Added regression tests verifying the bulk UPDATE path is used and the entity setter is never called
- [ ] Could not run the module test suite locally on this branch: this sandbox's checkout of `com.etendoerp.accounting.dimensions.assets` is on a main-era schema incompatible with 25.4's model, unrelated to this change