### PR TITLE
Issue #1102: Fix empty Purchase Order/Invoice combo in Firefox

### DIFF
--- a/src/org/openbravo/erpCommon/ad_actionButton/CreateFrom_F0.html
+++ b/src/org/openbravo/erpCommon/ad_actionButton/CreateFrom_F0.html
@@ -29,9 +29,18 @@ var arrDatos = null;
 var arrDatos2 = null
 </script>
 <script language="JavaScript" type="text/javascript">
-function responseReturn(dataArray, dataArray2){
-  if (parent.frameButton)
+var RESPONSE_RETURN_MAX_ATTEMPTS = 20;
+var RESPONSE_RETURN_RETRY_MS = 50;
+
+function responseReturn(dataArray, dataArray2, attempt){
+  attempt = attempt || 0;
+  if (parent.frameButton) {
     parent.frameButton.updateInvoices(dataArray, dataArray2);
+  } else if (attempt < RESPONSE_RETURN_MAX_ATTEMPTS) {
+    setTimeout(function(){ responseReturn(dataArray, dataArray2, attempt + 1); }, RESPONSE_RETURN_RETRY_MS);
+  } else if (window.console && console.warn) {
+    console.warn("CreateFrom_F0: parent.frameButton was not available, Invoice/Purchase Order combos were not refreshed.");
+  }
 }
 </script>
 </head>

--- a/src/org/openbravo/erpCommon/ad_actionButton/CreateFrom_Shipment.html
+++ b/src/org/openbravo/erpCommon/ad_actionButton/CreateFrom_Shipment.html
@@ -133,6 +133,9 @@
       enableShortcuts('popup');
       setBrowserAutoComplete(false);
 
+      reparentComboOptions(document.frmMain.inpPurchaseOrder);
+      reparentComboOptions(document.frmMain.inpInvoice);
+
       enableLocalShortcuts();
       try {
         onloadFunctions();

--- a/src/org/openbravo/erpCommon/ad_actionButton/CreateFrom_ShipmentPO.html
+++ b/src/org/openbravo/erpCommon/ad_actionButton/CreateFrom_ShipmentPO.html
@@ -203,6 +203,9 @@
       enableShortcuts('popup');
       setBrowserAutoComplete(false);
 
+      reparentComboOptions(document.frmMain.inpPurchaseOrder);
+      reparentComboOptions(document.frmMain.inpInvoice);
+
       enableLocalShortcuts();
       try {
         onloadFunctions();

--- a/web/js/utils.js
+++ b/web/js/utils.js
@@ -1945,6 +1945,31 @@ function getObjParent(obj) {
 }
 
 /**
+* Re-parents <option> elements that ended up nested inside a wrapper element (e.g. a
+* SUBREPORT placeholder <div>) instead of being direct children of the <select>. Some
+* browsers only recognize options as selectable when they are direct children of the
+* select, silently ignoring options left nested inside an intermediate container.
+* @param {Object} combo A reference to the combo (select) object.
+*/
+function reparentComboOptions(combo) {
+  if (!combo) return;
+  var options = Array.prototype.slice.call(combo.getElementsByTagName("option"));
+  for (var i = 0; i < options.length; i++) {
+    if (options[i].parentNode !== combo) {
+      combo.appendChild(options[i]);
+    }
+  }
+  var child = combo.firstChild;
+  while (child) {
+    var next = child.nextSibling;
+    if (child.nodeType === 1 && child.tagName !== "OPTION" && child.tagName !== "OPTGROUP") {
+      combo.removeChild(child);
+    }
+    child = next;
+  }
+}
+
+/**
 * Fills a combo with a data from an Array. Allows to set a default selected item, defined as boolean field in the Array.
 * @param {Object} combo A reference to the combo object.
 * @param {Array} dataArray Array containing the data for the combo. The structure of the array must be value, text, selected. Value is value of the item, text the string that will show the combo, an selected a boolean value to set if the item should appear selected.


### PR DESCRIPTION
## Summary

Y25 backport of #1104.

- Fixes the "Pedido" (Purchase Order) / Invoice combo boxes appearing empty in Firefox on the legacy "Create Lines From" popup (Goods Receipt), even though the backend data and Chrome both show the expected options.
- Root cause: the SUBREPORT placeholder used to inject the combo options is a `<div>` nested inside another `<div>` (from the shared `List.srpt` row template) inside the `<select>`. This double-nesting of invalid content inside `<select>` is tolerated by Chrome but causes Firefox to leave the real `<option>` elements out of the select's usable option list (they remain in the DOM, just not recognized as selectable options).
- Fix: added a `reparentComboOptions()` helper in `web/js/utils.js` that re-parents any `<option>` left nested inside a wrapper element to be a direct child of the `<select>`, and removes the leftover wrapper `<div>`s. Called on popup load for both the Purchase Order and Invoice combos in `CreateFrom_ShipmentPO.html` and `CreateFrom_Shipment.html`.
- Also hardened `CreateFrom_F0.html`'s `responseReturn()` (used for the live BP-change refresh path) to retry instead of silently doing nothing when `parent.frameButton` isn't resolved yet, and to log a warning if it never resolves.

Manually verified in Firefox: the Purchase Order combo now lists the available orders after opening "Create Lines From" with a Business Partner that has open orders. No regression observed in Chrome.

## Jira

ETP-4688

## Test plan

- [x] Manually reproduced the bug in Firefox and confirmed the combo is now populated
- [x] Confirmed Chrome behavior is unchanged
- No automated test added: this is a browser HTML-parsing/DOM quirk in a legacy frame-based popup with no JS test harness in this module.
