### PR TITLE
Feature EPL-1811: Move StoredComputedShapeValidator to src-core

### DIFF
--- a/src-core/src/org/openbravo/erpCommon/utility/StoredComputedShapeValidator.java
+++ b/src-core/src/org/openbravo/erpCommon/utility/StoredComputedShapeValidator.java
@@ -18,8 +18,8 @@ package org.openbravo.erpCommon.utility; // NOSONAR - package name fixed by Eten
 
 /**
  * Dependency-free shape predicate for stored computed column definitions (EPL-1807). This is the
- * single source of truth for the shape rule V1–V3, living in core {@code src/} so it can be shared by
- * both trees that need it without creating an illegal dependency edge:
+ * single source of truth for the shape rule V1–V3, shared by both trees that need it without creating
+ * an illegal dependency edge:
  *
  * <ul>
  * <li>the runtime DAL guard {@code org.openbravo.event.ColumnStoredComputedHandler} (compiled into the
@@ -28,9 +28,23 @@ package org.openbravo.erpCommon.utility; // NOSONAR - package name fixed by Eten
  *     separately under {@code src-util/modulescript/}), whose own {@code checkShape} delegates here.</li>
  * </ul>
  *
- * <p>This class is the core-{@code src/} (webapp / DAL classpath) home of the shape checks, extracted
- * here so the DAL observer can reach them without an illegal core&nbsp;&rarr;&nbsp;modulescript
- * dependency. It enforces only the <b>shape</b> subset of the catalogue; the full V-catalogue
+ * <p><b>Why this class lives in {@code src-core/} and MUST NOT be moved back to {@code src/}.</b> The
+ * build-time consumer runs inside {@code GenerateStoredComputedTriggers} during
+ * {@code update.database}, whose Ant {@code runtime-classpath}
+ * ({@code src-db/database/build.xml}) carries {@code build/classes} but does <b>not</b> depend on any
+ * target that populates it: {@code src/} is compiled by {@code compile.complete}, which runs
+ * <i>after</i> {@code update.database} in the standard flow (pull &rarr; update.database &rarr;
+ * smartbuild). A copy of this class under {@code src/} therefore resolves only on machines that happen
+ * to hold a stale {@code build/classes} from an earlier compile, and throws
+ * {@code NoClassDefFoundError} on every clean checkout. {@code src-core/} has no such hole: it is
+ * packaged into {@code openbravo-core.jar} by the {@code core.lib} target, which
+ * {@code compile.modulescript} declares as a dependency ({@code build.xml}, {@code depends="init,
+ * core.lib"}), so it is guaranteed present before any modulescript exists. This is the same placement
+ * that lets {@code org.openbravo.utils.FormatUtilities} and {@code org.openbravo.data.UtilSql} be used
+ * from modulescripts today. The resulting split of package {@code org.openbravo.erpCommon.utility}
+ * across two source trees is deliberate and mirrors the existing split of {@code org.openbravo.base}.</p>
+ *
+ * <p>It enforces only the <b>shape</b> subset of the catalogue; the full V-catalogue
  * (V4–V11, V14–V16 and the composite-PK target rule) lives in the modulescript
  * {@code StoredComputedValidator}, whose class javadoc holds the canonical Rule index.</p>
  *

--- a/src-util/modulescript/src/org/openbravo/modulescript/StoredComputedValidator.java
+++ b/src-util/modulescript/src/org/openbravo/modulescript/StoredComputedValidator.java
@@ -180,6 +180,13 @@ public final class StoredComputedValidator {
    * {@link StoredComputedShapeValidator#checkShape(String, String, String, Long)} so both this
    * build-time validator (JDBC) and the {@code src/} observer (DAL) evaluate the exact same predicate.
    *
+   * <p><b>Classpath constraint:</b> the delegate MUST stay in {@code src-core/} (packaged into
+   * {@code openbravo-core.jar} via {@code core.lib}, a declared dependency of
+   * {@code compile.modulescript}). This validator runs inside {@code update.database}, whose
+   * {@code runtime-classpath} does not guarantee {@code build/classes} is populated — {@code src/} is
+   * compiled later, by {@code compile.complete}. Moving the delegate to {@code src/} reintroduces a
+   * {@code NoClassDefFoundError} on every clean checkout; see that class's javadoc.</p>
+   *
    * <p>When {@code computationMode = 'S'} the column is recomputed by a database function, so
    * {@code sqlLogic} MUST be blank, {@code fn} MUST be set, and {@code seq} MUST be a positive number.
    * Returns {@link #ETGO_STORED_COMPUTED_COL_DEF} when any of the three is violated, otherwise


### PR DESCRIPTION
## Issue

`update.database` failed with `NoClassDefFoundError: org/openbravo/erpCommon/utility/StoredComputedShapeValidator` on clean checkouts, aborting the build.

Stack: `GenerateStoredComputedTriggers.execute()` (line 128) → `StoredComputedValidator.assertDefinitionsValid()` → `StoredComputedValidator.checkShape()` (line 199).

## Root cause

`StoredComputedShapeValidator` lived in `src/`, which is compiled by the `compile.complete` target — and that runs **after** `update.database` in the standard flow (`pull → update.database → smartbuild`).

The Ant `runtime-classpath` used by `update.database` (`src-db/database/build.xml`) references `build/classes`, but depends on no target that populates it. So the class only resolved on machines holding a stale `build/classes` from an earlier compile. Clean checkouts always failed.

The modulescript itself loads fine because its `.class` files are version-controlled under `src-util/modulescript/build/classes/` (repo-wide convention: the `compile.modulescript` target at `build.xml:675` is orphaned and never invoked). Its dependency `StoredComputedShapeValidator` was not covered by that mechanism, which is why the failure surfaced *inside* `checkShape()` rather than at modulescript load time.

## Solution

Moved the class to `src-core/`, which is packaged into `openbravo-core.jar` by the `core.lib` target — a declared dependency of `compile.modulescript` (`depends="init, core.lib"`). Guaranteed present before any modulescript runs.

This is the same placement that already lets `org.openbravo.utils.FormatUtilities` and `org.openbravo.data.UtilSql` be consumed from modulescripts today.

- The package name is **unchanged** (`org.openbravo.erpCommon.utility`), so **no imports were modified** — `ColumnStoredComputedHandler`, `StoredComputedValidator` and `StoredComputedShapeValidatorTest` are all untouched in that respect.
- The resulting split of `org.openbravo.erpCommon.utility` across two source trees is deliberate and mirrors the existing split of `org.openbravo.base`.
- Both javadocs now document *why* the class must stay in `src-core/`, so a later cleanup does not silently reintroduce the bug.

## Verification

Verified on a clean tree: the stale `build/classes/.../StoredComputedShapeValidator.class` was deleted, then a full compile followed by `update.database` completed successfully.

## Scope

Classpath fix only. No behavior change to the stored computed columns feature (EPL-1807).

---

https://etendoproject.atlassian.net/browse/EPL-1811
