### PR TITLE
Issue #1113: Fix empty report filter combos in Firefox 153+

### DIFF
--- a/src/org/openbravo/erpReports/ReportPaymentFilter.html
+++ b/src/org/openbravo/erpReports/ReportPaymentFilter.html
@@ -60,7 +60,7 @@ function validate() {
 }
 </script>
 </head>
-    <body leftmargin="0" topmargin="0" onload="reparentAllComboOptions();resizeArea();updateMenuIcon('buttonMenu');setFocusFirstControl();" onresize="resizeArea();">
+    <body leftmargin="0" topmargin="0" marginwidth="0" marginheight="0" onload="resizeArea();updateMenuIcon('buttonMenu');setFocusFirstControl();" onresize="resizeArea();">
 <form method="post" action="ReportPaymentFilter.html" name="frmMain" id="form">
   <input type="hidden" name="Command"></input>
   <input type="hidden" name="inpAuxd" value="" id="functionSumAux1"></input>
@@ -349,5 +349,11 @@ function validate() {
     </tr>
   </table>
 </form>
+<script type="text/javascript">
+  // Firefox 153+ keeps the SUBREPORT placeholder <div> inside the <select>, which
+  // leaves the generated <option> elements out of the layout. Normalize them here:
+  // this screen does not go through onLoadDo() / moreOnLoadDoFunctions().
+  reparentAllComboOptions();
+</script>
 </body>
 </html>

--- a/src/org/openbravo/erpReports/ReportPaymentFilter.html
+++ b/src/org/openbravo/erpReports/ReportPaymentFilter.html
@@ -60,7 +60,7 @@ function validate() {
 }
 </script>
 </head>
-    <body leftmargin="0" topmargin="0" marginwidth="0" marginheight="0" onload="reparentAllComboOptions();resizeArea();updateMenuIcon('buttonMenu');setFocusFirstControl();" onresize="resizeArea();">
+    <body leftmargin="0" topmargin="0" onload="reparentAllComboOptions();resizeArea();updateMenuIcon('buttonMenu');setFocusFirstControl();" onresize="resizeArea();">
 <form method="post" action="ReportPaymentFilter.html" name="frmMain" id="form">
   <input type="hidden" name="Command"></input>
   <input type="hidden" name="inpAuxd" value="" id="functionSumAux1"></input>

--- a/src/org/openbravo/erpReports/ReportPaymentFilter.html
+++ b/src/org/openbravo/erpReports/ReportPaymentFilter.html
@@ -60,7 +60,7 @@ function validate() {
 }
 </script>
 </head>
-    <body leftmargin="0" topmargin="0" marginwidth="0" marginheight="0" onload="resizeArea();updateMenuIcon('buttonMenu');setFocusFirstControl();" onresize="resizeArea();">
+    <body leftmargin="0" topmargin="0" marginwidth="0" marginheight="0" onload="reparentAllComboOptions();resizeArea();updateMenuIcon('buttonMenu');setFocusFirstControl();" onresize="resizeArea();">
 <form method="post" action="ReportPaymentFilter.html" name="frmMain" id="form">
   <input type="hidden" name="Command"></input>
   <input type="hidden" name="inpAuxd" value="" id="functionSumAux1"></input>

--- a/src/org/openbravo/erpReports/ReportRegisterFilter.html
+++ b/src/org/openbravo/erpReports/ReportRegisterFilter.html
@@ -60,7 +60,7 @@ function validate() {
 }
 </script>
 </head>
-    <body leftmargin="0" topmargin="0" onload="reparentAllComboOptions();resizeArea();updateMenuIcon('buttonMenu');setFocusFirstControl();" onresize="resizeArea();">
+    <body leftmargin="0" topmargin="0" marginwidth="0" marginheight="0" onload="resizeArea();updateMenuIcon('buttonMenu');setFocusFirstControl();" onresize="resizeArea();">
 <form method="post" action="ReportRegisterFilter.html" name="frmMain" id="form">
   <input type="hidden" name="Command"></input>
   <input type="hidden" name="inpAuxd" value="" id="functionSumAux1"></input>
@@ -351,5 +351,11 @@ function validate() {
     </tr>
   </table>
 </form>
+<script type="text/javascript">
+  // Firefox 153+ keeps the SUBREPORT placeholder <div> inside the <select>, which
+  // leaves the generated <option> elements out of the layout. Normalize them here:
+  // this screen does not go through onLoadDo() / moreOnLoadDoFunctions().
+  reparentAllComboOptions();
+</script>
 </body>
 </html>

--- a/src/org/openbravo/erpReports/ReportRegisterFilter.html
+++ b/src/org/openbravo/erpReports/ReportRegisterFilter.html
@@ -60,7 +60,7 @@ function validate() {
 }
 </script>
 </head>
-    <body leftmargin="0" topmargin="0" marginwidth="0" marginheight="0" onload="reparentAllComboOptions();resizeArea();updateMenuIcon('buttonMenu');setFocusFirstControl();" onresize="resizeArea();">
+    <body leftmargin="0" topmargin="0" onload="reparentAllComboOptions();resizeArea();updateMenuIcon('buttonMenu');setFocusFirstControl();" onresize="resizeArea();">
 <form method="post" action="ReportRegisterFilter.html" name="frmMain" id="form">
   <input type="hidden" name="Command"></input>
   <input type="hidden" name="inpAuxd" value="" id="functionSumAux1"></input>

--- a/src/org/openbravo/erpReports/ReportRegisterFilter.html
+++ b/src/org/openbravo/erpReports/ReportRegisterFilter.html
@@ -60,7 +60,7 @@ function validate() {
 }
 </script>
 </head>
-    <body leftmargin="0" topmargin="0" marginwidth="0" marginheight="0" onload="resizeArea();updateMenuIcon('buttonMenu');setFocusFirstControl();" onresize="resizeArea();">
+    <body leftmargin="0" topmargin="0" marginwidth="0" marginheight="0" onload="reparentAllComboOptions();resizeArea();updateMenuIcon('buttonMenu');setFocusFirstControl();" onresize="resizeArea();">
 <form method="post" action="ReportRegisterFilter.html" name="frmMain" id="form">
   <input type="hidden" name="Command"></input>
   <input type="hidden" name="inpAuxd" value="" id="functionSumAux1"></input>

--- a/web/js/utils.js
+++ b/web/js/utils.js
@@ -1974,12 +1974,17 @@ function reparentComboOptions(combo) {
 * Combos rendered by XmlEngine keep their <option> elements nested inside the SUBREPORT
 * placeholder <div>, which some browsers (Firefox 153+) no longer expose as selectable
 * options. Running this once the DOM is ready normalizes every combo of the page at once,
-* so no per-screen wiring is required.
+* so no per-screen wiring is required. It never throws, so it is safe to call from any
+* onload handler without guarding the call site.
 */
 function reparentAllComboOptions() {
-  var combos = document.getElementsByTagName("select");
-  for (var i = 0; i < combos.length; i++) {
-    reparentComboOptions(combos[i]);
+  try {
+    var combos = document.getElementsByTagName("select");
+    for (var i = 0; i < combos.length; i++) {
+      reparentComboOptions(combos[i]);
+    }
+  } catch (ignored) {
+    // Combo normalization must never break the onload sequence of any screen
   }
 }
 
@@ -5438,12 +5443,7 @@ function fixIE9WindowBorders() {
 }
 
 function moreOnLoadDoFunctions() {
-  try {
-    reparentAllComboOptions();
-  } catch (e) {
-    // Combo normalization must never break the page onload sequence
-    console.log(e);
-  }
+  reparentAllComboOptions();
   setMDIEnvironment();
   fixIE9WindowBorders();
 }

--- a/web/js/utils.js
+++ b/web/js/utils.js
@@ -1970,6 +1970,20 @@ function reparentComboOptions(combo) {
 }
 
 /**
+* Applies reparentComboOptions to every combo (select) present in the current document.
+* Combos rendered by XmlEngine keep their <option> elements nested inside the SUBREPORT
+* placeholder <div>, which some browsers (Firefox 153+) no longer expose as selectable
+* options. Running this once the DOM is ready normalizes every combo of the page at once,
+* so no per-screen wiring is required.
+*/
+function reparentAllComboOptions() {
+  var combos = document.getElementsByTagName("select");
+  for (var i = 0; i < combos.length; i++) {
+    reparentComboOptions(combos[i]);
+  }
+}
+
+/**
 * Fills a combo with a data from an Array. Allows to set a default selected item, defined as boolean field in the Array.
 * @param {Object} combo A reference to the combo object.
 * @param {Array} dataArray Array containing the data for the combo. The structure of the array must be value, text, selected. Value is value of the item, text the string that will show the combo, an selected a boolean value to set if the item should appear selected.
@@ -5424,6 +5438,12 @@ function fixIE9WindowBorders() {
 }
 
 function moreOnLoadDoFunctions() {
+  try {
+    reparentAllComboOptions();
+  } catch (e) {
+    // Combo normalization must never break the page onload sequence
+    console.log(e);
+  }
   setMDIEnvironment();
   fixIE9WindowBorders();
 }


### PR DESCRIPTION
## Summary

- Fixes filter combos rendering as empty dropdowns in Firefox 153+ across the Dimensional
  Analysis / JasperReport filter screens (Organization, Business Partner Group, Product Category,
  Currency, ...), reported for "Purchase Order Dimensional Analysis".
- Root cause: Firefox 153 enabled `dom.lift_select_parser_restrictions.enabled` by default
  ([bug 2019977](https://bugzilla.mozilla.org/show_bug.cgi?id=2019977)). Before that change, the
  HTML parser **dropped** elements that are not allowed inside `<select>`, so the SUBREPORT
  placeholder `<div>` disappeared and the generated `<option>` elements ended up as direct
  children of the `<select>` as a side effect. That silent parser fix-up is what made XmlEngine's
  invalid markup work for the past 20 years. The `<div>` is now kept in the DOM, and Firefox no
  longer includes the nested `<option>` elements in layout: they get a `0x0` box and are never
  painted, so the dropdown renders blank.
- Worth noting for reviewers: `select.options` **still reports the options** and they are
  programmatically selectable — only the rendering is broken. Any check based on
  `select.options.length` will look healthy while the user sees an empty list.
- Fix: adds `reparentAllComboOptions()` to `web/js/utils.js`, which applies the existing
  `reparentComboOptions()` helper (introduced in #1104) to every `<select>` in the document, and
  calls it from the shared `moreOnLoadDoFunctions()` hook. That hook already runs on virtually
  every classic screen via `setWindowTableParentElement()` (`web/js/windowKeyboard.js:170`), so a
  single change covers the whole `ad_reports` family plus `ad_forms`, `ad_process`, `info`,
  the WAD-generated action buttons under `srcAD/` and third-party module templates, with no
  per-screen wiring.
- `ReportRegisterFilter.html` and `ReportPaymentFilter.html` are the only two affected templates
  that do not go through that hook (their `<body onload>` does not call `onLoadDo()`), so they get
  an explicit `reparentAllComboOptions()` call. Both already load `utils.js`.
- The call is wrapped in `try/catch`: `moreOnLoadDoFunctions()` is the first statement of nearly
  every `onLoadDo()`, and an exception there would abort the rest of the onload sequence
  (shortcuts, focus, resize) on every classic screen, including third-party ones.
- The two existing per-combo calls in `CreateFrom_Shipment.html` / `CreateFrom_ShipmentPO.html`
  are left untouched. `reparentComboOptions()` is idempotent, so the double run is a no-op.

## Verification

Measured in Firefox 153.0.3 against Etendo 26.2.7. Because the
dropdown popup is an OS-level widget that cannot be captured, the combos were forced to
`size=6` so the list renders in-page, and each option's `getBoundingClientRect()` was measured.
An option that does not participate in layout (`0x0`) is an option the user cannot see.

Options painted / total:

| Screen | Before | After |
|---|---|---|
| Purchase Order Dimensional Analysis | `inpOrg` 1/9, `inpPartnerGroup2` 1/7, `inpProductCategory2` 1/8, `inpCurrencyId` 1/165 | 9/9, 7/7, 8/8, 165/165 |
| Sales Order Dimensional Analysis | 6 combos, all 1/N | all N/N |
| General Accounting Reports | `inpcAcctSchemaId` 1/3, `inpLevel` 1/5 | 3/3, 5/5 |
| Invoice Vendor Dimensional Analysis | 5 combos, all 1/N | all N/N |
| **Total unpainted options** | **575** | **0** |

Also confirmed: the `selected` attribute survives the re-parenting (`selectedIndex` and `value`
unchanged), running the sweep twice changes nothing (idempotent), and no `SEVERE`/exception
appears in the Tomcat log.

### Verified on the 25.4 line

The same measurement was run against a clean Etendo **25.4.26** environment. The affected
templates there are byte-identical to `origin/release/25.4`, and the served markup is identical to
26.2.7 (same nested `<div id="reportAD_ORGID"><div id="sectionDetail">` inside the `<select>`).

| | Unpainted options across the 4 screens |
|---|---|
| 25.4.26 without the fix | **575** |
| 25.4.26 with this backport | **0** |

## Test plan

- [x] Reproduced the empty dropdowns in Firefox 153.0.3 and confirmed they are populated after the fix
- [x] Verified the fix on three further report families beyond the reported one
- [x] Verified the default selected option is preserved
- [x] Verified idempotency against the combos already wired by #1104

**No automated test added.** This is a browser layout/parsing behaviour and the repository has no
JavaScript test harness (no `package.json`, karma, jest, qunit, Selenium or HtmlUnit); unit tests
here are Java-only. Same rationale as #1104.

## Known technical debt

The underlying cause is server-side: XmlEngine uses the `<SUBREPORT>` anchor as a *container*
instead of replacing it, and `src/org/openbravo/erpCommon/reference/List.srpt` adds a second
wrapper (`<div id="sectionDetail">`). The engine already has a transparent-container mechanism —
`TagValue.print()` suppresses any tag ending in `_TMP`, used for exactly this purpose in
`ModuleBox.srpt` — but applying it would mean touching `List.srpt` plus ~191 anchors across ~92
templates, and would still not cover third-party modules that ship their own templates. Left as
follow-up.

## Jira

ETP-4804

Fixes #1113
