### PR TITLE
Issue #1121: Fix blank Email options popup when adding an attachment

### DIFF
--- a/src-test/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerCommandHandlerTest.java
+++ b/src-test/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerCommandHandlerTest.java
@@ -61,6 +61,8 @@ public class PrintControllerCommandHandlerTest {
   private static final String DOC_ID = "DOC001";
   private static final String SUFFIX_DOCUMENTS = ".Documents";
   private static final String PATH_SEND_HTML = "/send.html";
+  private static final String PATH_PRINT_OPTIONS_HTML = "/invoices/PrintOptions.html";
+  private static final String METHOD_IS_PRINT_PATH = "isPrintPath";
 
   /** Context constructor stores all provided fields. */
   @Test
@@ -309,11 +311,58 @@ public class PrintControllerCommandHandlerTest {
   }
 
   /**
-   * ADD command on a path that is neither print nor send calls neither page builder.
+   * ADD command on the PrintOptions.html path delegates to createEmailOptionsPage. This is the
+   * path the "Add Attachment" button of the email options popup posts to, and it must render the
+   * email options page again instead of leaving the response empty.
    * @throws Exception if handle() propagates an unexpected error
    */
   @Test
-  public void testHandle_addCommand_otherPath_callsNeither() throws Exception {
+  public void testHandle_addCommand_printOptionsPath_callsCreateEmailOptionsPage()
+      throws Exception {
+    PrintController ctrl = mock(PrintController.class);
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    HttpServletResponse resp = mock(HttpServletResponse.class);
+    VariablesSecureApp vars = mock(VariablesSecureApp.class);
+    when(vars.commandIn("ADD")).thenReturn(true);
+    when(req.getServletPath()).thenReturn(PATH_PRINT_OPTIONS_HTML);
+
+    PrintControllerCommandHandler handler = new PrintControllerCommandHandler(
+        ctrl, req, resp, vars, makeContext(new String[]{ DOC_ID }, DocumentType.SALESINVOICE));
+    handler.handle();
+
+    verify(ctrl).createEmailOptionsPage(any(), any(), any(), any(), any(), any(), any());
+    verify(ctrl, never()).createPrintOptionsPage(any(), any(), any(), any(), any(), any());
+  }
+
+  /**
+   * ADD command on a document type other than invoice also reaches the email options page, since
+   * the command handler is shared by every printable document.
+   * @throws Exception if handle() propagates an unexpected error
+   */
+  @Test
+  public void testHandle_addCommand_printOptionsPath_salesOrder_callsCreateEmailOptionsPage()
+      throws Exception {
+    PrintController ctrl = mock(PrintController.class);
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    HttpServletResponse resp = mock(HttpServletResponse.class);
+    VariablesSecureApp vars = mock(VariablesSecureApp.class);
+    when(vars.commandIn("ADD")).thenReturn(true);
+    when(req.getServletPath()).thenReturn("/orders/PrintOptions.html");
+
+    PrintControllerCommandHandler handler = new PrintControllerCommandHandler(
+        ctrl, req, resp, vars, makeContext(new String[]{ DOC_ID }, DocumentType.SALESORDER));
+    handler.handle();
+
+    verify(ctrl).createEmailOptionsPage(any(), any(), any(), any(), any(), any(), any());
+  }
+
+  /**
+   * ADD command on any path that is not print.html falls back to the email options page, so the
+   * response is never left empty.
+   * @throws Exception if handle() propagates an unexpected error
+   */
+  @Test
+  public void testHandle_addCommand_otherPath_fallsBackToEmailOptionsPage() throws Exception {
     PrintController ctrl = mock(PrintController.class);
     HttpServletRequest req = mock(HttpServletRequest.class);
     HttpServletResponse resp = mock(HttpServletResponse.class);
@@ -326,7 +375,7 @@ public class PrintControllerCommandHandlerTest {
     handler.handle();
 
     verify(ctrl, never()).createPrintOptionsPage(any(), any(), any(), any(), any(), any());
-    verify(ctrl, never()).createEmailOptionsPage(any(), any(), any(), any(), any(), any(), any());
+    verify(ctrl).createEmailOptionsPage(any(), any(), any(), any(), any(), any(), any());
   }
 
   /**
@@ -456,7 +505,7 @@ public class PrintControllerCommandHandlerTest {
     HttpServletRequest req = mock(HttpServletRequest.class);
     when(req.getServletPath()).thenReturn("/print.html");
 
-    assertTrue(invokeBooleanReflection(req, "isPrintPath"));
+    assertTrue(invokeBooleanReflection(req, METHOD_IS_PRINT_PATH));
   }
 
   /**
@@ -468,19 +517,20 @@ public class PrintControllerCommandHandlerTest {
     HttpServletRequest req = mock(HttpServletRequest.class);
     when(req.getServletPath()).thenReturn(PATH_SEND_HTML);
 
-    assertFalse(invokeBooleanReflection(req, "isPrintPath"));
+    assertFalse(invokeBooleanReflection(req, METHOD_IS_PRINT_PATH));
   }
 
   /**
-   * isSendPath returns true when the servlet path contains "send.html".
+   * isPrintPath returns false for "printoptions.html": the characters following "print" are
+   * "options", not ".html". This is why that path must not rely on isPrintPath to be routed.
    * @throws Exception if reflection fails
    */
   @Test
-  public void testIsSendPath_sendHtml_returnsTrue() throws Exception {
+  public void testIsPrintPath_printOptionsHtml_returnsFalse() throws Exception {
     HttpServletRequest req = mock(HttpServletRequest.class);
-    when(req.getServletPath()).thenReturn(PATH_SEND_HTML);
+    when(req.getServletPath()).thenReturn(PATH_PRINT_OPTIONS_HTML);
 
-    assertTrue(invokeBooleanReflection(req, "isSendPath"));
+    assertFalse(invokeBooleanReflection(req, METHOD_IS_PRINT_PATH));
   }
 
   /**

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/EmailOptions.html
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/EmailOptions.html
@@ -968,7 +968,7 @@
                             <tbody>
                             <tr class="DataGrid_Body_Row"> 
                                 <th class="DataGrid_Header_Cell"><span>File name</span></th>
-                                <th width="20%" colspan="1" class="DataGrid_Header_Cell" id="fieldPartnerName"><span>Archive</span><th>
+                                <th style="width: 20%;" colspan="1" class="DataGrid_Header_Cell" id="fieldPartnerName"><span>Archive</span></th>
                             </tr>
                             <div id="sectionDetail2">
                             <tr id="funcEvenOddRowxx" class="DataGrid_Body_Row DataGrid_Body_Row_xx">
@@ -1028,7 +1028,7 @@
 </tr>
 
                     <tr id="emailField03">                      
-                        <td style="width: 1%; text-align: right; white-space: nowrap; padding-right: 10px;"> <input type="hidden" id="paramArchive" name="inpArchive" value="""/></td>
+                        <td style="width: 1%; text-align: right; white-space: nowrap; padding-right: 10px;"> <input type="hidden" id="paramArchive" name="inpArchive" value=""/></td>
                         <td  colspan="2" style="width: 99%"></td>           
                     </tr>   
                     </table>

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/PrintController.java
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/PrintController.java
@@ -580,8 +580,11 @@ public class PrintController extends HttpSecureAppServlet {
       VariablesSecureApp vars, DocumentType documentType, String strDocumentId,
       Map<String, Report> reports, HashMap<String, Boolean> checks)
       throws IOException, ServletException, ReportingException {
-    String fullDocumentIdentifier = PrintControllerDocumentHelper.normalizeDocumentId(strDocumentId)
-        + documentType.getTableName();
+    // Must use the same allowlist sanitizer as PrintControllerCommandHandler, which reads back the
+    // pocData session entry under this key. normalizeDocumentId() only strips parentheses and
+    // quotes, so the write side and the read side could build different keys for the same document.
+    String fullDocumentIdentifier = PrintControllerDocumentHelper
+        .sanitizeDocumentIdentifier(strDocumentId) + documentType.getTableName();
     PrintControllerEmailOptionsBuilder.Context context =
         new PrintControllerEmailOptionsBuilder.Context(documentType, strDocumentId, reports, checks,
             fullDocumentIdentifier);

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerCommandHandler.java
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerCommandHandler.java
@@ -365,10 +365,12 @@ final class PrintControllerCommandHandler {
           docIdsForPage, context.reports);
       return;
     }
-    if (isSendPath()) {
-      controller.createEmailOptionsPage(request, response, vars, context.documentType,
-          docIdsForPage, context.reports, context.checks);
-    }
+    // Every non print.html path renders the email options page: send.html on the initial load and
+    // PrintOptions.html when the popup itself posts back (ADD command). This must stay a fallback
+    // branch instead of a second condition, otherwise an unmatched path silently writes nothing to
+    // the response and the popup renders blank.
+    controller.createEmailOptionsPage(request, response, vars, context.documentType, docIdsForPage,
+        context.reports, context.checks);
   }
 
   private void validateSenderConfiguration(Report report) throws IOException, ServletException {
@@ -395,10 +397,6 @@ final class PrintControllerCommandHandler {
 
   private boolean isPrintOptionsPath() {
     return request.getServletPath().toLowerCase().indexOf("printoptions.html") != -1;
-  }
-
-  private boolean isSendPath() {
-    return request.getServletPath().toLowerCase().indexOf("send.html") != -1;
   }
 
 


### PR DESCRIPTION
Fixes #1121 — ETP-4868

## Root cause

`PrintInvoices` (and every other print controller) is mapped to three URLs: `/invoices/send.html`, `/invoices/print.html` and `/invoices/PrintOptions.html`. The Email options popup is opened through `send.html`, but its own form posts back to `PrintOptions.html`:

```html
<form id="form" method="POST" action="PrintOptions.html" name="frmMain" enctype="multipart/form-data">
```

So the `ADD` command issued by "Add Attachment" arrives on `PrintOptions.html`, where `openOptionsPage()` matched neither branch:

- `isPrintPath()` → `false`, because the literal substring `print.html` is not contained in `printoptions.html` (the characters after `print` are `options`, not `.html`)
- `isSendPath()` → `false`, no `send.html` substring

The method returned without writing anything to the response, producing the empty `200 OK` and the blank popup. No exception anywhere, because it was a silent no-op rather than a failure.

This is a regression from the ETP-4197 refactor (#1049, released in 26.1.10). Before it, the `ADD` command in `PrintController.post()` was an `if/else` with a fallback:

```java
} else if (vars.commandIn("ADD")) {
  if (request.getServletPath().toLowerCase().indexOf(PRINT_PATH) != -1) {
    createPrintOptionsPage(...);
  } else {
    createEmailOptionsPage(...);
  }
```

The refactor turned that into two independent `if`s with no fallback.

## Fix

Restore the `if/else` shape in `PrintControllerCommandHandler.openOptionsPage()`: `print.html` renders the print options page, **every other path** falls back to the email options page. This was preferred over adding `isPrintOptionsPath()` as a third condition because it removes the whole class of failure — an unmatched path can no longer leave the response empty — and it matches the pre-regression behaviour exactly.

`isSendPath()` becomes unused and is removed (`isPrintOptionsPath()` stays, it is still used by `validateSenderConfiguration()`).

## Tests

`PrintControllerCommandHandlerTest` had **encoded the bug**: `testHandle_addCommand_otherPath_callsNeither()` asserted that neither page builder was called. That expectation was replaced with correct coverage:

- `testHandle_addCommand_printOptionsPath_callsCreateEmailOptionsPage` — the exact regression
- `testHandle_addCommand_printOptionsPath_salesOrder_callsCreateEmailOptionsPage` — the handler is shared across document types
- `testHandle_addCommand_otherPath_fallsBackToEmailOptionsPage` — the response is never left empty
- `testIsPrintPath_printOptionsHtml_returnsFalse` — documents the substring trap that caused this

The three new `ADD` tests **fail against the pre-fix code** and pass with it. The whole `reporting.printing` test package (13 classes, 181 tests) passes.

## Manual verification

Verified on a local 26.2.7 instance whose core sources were confirmed byte-for-byte identical to `main` before patching:

1. Reproduced the blank popup on the unpatched instance.
2. Deployed the fixed class, restarted, repeated the flow with a real file attached → the popup re-renders with all fields plus the new entry in "Attached Documents".
3. Checked the Print options popup (`print.html` path) still renders correctly — no regression on that branch.

## Also included

Two malformed-markup fixes in the "Attached Documents" block of `EmailOptions.html`: an unclosed `<th>` and a `value="""` attribute. The deprecated `width` attribute on the same line was converted to an inline style so the change does not introduce a new Web-analyzer violation on a modified line.

**Deliberately not touched:** the unbalanced `div`/`tr`/`td` nesting around the same block. Those `<div id="sectionDetail">` / `<div id="sectionDetail2">` elements are declared as `<SECTION>` in `EmailOptions.xml`, so they are XmlEngine section markers and their boundaries define which markup repeats per row. Rebalancing them would change repetition semantics, not just formatting — it belongs in its own change with its own validation.
