### PR TITLE
Issue #1130: Show Description Only field in shipment and receipt lines

### DIFF
--- a/modules_core/org.openbravo.v3/src-db/database/configScript.xml
+++ b/modules_core/org.openbravo.v3/src-db/database/configScript.xml
@@ -1121,10 +1121,6 @@
       <oldValue><![CDATA[Y]]></oldValue>
       <newValue><![CDATA[N]]></newValue>
     </columnDataChange>
-    <columnDataChange tablename="AD_FIELD" columnname="ISDISPLAYED" pkRow="8251">
-      <oldValue><![CDATA[Y]]></oldValue>
-      <newValue><![CDATA[N]]></newValue>
-    </columnDataChange>
     <columnDataChange tablename="AD_FIELD" columnname="ISDISPLAYED" pkRow="800000">
       <oldValue><![CDATA[Y]]></oldValue>
       <newValue><![CDATA[N]]></newValue>

--- a/src/org/openbravo/erpReports/RptM_RMInOut_Lines.jrxml
+++ b/src/org/openbravo/erpReports/RptM_RMInOut_Lines.jrxml
@@ -35,19 +35,20 @@
             FROM M_PRODUCT_CUSTOMER
             WHERE M_PRODUCT_CUSTOMER.M_PRODUCT_ID=M_INOUTLINE.M_PRODUCT_ID
             AND M_PRODUCT_CUSTOMER.C_BPARTNER_ID=M_INOUT.C_BPARTNER_ID)
-            ,M_PRODUCT.NAME) AS NAME,SUM(M_INOUTLINE.MOVEMENTQTY) AS MOVEMENTQTY, M_ATTRIBUTESETINSTANCE.DESCRIPTION AS ATTRIBUTEDESC,
-            REPLACE(M_INOUTLINE.DESCRIPTION, CHR(10), '') AS LLOT, REPLACE(M_INOUT.DESCRIPTION, CHR(10), '') AS DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME AS UOM
+            ,M_PRODUCT.NAME, M_INOUTLINE.DESCRIPTION) AS NAME,SUM(M_INOUTLINE.MOVEMENTQTY) AS MOVEMENTQTY, M_ATTRIBUTESETINSTANCE.DESCRIPTION AS ATTRIBUTEDESC,
+            REPLACE(M_INOUTLINE.DESCRIPTION, CHR(10), '') AS LLOT, REPLACE(M_INOUT.DESCRIPTION, CHR(10), '') AS DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME AS UOM,
+            COALESCE(M_INOUTLINE.ISDESCRIPTION, 'N') AS ISDESCRIPTION
         FROM M_INOUTLINE left join C_ORDERLINE on M_INOUTLINE.C_ORDERLINE_ID = C_ORDERLINE.C_ORDERLINE_ID
                          left join C_ORDER on C_ORDERLINE.C_ORDER_ID = C_ORDER.C_ORDER_ID
-                         left join M_ATTRIBUTESETINSTANCE on M_INOUTLINE.M_ATTRIBUTESETINSTANCE_ID = M_ATTRIBUTESETINSTANCE.M_ATTRIBUTESETINSTANCE_ID,
-             M_INOUT, M_PRODUCT, C_UOM
+                         left join M_ATTRIBUTESETINSTANCE on M_INOUTLINE.M_ATTRIBUTESETINSTANCE_ID = M_ATTRIBUTESETINSTANCE.M_ATTRIBUTESETINSTANCE_ID
+                         left join M_PRODUCT on M_INOUTLINE.M_PRODUCT_ID = M_PRODUCT.M_PRODUCT_ID
+                         left join C_UOM on M_PRODUCT.C_UOM_ID = C_UOM.C_UOM_ID,
+             M_INOUT
         WHERE M_INOUT.M_INOUT_ID = M_INOUTLINE.M_INOUT_ID
-        AND M_INOUTLINE.M_PRODUCT_ID = M_PRODUCT.M_PRODUCT_ID
         AND M_INOUT.M_INOUT_ID = '$P!{M_INOUT_ID}'
-        AND M_PRODUCT.C_UOM_ID = C_UOM.C_UOM_ID
         GROUP BY C_ORDER.DOCUMENTNO, M_INOUT.C_BPARTNER_ID, C_ORDER.POREFERENCE, M_PRODUCT.VALUE, M_INOUTLINE.M_PRODUCT_ID, M_PRODUCT.NAME, M_ATTRIBUTESETINSTANCE.DESCRIPTION,
-        M_ATTRIBUTESETINSTANCE.GUARANTEEDATE, M_INOUT.DESCRIPTION, M_INOUTLINE.DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME
-        ORDER BY C_ORDER.DOCUMENTNO, M_PRODUCT.NAME]]>
+        M_ATTRIBUTESETINSTANCE.GUARANTEEDATE, M_INOUT.DESCRIPTION, M_INOUTLINE.DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME, COALESCE(M_INOUTLINE.ISDESCRIPTION, 'N')
+        ORDER BY C_ORDER.DOCUMENTNO, M_PRODUCT.NAME, MIN(M_INOUTLINE.LINE)]]>
 	</queryString>
 	<field name="value" class="java.lang.String"/>
 	<field name="name" class="java.lang.String"/>
@@ -57,6 +58,7 @@
 	<field name="description" class="java.lang.String"/>
 	<field name="upc" class="java.lang.String"/>
 	<field name="uom" class="java.lang.String"/>
+	<field name="isdescription" class="java.lang.String"/>
 	<group name="M_INOUT_ID">
 		<groupExpression><![CDATA[$P{M_INOUT_ID}]]></groupExpression>
 		<groupHeader>
@@ -181,7 +183,9 @@
 			<frame>
 				<reportElement key="frame-1" style="Detail_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="482" height="16" uuid="0201eeaf-8b7c-49d3-a3b4-c06edb40f6a6"/>
 				<textField isBlankWhenNull="true">
-					<reportElement key="textField-5" style="default" x="385" y="0" width="35" height="16" forecolor="#000000" uuid="56a36daf-577b-428f-8727-7029ba1e5d5d"/>
+					<reportElement key="textField-5" style="default" x="385" y="0" width="35" height="16" forecolor="#000000" uuid="56a36daf-577b-428f-8727-7029ba1e5d5d">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 					<box leftPadding="2" rightPadding="2"/>
 					<textElement verticalAlignment="Middle">
 						<font size="8"/>
@@ -190,7 +194,9 @@
 				</textField>
 			</frame>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField-1" style="default" x="0" y="0" width="90" height="16" forecolor="#000000" uuid="715a9803-e468-46ed-8e1e-4abffe833d03"/>
+				<reportElement key="textField-1" style="default" x="0" y="0" width="90" height="16" forecolor="#000000" uuid="715a9803-e468-46ed-8e1e-4abffe833d03">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 				<box leftPadding="2" rightPadding="2"/>
 				<textElement verticalAlignment="Middle">
 					<font size="8"/>
@@ -206,7 +212,9 @@
 				<textFieldExpression><![CDATA[$F{name}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField-3" style="default" x="255" y="0" width="130" height="16" forecolor="#000000" uuid="93834014-9b05-4afc-bc4a-408cd6b40cb8"/>
+				<reportElement key="textField-3" style="default" x="255" y="0" width="130" height="16" forecolor="#000000" uuid="93834014-9b05-4afc-bc4a-408cd6b40cb8">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 				<box leftPadding="2" rightPadding="2"/>
 				<textElement verticalAlignment="Middle">
 					<font size="8"/>
@@ -214,7 +222,9 @@
 				<textFieldExpression><![CDATA[$F{attributedesc}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-4" style="default" x="420" y="0" width="60" height="16" forecolor="#000000" uuid="46cfb2a8-96fe-474e-bfa5-be6467a48987"/>
+				<reportElement key="textField-4" style="default" x="420" y="0" width="60" height="16" forecolor="#000000" uuid="46cfb2a8-96fe-474e-bfa5-be6467a48987">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 				<box leftPadding="2" rightPadding="2"/>
 				<textElement textAlignment="Right" verticalAlignment="Middle">
 					<font size="8"/>

--- a/src/org/openbravo/erpReports/Rptm_InOut_Lines.jrxml
+++ b/src/org/openbravo/erpReports/Rptm_InOut_Lines.jrxml
@@ -35,19 +35,20 @@
             FROM M_PRODUCT_CUSTOMER 
             WHERE M_PRODUCT_CUSTOMER.M_PRODUCT_ID=M_INOUTLINE.M_PRODUCT_ID
             AND M_PRODUCT_CUSTOMER.C_BPARTNER_ID=M_INOUT.C_BPARTNER_ID)
-            ,M_PRODUCT.NAME) AS NAME,SUM(M_INOUTLINE.MOVEMENTQTY) AS MOVEMENTQTY, M_ATTRIBUTESETINSTANCE.LOT || ' - ' || M_ATTRIBUTESETINSTANCE.GUARANTEEDATE AS LOT,
-            REPLACE(M_INOUTLINE.DESCRIPTION, CHR(10), '') AS LLOT, REPLACE(M_INOUT.DESCRIPTION, CHR(10), '') AS DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME AS UOM
+            ,M_PRODUCT.NAME, M_INOUTLINE.DESCRIPTION) AS NAME,SUM(M_INOUTLINE.MOVEMENTQTY) AS MOVEMENTQTY, M_ATTRIBUTESETINSTANCE.LOT || ' - ' || M_ATTRIBUTESETINSTANCE.GUARANTEEDATE AS LOT,
+            REPLACE(M_INOUTLINE.DESCRIPTION, CHR(10), '') AS LLOT, REPLACE(M_INOUT.DESCRIPTION, CHR(10), '') AS DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME AS UOM,
+            COALESCE(M_INOUTLINE.ISDESCRIPTION, 'N') AS ISDESCRIPTION
         FROM M_INOUTLINE left join C_ORDERLINE on M_INOUTLINE.C_ORDERLINE_ID = C_ORDERLINE.C_ORDERLINE_ID
                          left join C_ORDER on C_ORDERLINE.C_ORDER_ID = C_ORDER.C_ORDER_ID
-                         left join M_ATTRIBUTESETINSTANCE on M_INOUTLINE.M_ATTRIBUTESETINSTANCE_ID = M_ATTRIBUTESETINSTANCE.M_ATTRIBUTESETINSTANCE_ID,
-             M_INOUT, M_PRODUCT, C_UOM
+                         left join M_ATTRIBUTESETINSTANCE on M_INOUTLINE.M_ATTRIBUTESETINSTANCE_ID = M_ATTRIBUTESETINSTANCE.M_ATTRIBUTESETINSTANCE_ID
+                         left join M_PRODUCT on M_INOUTLINE.M_PRODUCT_ID = M_PRODUCT.M_PRODUCT_ID
+                         left join C_UOM on M_PRODUCT.C_UOM_ID = C_UOM.C_UOM_ID,
+             M_INOUT
         WHERE M_INOUT.M_INOUT_ID = M_INOUTLINE.M_INOUT_ID
-        AND M_INOUTLINE.M_PRODUCT_ID = M_PRODUCT.M_PRODUCT_ID
         AND M_INOUT.M_INOUT_ID = '$P!{M_INOUT_ID}'
-        AND M_PRODUCT.C_UOM_ID = C_UOM.C_UOM_ID
         GROUP BY C_ORDER.DOCUMENTNO, M_INOUT.C_BPARTNER_ID, C_ORDER.POREFERENCE, M_PRODUCT.VALUE, M_INOUTLINE.M_PRODUCT_ID, M_PRODUCT.NAME, M_ATTRIBUTESETINSTANCE.LOT,
-        M_ATTRIBUTESETINSTANCE.GUARANTEEDATE, M_INOUT.DESCRIPTION, M_INOUTLINE.DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME
-        ORDER BY C_ORDER.DOCUMENTNO, M_PRODUCT.NAME]]>
+        M_ATTRIBUTESETINSTANCE.GUARANTEEDATE, M_INOUT.DESCRIPTION, M_INOUTLINE.DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME, COALESCE(M_INOUTLINE.ISDESCRIPTION, 'N')
+        ORDER BY C_ORDER.DOCUMENTNO, M_PRODUCT.NAME, MIN(M_INOUTLINE.LINE)]]>
 	</queryString>
 	<field name="value" class="java.lang.String"/>
 	<field name="name" class="java.lang.String"/>
@@ -57,6 +58,7 @@
 	<field name="description" class="java.lang.String"/>
 	<field name="upc" class="java.lang.String"/>
 	<field name="uom" class="java.lang.String"/>
+	<field name="isdescription" class="java.lang.String"/>
 	<group name="M_INOUT_ID">
 		<groupExpression><![CDATA[$P{M_INOUT_ID}]]></groupExpression>
 		<groupHeader>
@@ -181,7 +183,9 @@
 			<frame>
 				<reportElement key="frame-1" style="Detail_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="482" height="16" uuid="8402283f-3a9a-424a-8667-2861e3897b51"/>
 				<textField isBlankWhenNull="false">
-					<reportElement key="textField-5" style="default" x="386" y="0" width="35" height="16" forecolor="#000000" uuid="13597421-9850-4f65-b6d6-e62bfdfed331"/>
+					<reportElement key="textField-5" style="default" x="386" y="0" width="35" height="16" forecolor="#000000" uuid="13597421-9850-4f65-b6d6-e62bfdfed331">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 					<textElement verticalAlignment="Middle">
 						<font size="8"/>
 					</textElement>
@@ -189,7 +193,9 @@
 				</textField>
 			</frame>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-1" style="default" x="0" y="0" width="90" height="16" forecolor="#000000" uuid="e1ce06e4-4f0e-492f-9efd-779ae7b116a3"/>
+				<reportElement key="textField-1" style="default" x="0" y="0" width="90" height="16" forecolor="#000000" uuid="e1ce06e4-4f0e-492f-9efd-779ae7b116a3">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
@@ -215,7 +221,9 @@
 				<textFieldExpression><![CDATA[($F{name}==null ? " " : " " + $F{name})]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-3" style="default" x="255" y="0" width="130" height="16" forecolor="#000000" uuid="a73b2096-8fd2-4ba9-beef-e1af56e86615"/>
+				<reportElement key="textField-3" style="default" x="255" y="0" width="130" height="16" forecolor="#000000" uuid="a73b2096-8fd2-4ba9-beef-e1af56e86615">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
@@ -228,7 +236,9 @@
 				<textFieldExpression><![CDATA[($F{lot}==null ? " " : " " + $F{lot})]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-4" style="default" x="422" y="0" width="59" height="16" forecolor="#000000" uuid="56c70f0a-3b29-4ea6-a473-e51a62588b70"/>
+				<reportElement key="textField-4" style="default" x="422" y="0" width="59" height="16" forecolor="#000000" uuid="56c70f0a-3b29-4ea6-a473-e51a62588b70">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>

--- a/src/org/openbravo/erpReports/Rptm_InOut_Lines_new.jrxml
+++ b/src/org/openbravo/erpReports/Rptm_InOut_Lines_new.jrxml
@@ -38,18 +38,19 @@
             FROM M_PRODUCT_CUSTOMER
             WHERE M_PRODUCT_CUSTOMER.M_PRODUCT_ID=M_INOUTLINE.M_PRODUCT_ID
             AND M_PRODUCT_CUSTOMER.C_BPARTNER_ID=M_INOUT.C_BPARTNER_ID)
-            ,M_PRODUCT.NAME) AS NAME,SUM(M_INOUTLINE.MOVEMENTQTY) AS MOVEMENTQTY, M_ATTRIBUTESETINSTANCE.DESCRIPTION AS LOT,
-            REPLACE(M_INOUTLINE.DESCRIPTION, CHR(10), '') AS LLOT, REPLACE(M_INOUT.DESCRIPTION, CHR(10), '') AS DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME AS UOM
+            ,M_PRODUCT.NAME, M_INOUTLINE.DESCRIPTION) AS NAME,SUM(M_INOUTLINE.MOVEMENTQTY) AS MOVEMENTQTY, M_ATTRIBUTESETINSTANCE.DESCRIPTION AS LOT,
+            REPLACE(M_INOUTLINE.DESCRIPTION, CHR(10), '') AS LLOT, REPLACE(M_INOUT.DESCRIPTION, CHR(10), '') AS DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME AS UOM,
+            COALESCE(M_INOUTLINE.ISDESCRIPTION, 'N') AS ISDESCRIPTION
         FROM M_INOUTLINE left join C_ORDERLINE on M_INOUTLINE.C_ORDERLINE_ID = C_ORDERLINE.C_ORDERLINE_ID
                          left join C_ORDER on C_ORDERLINE.C_ORDER_ID = C_ORDER.C_ORDER_ID
-                         left join M_ATTRIBUTESETINSTANCE on M_INOUTLINE.M_ATTRIBUTESETINSTANCE_ID = M_ATTRIBUTESETINSTANCE.M_ATTRIBUTESETINSTANCE_ID,
-             M_INOUT, M_PRODUCT, C_UOM
+                         left join M_ATTRIBUTESETINSTANCE on M_INOUTLINE.M_ATTRIBUTESETINSTANCE_ID = M_ATTRIBUTESETINSTANCE.M_ATTRIBUTESETINSTANCE_ID
+                         left join M_PRODUCT on M_INOUTLINE.M_PRODUCT_ID = M_PRODUCT.M_PRODUCT_ID
+                         left join C_UOM on M_PRODUCT.C_UOM_ID = C_UOM.C_UOM_ID,
+             M_INOUT
         WHERE M_INOUT.M_INOUT_ID = M_INOUTLINE.M_INOUT_ID
-        AND M_INOUTLINE.M_PRODUCT_ID = M_PRODUCT.M_PRODUCT_ID
         AND M_INOUT.M_INOUT_ID = '$P!{M_INOUT_ID}'
-        AND M_PRODUCT.C_UOM_ID = C_UOM.C_UOM_ID
-        GROUP BY C_ORDER.DOCUMENTNO, M_INOUT.C_BPARTNER_ID, C_ORDER.POREFERENCE, M_PRODUCT.VALUE, M_INOUTLINE.M_PRODUCT_ID, M_PRODUCT.NAME, M_ATTRIBUTESETINSTANCE.DESCRIPTION, M_INOUT.DESCRIPTION, M_INOUTLINE.DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME
-        ORDER BY C_ORDER.DOCUMENTNO, M_PRODUCT.NAME]]>
+        GROUP BY C_ORDER.DOCUMENTNO, M_INOUT.C_BPARTNER_ID, C_ORDER.POREFERENCE, M_PRODUCT.VALUE, M_INOUTLINE.M_PRODUCT_ID, M_PRODUCT.NAME, M_ATTRIBUTESETINSTANCE.DESCRIPTION, M_INOUT.DESCRIPTION, M_INOUTLINE.DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME, COALESCE(M_INOUTLINE.ISDESCRIPTION, 'N')
+        ORDER BY C_ORDER.DOCUMENTNO, M_PRODUCT.NAME, MIN(M_INOUTLINE.LINE)]]>
 	</queryString>
 	<field name="value" class="java.lang.String"/>
 	<field name="name" class="java.lang.String"/>
@@ -59,6 +60,7 @@
 	<field name="description" class="java.lang.String"/>
 	<field name="upc" class="java.lang.String"/>
 	<field name="uom" class="java.lang.String"/>
+	<field name="isdescription" class="java.lang.String"/>
 	<group name="M_INOUT_ID">
 		<groupExpression><![CDATA[$P{M_INOUT_ID}]]></groupExpression>
 		<groupHeader>
@@ -172,7 +174,9 @@
 			<frame>
 				<reportElement key="frame-1" style="default" stretchType="RelativeToBandHeight" x="0" y="0" width="482" height="21" uuid="f170c6be-337a-45b9-a5bc-be2c6dd1c874"/>
 				<textField isBlankWhenNull="false">
-					<reportElement key="textField-5" style="default" x="386" y="0" width="35" height="21" forecolor="#000000" uuid="9d25a9eb-1dd0-435b-a89f-3250d84f0c20"/>
+					<reportElement key="textField-5" style="default" x="386" y="0" width="35" height="21" forecolor="#000000" uuid="9d25a9eb-1dd0-435b-a89f-3250d84f0c20">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 					<textElement verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
@@ -180,7 +184,9 @@
 				</textField>
 			</frame>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-1" style="default" x="0" y="0" width="90" height="21" forecolor="#000000" uuid="97ea4cd2-7c66-45e8-bbb0-50ae3fdb2bb5"/>
+				<reportElement key="textField-1" style="default" x="0" y="0" width="90" height="21" forecolor="#000000" uuid="97ea4cd2-7c66-45e8-bbb0-50ae3fdb2bb5">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
@@ -206,7 +212,9 @@
 				<textFieldExpression><![CDATA[($F{name}==null ? " " : " " + $F{name})]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-3" style="default" x="255" y="0" width="130" height="21" forecolor="#000000" uuid="cd437130-1b14-4955-8887-17835e8d310f"/>
+				<reportElement key="textField-3" style="default" x="255" y="0" width="130" height="21" forecolor="#000000" uuid="cd437130-1b14-4955-8887-17835e8d310f">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
@@ -219,7 +227,9 @@
 				<textFieldExpression><![CDATA[($F{lot}==null ? " " : " " + $F{lot})]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-4" style="default" x="422" y="0" width="59" height="21" forecolor="#000000" uuid="5e627541-5158-4d30-8185-b2a0dcc1eac5"/>
+				<reportElement key="textField-4" style="default" x="422" y="0" width="59" height="21" forecolor="#000000" uuid="5e627541-5158-4d30-8185-b2a0dcc1eac5">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>


### PR DESCRIPTION
## Summary

- Fixes #1130 (ETP-4915): the "Description Only" checkbox (`M_InOutLine.IsDescription`) is hidden by
  default in the Lines tab of Goods Shipment and Goods Receipt, so the validation added by ETP-3992
  (Core 26.1.7 / 25.4.16) cannot be satisfied without a per-client Application Dictionary
  customization. That blocks a previously supported use case: description-only lines used as order
  separators or delivery clarifications on the printed document.
- Root cause is **not** the same in both windows, and the sourcedata alone is misleading:
  - **Goods Receipt** (`AD_FIELD` 8245, tab 297): the sourcedata really does ship `ISDISPLAYED=N`.
  - **Goods Shipment** (`AD_FIELD` 8251, tab 258): the sourcedata already ships `ISDISPLAYED=Y`, but
    `modules_core/org.openbravo.v3/src-db/database/configScript.xml` rewrites it to `N` through a
    `columnDataChange` every time modules are applied. This is why no real instance has ever shown
    the field even though `AD_FIELD.xml` says `Y`. On a fresh 26.2.7 install, `ad_field.updated` for
    8251 is 9 seconds later than its `created` — that gap is the configScript.
- Fix follows the precedent set by 6b3501fb ("Feature ETP-1189: Display Cancel Promotions columns"),
  which solved exactly this shape of problem: set the value in the sourcedata **and** delete the
  configScript override.
  - 8245: `ISDISPLAYED` `N` → `Y`, plus `SEQNO=105`. 110 is taken by *Canceled Inout line* in that
    tab, and 105 puts the field right after *Order Quantity* (100), mirroring where it sits in Goods
    Shipment (110). Non-multiples of 10 are already used in both tabs (35, 37).
  - 8251: no sourcedata change needed — only the configScript block is removed.
- `MInOutLineEventHandler` is untouched, so the ETP-3992 validation is preserved exactly: a line with
  no product and quantity 0 still fails with `ProductNullAndMovementQtyZero` when the checkbox is not
  marked. That behaviour is already covered by the 8 tests in `MInOutLineEventHandlerTest`
  (registered in `CoverageTestSuite`).
- No tests are added: this is a pure Application Dictionary data change with no code involved.

## Windows deliberately left out

*Return to Vendor Shipment* (`AD_FIELD` F06493388D514388BE2B83277F1B3B0F) and *Return Material
Receipt* (`FC468BA33C6A479B889E219D22575F31`) use the same table and also hide the field, but **every**
line field in those two tabs is `ISREADONLY=Y` (Line, Product, MovementQty, Storage Bin, UOM…) because
the lines are produced by *Create Lines From*. Showing a read-only checkbox there would not unblock
anything, so they are left as they are. Worth revisiting if manual line entry is ever allowed in those
windows.

## Verification

Both the fresh-install path (sourcedata) and the upgrade path (an existing database whose
`ad_field` row says `N`) were exercised on real instances.

**Etendo 26.2.7** — `./gradlew update.database` on an existing instance, then a full `smartbuild`
on top:

```
ad_field_id | window         | isdisplayed | seqno
8245        | Goods Receipt  | Y           | 105
8251        | Goods Shipment | Y           | 110
```

8251 flipped from `N` to `Y` precisely because the configScript entry is gone. The values survive a
full `smartbuild`, and the `CheckSumCondition` build step passes with the modified configScript.

Functionally validated in the UI by the reporter's workflow on that instance: with the checkbox
visible, a line with no product, quantity 0 and *Description Only* marked saves; leaving it unmarked
still fails with the ETP-3992 message.

**Etendo 25.4.26** (same change, see the Y25 PR) — same result: 8245 `Y`/105 and 8251 `Y`/110 after
`update.database`.

Note for anyone reproducing this: `smartbuild` alone is not enough. Its `update.database.if.no.local`
step skipped the sourcedata import on the 25.4 instance and the fields stayed at `N`; the explicit
`update.database` task is what applies the change.

SonarQube is not affected — `sonar-project.properties` excludes `**/*.xml`, and this PR changes only
two XML files.

## Backport

`hotfix/#1130-ETP-4915-Y25` → `release/25.4`, identical change.


---

## Second commit: printing the description-only lines

Making the field visible let users create the line, but the printed document dropped it, which is
the reason the customer asked for it in the first place. The line subreports of the shipment family
joined `M_INOUTLINE` to `M_PRODUCT` with an **inner join**, so every line without a product was
filtered out of the print:

```sql
-- src/org/openbravo/erpReports/Rptm_InOut_Lines_new.jrxml (before)
AND M_INOUTLINE.M_PRODUCT_ID = M_PRODUCT.M_PRODUCT_ID
AND M_PRODUCT.C_UOM_ID = C_UOM.C_UOM_ID
ORDER BY C_ORDER.DOCUMENTNO, M_PRODUCT.NAME
```

Worth noting for reviewers: the order and invoice subreports (`C_OrderLinesJR_new`,
`RptC_Invoice_Lines_new`) already use `left join` plus `ORDER BY LINE` and have always printed these
lines correctly. The shipment family was the exception inside core, so this is a consistency defect
rather than a new feature.

### Templates changed

| Template | Doc-type configurations using it | Documents |
|---|---|---|
| `Rptm_InOut_Lines_new.jrxml` | 10 | Goods Shipment, Goods Receipt, MM Shipment Indirect, RFC Receipt |
| `RptM_RMInOut_Lines.jrxml` | 5 | RTV Shipment, return documents |
| `Rptm_InOut_Lines.jrxml` | 0 | orphan; aligned for consistency |

### What changed in each

- `M_PRODUCT` and `C_UOM` become `left join`, so productless lines are no longer discarded. The UOM
  is still taken from the product (`M_PRODUCT.C_UOM_ID`) on purpose: switching to the line's UOM
  would be conceptually cleaner but would change the printed unit on lines whose UOM differs from
  the product's default.
- The product-name column falls back to the line description via `COALESCE`, the same pattern the
  invoice subreport already uses. No new layout element is needed.
- A new `ISDESCRIPTION` field drives `printWhenExpression` on reference, UOM, attributes and
  quantity, so those columns stay empty on a description row instead of printing a meaningless
  `0.00`.
- **The existing ordering is deliberately preserved.** `ORDER BY C_ORDER.DOCUMENTNO,
  M_PRODUCT.NAME` stays as it is and `MIN(M_INOUTLINE.LINE)` is appended only as a deterministic
  tie-breaker (today two rows sharing a product name but differing in attributes come out in an
  undefined order).

### Consequence, agreed with the release manager

Because a description-only line has neither an order nor a product to sort by, it is printed **at
the end of the document**. It therefore does not work as an inline separator in the standard
template. This was the explicit decision: core offers the option of printing these lines without
altering the current output, and customers who need a specific position will handle it in their own
templates. Ordering by line number was evaluated and rejected, since it would change the printed
order for every customer.

### Verification

Four cases printed on 26.2.7, each before and after:

1. Shipment with a description-only line → the line now prints; the three product lines keep their
   exact order.
2. Shipment consolidating two orders, with a description-only line interleaved and one product
   repeated across three lines → product order unchanged, the grouping still merges the three
   Lager Beer lines into a single row of 300, description line at the end.
3. **No regression:** shipment `1000013`, 14 real sample-data lines from two orders and no
   description-only line, printed with the old and the new template. The two PDFs were compared
   line by line and are **identical**.
4. Return document (`RptM_RMInOut_Lines`) → same result.

No automated tests are possible: Jasper templates are not part of the pipeline and
`sonar-project.properties` excludes `**/*.xml`. Not verified on Oracle — the query uses no
dialect-specific syntax and `MIN()` over a grouped set behaves the same on both engines, but no
Oracle environment was available.
