### PR TITLE
Issue #1130: Show Description Only field in shipment and receipt lines

### DIFF
--- a/modules_core/org.openbravo.v3/src-db/database/configScript.xml
+++ b/modules_core/org.openbravo.v3/src-db/database/configScript.xml
@@ -1121,10 +1121,6 @@
       <oldValue><![CDATA[Y]]></oldValue>
       <newValue><![CDATA[N]]></newValue>
     </columnDataChange>
-    <columnDataChange tablename="AD_FIELD" columnname="ISDISPLAYED" pkRow="8251">
-      <oldValue><![CDATA[Y]]></oldValue>
-      <newValue><![CDATA[N]]></newValue>
-    </columnDataChange>
     <columnDataChange tablename="AD_FIELD" columnname="ISDISPLAYED" pkRow="800000">
       <oldValue><![CDATA[Y]]></oldValue>
       <newValue><![CDATA[N]]></newValue>

--- a/src/org/openbravo/erpReports/RptM_RMInOut_Lines.jrxml
+++ b/src/org/openbravo/erpReports/RptM_RMInOut_Lines.jrxml
@@ -35,19 +35,20 @@
             FROM M_PRODUCT_CUSTOMER
             WHERE M_PRODUCT_CUSTOMER.M_PRODUCT_ID=M_INOUTLINE.M_PRODUCT_ID
             AND M_PRODUCT_CUSTOMER.C_BPARTNER_ID=M_INOUT.C_BPARTNER_ID)
-            ,M_PRODUCT.NAME) AS NAME,SUM(M_INOUTLINE.MOVEMENTQTY) AS MOVEMENTQTY, M_ATTRIBUTESETINSTANCE.DESCRIPTION AS ATTRIBUTEDESC,
-            REPLACE(M_INOUTLINE.DESCRIPTION, CHR(10), '') AS LLOT, REPLACE(M_INOUT.DESCRIPTION, CHR(10), '') AS DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME AS UOM
+            ,M_PRODUCT.NAME, M_INOUTLINE.DESCRIPTION) AS NAME,SUM(M_INOUTLINE.MOVEMENTQTY) AS MOVEMENTQTY, M_ATTRIBUTESETINSTANCE.DESCRIPTION AS ATTRIBUTEDESC,
+            REPLACE(M_INOUTLINE.DESCRIPTION, CHR(10), '') AS LLOT, REPLACE(M_INOUT.DESCRIPTION, CHR(10), '') AS DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME AS UOM,
+            COALESCE(M_INOUTLINE.ISDESCRIPTION, 'N') AS ISDESCRIPTION
         FROM M_INOUTLINE left join C_ORDERLINE on M_INOUTLINE.C_ORDERLINE_ID = C_ORDERLINE.C_ORDERLINE_ID
                          left join C_ORDER on C_ORDERLINE.C_ORDER_ID = C_ORDER.C_ORDER_ID
-                         left join M_ATTRIBUTESETINSTANCE on M_INOUTLINE.M_ATTRIBUTESETINSTANCE_ID = M_ATTRIBUTESETINSTANCE.M_ATTRIBUTESETINSTANCE_ID,
-             M_INOUT, M_PRODUCT, C_UOM
+                         left join M_ATTRIBUTESETINSTANCE on M_INOUTLINE.M_ATTRIBUTESETINSTANCE_ID = M_ATTRIBUTESETINSTANCE.M_ATTRIBUTESETINSTANCE_ID
+                         left join M_PRODUCT on M_INOUTLINE.M_PRODUCT_ID = M_PRODUCT.M_PRODUCT_ID
+                         left join C_UOM on M_PRODUCT.C_UOM_ID = C_UOM.C_UOM_ID,
+             M_INOUT
         WHERE M_INOUT.M_INOUT_ID = M_INOUTLINE.M_INOUT_ID
-        AND M_INOUTLINE.M_PRODUCT_ID = M_PRODUCT.M_PRODUCT_ID
         AND M_INOUT.M_INOUT_ID = '$P!{M_INOUT_ID}'
-        AND M_PRODUCT.C_UOM_ID = C_UOM.C_UOM_ID
         GROUP BY C_ORDER.DOCUMENTNO, M_INOUT.C_BPARTNER_ID, C_ORDER.POREFERENCE, M_PRODUCT.VALUE, M_INOUTLINE.M_PRODUCT_ID, M_PRODUCT.NAME, M_ATTRIBUTESETINSTANCE.DESCRIPTION,
-        M_ATTRIBUTESETINSTANCE.GUARANTEEDATE, M_INOUT.DESCRIPTION, M_INOUTLINE.DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME
-        ORDER BY C_ORDER.DOCUMENTNO, M_PRODUCT.NAME]]>
+        M_ATTRIBUTESETINSTANCE.GUARANTEEDATE, M_INOUT.DESCRIPTION, M_INOUTLINE.DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME, COALESCE(M_INOUTLINE.ISDESCRIPTION, 'N')
+        ORDER BY C_ORDER.DOCUMENTNO, M_PRODUCT.NAME, MIN(M_INOUTLINE.LINE)]]>
 	</queryString>
 	<field name="value" class="java.lang.String"/>
 	<field name="name" class="java.lang.String"/>
@@ -57,6 +58,7 @@
 	<field name="description" class="java.lang.String"/>
 	<field name="upc" class="java.lang.String"/>
 	<field name="uom" class="java.lang.String"/>
+	<field name="isdescription" class="java.lang.String"/>
 	<group name="M_INOUT_ID">
 		<groupExpression><![CDATA[$P{M_INOUT_ID}]]></groupExpression>
 		<groupHeader>
@@ -181,7 +183,9 @@
 			<frame>
 				<reportElement key="frame-1" style="Detail_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="482" height="16" uuid="0201eeaf-8b7c-49d3-a3b4-c06edb40f6a6"/>
 				<textField isBlankWhenNull="true">
-					<reportElement key="textField-5" style="default" x="385" y="0" width="35" height="16" forecolor="#000000" uuid="56a36daf-577b-428f-8727-7029ba1e5d5d"/>
+					<reportElement key="textField-5" style="default" x="385" y="0" width="35" height="16" forecolor="#000000" uuid="56a36daf-577b-428f-8727-7029ba1e5d5d">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 					<box leftPadding="2" rightPadding="2"/>
 					<textElement verticalAlignment="Middle">
 						<font size="8"/>
@@ -190,7 +194,9 @@
 				</textField>
 			</frame>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField-1" style="default" x="0" y="0" width="90" height="16" forecolor="#000000" uuid="715a9803-e468-46ed-8e1e-4abffe833d03"/>
+				<reportElement key="textField-1" style="default" x="0" y="0" width="90" height="16" forecolor="#000000" uuid="715a9803-e468-46ed-8e1e-4abffe833d03">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 				<box leftPadding="2" rightPadding="2"/>
 				<textElement verticalAlignment="Middle">
 					<font size="8"/>
@@ -206,7 +212,9 @@
 				<textFieldExpression><![CDATA[$F{name}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement key="textField-3" style="default" x="255" y="0" width="130" height="16" forecolor="#000000" uuid="93834014-9b05-4afc-bc4a-408cd6b40cb8"/>
+				<reportElement key="textField-3" style="default" x="255" y="0" width="130" height="16" forecolor="#000000" uuid="93834014-9b05-4afc-bc4a-408cd6b40cb8">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 				<box leftPadding="2" rightPadding="2"/>
 				<textElement verticalAlignment="Middle">
 					<font size="8"/>
@@ -214,7 +222,9 @@
 				<textFieldExpression><![CDATA[$F{attributedesc}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-4" style="default" x="420" y="0" width="60" height="16" forecolor="#000000" uuid="46cfb2a8-96fe-474e-bfa5-be6467a48987"/>
+				<reportElement key="textField-4" style="default" x="420" y="0" width="60" height="16" forecolor="#000000" uuid="46cfb2a8-96fe-474e-bfa5-be6467a48987">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 				<box leftPadding="2" rightPadding="2"/>
 				<textElement textAlignment="Right" verticalAlignment="Middle">
 					<font size="8"/>

--- a/src/org/openbravo/erpReports/Rptm_InOut_Lines.jrxml
+++ b/src/org/openbravo/erpReports/Rptm_InOut_Lines.jrxml
@@ -35,19 +35,20 @@
             FROM M_PRODUCT_CUSTOMER 
             WHERE M_PRODUCT_CUSTOMER.M_PRODUCT_ID=M_INOUTLINE.M_PRODUCT_ID
             AND M_PRODUCT_CUSTOMER.C_BPARTNER_ID=M_INOUT.C_BPARTNER_ID)
-            ,M_PRODUCT.NAME) AS NAME,SUM(M_INOUTLINE.MOVEMENTQTY) AS MOVEMENTQTY, M_ATTRIBUTESETINSTANCE.LOT || ' - ' || M_ATTRIBUTESETINSTANCE.GUARANTEEDATE AS LOT,
-            REPLACE(M_INOUTLINE.DESCRIPTION, CHR(10), '') AS LLOT, REPLACE(M_INOUT.DESCRIPTION, CHR(10), '') AS DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME AS UOM
+            ,M_PRODUCT.NAME, M_INOUTLINE.DESCRIPTION) AS NAME,SUM(M_INOUTLINE.MOVEMENTQTY) AS MOVEMENTQTY, M_ATTRIBUTESETINSTANCE.LOT || ' - ' || M_ATTRIBUTESETINSTANCE.GUARANTEEDATE AS LOT,
+            REPLACE(M_INOUTLINE.DESCRIPTION, CHR(10), '') AS LLOT, REPLACE(M_INOUT.DESCRIPTION, CHR(10), '') AS DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME AS UOM,
+            COALESCE(M_INOUTLINE.ISDESCRIPTION, 'N') AS ISDESCRIPTION
         FROM M_INOUTLINE left join C_ORDERLINE on M_INOUTLINE.C_ORDERLINE_ID = C_ORDERLINE.C_ORDERLINE_ID
                          left join C_ORDER on C_ORDERLINE.C_ORDER_ID = C_ORDER.C_ORDER_ID
-                         left join M_ATTRIBUTESETINSTANCE on M_INOUTLINE.M_ATTRIBUTESETINSTANCE_ID = M_ATTRIBUTESETINSTANCE.M_ATTRIBUTESETINSTANCE_ID,
-             M_INOUT, M_PRODUCT, C_UOM
+                         left join M_ATTRIBUTESETINSTANCE on M_INOUTLINE.M_ATTRIBUTESETINSTANCE_ID = M_ATTRIBUTESETINSTANCE.M_ATTRIBUTESETINSTANCE_ID
+                         left join M_PRODUCT on M_INOUTLINE.M_PRODUCT_ID = M_PRODUCT.M_PRODUCT_ID
+                         left join C_UOM on M_PRODUCT.C_UOM_ID = C_UOM.C_UOM_ID,
+             M_INOUT
         WHERE M_INOUT.M_INOUT_ID = M_INOUTLINE.M_INOUT_ID
-        AND M_INOUTLINE.M_PRODUCT_ID = M_PRODUCT.M_PRODUCT_ID
         AND M_INOUT.M_INOUT_ID = '$P!{M_INOUT_ID}'
-        AND M_PRODUCT.C_UOM_ID = C_UOM.C_UOM_ID
         GROUP BY C_ORDER.DOCUMENTNO, M_INOUT.C_BPARTNER_ID, C_ORDER.POREFERENCE, M_PRODUCT.VALUE, M_INOUTLINE.M_PRODUCT_ID, M_PRODUCT.NAME, M_ATTRIBUTESETINSTANCE.LOT,
-        M_ATTRIBUTESETINSTANCE.GUARANTEEDATE, M_INOUT.DESCRIPTION, M_INOUTLINE.DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME
-        ORDER BY C_ORDER.DOCUMENTNO, M_PRODUCT.NAME]]>
+        M_ATTRIBUTESETINSTANCE.GUARANTEEDATE, M_INOUT.DESCRIPTION, M_INOUTLINE.DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME, COALESCE(M_INOUTLINE.ISDESCRIPTION, 'N')
+        ORDER BY C_ORDER.DOCUMENTNO, M_PRODUCT.NAME, MIN(M_INOUTLINE.LINE)]]>
 	</queryString>
 	<field name="value" class="java.lang.String"/>
 	<field name="name" class="java.lang.String"/>
@@ -57,6 +58,7 @@
 	<field name="description" class="java.lang.String"/>
 	<field name="upc" class="java.lang.String"/>
 	<field name="uom" class="java.lang.String"/>
+	<field name="isdescription" class="java.lang.String"/>
 	<group name="M_INOUT_ID">
 		<groupExpression><![CDATA[$P{M_INOUT_ID}]]></groupExpression>
 		<groupHeader>
@@ -181,7 +183,9 @@
 			<frame>
 				<reportElement key="frame-1" style="Detail_Line" stretchType="RelativeToBandHeight" x="0" y="0" width="482" height="16" uuid="8402283f-3a9a-424a-8667-2861e3897b51"/>
 				<textField isBlankWhenNull="false">
-					<reportElement key="textField-5" style="default" x="386" y="0" width="35" height="16" forecolor="#000000" uuid="13597421-9850-4f65-b6d6-e62bfdfed331"/>
+					<reportElement key="textField-5" style="default" x="386" y="0" width="35" height="16" forecolor="#000000" uuid="13597421-9850-4f65-b6d6-e62bfdfed331">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 					<textElement verticalAlignment="Middle">
 						<font size="8"/>
 					</textElement>
@@ -189,7 +193,9 @@
 				</textField>
 			</frame>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-1" style="default" x="0" y="0" width="90" height="16" forecolor="#000000" uuid="e1ce06e4-4f0e-492f-9efd-779ae7b116a3"/>
+				<reportElement key="textField-1" style="default" x="0" y="0" width="90" height="16" forecolor="#000000" uuid="e1ce06e4-4f0e-492f-9efd-779ae7b116a3">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
@@ -215,7 +221,9 @@
 				<textFieldExpression><![CDATA[($F{name}==null ? " " : " " + $F{name})]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-3" style="default" x="255" y="0" width="130" height="16" forecolor="#000000" uuid="a73b2096-8fd2-4ba9-beef-e1af56e86615"/>
+				<reportElement key="textField-3" style="default" x="255" y="0" width="130" height="16" forecolor="#000000" uuid="a73b2096-8fd2-4ba9-beef-e1af56e86615">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
@@ -228,7 +236,9 @@
 				<textFieldExpression><![CDATA[($F{lot}==null ? " " : " " + $F{lot})]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-4" style="default" x="422" y="0" width="59" height="16" forecolor="#000000" uuid="56c70f0a-3b29-4ea6-a473-e51a62588b70"/>
+				<reportElement key="textField-4" style="default" x="422" y="0" width="59" height="16" forecolor="#000000" uuid="56c70f0a-3b29-4ea6-a473-e51a62588b70">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>

--- a/src/org/openbravo/erpReports/Rptm_InOut_Lines_new.jrxml
+++ b/src/org/openbravo/erpReports/Rptm_InOut_Lines_new.jrxml
@@ -38,18 +38,19 @@
             FROM M_PRODUCT_CUSTOMER
             WHERE M_PRODUCT_CUSTOMER.M_PRODUCT_ID=M_INOUTLINE.M_PRODUCT_ID
             AND M_PRODUCT_CUSTOMER.C_BPARTNER_ID=M_INOUT.C_BPARTNER_ID)
-            ,M_PRODUCT.NAME) AS NAME,SUM(M_INOUTLINE.MOVEMENTQTY) AS MOVEMENTQTY, M_ATTRIBUTESETINSTANCE.DESCRIPTION AS LOT,
-            REPLACE(M_INOUTLINE.DESCRIPTION, CHR(10), '') AS LLOT, REPLACE(M_INOUT.DESCRIPTION, CHR(10), '') AS DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME AS UOM
+            ,M_PRODUCT.NAME, M_INOUTLINE.DESCRIPTION) AS NAME,SUM(M_INOUTLINE.MOVEMENTQTY) AS MOVEMENTQTY, M_ATTRIBUTESETINSTANCE.DESCRIPTION AS LOT,
+            REPLACE(M_INOUTLINE.DESCRIPTION, CHR(10), '') AS LLOT, REPLACE(M_INOUT.DESCRIPTION, CHR(10), '') AS DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME AS UOM,
+            COALESCE(M_INOUTLINE.ISDESCRIPTION, 'N') AS ISDESCRIPTION
         FROM M_INOUTLINE left join C_ORDERLINE on M_INOUTLINE.C_ORDERLINE_ID = C_ORDERLINE.C_ORDERLINE_ID
                          left join C_ORDER on C_ORDERLINE.C_ORDER_ID = C_ORDER.C_ORDER_ID
-                         left join M_ATTRIBUTESETINSTANCE on M_INOUTLINE.M_ATTRIBUTESETINSTANCE_ID = M_ATTRIBUTESETINSTANCE.M_ATTRIBUTESETINSTANCE_ID,
-             M_INOUT, M_PRODUCT, C_UOM
+                         left join M_ATTRIBUTESETINSTANCE on M_INOUTLINE.M_ATTRIBUTESETINSTANCE_ID = M_ATTRIBUTESETINSTANCE.M_ATTRIBUTESETINSTANCE_ID
+                         left join M_PRODUCT on M_INOUTLINE.M_PRODUCT_ID = M_PRODUCT.M_PRODUCT_ID
+                         left join C_UOM on M_PRODUCT.C_UOM_ID = C_UOM.C_UOM_ID,
+             M_INOUT
         WHERE M_INOUT.M_INOUT_ID = M_INOUTLINE.M_INOUT_ID
-        AND M_INOUTLINE.M_PRODUCT_ID = M_PRODUCT.M_PRODUCT_ID
         AND M_INOUT.M_INOUT_ID = '$P!{M_INOUT_ID}'
-        AND M_PRODUCT.C_UOM_ID = C_UOM.C_UOM_ID
-        GROUP BY C_ORDER.DOCUMENTNO, M_INOUT.C_BPARTNER_ID, C_ORDER.POREFERENCE, M_PRODUCT.VALUE, M_INOUTLINE.M_PRODUCT_ID, M_PRODUCT.NAME, M_ATTRIBUTESETINSTANCE.DESCRIPTION, M_INOUT.DESCRIPTION, M_INOUTLINE.DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME
-        ORDER BY C_ORDER.DOCUMENTNO, M_PRODUCT.NAME]]>
+        GROUP BY C_ORDER.DOCUMENTNO, M_INOUT.C_BPARTNER_ID, C_ORDER.POREFERENCE, M_PRODUCT.VALUE, M_INOUTLINE.M_PRODUCT_ID, M_PRODUCT.NAME, M_ATTRIBUTESETINSTANCE.DESCRIPTION, M_INOUT.DESCRIPTION, M_INOUTLINE.DESCRIPTION, M_PRODUCT.UPC, C_UOM.NAME, COALESCE(M_INOUTLINE.ISDESCRIPTION, 'N')
+        ORDER BY C_ORDER.DOCUMENTNO, M_PRODUCT.NAME, MIN(M_INOUTLINE.LINE)]]>
 	</queryString>
 	<field name="value" class="java.lang.String"/>
 	<field name="name" class="java.lang.String"/>
@@ -59,6 +60,7 @@
 	<field name="description" class="java.lang.String"/>
 	<field name="upc" class="java.lang.String"/>
 	<field name="uom" class="java.lang.String"/>
+	<field name="isdescription" class="java.lang.String"/>
 	<group name="M_INOUT_ID">
 		<groupExpression><![CDATA[$P{M_INOUT_ID}]]></groupExpression>
 		<groupHeader>
@@ -172,7 +174,9 @@
 			<frame>
 				<reportElement key="frame-1" style="default" stretchType="RelativeToBandHeight" x="0" y="0" width="482" height="21" uuid="f170c6be-337a-45b9-a5bc-be2c6dd1c874"/>
 				<textField isBlankWhenNull="false">
-					<reportElement key="textField-5" style="default" x="386" y="0" width="35" height="21" forecolor="#000000" uuid="9d25a9eb-1dd0-435b-a89f-3250d84f0c20"/>
+					<reportElement key="textField-5" style="default" x="386" y="0" width="35" height="21" forecolor="#000000" uuid="9d25a9eb-1dd0-435b-a89f-3250d84f0c20">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 					<textElement verticalAlignment="Middle">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
@@ -180,7 +184,9 @@
 				</textField>
 			</frame>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-1" style="default" x="0" y="0" width="90" height="21" forecolor="#000000" uuid="97ea4cd2-7c66-45e8-bbb0-50ae3fdb2bb5"/>
+				<reportElement key="textField-1" style="default" x="0" y="0" width="90" height="21" forecolor="#000000" uuid="97ea4cd2-7c66-45e8-bbb0-50ae3fdb2bb5">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
@@ -206,7 +212,9 @@
 				<textFieldExpression><![CDATA[($F{name}==null ? " " : " " + $F{name})]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-3" style="default" x="255" y="0" width="130" height="21" forecolor="#000000" uuid="cd437130-1b14-4955-8887-17835e8d310f"/>
+				<reportElement key="textField-3" style="default" x="255" y="0" width="130" height="21" forecolor="#000000" uuid="cd437130-1b14-4955-8887-17835e8d310f">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
@@ -219,7 +227,9 @@
 				<textFieldExpression><![CDATA[($F{lot}==null ? " " : " " + $F{lot})]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="false">
-				<reportElement key="textField-4" style="default" x="422" y="0" width="59" height="21" forecolor="#000000" uuid="5e627541-5158-4d30-8185-b2a0dcc1eac5"/>
+				<reportElement key="textField-4" style="default" x="422" y="0" width="59" height="21" forecolor="#000000" uuid="5e627541-5158-4d30-8185-b2a0dcc1eac5">
+					<printWhenExpression><![CDATA["N".equals($F{isdescription})]]></printWhenExpression>
+				</reportElement>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>


### PR DESCRIPTION
## Summary

Backport of #1134 to `release/25.4`. Same change, applied with `git cherry-pick` with no conflicts.

- Fixes #1130 (ETP-4915): the "Description Only" checkbox (`M_InOutLine.IsDescription`) is hidden by
  default in the Lines tab of Goods Shipment and Goods Receipt, so the validation added by ETP-3992
  (Core 26.1.7 / **25.4.16**) cannot be satisfied without a per-client Application Dictionary
  customization.
- Root cause differs per window, and the sourcedata alone is misleading:
  - **Goods Receipt** (`AD_FIELD` 8245, tab 297): the sourcedata ships `ISDISPLAYED=N`.
  - **Goods Shipment** (`AD_FIELD` 8251, tab 258): the sourcedata ships `ISDISPLAYED=Y`, but
    `modules_core/org.openbravo.v3/src-db/database/configScript.xml` rewrites it to `N` every time
    modules are applied.
- Fix follows the precedent of 6b3501fb ("Feature ETP-1189: Display Cancel Promotions columns"): set
  the sourcedata value **and** delete the configScript override.
  - 8245: `ISDISPLAYED` `N` → `Y` plus `SEQNO=105` (110 is taken by *Canceled Inout line* in that tab;
    105 places it right after *Order Quantity*, mirroring Goods Shipment).
  - 8251: configScript block removed, sourcedata untouched.
- `MInOutLineEventHandler` is untouched, so the ETP-3992 validation still blocks an unmarked line with
  no product and quantity 0. Covered by the existing `MInOutLineEventHandlerTest`.
- *Return to Vendor Shipment* and *Return Material Receipt* are deliberately left out: every line field
  in those tabs is `ISREADONLY=Y` because the lines come from *Create Lines From*, so a visible
  read-only checkbox would not unblock anything.

## Verification

Run on a real **25.4.26** instance whose `ad_field` rows started at `N` (8245 with no `SEQNO`, 8251
with `SEQNO=110`), i.e. the upgrade path:

```
ad_field_id | window         | isdisplayed | seqno
8245        | Goods Receipt  | Y           | 105
8251        | Goods Shipment | Y           | 110
```

Sequence: patched sourcedata + configScript → `./gradlew update.database` → `./gradlew smartbuild` →
Tomcat restart, ending at `system_status = RB70` with the instance serving normally.

Worth flagging: `smartbuild` on its own is **not** enough. Its `update.database.if.no.local` step
skipped the sourcedata import and the fields stayed at `N`; the explicit `update.database` task is what
applies the change.

The functional UI check (mark the checkbox → line saves; unmarked → still blocked) was done on the
26.2.7 instance in #1134. On 25.4 only the resulting Application Dictionary state was verified, since
the change and the validation code are identical on both lines.

SonarQube is not affected — `sonar-project.properties` excludes `**/*.xml`.


---

## Second commit: printing the description-only lines

Backport of the same change. Making the field visible let users create the line, but the printed
document dropped it: the line subreports of the shipment family joined `M_INOUTLINE` to `M_PRODUCT`
with an **inner join**, filtering out every line without a product.

Note for reviewers: the order and invoice subreports already use `left join` plus `ORDER BY LINE`
and have always printed these lines. The shipment family was the exception inside core, so this is
a consistency defect rather than a new feature.

### Templates changed

| Template | Doc-type configurations using it | Documents |
|---|---|---|
| `Rptm_InOut_Lines_new.jrxml` | 10 | Goods Shipment, Goods Receipt, MM Shipment Indirect, RFC Receipt |
| `RptM_RMInOut_Lines.jrxml` | 5 | RTV Shipment, return documents |
| `Rptm_InOut_Lines.jrxml` | 0 | orphan; aligned for consistency |

### What changed in each

- `M_PRODUCT` and `C_UOM` become `left join`. The UOM is still taken from the product on purpose:
  switching to the line's UOM would change the printed unit where they differ.
- The product-name column falls back to the line description via `COALESCE`, the same pattern the
  invoice subreport already uses.
- A new `ISDESCRIPTION` field drives `printWhenExpression` on reference, UOM, attributes and
  quantity, so those columns stay empty instead of printing `0.00`.
- **The existing ordering is preserved on purpose.** `ORDER BY C_ORDER.DOCUMENTNO, M_PRODUCT.NAME`
  is untouched; `MIN(M_INOUTLINE.LINE)` is appended only as a deterministic tie-breaker.

### Consequence, agreed with the release manager

A description-only line has neither an order nor a product to sort by, so it prints **at the end of
the document** and does not work as an inline separator in the standard template. That was the
explicit decision: core prints these lines without altering the current output, and customers with
their own templates handle positioning themselves.

### Verification

Verified on 26.2.7 in #1134 with four printed cases, including a no-regression check on a real
14-line shipment from two orders whose before/after PDFs are byte-for-byte identical in content. The
templates are the same on both lines, and the cherry-pick applied with no conflicts.

No automated tests are possible: Jasper templates are outside the pipeline and Sonar excludes XML.
