### PR TITLE
Issue #1121: Clear email attachments when the popup is opened fresh

### DIFF
--- a/src-test/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerEmailOptionsBuilderTest.java
+++ b/src-test/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerEmailOptionsBuilderTest.java
@@ -576,6 +576,70 @@ public class PrintControllerEmailOptionsBuilderTest { //NOSONAR
   }
 
   // -------------------------------------------------------------------------
+  // discardAttachmentsOnFreshOpen (private) via reflection
+  // -------------------------------------------------------------------------
+
+  /**
+   * A fresh open of the popup drops any attachment list left in the session. Closing the popup
+   * sends no request to the server, so attachments uploaded for one record would otherwise still
+   * be listed when the popup is reopened, for that record or for any other one.
+   * @throws Exception if reflection fails
+   */
+  @Test
+  public void testDiscardAttachmentsOnFreshOpen_defaultCommand_removesSessionAttachments()
+      throws Exception {
+    HttpSession session = invokeDiscardAttachmentsOnFreshOpen(false);
+
+    verify(session).removeAttribute(PrintController.SESSION_FILES);
+  }
+
+  /**
+   * The ADD postback is not a fresh open: the attachment just uploaded, and every attachment
+   * uploaded before it in the same popup, must survive the re-render.
+   * @throws Exception if reflection fails
+   */
+  @Test
+  public void testDiscardAttachmentsOnFreshOpen_addCommand_keepsSessionAttachments()
+      throws Exception {
+    HttpSession session = invokeDiscardAttachmentsOnFreshOpen(true);
+
+    verify(session, never()).removeAttribute(PrintController.SESSION_FILES);
+  }
+
+  /**
+   * The DEL postback is not a fresh open either: removing one attachment must leave the rest of
+   * the list in place.
+   * @throws Exception if reflection fails
+   */
+  @Test
+  public void testDiscardAttachmentsOnFreshOpen_delCommand_keepsSessionAttachments()
+      throws Exception {
+    HttpSession session = invokeDiscardAttachmentsOnFreshOpen(true);
+
+    verify(session, never()).removeAttribute(PrintController.SESSION_FILES);
+  }
+
+  private static HttpSession invokeDiscardAttachmentsOnFreshOpen(boolean isAddOrDelPostback)
+      throws Exception {
+    VariablesSecureApp vars = mock(VariablesSecureApp.class);
+    when(vars.commandIn("ADD", "DEL")).thenReturn(isAddOrDelPostback);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpSession session = mock(HttpSession.class);
+    when(request.getSession()).thenReturn(session);
+
+    PrintControllerEmailOptionsBuilder builder =
+        new ObjenesisStd().newInstance(PrintControllerEmailOptionsBuilder.class);
+    setBuilderField(builder, "vars", vars);
+    setBuilderField(builder, "request", request);
+
+    Method m = PrintControllerEmailOptionsBuilder.class.getDeclaredMethod(
+        "discardAttachmentsOnFreshOpen");
+    m.setAccessible(true);
+    m.invoke(builder);
+    return session;
+  }
+
+  // -------------------------------------------------------------------------
   // applyEditedEmailParams (private) via reflection
   // -------------------------------------------------------------------------
 

--- a/src-test/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerEmailOptionsBuilderTest.java
+++ b/src-test/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerEmailOptionsBuilderTest.java
@@ -74,6 +74,8 @@ public class PrintControllerEmailOptionsBuilderTest { //NOSONAR
   private static final String METHOD_RESOLVE_CONTACT = "resolvePreselectedContact";
   private static final String PARAM_CLOSED = "closed";
   private static final String FIELD_CONTEXT = "context";
+  private static final String FIELD_REQUEST = "request";
+  private static final String FIELD_VARS = "vars";
 
   // -------------------------------------------------------------------------
   // instantiation smoke test
@@ -497,7 +499,7 @@ public class PrintControllerEmailOptionsBuilderTest { //NOSONAR
     PrintControllerEmailOptionsBuilder b =
         new ObjenesisStd().newInstance(PrintControllerEmailOptionsBuilder.class);
     setBuilderField(b, "controller", ctrl);
-    setBuilderField(b, "vars", vars);
+    setBuilderField(b, FIELD_VARS, vars);
     setBuilderField(b, FIELD_CONTEXT, buildContext(reports));
     return b;
   }
@@ -535,8 +537,8 @@ public class PrintControllerEmailOptionsBuilderTest { //NOSONAR
 
     PrintControllerEmailOptionsBuilder builder =
         new ObjenesisStd().newInstance(PrintControllerEmailOptionsBuilder.class);
-    setBuilderField(builder, "vars", vars);
-    setBuilderField(builder, "request", request);
+    setBuilderField(builder, FIELD_VARS, vars);
+    setBuilderField(builder, FIELD_REQUEST, request);
     setBuilderField(builder, FIELD_CONTEXT, buildContext(Collections.emptyMap()));
 
     Method m = PrintControllerEmailOptionsBuilder.class.getDeclaredMethod(
@@ -562,8 +564,8 @@ public class PrintControllerEmailOptionsBuilderTest { //NOSONAR
 
     PrintControllerEmailOptionsBuilder builder =
         new ObjenesisStd().newInstance(PrintControllerEmailOptionsBuilder.class);
-    setBuilderField(builder, "vars", vars);
-    setBuilderField(builder, "request", request);
+    setBuilderField(builder, FIELD_VARS, vars);
+    setBuilderField(builder, FIELD_REQUEST, request);
     setBuilderField(builder, FIELD_CONTEXT, buildContext(Collections.emptyMap()));
 
     Method m = PrintControllerEmailOptionsBuilder.class.getDeclaredMethod(
@@ -629,8 +631,8 @@ public class PrintControllerEmailOptionsBuilderTest { //NOSONAR
 
     PrintControllerEmailOptionsBuilder builder =
         new ObjenesisStd().newInstance(PrintControllerEmailOptionsBuilder.class);
-    setBuilderField(builder, "vars", vars);
-    setBuilderField(builder, "request", request);
+    setBuilderField(builder, FIELD_VARS, vars);
+    setBuilderField(builder, FIELD_REQUEST, request);
 
     Method m = PrintControllerEmailOptionsBuilder.class.getDeclaredMethod(
         "discardAttachmentsOnFreshOpen");

--- a/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerEmailOptionsBuilder.java
+++ b/src/org/openbravo/erpCommon/utility/reporting/printing/PrintControllerEmailOptionsBuilder.java
@@ -62,6 +62,7 @@ final class PrintControllerEmailOptionsBuilder {
 
   void render() throws IOException, ServletException, ReportingException {
     PocData[] pocData = EmailUtilities.getContactDetails(context.documentType, context.strDocumentId, controller);
+    discardAttachmentsOnFreshOpen();
     List<AttachContent> attachments = getSessionAttachments();
     boolean isTheFirstEntry = attachments == null;
     if (attachments == null) {
@@ -102,6 +103,24 @@ final class PrintControllerEmailOptionsBuilder {
     PrintWriter out = response.getWriter();
     out.println(xmlDocument.print());
     out.close();
+  }
+
+  /**
+   * Drops the attachment list left in the session when the popup is being opened fresh, as opposed
+   * to re-rendered by its own ADD or DEL postback.
+   * <p>
+   * The attachment list lives under a single session-wide key, so without this it is shared by
+   * every record for the whole session. Closing the popup sends no request to the server -- the
+   * Cancel button, the ESC shortcut and the popup's close box are all handled client side -- so a
+   * fresh open is the only reliable point at which stale attachments can be dropped. This mirrors
+   * what {@code applyEmailFormData} already does with the recipients, the subject and the body:
+   * kept across an ADD or DEL postback, rebuilt on a fresh open.
+   */
+  private void discardAttachmentsOnFreshOpen() {
+    if (vars.commandIn("ADD", "DEL")) {
+      return;
+    }
+    request.getSession().removeAttribute(PrintController.SESSION_FILES);
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
Follow-up on #1121 — ETP-4868. The blank-popup regression is fixed and merged in #1127; this is a second defect found in the same flow.

## Symptom

Attach a file in the Email options popup, close the popup without sending, then open the Email popup again — on the same record or on any other one. The attachment is still listed.

## Root cause

Attachments live under a single session-wide key, with no document identifier:

```java
// PrintController.java:111
static final String SESSION_FILES = "files";
```

Compare with the document data in the same class, which *is* scoped: `SESSION_POC_DATA + context.fullDocumentIdentifier`. So one uploaded file is shared by every record for the rest of the HTTP session.

Only two paths ever clear it:

1. `PrintControllerCommandHandler.handleEmailCommand():232` — after an email is actually sent. This one works, which is why sending resets the list.
2. `PrintControllerEmailOptionsBuilder.handleClosedPopup():138` — gated on the request carrying `closed=yes`.

**Nothing ever sends `closed=yes`.** Every occurrence of that token in the package is a closed loop with no entry point: the server writes it into the template only if the incoming request already had it (`EmailOptionsBuilder:134,137`), and the hidden input is declared `value=""` and only ever read (`EmailOptions.html:196,681`). No client code assigns it.

The close paths confirm why. All three are pure client side, and two of them bypass the page's own handler entirely:

| Close action | What runs | Reaches the server |
|---|---|---|
| Cancel button | `closePopUp()` → `closePage()` | no |
| ESCAPE key | `closePage()` directly (`web/js/shortcuts.js:152`) | no |
| Popup close box | `Popup.close()` (`utils.js:5177`) | no |

So `handleClosedPopup` is unreachable in practice and the list survives until an email is sent or the session expires.

## Fix

Discard the list on a fresh open, keep it across the popup's own `ADD`/`DEL` postbacks:

```java
private void discardAttachmentsOnFreshOpen() {
  if (vars.commandIn("ADD", "DEL")) {
    return;
  }
  request.getSession().removeAttribute(PrintController.SESSION_FILES);
}
```

This is deliberately **not** a client-side fix to the close event. Only the Cancel button could be wired up; ESCAPE and the close box cannot, so that approach would turn a 100%-reproducible bug into an intermittent one.

It lands in the builder rather than in `handleDefaultCommand` because `vars.commandIn("ADD", "DEL")` is the same predicate `applyEmailFormData()` already uses to decide whether to keep the recipients, subject and body or rebuild them from the template (`EmailOptionsBuilder:384`). Attachments now follow the rule the rest of the form already follows, in the same place. It also covers all three render entry points — `CommandHandler:214` (DEL) and `:372` (DEFAULT and ADD) are the only callers of `createEmailOptionsPage`.

Side effect, also a fix: `isTheFirstEntry` (`EmailOptionsBuilder:66`) is `attachments == null`. With a stale list present it was `false` on a fresh open, which mislabelled the auto-attached document in `setupAttachmentParams()`. It is correct again.

## Tests

Three new cases in `PrintControllerEmailOptionsBuilderTest`: fresh open drops the list, `ADD` postback keeps it, `DEL` postback keeps it.

The whole `reporting.printing` package passes: **184 tests, 184 pass**. The new tests were verified to have teeth by inverting the predicate to `if (!vars.commandIn(...))` and rebuilding — exactly the 3 new tests fail and none of the 181 pre-existing ones do.

## Manual verification

Deployed to a local 26.2.7 instance (sources checksummed against this branch, `discardAttachmentsOnFreshOpen` confirmed present in the deployed bytecode).