### PR TITLE
Issue #1131: Keep header amount when Add Payment auto-selects a document

### DIFF
--- a/modules_core/org.openbravo.advpaymentmngt/web-test/ob-aprm-addPayment.test.js
+++ b/modules_core/org.openbravo.advpaymentmngt/web-test/ob-aprm-addPayment.test.js
@@ -1,0 +1,133 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Openbravo  Public  License
+ * Version  1.0  (the  "License"),  being   the  Mozilla   Public  License
+ * Version 1.1  with a permitted attribution clause; you may not  use this
+ * file except in compliance with the License. You  may  obtain  a copy of
+ * the License at http://www.openbravo.com/legal/license.html
+ * Software distributed under the License  is  distributed  on  an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific  language  governing  rights  and  limitations
+ * under the License.
+ * The Original Code is Openbravo ERP.
+ * The Initial Developer of the Original Code is Openbravo SLU
+ * All portions are Copyright (C) 2026 Openbravo SLU
+ * All Rights Reserved.
+ * Contributor(s):  ______________________________________.
+ ************************************************************************
+ */
+
+/* global global */
+
+global.OB = { APRM: {} };
+require('../../org.openbravo.client.kernel/web/org.openbravo.client.kernel/js/BigDecimal-all-1.0.3');
+require('../web/org.openbravo.advpaymentmngt/js/ob-aprm-addPayment');
+
+const EUR = 'EUR_ID';
+const USD = 'USD_ID';
+
+const createItem = value => {
+  let current = value;
+  return {
+    getValue: () => current,
+    setValue: newValue => {
+      current = newValue;
+    },
+  };
+};
+
+// Minimal stand-in for the Order/Invoice grid of the Add Payment popup, holding a
+// single pending document with the given outstanding amount.
+const createOrderInvoiceGrid = outstandingAmount => {
+  const record = { id: 'invoice1' };
+  return {
+    selectedIds: [record.id],
+    data: { localData: { find: () => record } },
+    getRecordIndex: () => 0,
+    getFieldByColumnName: columnName => columnName,
+    getEditedCell: () => outstandingAmount,
+  };
+};
+
+// Builds a form equivalent to a saved Payment In whose Add Details popup has just
+// auto-selected a pending document.
+const createForm = ({ actualPayment, outstandingAmount, currencyToId }) => {
+  const items = {
+    order_invoice: {
+      canvas: { viewGrid: createOrderInvoiceGrid(outstandingAmount) },
+    },
+    issotrx: createItem(true),
+    actual_payment: createItem(actualPayment),
+    expected_payment: createItem(0),
+    generateCredit: createItem(0),
+    amount_gl_items: createItem(0),
+    used_credit: createItem(0),
+    bslamount: createItem(0),
+    conversion_rate: createItem(1.19),
+    StdPrecision: createItem(2),
+    c_currency_id: createItem(EUR),
+    c_currency_to_id: createItem(currencyToId),
+  };
+  return {
+    // the multi-currency block became visible when the popup was opened
+    _mcPendingSyncMC: true,
+    getItem: name => items[name],
+    redraw: () => {},
+  };
+};
+
+describe('OB.APRM.AddPayment.updateActualExpected', () => {
+  beforeEach(() => {
+    // these only recalculate dependent fields and pull in the whole popup
+    jest
+      .spyOn(OB.APRM.AddPayment, 'distributeAmount')
+      .mockImplementation(() => {});
+    jest
+      .spyOn(OB.APRM.AddPayment, 'updateDifference')
+      .mockImplementation(() => {});
+    jest
+      .spyOn(OB.APRM.AddPayment, 'updateConvertedAmount')
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('keeps the amount entered in the document header on multi-currency payments', () => {
+    const form = createForm({
+      actualPayment: 3332,
+      outstandingAmount: '2140.16',
+      currencyToId: USD,
+    });
+
+    OB.APRM.AddPayment.updateActualExpected(form);
+
+    expect(form.getItem('actual_payment').getValue()).toEqual(3332);
+    expect(form.getItem('expected_payment').getValue()).toEqual(2140.16);
+  });
+
+  it('inherits the expected payment when no amount was entered at all', () => {
+    const form = createForm({
+      actualPayment: 0,
+      outstandingAmount: '2140.16',
+      currencyToId: USD,
+    });
+
+    OB.APRM.AddPayment.updateActualExpected(form);
+
+    expect(form.getItem('actual_payment').getValue()).toEqual(2140.16);
+  });
+
+  it('does not touch the actual payment when the currencies match', () => {
+    const form = createForm({
+      actualPayment: 0,
+      outstandingAmount: '2140.16',
+      currencyToId: EUR,
+    });
+
+    OB.APRM.AddPayment.updateActualExpected(form);
+
+    expect(form.getItem('actual_payment').getValue()).toEqual(0);
+  });
+});

--- a/modules_core/org.openbravo.advpaymentmngt/web/org.openbravo.advpaymentmngt/js/ob-aprm-addPayment.js
+++ b/modules_core/org.openbravo.advpaymentmngt/web/org.openbravo.advpaymentmngt/js/ob-aprm-addPayment.js
@@ -442,7 +442,6 @@ OB.APRM.AddPayment.transactionTypeOnChangeFunction = function(
 };
 
 OB.APRM.AddPayment.actualPaymentOnChange = function(item, view, form, grid) {
-  form._mcActualTouched = true;
   var issotrx = form.getItem('issotrx').getValue();
   if (issotrx) {
     OB.APRM.AddPayment.distributeAmount(view, form, true);
@@ -1065,7 +1064,9 @@ OB.APRM.AddPayment.updateActualExpected = function(form) {
   } else if (form._mcPendingSyncMC && OB.APRM.AddPayment.isMultiCurrency(form)) {
     var expNow = Number(form.getItem('expected_payment').getValue() || 0);
     var actNow = Number(form.getItem('actual_payment').getValue() || 0);
-    if (expNow > 0 && (actNow === 0 || !form._mcActualTouched)) {
+    // only inherit the expected payment when no amount was entered at all: an
+    // amount already set in the document header must not be overwritten
+    if (expNow > 0 && actNow === 0) {
       form._mcPendingSyncMC = false;
       form._mcSyncInProgress = true;
       OB.APRM.AddPayment.syncActualWithExpectedIfMC(form);
@@ -1145,7 +1146,6 @@ OB.APRM.AddPayment.syncActualWithExpectedIfMC = function(form) {
   form._mcAutoSync = true;
   form.getItem('actual_payment').setValue(expected);
   form._mcAutoSync = false;
-  form._mcActualTouched = false;
   if (form.getItem('issotrx').getValue()) {
     OB.APRM.AddPayment.distributeAmount(null, form, true);
   }


### PR DESCRIPTION
Backport of #1137 to the 25.4 maintenance line (affected version 25.4.27). Cherry-picked cleanly; the file is identical on both lines.

## Summary

- Fixes the Add Payment popup silently discarding the amount entered in the Payment In/Out header
  when the deposit-to Financial Account has `Receive Payments in Multiple Currencies = Yes` and the
  payment currency differs from the account currency. Opening **Add Details** on a saved payment and
  letting the grid auto-select a pending document replaced *Actual Payment* with the *Expected
  Payment* computed from that document.
- Root cause: the multi-currency inheritance added by ETP-2285 guards the sync with an OR —
  `if (expNow > 0 && (actNow === 0 || !form._mcActualTouched))` — so it also fires whenever the flag
  is falsy, regardless of whether an amount is actually present. `_mcActualTouched` was only ever set
  to `true` in `actualPaymentOnChange`, i.e. on manual edits **inside** the popup. The header amount
  reaches the popup as a default value (`AddPaymentDefaultValuesExpression`), which does not trigger
  that onChange, so the flag stayed falsy even though the user had already entered an amount and
  `syncActualWithExpectedIfMC()` overwrote it.
- Fix: inherit the expected payment only when no amount was entered at all (`actNow === 0`). This
  keeps the original ETP-2285 case working — a popup opened with no amount still satisfies
  `actNow === 0` — and stops the overwrite in every other case, including a value the user typed
  inside the popup.
- With the guard corrected, `_mcActualTouched` has no readers left, so its three occurrences are
  removed rather than left as a write-only flag.

Worth noting for reviewers: two adjacent findings were deliberately left out of this hotfix to keep
the diff minimal. `_mcSyncedOnce` and `_mcAutoSync` are also written and never read — `_mcAutoSync`
looks like it was meant to stop `actualPaymentOnChange` from marking the field as touched on a
programmatic `setValue`, but that check was never implemented. And `if (form._mcSyncInProgress) {}
else if (...)` at line 1063 is an empty block used as a guard.

## Verification

Reproduced and verified end-to-end on a local 26.2.8 instance, running the same scenario twice —
first with the base code, then with this branch — and confirming in each phase which code the browser
had actually loaded (whether `updateActualExpected.toString()` still contained `_mcActualTouched`).

Setup: Financial Account in USD (`F&B España - Región Norte`) with payment method *Transferencia*
and `Receive Payments in Multiple Currencies` enabled; pending sales invoice `1000367` in EUR with
4.10 outstanding; Payment In `1000373` in EUR with 3,332.00 entered in the header, deposit-to the USD
account (rate 1.19).

| Case | Base code | This branch |
|---|---|---|
| Add Details auto-selects the pending invoice | Actual Payment drops to **4.10** | Actual Payment keeps **3,332.00**, Expected 4.10, Converted 3,965.08 |
| Actual Payment edited by hand inside the popup | — | keeps **5,000.00**, Converted recalculated to 5,950.00 |
| Header amount 0, invoice selected in the grid (ETP-2285 case) | — | inherits **4.10**, Converted 4.88 |

Regression test: new `modules_core/org.openbravo.advpaymentmngt/web-test/ob-aprm-addPayment.test.js`,
following the pattern of the existing jest tests in `modules_core/org.openbravo.client.application/web-test`.
It drives the real `OB.APRM.AddPayment.updateActualExpected` over a stubbed form and covers the three
cases from the ticket, including the same-currency control case. Verified in both directions: 3/3 pass
on this branch, and reverting only the JS change makes the first case fail with
`Expected: 3332 / Received: 2140.16`.

Scope of that check, for the record: jest is not run by `.github/workflows/build.yml`, so this test
does not gate the PR; it was run locally with the jest version pinned in `package.json`. eslint could
not be run locally (version mismatch between the pinned eslint 7 and eslint-plugin-prettier 5 in an
ad-hoc dependency install); formatting was checked with prettier 3.5.0, both for the new test and to
confirm the edited lines of the production file are prettier-clean — the file's pre-existing
formatting deviations were left untouched.
