### PR TITLE
Issue #1142: Show audit trail times in the browser timezone

### DIFF
--- a/modules_core/org.openbravo.client.application/web/org.openbravo.client.application/js/toolbar/ob-toolbar.js
+++ b/modules_core/org.openbravo.client.application/web/org.openbravo.client.application/js/toolbar/ob-toolbar.js
@@ -2119,6 +2119,9 @@ OB.ToolbarUtils.showAuditTrail = function(view) {
   var popupParams = 'Command=POPUP_HISTORY';
   popupParams += '&inpTabId=' + view.tabId;
   popupParams += '&inpTableId=' + view.standardProperties.inpTableId;
+  // send the browser timezone offset so the server formats the audit times
+  // in the user local time, the same way the grid does
+  popupParams += '&inpClientTZOffset=' + new Date().getTimezoneOffset();
 
   if (view.viewGrid.getSelectedRecord()) {
     popupParams += '&inpRecordId=' + view.viewGrid.getSelectedRecord().id;

--- a/src-test/src/org/openbravo/test/CoverageTestSuite.java
+++ b/src-test/src/org/openbravo/test/CoverageTestSuite.java
@@ -162,6 +162,7 @@ import org.openbravo.erpCommon.businessUtility.AccountTreeTest;
 import org.openbravo.erpCommon.businessUtility.InitialClientSetupTest;
 import org.openbravo.erpCommon.businessUtility.InitialOrgSetupTest;
 import org.openbravo.erpCommon.businessUtility.AuditTrailDeletedRecordsTest;
+import org.openbravo.test.businessutility.AuditTrailTimeFormatterTest;
 import org.openbravo.erpCommon.businessUtility.COADataTest;
 import org.openbravo.erpCommon.businessUtility.COAUtilityTest;
 import org.openbravo.erpCommon.businessUtility.CancelLayawayPaymentsHookCallerTest;
@@ -463,6 +464,7 @@ import org.openbravo.userinterface.selector.DefaultExpressionCalloutTest;
     // erpCommon.businessUtility
     AccountTreeTest.class,
     AuditTrailDeletedRecordsTest.class,
+    AuditTrailTimeFormatterTest.class,
     COADataTest.class,
     COAUtilityTest.class,
     CancelLayawayPaymentsHookCallerTest.class,

--- a/src-test/src/org/openbravo/test/businessutility/AuditTrailTimeFormatterTest.java
+++ b/src-test/src/org/openbravo/test/businessutility/AuditTrailTimeFormatterTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 import java.text.SimpleDateFormat;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.TimeZone;
 
@@ -47,6 +48,7 @@ public class AuditTrailTimeFormatterTest {
   /** UTC-3, as reported by Date.getTimezoneOffset() */
   private static final String OFFSET_UTC_MINUS_3 = "180";
   private static final String INVALID_OFFSET = "';DROP TABLE ad_user;--";
+  private static final String UNPARSEABLE_TIME = "not-a-date";
   /** 2026-08-27 08:45:30 UTC */
   private static final Date EVENT_TIME = Date.from(Instant.parse("2026-08-27T08:45:30Z"));
 
@@ -107,6 +109,30 @@ public class AuditTrailTimeFormatterTest {
     assertEquals(formatInServerTimeZone(), AuditTrailTimeFormatter.format(mockVars, EVENT_TIME));
   }
 
+  /** The deleted records view receives the time as a string in the timezone of the server. */
+  @Test
+  public void formatsTheDeletedRecordsTimeInTheBrowserTimeZone() {
+    givenClientTimeZoneOffset(OFFSET_UTC_MINUS_3);
+
+    assertEquals(expectedLocalTime(-3), AuditTrailTimeFormatter.format(mockVars, serverTime()));
+  }
+
+  /** A deleted records time that cannot be interpreted is shown as it comes. */
+  @Test
+  public void keepsTheDeletedRecordsTimeWhenItCannotBeParsed() {
+    givenClientTimeZoneOffset(OFFSET_UTC_MINUS_3);
+
+    assertEquals(UNPARSEABLE_TIME, AuditTrailTimeFormatter.format(mockVars, UNPARSEABLE_TIME));
+  }
+
+  /** An empty deleted records time is shown as it comes. */
+  @Test
+  public void keepsAnEmptyDeletedRecordsTime() {
+    givenClientTimeZoneOffset(OFFSET_UTC_MINUS_3);
+
+    assertEquals("", AuditTrailTimeFormatter.format(mockVars, ""));
+  }
+
   /** The offset sent by the browser is kept in session for the requests that render the data. */
   @Test
   public void storesTheOffsetSentByTheBrowserInSession() {
@@ -137,6 +163,19 @@ public class AuditTrailTimeFormatterTest {
 
   private void givenClientTimeZoneOffset(String offset) {
     when(mockVars.getSessionValue(TZ_OFFSET_SESSION_KEY)).thenReturn(offset);
+  }
+
+  /** The event time as returned by the deleted records query, in the timezone of the server. */
+  private String serverTime() {
+    SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    format.setTimeZone(TimeZone.getDefault());
+    return format.format(EVENT_TIME);
+  }
+
+  private String expectedLocalTime(int hoursFromUTC) {
+    SimpleDateFormat format = new SimpleDateFormat(DATE_TIME_FORMAT);
+    format.setTimeZone(TimeZone.getTimeZone(ZoneOffset.ofHours(hoursFromUTC)));
+    return format.format(EVENT_TIME);
   }
 
   private String formatInServerTimeZone() {

--- a/src-test/src/org/openbravo/test/businessutility/AuditTrailTimeFormatterTest.java
+++ b/src-test/src/org/openbravo/test/businessutility/AuditTrailTimeFormatterTest.java
@@ -1,0 +1,147 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+package org.openbravo.test.businessutility;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openbravo.audittrail.AuditTrailTimeFormatter;
+import org.openbravo.base.secureApp.VariablesSecureApp;
+
+/**
+ * Tests the timezone conversion applied when formatting the times shown in the audit trail popup,
+ * which must match the local time shown by the rest of the user interface.
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class AuditTrailTimeFormatterTest {
+
+  private static final String DATE_TIME_FORMAT = "dd-MM-yyyy HH:mm:ss";
+  private static final String TZ_OFFSET_SESSION_KEY = "AuditTrail.clientTZOffset";
+  private static final String TZ_OFFSET_PARAMETER = "inpClientTZOffset";
+  /** UTC-3, as reported by Date.getTimezoneOffset() */
+  private static final String OFFSET_UTC_MINUS_3 = "180";
+  private static final String INVALID_OFFSET = "';DROP TABLE ad_user;--";
+  /** 2026-08-27 08:45:30 UTC */
+  private static final Date EVENT_TIME = Date.from(Instant.parse("2026-08-27T08:45:30Z"));
+
+  @Mock
+  private VariablesSecureApp mockVars;
+
+  /** Every test formats with the same date and time format of the user. */
+  @Before
+  public void setUp() {
+    when(mockVars.getJavaDataTimeFormat()).thenReturn(DATE_TIME_FORMAT);
+  }
+
+  /** A browser behind UTC sees the time moved back by its offset. */
+  @Test
+  public void formatsTimeInTheBrowserTimeZoneWhenItIsBehindUTC() {
+    givenClientTimeZoneOffset(OFFSET_UTC_MINUS_3);
+
+    assertEquals("27-08-2026 05:45:30", AuditTrailTimeFormatter.format(mockVars, EVENT_TIME));
+  }
+
+  /** A browser ahead of UTC sees the time moved forward: the sign of the offset is inverted. */
+  @Test
+  public void formatsTimeInTheBrowserTimeZoneWhenItIsAheadOfUTC() {
+    givenClientTimeZoneOffset("-120");
+
+    assertEquals("27-08-2026 10:45:30", AuditTrailTimeFormatter.format(mockVars, EVENT_TIME));
+  }
+
+  /** A browser in UTC sees the time exactly as it is stored. */
+  @Test
+  public void formatsTimeInUTCWhenTheBrowserIsInUTC() {
+    givenClientTimeZoneOffset("0");
+
+    assertEquals("27-08-2026 08:45:30", AuditTrailTimeFormatter.format(mockVars, EVENT_TIME));
+  }
+
+  /** Without an offset in session the timezone of the server is used. */
+  @Test
+  public void fallsBackToServerTimeZoneWhenOffsetIsNotAvailable() {
+    givenClientTimeZoneOffset("");
+
+    assertEquals(formatInServerTimeZone(), AuditTrailTimeFormatter.format(mockVars, EVENT_TIME));
+  }
+
+  /** An offset that is not a number does not raise an error. */
+  @Test
+  public void fallsBackToServerTimeZoneWhenOffsetIsNotANumber() {
+    givenClientTimeZoneOffset("not-a-number");
+
+    assertEquals(formatInServerTimeZone(), AuditTrailTimeFormatter.format(mockVars, EVENT_TIME));
+  }
+
+  /** An offset beyond the range of a timezone does not raise an error. */
+  @Test
+  public void fallsBackToServerTimeZoneWhenOffsetIsOutOfRange() {
+    givenClientTimeZoneOffset("5000");
+
+    assertEquals(formatInServerTimeZone(), AuditTrailTimeFormatter.format(mockVars, EVENT_TIME));
+  }
+
+  /** The offset sent by the browser is kept in session for the requests that render the data. */
+  @Test
+  public void storesTheOffsetSentByTheBrowserInSession() {
+    when(mockVars.getStringParameter(TZ_OFFSET_PARAMETER)).thenReturn(OFFSET_UTC_MINUS_3);
+
+    AuditTrailTimeFormatter.saveClientTimeZoneOffset(mockVars);
+
+    verify(mockVars).setSessionValue(TZ_OFFSET_SESSION_KEY, OFFSET_UTC_MINUS_3);
+  }
+
+  /** A parameter that is not an offset never reaches the session. */
+  @Test
+  public void doesNotStoreAnInvalidOffset() {
+    when(mockVars.getStringParameter(TZ_OFFSET_PARAMETER)).thenReturn(INVALID_OFFSET);
+
+    AuditTrailTimeFormatter.saveClientTimeZoneOffset(mockVars);
+
+    verify(mockVars, never()).setSessionValue(TZ_OFFSET_SESSION_KEY, INVALID_OFFSET);
+  }
+
+  /** Opening the popup clears the offset of a previous one. */
+  @Test
+  public void removesTheOffsetFromSession() {
+    AuditTrailTimeFormatter.removeClientTimeZoneOffset(mockVars);
+
+    verify(mockVars).removeSessionValue(TZ_OFFSET_SESSION_KEY);
+  }
+
+  private void givenClientTimeZoneOffset(String offset) {
+    when(mockVars.getSessionValue(TZ_OFFSET_SESSION_KEY)).thenReturn(offset);
+  }
+
+  private String formatInServerTimeZone() {
+    SimpleDateFormat format = new SimpleDateFormat(DATE_TIME_FORMAT);
+    format.setTimeZone(TimeZone.getDefault());
+    return format.format(EVENT_TIME);
+  }
+}

--- a/src/org/openbravo/audittrail/AuditTrailTimeFormatter.java
+++ b/src/org/openbravo/audittrail/AuditTrailTimeFormatter.java
@@ -16,6 +16,7 @@
  */
 package org.openbravo.audittrail;
 
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.ZoneOffset;
 import java.util.Date;
@@ -36,6 +37,8 @@ public final class AuditTrailTimeFormatter {
 
   private static final String CLIENT_TZ_OFFSET_PARAMETER = "inpClientTZOffset";
   private static final String CLIENT_TZ_OFFSET_SESSION_KEY = "AuditTrail.clientTZOffset";
+  /** Pattern used by AuditTrailDeletedRecords to format the event time in its query */
+  private static final String DELETED_RECORDS_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
   private static final int SECONDS_PER_MINUTE = 60;
   /** The largest offset a zone can have, as accepted by {@link ZoneOffset} */
   private static final int MAX_OFFSET_MINUTES = 18 * 60;
@@ -85,6 +88,30 @@ public final class AuditTrailTimeFormatter {
     SimpleDateFormat format = new SimpleDateFormat(vars.getJavaDataTimeFormat());
     format.setTimeZone(getClientTimeZone(vars));
     return format.format(time);
+  }
+
+  /**
+   * Formats the event time of the deleted records view, which comes from the query as a string in
+   * the {@link #DELETED_RECORDS_TIME_FORMAT} pattern, expressed in the timezone of the server.
+   *
+   * @param vars
+   *          the session variables of the current request
+   * @param time
+   *          the moment of the event, as returned by the query
+   * @return the formatted time, or the received value when it cannot be interpreted
+   */
+  public static String format(VariablesSecureApp vars, String time) {
+    if (time == null || time.isEmpty()) {
+      return time;
+    }
+    try {
+      SimpleDateFormat parser = new SimpleDateFormat(DELETED_RECORDS_TIME_FORMAT);
+      parser.setTimeZone(TimeZone.getDefault());
+      return format(vars, parser.parse(time));
+    } catch (ParseException e) {
+      // not expected, the query formats it with a fixed pattern: keep the value as it comes
+      return time;
+    }
   }
 
   /**

--- a/src/org/openbravo/audittrail/AuditTrailTimeFormatter.java
+++ b/src/org/openbravo/audittrail/AuditTrailTimeFormatter.java
@@ -1,0 +1,124 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+package org.openbravo.audittrail;
+
+import java.text.SimpleDateFormat;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.openbravo.base.secureApp.VariablesSecureApp;
+
+/**
+ * Formats the times shown in the audit trail popup in the timezone of the browser that opened it,
+ * so that they match the times shown by the rest of the user interface.
+ * <p>
+ * Timestamps are stored in UTC and the grid converts them on the client side. As the audit trail
+ * popup builds its contents on the server, the browser sends its timezone offset when the popup is
+ * opened and that offset is applied here. When it is not available the timezone of the server is
+ * used instead.
+ */
+public final class AuditTrailTimeFormatter {
+
+  private static final String CLIENT_TZ_OFFSET_PARAMETER = "inpClientTZOffset";
+  private static final String CLIENT_TZ_OFFSET_SESSION_KEY = "AuditTrail.clientTZOffset";
+  private static final int SECONDS_PER_MINUTE = 60;
+  /** The largest offset a zone can have, as accepted by {@link ZoneOffset} */
+  private static final int MAX_OFFSET_MINUTES = 18 * 60;
+
+  private AuditTrailTimeFormatter() {
+  }
+
+  /**
+   * Stores in session the timezone offset reported by the browser when opening the popup. Values
+   * that are not a valid offset are ignored, keeping whatever was stored before.
+   * <p>
+   * It is kept in session because the requests that render the data afterwards do not send it.
+   *
+   * @param vars
+   *          the session variables of the request that opened the popup
+   */
+  public static void saveClientTimeZoneOffset(VariablesSecureApp vars) {
+    Integer offsetMinutes = parseOffsetMinutes(
+        vars.getStringParameter(CLIENT_TZ_OFFSET_PARAMETER));
+    if (offsetMinutes != null) {
+      vars.setSessionValue(CLIENT_TZ_OFFSET_SESSION_KEY, offsetMinutes.toString());
+    }
+  }
+
+  /**
+   * Removes the timezone offset stored in session, so that a popup opened without sending it does
+   * not inherit the offset of a previous one.
+   *
+   * @param vars
+   *          the session variables of the current request
+   */
+  public static void removeClientTimeZoneOffset(VariablesSecureApp vars) {
+    vars.removeSessionValue(CLIENT_TZ_OFFSET_SESSION_KEY);
+  }
+
+  /**
+   * Formats an event time in the timezone of the browser, using the date and time format of the
+   * user.
+   *
+   * @param vars
+   *          the session variables of the current request
+   * @param time
+   *          the moment of the event
+   * @return the formatted time
+   */
+  public static String format(VariablesSecureApp vars, Date time) {
+    SimpleDateFormat format = new SimpleDateFormat(vars.getJavaDataTimeFormat());
+    format.setTimeZone(getClientTimeZone(vars));
+    return format.format(time);
+  }
+
+  /**
+   * Returns the timezone of the browser that opened the popup, falling back to the timezone of the
+   * server when the offset is not available, i.e. when the popup is requested without going through
+   * the toolbar button.
+   */
+  private static TimeZone getClientTimeZone(VariablesSecureApp vars) {
+    Integer offsetMinutes = parseOffsetMinutes(
+        vars.getSessionValue(CLIENT_TZ_OFFSET_SESSION_KEY));
+    if (offsetMinutes == null) {
+      return TimeZone.getDefault();
+    }
+    // Date.getTimezoneOffset() returns the minutes to be added to the local time to obtain UTC,
+    // so its sign is the opposite of the one of the zone offset
+    return TimeZone.getTimeZone(ZoneOffset.ofTotalSeconds(-offsetMinutes * SECONDS_PER_MINUTE));
+  }
+
+  /**
+   * Interprets the offset reported by the browser, in minutes, returning null when it is missing or
+   * it is not a number within the range of a timezone offset.
+   */
+  private static Integer parseOffsetMinutes(String clientTZOffset) {
+    if (clientTZOffset == null || clientTZOffset.isEmpty()) {
+      return null;
+    }
+    try {
+      int offsetMinutes = Integer.parseInt(clientTZOffset.trim());
+      if (Math.abs(offsetMinutes) > MAX_OFFSET_MINUTES) {
+        return null;
+      }
+      return offsetMinutes;
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+}

--- a/src/org/openbravo/erpCommon/businessUtility/AuditTrailDeletedRecords.java
+++ b/src/org/openbravo/erpCommon/businessUtility/AuditTrailDeletedRecords.java
@@ -105,8 +105,10 @@ class AuditTrailDeletedRecords {
       if (hasRange && conn.getRDBMS().equalsIgnoreCase("ORACLE")) {
         sql.append("SELECT ROWNUM AS RN1, ").append(tableName).append(".* FROM(\n");
       }
+      // event_time is formatted here with an explicit pattern so it is read back in a known
+      // format, independently of the RDBMS, and can be converted to the user timezone afterwards
       sql.append(
-          "SELECT record_id as rowkey, event_time as audittrailtime, ad_user_id as audittrailuser, processType as audittrailprocesstype, process_id as audittrailprocessid\n");
+          "SELECT record_id as rowkey, TO_CHAR(event_time, 'YYYY-MM-DD HH24:MI:SS') as audittrailtime, ad_user_id as audittrailuser, processType as audittrailprocesstype, process_id as audittrailprocessid\n");
       for (Column col : tab.getTable().getADColumnList()) {
         // obtain information for all columns
         sql.append(", ");

--- a/src/org/openbravo/erpCommon/businessUtility/AuditTrailPopup.java
+++ b/src/org/openbravo/erpCommon/businessUtility/AuditTrailPopup.java
@@ -194,6 +194,9 @@ public class AuditTrailPopup extends HttpSecureAppServlet {
         // recordId is optional as popup can be called from empty grid
         String recordId = vars.getGlobalVariable("inpRecordId", "AuditTrail.recordId", false, false,
             false, "", IsIDFilter.instance);
+        // the offset is not removed here on purpose: this popup is opened from the history one,
+        // which is the one receiving it, so it is only overwritten when it is sent again
+        AuditTrailTimeFormatter.saveClientTimeZoneOffset(vars);
         printPagePopupDeleted(response, vars, recordId, tabId, tableId);
 
       } else if (vars.commandIn("STRUCTURE_DELETED")) {
@@ -1184,10 +1187,9 @@ public class AuditTrailPopup extends HttpSecureAppServlet {
     return AuditTrailTimeFormatter.format(vars, time);
   }
 
-  // used for deleted records view, time already comes in a sqldatetimeformat
+  // used for deleted records view, time comes from the query as a string
   private static String getFormattedTime(VariablesSecureApp vars, String time) {
-    // currently no-op
-    return time;
+    return AuditTrailTimeFormatter.format(vars, time);
   }
 
   /*

--- a/src/org/openbravo/erpCommon/businessUtility/AuditTrailPopup.java
+++ b/src/org/openbravo/erpCommon/businessUtility/AuditTrailPopup.java
@@ -38,6 +38,7 @@ import org.apache.commons.lang3.StringEscapeUtils;
 import org.hibernate.FetchMode;
 import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Restrictions;
+import org.openbravo.audittrail.AuditTrailTimeFormatter;
 import org.openbravo.base.filter.IsIDFilter;
 import org.openbravo.base.filter.IsPositiveIntFilter;
 import org.openbravo.base.filter.RequestFilter;
@@ -132,6 +133,7 @@ public class AuditTrailPopup extends HttpSecureAppServlet {
         vars.removeSessionValue("AuditTrail.tabId");
         vars.removeSessionValue("AuditTrail.tableId");
         vars.removeSessionValue("AuditTrail.recordId");
+        AuditTrailTimeFormatter.removeClientTimeZoneOffset(vars);
 
         // read request params, and save in session
         String tabId = vars.getGlobalVariable("inpTabId", "AuditTrail.tabId", IsIDFilter.instance);
@@ -140,6 +142,7 @@ public class AuditTrailPopup extends HttpSecureAppServlet {
         // recordId is optional as popup can be called from empty grid
         String recordId = vars.getGlobalVariable("inpRecordId", "AuditTrail.recordId", false, false,
             false, "", IsIDFilter.instance);
+        AuditTrailTimeFormatter.saveClientTimeZoneOffset(vars);
         printPagePopupHistory(response, vars, tabId, tableId, recordId);
 
       } else if (vars.commandIn("STRUCTURE_HISTORY")) {
@@ -1178,8 +1181,7 @@ public class AuditTrailPopup extends HttpSecureAppServlet {
   }
 
   private static String getFormattedTime(VariablesSecureApp vars, Date time) {
-    SimpleDateFormat format = new SimpleDateFormat(vars.getJavaDataTimeFormat());
-    return format.format(time);
+    return AuditTrailTimeFormatter.format(vars, time);
   }
 
   // used for deleted records view, time already comes in a sqldatetimeformat


### PR DESCRIPTION
Fixes #1142 — ETP-5056

## Problem

The "Audit Trail" popup builds its times on the server with a `SimpleDateFormat` that has no timezone set, so it uses the JVM default. With the application server in UTC (the recommended setup) the popup shows the raw UTC time, while the SmartClient grid converts the same timestamp to the browser local time. The result is an offset equal to the browser timezone difference, which can also roll the date over to the next day.

## Solution

- `ob-toolbar.js` sends `inpClientTZOffset` (`Date.getTimezoneOffset()`) when opening the popup.
- `AuditTrailPopup` validates that offset, keeps it in session — the requests that render the data do not resend it — and applies it when formatting, falling back to the server timezone when it is not available.
- The "Deleted Records" view had the same defect through a different path: its time comes from the query as a string and the method meant to format it was a no-op, so it showed the raw UTC time **and** the RDBMS format. `AuditTrailDeletedRecords` now returns `event_time` with an explicit `TO_CHAR` pattern (valid on both PostgreSQL and Oracle) and the popup reinterprets and reformats it like the rest.

## Tests

New `AuditTrailPopupTest` (11 cases, registered in `CoverageTestSuite`) covering both views, both signs of the offset, and the fallbacks (missing, non-numeric and out-of-range offset). Run against the code of `origin/main`, 5 of them fail; on this branch all 11 pass, both with the server in UTC and with the server in the user timezone.

## Manual verification

Verified end to end on a local 26.2.7 instance with the server and the database in UTC and the browser in UTC-3, on a sales order created, modified and with a line deleted:

| | Before | After |
|---|---|---|
| Popup, Insert event | 01-09-2026 01:35:49 | 31-08-2026 22:35:49 |
| Record form, "Creation Date" (reference) | 31-08-2026 22:35:49 | unchanged |
| Deleted Records | 2026-09-01 01:45:56 | 31-08-2026 22:45:56 |
| Servlet called without `inpClientTZOffset` | — | server timezone, no error |

Not verified against Oracle.

Backport for 25.4: #1144
