### PR TITLE
Issue #1146: Fix legacy .xls report export

### DIFF
--- a/artifacts.list.COMPILATION.gradle
+++ b/artifacts.list.COMPILATION.gradle
@@ -35,8 +35,8 @@ List<String> _dependenciesListCOMPILATION = [
   // Reporting and Document Generation
   'com.lowagie:itext:2.1.7',
   'jfree:jfreechart:1.0.12',
-  'net.sf.jasperreports:jasperreports:6.17.0',
-  'net.sf.jasperreports:jasperreports-fonts:6.17.0',
+  'net.sf.jasperreports:jasperreports:6.20.0',
+  'net.sf.jasperreports:jasperreports-fonts:6.20.0',
 
   // Database Drivers and Persistence Connectors
   'com.oracle.database.jdbc:ojdbc8:19.8.0.0',
@@ -114,6 +114,7 @@ List<String> _dependenciesListCOMPILATION = [
   'org.apache.poi:poi:5.4.0',
   'org.apache.poi:poi-ooxml:5.4.0',
   'org.apache.poi:poi-ooxml-lite:5.4.0',
+  'com.zaxxer:SparseBitSet:1.3',
 
   // File and Content Analysis
   'org.apache.tika:tika-core:0.9',

--- a/src-test/src/org/openbravo/test/reporting/ReportingUtilsTest.java
+++ b/src-test/src/org/openbravo/test/reporting/ReportingUtilsTest.java
@@ -22,11 +22,13 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.After;
@@ -52,9 +54,12 @@ public class ReportingUtilsTest extends WeldBaseTest {
 
   @After
   public void cleanUp() {
-    File report = getTmpFile();
-    if (report.exists()) {
-      report.delete();
+    for (ExportType exportType : new ExportType[] { ExportType.HTML, ExportType.XLS,
+        ExportType.XLSX }) {
+      File report = getTmpFile(exportType);
+      if (report.exists()) {
+        report.delete();
+      }
     }
   }
 
@@ -84,15 +89,57 @@ public class ReportingUtilsTest extends WeldBaseTest {
 
   private void generateReport(File report, ConnectionProvider connectionProvider) {
     try {
-      ReportingUtils.exportJR(getReportPath().toString(), ExportType.HTML, new HashMap<>(), report,
-          true, connectionProvider, null, new HashMap<>());
+      exportReport(report, connectionProvider, ExportType.HTML);
     } catch (Exception ex) {
       log.error("Could not generate test report", ex);
     }
   }
 
+  private void exportReport(File report, ConnectionProvider connectionProvider,
+      ExportType exportType) throws Exception {
+    ReportingUtils.exportJR(getReportPath().toString(), exportType, new HashMap<>(), report, true,
+        connectionProvider, null, new HashMap<>());
+  }
+
   private File getTmpFile() {
-    return new File(ReportingUtils.getTempFolder(), "tmp.html");
+    return getTmpFile(ExportType.HTML);
+  }
+
+  private File getTmpFile(ExportType exportType) {
+    return new File(ReportingUtils.getTempFolder(), "tmp." + exportType.getExtension());
+  }
+
+  /**
+   * Exports a report to the legacy Excel format, which relies on the Apache POI HSSF
+   * implementation. It ensures that the JasperReports and POI libraries shipped with the platform
+   * are compatible and that all their runtime dependencies are available.
+   * 
+   * @throws Exception
+   *           if the report cannot be exported or the generated file cannot be read
+   */
+  @Test
+  @Issue("#1146")
+  public void generateLegacyExcelReport() throws Exception {
+    File report = getTmpFile(ExportType.XLS);
+    exportReport(report, null, ExportType.XLS);
+    assertThat("xls report generated correctly", report.exists(), equalTo(true));
+    try (HSSFWorkbook workbook = new HSSFWorkbook(new FileInputStream(report))) {
+      assertThat("xls report contains a sheet", workbook.getNumberOfSheets() > 0, equalTo(true));
+    }
+  }
+
+  /**
+   * Exports a report to the OOXML Excel format, which is the default one.
+   * 
+   * @throws Exception
+   *           if the report cannot be exported
+   */
+  @Test
+  @Issue("#1146")
+  public void generateExcelReport() throws Exception {
+    File report = getTmpFile(ExportType.XLSX);
+    exportReport(report, null, ExportType.XLSX);
+    assertThat("xlsx report generated correctly", report.exists(), equalTo(true));
   }
 
   private Path getReportPath() throws URISyntaxException {


### PR DESCRIPTION
Closes #1146 — ETP-5127

## Problem

With the preference `ExcelExportFormat = xls`, every report exported through the
legacy Excel path fails at runtime, and the UI hangs on *Processing…* with no
message. Two independent defects are chained:

1. **Missing runtime dependency.** `org.apache.poi:poi` declares
   `com.zaxxer:SparseBitSet`, which POI needs while creating the drawing
   patriarch of an HSSF sheet. Core enumerates its jars one by one in
   `artifacts.list.COMPILATION.gradle`, so the jar never reached `WEB-INF/lib`
   and the export died with `NoClassDefFoundError: com/zaxxer/sparsebits/SparseBitSet`.
   The `.xlsx` (XSSF) path never touches it, which is why this stayed hidden.
2. **Binary incompatibility.** JasperReports 6.17.0 was compiled against POI
   4.1.1, where `HSSFFont.getIndex()` returned a `short`. POI 5.4.0 exposes it
   as `int` and the old signature is gone, so `JRXlsExporter$StyleInfo` fails
   with `NoSuchMethodError: 'short org.apache.poi.hssf.usermodel.HSSFFont.getIndex()'`.
   Verified on the shipped jars: `javap` shows `HSSFFont.getIndex:()S` in three
   places of `JRXlsExporter$StyleInfo` and `public int getIndex()` in POI 5.4.0.

Both fixes are needed: without the first the second is never reached, and
without the second the first changes nothing.

## Fix

- Add `com.zaxxer:SparseBitSet:1.3` to the dependency list.
- Upgrade `jasperreports` and `jasperreports-fonts` to **6.20.0**.

6.19.0 is the first release whose exporter calls `getIndexAsInt()`, so anything
from there on fixes defect B. 6.20.0 was picked because it is the newest release
that still uses `com.lowagie:itext` — the PDF library Core already declares —
and needs no new jars: from 6.20.6 on JasperReports replaces iText with OpenPDF,
which would also alter the PDF export path that works today. The 6.20.0 jar was
checked not to reference any `jackson-dataformat-xml` or Castor class, the other
dependencies whose versions change in its POM.

## Regression test

`ReportingUtilsTest.generateLegacyExcelReport` exports the test report to XLS and
reads it back with POI HSSF; `generateExcelReport` covers the XLSX path. The
class is already registered in `StandaloneTestSuite`. The shared
`exportReport(...)` helper was extracted instead of duplicating the export call.

The test was checked to actually catch the bug, running the class against the
same classpath except for the jars under discussion:

| Jars | Result | Failure |
|---|---|---|
| JasperReports 6.17.0, no SparseBitSet | 4 tests, 1 failure | `com/zaxxer/sparsebits/SparseBitSet` |
| JasperReports 6.17.0 + SparseBitSet | 4 tests, 1 failure | `'short …HSSFFont.getIndex()'` |
| JasperReports 6.20.0 + SparseBitSet | 4 tests, 0 failures | — |

## Testing

Local instance (Core 26.2.7), preference `ExcelExportFormat = xls`, patched in
three successive states to isolate each defect:

- **Trial Balance → Export to Excel**: reproduced both errors, then succeeded.
  The generated file is a genuine OLE2 document (`Name of Creating Application:
  JasperReports Library version 6.20.0`) with one sheet and 12 data rows,
  re-read with POI and opened in a spreadsheet.
- **General Ledger Report → Excel** (classic window, different code path):
  228 KB `.xls` with 1,138 rows.
- **Regressions**: PDF export of the same report still works; `AllJrxmlCompilation`
  compiles the 153 `.jrxml` under `src` and `modules` with no failures;
  `javac` of the 32 Core sources importing `net.sf.jasperreports` against the new
  jar compiles clean (this covers the internal fill/subreport API Core relies on);
  `JasperReportsCompilation`, `CompiledReportsCacheTest` and `ReportingUtilsTest`
  pass.

### Packaging: the real build path

The runtime tests above were done by swapping jars in `WEB-INF/lib`, so the
dependency list change was also validated through the actual build. The list
becomes the project's dependency configuration, and `build.local.context` in
`src/build.xml` wipes `WEB-INF/lib` and repopulates it from the files Gradle
resolved (`<filelist refid="gradle.libs"/>`).

- `dependencyInsight` resolves `com.zaxxer:SparseBitSet:1.3`, `jasperreports:6.20.0`
  and `jasperreports-fonts:6.20.0` with no conflicts.
- `./gradlew smartbuild` → BUILD SUCCESSFUL in 4m 33s.
- After the build, `WEB-INF/lib` holds the three jars with the build's timestamp
  and no longer holds the 6.17.0 ones. The `md5` of the delivered
  `SparseBitSet-1.3.jar` matches the artifact Gradle downloaded to its cache.
- Tomcat restarted → export succeeds; `ReportingUtilsTest` passes against the
  jars the build placed (4 tests, 0 failures).

### Backport corroborated on 25.4

Validated on a second local instance, Core **25.4.26** (its own database and
Tomcat), whose dependency list has the `release/25.4` ordering:

1. Reproduced `NoClassDefFoundError: com/zaxxer/sparsebits/SparseBitSet` on
   Trial Balance (a classic window in 25.4).
2. Applied the change — the resulting lines are identical to this branch's.
3. `./gradlew smartbuild` → BUILD SUCCESSFUL in 3m; `WEB-INF/lib` goes from 241
   to 242 jars and the listing diff contains only the three expected entries.
4. After restarting Tomcat the export produces a valid OLE2 `.xls` written by
   JasperReports 6.20.0 (39 rows), with no errors in the log.
5. The backported test file compiles against the 25.4.26 classpath.

Not covered: the new test was not *run* on the 25.4 instance (it has no compiled
Weld test infrastructure there); CI will run it on both branches. Artifacts were
resolved from Maven Central, the repository the instances' `build.gradle`
declares — not checked against Etendo's own Nexus. Of the 153 `.jrxml`, only the
three reports named above were actually rendered; the rest were only compiled.
